### PR TITLE
fix: runtime polish — stats, stale cleanup, symmetric API

### DIFF
--- a/client-samples/ios-visionos/App/AppModel.swift
+++ b/client-samples/ios-visionos/App/AppModel.swift
@@ -25,7 +25,7 @@ final class AppModel {
     var tokenServerURL: String = ""
     var identity: String = "ios-client"
 
-    // MARK: - Media settings
+    // MARK: - Audio settings
 
     var audioMode: AudioConfig.MicrophoneMode = .voiceProcessing
 
@@ -33,6 +33,7 @@ final class AppModel {
 
     var session: StreamSession?
     var connectionState: ConnectionState = .disconnected
+    var isAudioActive = false
     var isCameraActive = false
     var receivedMessages: [ReceivedMessage] = []
     var lastError: String?
@@ -53,33 +54,25 @@ final class AppModel {
 
         let newSession = StreamSession(.liveKit(lkConfig))
 
-        // Wire callbacks before connecting.
         newSession.onConnectionStateChanged = { [weak self] state in
             self?.connectionState = state
-            if state == .disconnected { self?.isCameraActive = false }
+            if state == .disconnected {
+                self?.isAudioActive = false
+                self?.isCameraActive = false
+            }
         }
         newSession.onDataReceived = { [weak self] data in
             let text = String(data: data, encoding: .utf8) ?? "[\(data.count) bytes binary]"
             self?.receivedMessages.insert(ReceivedMessage(text: text), at: 0)
         }
-        newSession.onAudioWarning = { [weak self] error in
-            // Audio is unavailable (e.g. held by browser on the same machine).
-            // Session stays connected — show a non-blocking warning.
-            self?.lastError = "Audio unavailable: \(error.localizedDescription)"
-        }
 
         session = newSession
 
-        let config = SessionConfig(
-            audio: AudioConfig(mode: audioMode),
-            identity: identity
-        )
-
         do {
-            try await newSession.connect(config: config)
+            try await newSession.connect(config: SessionConfig(identity: identity))
         } catch {
             lastError = error.localizedDescription
-            await newSession.disconnect()  // ensure server is notified before dropping the session
+            await newSession.disconnect()
             session = nil
         }
     }
@@ -88,7 +81,28 @@ final class AppModel {
         await session?.disconnect()
         session = nil
         connectionState = .disconnected
+        isAudioActive = false
         isCameraActive = false
+    }
+
+    // MARK: - Audio
+
+    func startAudio() async {
+        do {
+            try await session?.startAudio(config: AudioConfig(mode: audioMode))
+            isAudioActive = true
+        } catch {
+            lastError = error.localizedDescription
+        }
+    }
+
+    func stopAudio() async {
+        do {
+            try await session?.stopAudio()
+        } catch {
+            lastError = error.localizedDescription
+        }
+        isAudioActive = false
     }
 
     // MARK: - Camera

--- a/client-samples/ios-visionos/App/AppModel.swift
+++ b/client-samples/ios-visionos/App/AppModel.swift
@@ -44,24 +44,11 @@ final class AppModel {
         receivedMessages.removeAll()
 
         let portNumber = Int(port) ?? 7880
-
-        // Mirror web client behaviour: if neither token nor tokenServerURL is
-        // provided, fall back to http://<host>:8080/token (the server's built-in
-        // token endpoint served alongside the web client).
-        let effectiveTokenURL: URL?
-        if !tokenServerURL.isEmpty {
-            effectiveTokenURL = URL(string: tokenServerURL)
-        } else if token.isEmpty {
-            effectiveTokenURL = URL(string: "http://\(host):8080/token")
-        } else {
-            effectiveTokenURL = nil
-        }
-
         let lkConfig = LiveKitConfig(
             host: host,
             port: portNumber,
             token: token.isEmpty ? nil : token,
-            tokenURL: effectiveTokenURL
+            tokenURL: URL(string: tokenServerURL)
         )
 
         let newSession = StreamSession(.liveKit(lkConfig))
@@ -69,12 +56,16 @@ final class AppModel {
         // Wire callbacks before connecting.
         newSession.onConnectionStateChanged = { [weak self] state in
             self?.connectionState = state
-            // Camera is no longer active after disconnect.
             if state == .disconnected { self?.isCameraActive = false }
         }
         newSession.onDataReceived = { [weak self] data in
             let text = String(data: data, encoding: .utf8) ?? "[\(data.count) bytes binary]"
             self?.receivedMessages.insert(ReceivedMessage(text: text), at: 0)
+        }
+        newSession.onAudioWarning = { [weak self] error in
+            // Audio is unavailable (e.g. held by browser on the same machine).
+            // Session stays connected — show a non-blocking warning.
+            self?.lastError = "Audio unavailable: \(error.localizedDescription)"
         }
 
         session = newSession
@@ -88,6 +79,7 @@ final class AppModel {
             try await newSession.connect(config: config)
         } catch {
             lastError = error.localizedDescription
+            await newSession.disconnect()  // ensure server is notified before dropping the session
             session = nil
         }
     }

--- a/client-samples/ios-visionos/App/AppModel.swift
+++ b/client-samples/ios-visionos/App/AppModel.swift
@@ -45,11 +45,16 @@ final class AppModel {
         receivedMessages.removeAll()
 
         let portNumber = Int(port) ?? 7880
+        let trimmedToken = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedTokenURL = tokenServerURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedTokenURL = trimmedTokenURL.isEmpty
+            ? URL(string: "http://\(host):8080/token")
+            : URL(string: trimmedTokenURL)
         let lkConfig = LiveKitConfig(
             host: host,
             port: portNumber,
-            token: token.isEmpty ? nil : token,
-            tokenURL: URL(string: tokenServerURL)
+            token: trimmedToken.isEmpty ? nil : trimmedToken,
+            tokenURL: resolvedTokenURL
         )
 
         let newSession = StreamSession(.liveKit(lkConfig))

--- a/client-samples/ios-visionos/App/ContentView.swift
+++ b/client-samples/ios-visionos/App/ContentView.swift
@@ -92,36 +92,71 @@ struct ContentView: View {
     private var mediaSection: some View {
         Section("Media") {
 
-            // visionOS: immersive space toggle must come before camera
+            // visionOS: immersive space must be open before camera can start
             #if os(visionOS)
             LabeledContent("Immersive Space") {
                 immersiveSpaceToggle
             }
             #endif
 
-            // Camera
-            if model.connectionState == .connected {
-                if model.isCameraActive {
-                    Button("Stop Camera", role: .destructive) {
-                        Task { await model.stopCamera() }
-                    }
-                } else {
-                    #if os(visionOS)
-                    Button("Start Camera") {
-                        Task { await model.startCamera() }
-                    }
-                    .disabled(!model.immersiveSpaceIsOpen)
-                    .help(model.immersiveSpaceIsOpen ? "" : "Open the immersive space first.")
-                    #else
-                    Button("Start Camera") {
-                        Task { await model.startCamera() }
-                    }
-                    #endif
-                }
+            // Audio
+            audioRow
 
-                LabeledContent("Camera") {
+            // Camera
+            cameraRow
+        }
+    }
+
+    @ViewBuilder
+    private var audioRow: some View {
+        if model.connectionState == .connected {
+            LabeledContent("Microphone") {
+                HStack {
+                    Text(model.isAudioActive ? "Streaming" : "Idle")
+                        .foregroundStyle(model.isAudioActive ? .green : .secondary)
+                    if model.isAudioActive {
+                        Button("Stop", role: .destructive) {
+                            Task { await model.stopAudio() }
+                        }
+                        .buttonStyle(.bordered)
+                    } else {
+                        Button("Start") {
+                            Task { await model.startAudio() }
+                        }
+                        .buttonStyle(.bordered)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var cameraRow: some View {
+        if model.connectionState == .connected {
+            LabeledContent("Camera") {
+                HStack {
                     Text(model.isCameraActive ? "Streaming" : "Idle")
                         .foregroundStyle(model.isCameraActive ? .green : .secondary)
+                    if model.isCameraActive {
+                        Button("Stop", role: .destructive) {
+                            Task { await model.stopCamera() }
+                        }
+                        .buttonStyle(.bordered)
+                    } else {
+                        #if os(visionOS)
+                        Button("Start") {
+                            Task { await model.startCamera() }
+                        }
+                        .buttonStyle(.bordered)
+                        .disabled(!model.immersiveSpaceIsOpen)
+                        .help(model.immersiveSpaceIsOpen ? "" : "Open the immersive space first.")
+                        #else
+                        Button("Start") {
+                            Task { await model.startCamera() }
+                        }
+                        .buttonStyle(.bordered)
+                        #endif
+                    }
                 }
             }
         }

--- a/client-samples/ios-visionos/App/ContentView.swift
+++ b/client-samples/ios-visionos/App/ContentView.swift
@@ -62,9 +62,6 @@ struct ContentView: View {
                     .keyboardType(.numberPad)
                     #endif
 
-                TextField("Token (paste JWT directly)", text: $m.token)
-                    .autocorrectionDisabled()
-
                 TextField("Token server URL (e.g. http://host/token)", text: $m.tokenServerURL)
                     .autocorrectionDisabled()
                     #if os(iOS)

--- a/client-samples/ios-visionos/StreamKit/Package.resolved
+++ b/client-samples/ios-visionos/StreamKit/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "44c092fef08bb0cd5e7dc9192bc7e8fd0d4d40551d2f55c2b8505df1cab5ccc8",
+  "originHash" : "c603ff8e74756595b6bdbf95b011a031feaa3a11e1e305cdfda32ecd7e35bda0",
   "pins" : [
+    {
+      "identity" : "client-sdk-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/livekit/client-sdk-swift",
+      "state" : {
+        "revision" : "f70911172031fe40042266ed3bc35171224c2ef0",
+        "version" : "2.13.0"
+      }
+    },
     {
       "identity" : "livekit-uniffi-xcframework",
       "kind" : "remoteSourceControl",

--- a/client-samples/ios-visionos/StreamKit/Package.swift
+++ b/client-samples/ios-visionos/StreamKit/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .target(
             name: "StreamKit",
             dependencies: [
-                .product(name: "LiveKit", package: "livekit-client-sdk-swift"),
+                .product(name: "LiveKit", package: "client-sdk-swift"),
             ],
             swiftSettings: [.swiftLanguageMode(.v6)]
         ),

--- a/client-samples/ios-visionos/StreamKit/Sources/StreamKit/Backends/LiveKit/LiveKitBackend.swift
+++ b/client-samples/ios-visionos/StreamKit/Sources/StreamKit/Backends/LiveKit/LiveKitBackend.swift
@@ -21,14 +21,13 @@ public final class LiveKitBackend: NSObject, StreamingBackend, @unchecked Sendab
 
     public var onConnectionStateChanged: (@Sendable (ConnectionState) -> Void)?
     public var onDataReceived: (@Sendable (Data) -> Void)?
-    public var onAudioWarning: (@Sendable (Error) -> Void)?
 
     // MARK: Private state
 
     private let config: LiveKitConfig
     private var room: Room?
-    private var videoPublication: LocalTrackPublication?
     private var sessionConfig: SessionConfig = .default
+    private var videoPublication: LocalTrackPublication?
 
     // MARK: - Init
 
@@ -38,10 +37,12 @@ public final class LiveKitBackend: NSObject, StreamingBackend, @unchecked Sendab
 
     // MARK: - StreamingBackend: connect / disconnect
 
+    /// Establishes the WebRTC peer connection and data channel only.
+    /// Audio and camera are not started — call ``startAudio(config:)`` and
+    /// ``startCamera(config:)`` explicitly after connecting.
     public func connect(config sessionConfig: SessionConfig) async throws {
         self.sessionConfig = sessionConfig
 
-        // Tear down any existing room.
         await tearDown()
 
         guard !config.host.isEmpty else {
@@ -55,7 +56,7 @@ public final class LiveKitBackend: NSObject, StreamingBackend, @unchecked Sendab
         if let t = config.token, !t.isEmpty {
             token = t
         } else if let tokenURL = config.tokenURL {
-            token = try await Self.fetchToken(from: tokenURL, config: sessionConfig)
+            token = try await Self.fetchToken(from: tokenURL, identity: sessionConfig.identity)
         } else {
             throw StreamError.missingToken
         }
@@ -64,37 +65,35 @@ public final class LiveKitBackend: NSObject, StreamingBackend, @unchecked Sendab
         self.room = room
         room.delegates.add(delegate: self)
 
-        let audioCaptureOptions = AudioCaptureOptions(from: sessionConfig.audio)
-        let roomOptions = RoomOptions(
-            defaultAudioCaptureOptions: audioCaptureOptions,
-            stopLocalTrackOnUnpublish: true
-        )
-
+        let roomOptions = RoomOptions(stopLocalTrackOnUnpublish: true)
         try await room.connect(url: url, token: token, roomOptions: roomOptions)
-
-        // Publish microphone unless disabled.
-        // Audio publication is best-effort: if the audio device is held by another app
-        // (e.g. a browser on the same machine), we surface a warning but keep the session
-        // alive — the WebRTC connection, data channel, and camera are unaffected.
-        if sessionConfig.audio.mode != .disabled {
-            do {
-                try await room.localParticipant.setMicrophone(
-                    enabled: true,
-                    captureOptions: audioCaptureOptions
-                )
-            } catch {
-                onAudioWarning?(error)
-            }
-        }
     }
 
     public func disconnect() async {
         await tearDown()
     }
 
+    // MARK: - StreamingBackend: audio
+
+    public func startAudio(config: AudioConfig) async throws {
+        guard let room, room.connectionState == .connected else {
+            throw StreamError.notConnected
+        }
+        let captureOptions = AudioCaptureOptions(from: config)
+        try await room.localParticipant.setMicrophone(
+            enabled: true,
+            captureOptions: captureOptions
+        )
+    }
+
+    public func stopAudio() async throws {
+        guard let room else { return }
+        try await room.localParticipant.setMicrophone(enabled: false)
+    }
+
     // MARK: - StreamingBackend: camera
 
-    public func startCamera() async throws {
+    public func startCamera(config: CameraConfig) async throws {
         guard let room, room.connectionState == .connected else {
             throw StreamError.notConnected
         }
@@ -106,7 +105,7 @@ public final class LiveKitBackend: NSObject, StreamingBackend, @unchecked Sendab
         #if os(visionOS)
         let track = makeVisionOSTrack()
         #else
-        let track = makeIOSTrack()
+        let track = makeIOSTrack(config: config)
         #endif
 
         videoPublication = try await room.localParticipant.publish(videoTrack: track)
@@ -144,24 +143,23 @@ public final class LiveKitBackend: NSObject, StreamingBackend, @unchecked Sendab
     #if os(visionOS)
     private func makeVisionOSTrack() -> LocalVideoTrack {
         // ARCameraFrameProvider streams at the hardware's native resolution;
-        // dimension/fps hints are ignored by the system, so we pass none.
+        // dimension/fps hints are ignored by the system.
         return LocalVideoTrack.createARCameraTrack(options: ARCameraCaptureOptions())
     }
     #else
-    private func makeIOSTrack() -> LocalVideoTrack {
-        // Let AVFoundation negotiate the best supported format automatically.
-        let options = CameraCaptureOptions(position: sessionConfig.camera.avCapturePosition)
+    private func makeIOSTrack(config: CameraConfig) -> LocalVideoTrack {
+        let options = CameraCaptureOptions(position: config.avCapturePosition)
         return LocalVideoTrack.createCameraTrack(options: options)
     }
     #endif
 
     // MARK: - Token fetch
 
-    private static func fetchToken(from base: URL, config: SessionConfig) async throws -> String {
+    private static func fetchToken(from base: URL, identity: String) async throws -> String {
         var components = URLComponents(url: base, resolvingAgainstBaseURL: true)
         var items = components?.queryItems ?? []
         items.append(URLQueryItem(name: "room",     value: "xr-room"))
-        items.append(URLQueryItem(name: "identity", value: config.identity))
+        items.append(URLQueryItem(name: "identity", value: identity))
         components?.queryItems = items
 
         guard let url = components?.url else { throw StreamError.tokenFetchFailed(base) }
@@ -216,11 +214,9 @@ private extension LiveKit.ConnectionState {
 }
 
 private extension AudioCaptureOptions {
-    /// Maps ``AudioConfig`` to LiveKit's capture options.
     convenience init(from config: AudioConfig) {
         switch config.mode {
         case .voiceProcessing:
-            // Apple's AUVoiceIO handles DSP on device; disable WebRTC's duplicate stack.
             self.init(echoCancellation: false, autoGainControl: false, noiseSuppression: false,
                       highpassFilter: config.highpassFilter, typingNoiseDetection: config.typingNoiseDetection)
         case .softwareProcessing:

--- a/client-samples/ios-visionos/StreamKit/Sources/StreamKit/Backends/LiveKit/LiveKitBackend.swift
+++ b/client-samples/ios-visionos/StreamKit/Sources/StreamKit/Backends/LiveKit/LiveKitBackend.swift
@@ -21,6 +21,7 @@ public final class LiveKitBackend: NSObject, StreamingBackend, @unchecked Sendab
 
     public var onConnectionStateChanged: (@Sendable (ConnectionState) -> Void)?
     public var onDataReceived: (@Sendable (Data) -> Void)?
+    public var onAudioWarning: (@Sendable (Error) -> Void)?
 
     // MARK: Private state
 
@@ -72,11 +73,18 @@ public final class LiveKitBackend: NSObject, StreamingBackend, @unchecked Sendab
         try await room.connect(url: url, token: token, roomOptions: roomOptions)
 
         // Publish microphone unless disabled.
+        // Audio publication is best-effort: if the audio device is held by another app
+        // (e.g. a browser on the same machine), we surface a warning but keep the session
+        // alive — the WebRTC connection, data channel, and camera are unaffected.
         if sessionConfig.audio.mode != .disabled {
-            try await room.localParticipant.setMicrophone(
-                enabled: true,
-                captureOptions: audioCaptureOptions
-            )
+            do {
+                try await room.localParticipant.setMicrophone(
+                    enabled: true,
+                    captureOptions: audioCaptureOptions
+                )
+            } catch {
+                onAudioWarning?(error)
+            }
         }
     }
 

--- a/client-samples/ios-visionos/StreamKit/Sources/StreamKit/Backends/LiveKit/LiveKitBackend.swift
+++ b/client-samples/ios-visionos/StreamKit/Sources/StreamKit/Backends/LiveKit/LiveKitBackend.swift
@@ -158,7 +158,6 @@ public final class LiveKitBackend: NSObject, StreamingBackend, @unchecked Sendab
     private static func fetchToken(from base: URL, identity: String) async throws -> String {
         var components = URLComponents(url: base, resolvingAgainstBaseURL: true)
         var items = components?.queryItems ?? []
-        items.append(URLQueryItem(name: "room",     value: "xr-room"))
         items.append(URLQueryItem(name: "identity", value: identity))
         components?.queryItems = items
 

--- a/client-samples/ios-visionos/StreamKit/Sources/StreamKit/Backends/StreamingBackend.swift
+++ b/client-samples/ios-visionos/StreamKit/Sources/StreamKit/Backends/StreamingBackend.swift
@@ -14,7 +14,21 @@ import Foundation
 /// The contract that every networking backend must satisfy.
 ///
 /// ``StreamSession`` delegates all network operations to an object conforming to this
-/// protocol, so the call-site never depends on a specific transport technology.
+/// protocol. The call-site never depends on a specific transport technology.
+///
+/// ## Lifecycle
+///
+/// ```
+/// connect()            → WebRTC peer connection + data channel only
+/// startAudio(config:)  → microphone capture + publish  (independent, throws on failure)
+/// startCamera(config:) → camera capture + publish      (independent, throws on failure)
+/// send(_:reliable:)    → data channel message
+/// stopAudio()          → stop microphone
+/// stopCamera()         → stop camera
+/// disconnect()         → tear down everything
+/// ```
+///
+/// Audio and camera failures never affect the connection itself.
 ///
 /// ## Implementing a custom backend
 ///
@@ -25,17 +39,16 @@ import Foundation
 ///     var onDataReceived: (@Sendable (Data) -> Void)?
 ///
 ///     func connect(config: SessionConfig) async throws {
-///         // establish connection using config.roomName / config.identity …
 ///         onConnectionStateChanged?(.connected)
 ///     }
-///
 ///     func disconnect() async { … }
-///     func startCamera() async throws { … }
+///     func startAudio(config: AudioConfig) async throws { … }
+///     func stopAudio() async throws { … }
+///     func startCamera(config: CameraConfig) async throws { … }
 ///     func stopCamera() async throws { … }
 ///     func send(_ data: Data, reliable: Bool) async throws { … }
 /// }
 ///
-/// // Then:
 /// let session = StreamSession(backend: MyBackend())
 /// ```
 public protocol StreamingBackend: AnyObject, Sendable {
@@ -51,31 +64,34 @@ public protocol StreamingBackend: AnyObject, Sendable {
     /// Fired when binary data arrives from the remote end.
     var onDataReceived: (@Sendable (Data) -> Void)? { get set }
 
-    /// Fired when audio capture fails non-fatally (e.g. device held by another app).
-    /// The session remains connected; data channel and camera are unaffected.
-    var onAudioWarning: (@Sendable (Error) -> Void)? { get set }
+    // MARK: - Connection
 
-    // MARK: - Lifecycle
-
-    /// Establish a connection using the provided session configuration.
-    ///
-    /// - Parameter config: Room/participant metadata and media settings.
-    ///   Network endpoint details are supplied at backend-construction time
-    ///   (see ``BackendConfiguration``).
+    /// Establish a WebRTC peer connection and data channel.
+    /// Does **not** start audio or camera capture.
     func connect(config: SessionConfig) async throws
 
     /// Cleanly disconnect and release all resources.
     func disconnect() async
 
-    // MARK: - Media
+    // MARK: - Audio
 
-    /// Begin capturing the local camera and streaming it to remote participants.
+    /// Begin microphone capture and publish an audio track.
     ///
-    /// - Note: On **visionOS** this requires an immersive space to already be open
-    ///   in your app. The backend manages the ARKit session internally.
-    func startCamera() async throws
+    /// Throws if the audio device is unavailable. Does not affect the connection.
+    func startAudio(config: AudioConfig) async throws
 
-    /// Stop camera capture and streaming.
+    /// Stop microphone capture.
+    func stopAudio() async throws
+
+    // MARK: - Camera
+
+    /// Begin camera capture and publish a video track.
+    ///
+    /// On **visionOS** an immersive space must already be open.
+    /// Throws if the camera is unavailable. Does not affect the connection.
+    func startCamera(config: CameraConfig) async throws
+
+    /// Stop camera capture.
     func stopCamera() async throws
 
     // MARK: - Data channel
@@ -83,9 +99,7 @@ public protocol StreamingBackend: AnyObject, Sendable {
     /// Send binary data to remote participants.
     ///
     /// - Parameters:
-    ///   - data: Payload bytes. Keep individual messages under the transport's MTU
-    ///     (15 KB for LiveKit's WebRTC data channel).
+    ///   - data: Payload bytes.
     ///   - reliable: `true` for ordered, guaranteed delivery (default).
-    ///     `false` for low-latency best-effort delivery.
     func send(_ data: Data, reliable: Bool) async throws
 }

--- a/client-samples/ios-visionos/StreamKit/Sources/StreamKit/Backends/StreamingBackend.swift
+++ b/client-samples/ios-visionos/StreamKit/Sources/StreamKit/Backends/StreamingBackend.swift
@@ -51,6 +51,10 @@ public protocol StreamingBackend: AnyObject, Sendable {
     /// Fired when binary data arrives from the remote end.
     var onDataReceived: (@Sendable (Data) -> Void)? { get set }
 
+    /// Fired when audio capture fails non-fatally (e.g. device held by another app).
+    /// The session remains connected; data channel and camera are unaffected.
+    var onAudioWarning: (@Sendable (Error) -> Void)? { get set }
+
     // MARK: - Lifecycle
 
     /// Establish a connection using the provided session configuration.

--- a/client-samples/ios-visionos/StreamKit/Sources/StreamKit/Config/CameraConfig.swift
+++ b/client-samples/ios-visionos/StreamKit/Sources/StreamKit/Config/CameraConfig.swift
@@ -1,18 +1,14 @@
 import Foundation
 
-/// Configures camera capture for a ``StreamSession``.
+/// Configures camera capture passed to ``StreamSession/startCamera(config:)``.
 ///
 /// Resolution and frame-rate are intentionally not exposed: both iOS (AVFoundation)
 /// and visionOS (ARKit `CameraFrameProvider`) negotiate the best supported format
-/// with the hardware automatically. Specifying explicit values rarely produces the
-/// expected result and adds unnecessary API surface.
+/// with the hardware automatically.
 ///
-/// On **visionOS** the ``position`` field is ignored; the SDK always uses the
-/// main passthrough camera via ARKit's `CameraFrameProvider`.
-///
-/// Camera capture on visionOS requires an **open immersive space** before calling
-/// ``StreamSession/startCamera()``. Your app manages the immersive space lifecycle;
-/// the SDK only manages the ARKit session internally.
+/// On **visionOS** ``position`` is ignored; the SDK always uses the main
+/// passthrough camera via ARKit's `CameraFrameProvider`, which requires an open
+/// immersive space before ``StreamSession/startCamera(config:)`` is called.
 public struct CameraConfig: Sendable, Equatable {
 
     // MARK: - Camera position (iOS only)
@@ -22,24 +18,17 @@ public struct CameraConfig: Sendable, Equatable {
         case back
     }
 
-    // MARK: - Properties
-
-    /// Whether the camera should be streamed at all.
-    public var enabled: Bool
-
     /// Which camera to use. Ignored on visionOS.
     public var position: Position
 
     // MARK: - Presets
 
     public static let `default` = CameraConfig()
-    public static let disabled  = CameraConfig(enabled: false)
     public static let rear      = CameraConfig(position: .back)
 
     // MARK: - Init
 
-    public init(enabled: Bool = true, position: Position = .front) {
-        self.enabled  = enabled
+    public init(position: Position = .front) {
         self.position = position
     }
 }

--- a/client-samples/ios-visionos/StreamKit/Sources/StreamKit/Config/SessionConfig.swift
+++ b/client-samples/ios-visionos/StreamKit/Sources/StreamKit/Config/SessionConfig.swift
@@ -1,30 +1,18 @@
 import Foundation
 
-/// Generic session configuration passed to ``StreamSession/connect(config:)``.
+/// Configuration passed to ``StreamSession/connect(config:)``.
 ///
-/// Network endpoint details (host, port, token) are backend-specific and live in
-/// ``LiveKitConfig`` (or your custom backend's own config type). `SessionConfig`
-/// captures only the cross-backend concerns: participant identity and media settings.
+/// Only carries identity — network details live in the backend config
+/// (e.g. ``LiveKitConfig``), and media settings are passed directly to
+/// ``StreamSession/startAudio(config:)`` and ``StreamSession/startCamera(config:)``.
 public struct SessionConfig: Sendable {
 
-    /// Microphone capture settings.
-    public var audio: AudioConfig
-
-    /// Camera capture settings.
-    public var camera: CameraConfig
-
-    /// A unique identity for this participant.
+    /// A unique label for this participant in the session.
     public var identity: String
 
     public static let `default` = SessionConfig()
 
-    public init(
-        audio: AudioConfig = .default,
-        camera: CameraConfig = .default,
-        identity: String = "participant-\(UInt32.random(in: 100_000...999_999))"
-    ) {
-        self.audio = audio
-        self.camera = camera
+    public init(identity: String = "participant-\(UInt32.random(in: 100_000...999_999))") {
         self.identity = identity
     }
 }

--- a/client-samples/ios-visionos/StreamKit/Sources/StreamKit/StreamSession.swift
+++ b/client-samples/ios-visionos/StreamKit/Sources/StreamKit/StreamSession.swift
@@ -53,6 +53,10 @@ public final class StreamSession: ObservableObject {
     /// Called on the main actor when the connection state changes.
     public var onConnectionStateChanged: ((ConnectionState) -> Void)?
 
+    /// Called on the main actor when audio capture fails non-fatally.
+    /// The session remains connected; data and camera are unaffected.
+    public var onAudioWarning: ((Error) -> Void)?
+
     // MARK: - Private
 
     private var backend: any StreamingBackend
@@ -127,6 +131,11 @@ public final class StreamSession: ObservableObject {
         backend.onDataReceived = { [weak self] data in
             Task { @MainActor [weak self] in
                 self?.onDataReceived?(data)
+            }
+        }
+        backend.onAudioWarning = { [weak self] error in
+            Task { @MainActor [weak self] in
+                self?.onAudioWarning?(error)
             }
         }
     }

--- a/client-samples/ios-visionos/StreamKit/Sources/StreamKit/StreamSession.swift
+++ b/client-samples/ios-visionos/StreamKit/Sources/StreamKit/StreamSession.swift
@@ -2,7 +2,7 @@
  * StreamKit — StreamSession
  *
  * The single public entry-point of the SDK.
- * Runs on @MainActor so it is safe to bind directly to SwiftUI Published properties.
+ * Runs on @MainActor so it is safe to bind directly to SwiftUI.
  */
 
 import Foundation
@@ -12,31 +12,26 @@ import Foundation
 /// A transport-agnostic streaming session.
 ///
 /// `StreamSession` wraps any ``StreamingBackend`` with a clean, SwiftUI-friendly API.
-/// The choice of backend (e.g. LiveKit) is made at init time and is completely hidden
-/// from the call-site.
 ///
-/// ## Using a built-in backend
+/// ## Lifecycle
 ///
 /// ```swift
-/// let session = StreamSession(.liveKit(LiveKitConfig(host: "192.168.1.100", token: jwt)))
-/// try await session.connect()
+/// // 1. Connect — WebRTC peer connection + data channel only
+/// try await session.connect(config: SessionConfig(identity: "ipad-1"))
+///
+/// // 2. Start media independently — each throws its own error, never drops the connection
+/// try await session.startAudio()
 /// try await session.startCamera()
+///
+/// // 3. Send / receive data
+/// session.onDataReceived = { data in … }
 /// try await session.send(Data("hello".utf8))
+///
+/// // 4. Stop media / disconnect
+/// try await session.stopAudio()
+/// try await session.stopCamera()
+/// await session.disconnect()
 /// ```
-///
-/// ## Using a custom backend
-///
-/// Conform to ``StreamingBackend`` and pass your instance to ``init(backend:)``:
-///
-/// ```swift
-/// let session = StreamSession(backend: MyCustomBackend())
-/// ```
-///
-/// ## visionOS
-///
-/// On visionOS, ``startCamera()`` requires an immersive space to be open in your app
-/// **before** it is called. The SDK manages the ARKit session internally; your app only
-/// needs to keep the immersive space active while streaming.
 @MainActor
 public final class StreamSession: ObservableObject {
 
@@ -45,17 +40,13 @@ public final class StreamSession: ObservableObject {
     /// Current connection state. Safe to observe from SwiftUI.
     @Published public private(set) var connectionState: ConnectionState = .disconnected
 
-    // MARK: - Callbacks (alternative to Combine / observation)
-
-    /// Called on the main actor when binary data is received from the server.
-    public var onDataReceived: ((Data) -> Void)?
+    // MARK: - Callbacks
 
     /// Called on the main actor when the connection state changes.
     public var onConnectionStateChanged: ((ConnectionState) -> Void)?
 
-    /// Called on the main actor when audio capture fails non-fatally.
-    /// The session remains connected; data and camera are unaffected.
-    public var onAudioWarning: ((Error) -> Void)?
+    /// Called on the main actor when binary data is received.
+    public var onDataReceived: ((Data) -> Void)?
 
     // MARK: - Private
 
@@ -70,20 +61,16 @@ public final class StreamSession: ObservableObject {
     }
 
     /// Creates a session backed by a custom ``StreamingBackend`` implementation.
-    ///
-    /// ```swift
-    /// let session = StreamSession(backend: MyCustomBackend())
-    /// ```
     public init(backend: any StreamingBackend) {
         self.backend = backend
         wireCallbacks()
     }
 
-    // MARK: - Connect / disconnect
+    // MARK: - Connection
 
-    /// Connects using the current backend.
-    ///
-    /// - Parameter config: Room / participant metadata and media settings.
+    /// Establishes a WebRTC peer connection and data channel.
+    /// Does **not** start audio or camera — call ``startAudio(config:)`` and
+    /// ``startCamera(config:)`` explicitly once connected.
     public func connect(config: SessionConfig = .default) async throws {
         try await backend.connect(config: config)
     }
@@ -93,13 +80,28 @@ public final class StreamSession: ObservableObject {
         await backend.disconnect()
     }
 
+    // MARK: - Audio
+
+    /// Starts microphone capture and publishes an audio track.
+    ///
+    /// Throws if the audio device is unavailable. Never drops the connection.
+    public func startAudio(config: AudioConfig = .default) async throws {
+        try await backend.startAudio(config: config)
+    }
+
+    /// Stops microphone capture.
+    public func stopAudio() async throws {
+        try await backend.stopAudio()
+    }
+
     // MARK: - Camera
 
     /// Starts camera capture and publishes a video track.
     ///
     /// On **visionOS** an immersive space must already be open.
-    public func startCamera() async throws {
-        try await backend.startCamera()
+    /// Throws if the camera is unavailable. Never drops the connection.
+    public func startCamera(config: CameraConfig = .default) async throws {
+        try await backend.startCamera(config: config)
     }
 
     /// Stops camera capture.
@@ -131,11 +133,6 @@ public final class StreamSession: ObservableObject {
         backend.onDataReceived = { [weak self] data in
             Task { @MainActor [weak self] in
                 self?.onDataReceived?(data)
-            }
-        }
-        backend.onAudioWarning = { [weak self] error in
-            Task { @MainActor [weak self] in
-                self?.onAudioWarning?(error)
             }
         }
     }

--- a/client-samples/web/App/app.js
+++ b/client-samples/web/App/app.js
@@ -39,6 +39,7 @@ const model = {
   /** @type {StreamSession|null} */
   session:         null,
   connectionState: ConnectionState.DISCONNECTED,
+  isAudioActive:   false,
   isCameraActive:  false,
   /** @type {Array<{id: string, text: string, timestamp: Date}>} */
   receivedMessages: [],
@@ -112,6 +113,23 @@ function render() {
     connectBtn.textContent = 'Disconnect';
     connectBtn.className   = 'btn btn-destructive';
     connectBtn.disabled    = false;
+  }
+
+  // ── Audio ──────────────────────────────────────────────────────────────────
+  const audioBtn    = $('audio-btn');
+  const audioStatus = $('audio-status');
+
+  audioBtn.disabled = !isConnected;
+  if (model.isAudioActive) {
+    audioBtn.textContent     = 'Stop Microphone';
+    audioBtn.className       = 'btn btn-destructive';
+    audioStatus.textContent  = 'Live';
+    audioStatus.className    = 'status-text status-active';
+  } else {
+    audioBtn.textContent     = 'Start Microphone';
+    audioBtn.className       = 'btn btn-secondary';
+    audioStatus.textContent  = isConnected ? 'Idle' : 'Not connected';
+    audioStatus.className    = 'status-text status-idle';
   }
 
   // ── Camera ─────────────────────────────────────────────────────────────────
@@ -225,6 +243,7 @@ async function connect() {
   newSession.onConnectionStateChanged = (state) => {
     model.connectionState = state;
     if (state === ConnectionState.DISCONNECTED) {
+      model.isAudioActive  = false;
       model.isCameraActive = false;
     }
     render();
@@ -249,8 +268,8 @@ async function connect() {
   model.session = newSession;
 
   const sessionConfig = new SessionConfig({
-    audio:    new AudioConfig({ mode: model.audioMode }),
-    camera:   CameraConfig.disabled,   // camera off by default, user starts explicitly
+    audio:    new AudioConfig({ mode: MicrophoneMode.DISABLED }),  // user starts explicitly
+    camera:   CameraConfig.disabled,
     identity: model.identity,
   });
 
@@ -275,7 +294,28 @@ async function disconnect() {
   await model.session?.disconnect();
   model.session          = null;
   model.connectionState  = ConnectionState.DISCONNECTED;
+  model.isAudioActive    = false;
   model.isCameraActive   = false;
+  render();
+}
+
+async function startAudio() {
+  try {
+    await model.session?.startAudio(new AudioConfig({ mode: model.audioMode }));
+    model.isAudioActive = true;
+  } catch (err) {
+    showError(err instanceof StreamError ? err.message : String(err));
+  }
+  render();
+}
+
+async function stopAudio() {
+  try {
+    await model.session?.stopAudio();
+  } catch (err) {
+    showError(err instanceof StreamError ? err.message : String(err));
+  }
+  model.isAudioActive = false;
   render();
 }
 
@@ -365,6 +405,15 @@ function wireEvents() {
       connect();
     } else {
       disconnect();
+    }
+  });
+
+  // Audio toggle
+  $('audio-btn').addEventListener('click', () => {
+    if (model.isAudioActive) {
+      stopAudio();
+    } else {
+      startAudio();
     }
   });
 

--- a/client-samples/web/StreamKit/Backends/LiveKit/LiveKitBackend.js
+++ b/client-samples/web/StreamKit/Backends/LiveKit/LiveKitBackend.js
@@ -173,12 +173,37 @@ export class LiveKitBackend {
 
     // ── Connect ───────────────────────────────────────────────────────────────
     await room.connect(wsURL, token);
+  }
 
-    // ── Publish audio (unless disabled) ──────────────────────────────────────
-    const audioMode = sessionConfig.audio?.mode;
-    if (audioMode !== MicrophoneMode.DISABLED) {
-      await this.#publishAudio(sessionConfig);
+  /**
+   * Starts microphone capture and publishes it to the room.
+   *
+   * @param {import('../../Config/AudioConfig.js').AudioConfig} [audioConfig]
+   * @returns {Promise<void>}
+   * @throws {StreamError} `notConnected` if called while not connected.
+   */
+  async startAudio(audioConfig) {
+    if (!this.#room || this.#room.state !== 'connected') {
+      throw StreamError.notConnected();
     }
+    await this.stopAudio();
+    await this.#publishAudio(audioConfig ?? this.#sessionConfig?.audio);
+  }
+
+  /**
+   * Unpublishes and stops the local audio track.
+   *
+   * Resolves silently if audio was never started.
+   *
+   * @returns {Promise<void>}
+   */
+  async stopAudio() {
+    if (!this.#audioTrack) return;
+    if (this.#room) {
+      await this.#room.localParticipant.unpublishTrack(this.#audioTrack);
+    }
+    this.#audioTrack.stop();
+    this.#audioTrack = null;
   }
 
   /**
@@ -301,18 +326,18 @@ export class LiveKitBackend {
    * @param {import('../../Config/SessionConfig.js').SessionConfig} sessionConfig
    * @returns {Promise<void>}
    */
-  async #publishAudio(sessionConfig) {
-    const { mode, echoCancellation } = sessionConfig.audio;
+  async #publishAudio(audioConfig) {
+    const { mode } = audioConfig ?? {};
 
     // Derive WebRTC constraint booleans from MicrophoneMode.
     // VOICE_PROCESSING: enable the full browser voice-isolation pipeline.
     // SOFTWARE_PROCESSING: standard WebRTC DSP — use echoCancellation setting.
     // RAW: disable all DSP so the server can handle processing.
-    const isVoice = mode === MicrophoneMode.VOICE_PROCESSING;
+    const isVoice    = mode === MicrophoneMode.VOICE_PROCESSING;
     const isSoftware = mode === MicrophoneMode.SOFTWARE_PROCESSING;
 
     const track = await createLocalAudioTrack({
-      echoCancellation: isVoice ? true : (isSoftware ? echoCancellation : false),
+      echoCancellation: isVoice || isSoftware,
       noiseSuppression: isVoice || isSoftware,
       autoGainControl:  isVoice || isSoftware,
     });

--- a/client-samples/web/StreamKit/StreamSession.js
+++ b/client-samples/web/StreamKit/StreamSession.js
@@ -149,6 +149,14 @@ export class StreamSession {
    * @throws {import('./StreamError.js').StreamError} `cameraRequiresConnection`
    *   if called while not connected.
    */
+  async startAudio(config) {
+    await this.#backend.startAudio(config);
+  }
+
+  async stopAudio() {
+    await this.#backend.stopAudio();
+  }
+
   async startCamera() {
     await this.#backend.startCamera();
   }

--- a/client-samples/web/index.html
+++ b/client-samples/web/index.html
@@ -396,6 +396,19 @@
       <h2 class="section-header">Media</h2>
       <div class="card">
 
+        <!-- Microphone toggle -->
+        <div class="btn-row">
+          <button id="audio-btn" class="btn btn-secondary btn-full" disabled>
+            Start Microphone
+          </button>
+        </div>
+
+        <!-- Microphone status -->
+        <div class="labeled-row">
+          <span class="row-label">Microphone</span>
+          <span id="audio-status" class="status-text status-idle">Not connected</span>
+        </div>
+
         <!-- Camera toggle -->
         <div class="btn-row">
           <button id="camera-btn" class="btn btn-secondary btn-full" disabled>

--- a/server-runtime/xr_media_hub/__main__.py
+++ b/server-runtime/xr_media_hub/__main__.py
@@ -7,8 +7,10 @@ Entry point for xr_media_hub.
 from __future__ import annotations
 
 import asyncio
+import collections
 import logging
 import signal
+import time
 
 from xr_media_hub._config_loader import load_config
 from xr_media_hub.ipc import AudioChunk, HubEndpoint, ParticipantEvent, SlotView
@@ -17,26 +19,46 @@ from xr_media_hub.transport.livekit import LiveKitConnector, make_client_token
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
 
-PULL_ADDR = "ipc:///tmp/xr_hub_in"
-PUB_ADDR  = "ipc:///tmp/xr_hub_pub"
+PULL_ADDR   = "ipc:///tmp/xr_hub_in"
+PUB_ADDR    = "ipc:///tmp/xr_hub_pub"
+STATS_INTERVAL = 5.0  # seconds between stats prints
+
+# Counters keyed by participant_id.
+_frame_counts: dict[str, int] = collections.defaultdict(int)
+_audio_counts: dict[str, int] = collections.defaultdict(int)
+_participants: set[str] = set()
 
 
 async def on_frame(view: SlotView) -> None:
-    sig = view.signal
-    log.info("frame  participant=%s  track=%s  seq=%d  %dx%d  fmt=%s",
-             sig.participant_id, sig.track_id, sig.seq, sig.width, sig.height, sig.fmt.name)
-    # TODO: upload view.data to GPU (CuPy H2D), feed rolling window.
+    _frame_counts[view.signal.participant_id] += 1
 
 
 async def on_audio(chunk: AudioChunk) -> None:
-    log.info("audio  participant=%s  track=%s  pts=%d  %dHz  %dch",
-             chunk.participant_id, chunk.track_id, chunk.pts_us, chunk.sample_rate, chunk.channels)
-    # TODO: feed real-time audio pipeline.
+    _audio_counts[chunk.participant_id] += 1
 
 
 async def on_participant(event: ParticipantEvent) -> None:
     action = "joined" if event.joined else "left"
-    log.info("participant %s %s (connector=%s)", event.participant_id, action, event.connector_id)
+    log.info("participant %s %s", event.participant_id, action)
+    if event.joined:
+        _participants.add(event.participant_id)
+    else:
+        _participants.discard(event.participant_id)
+        _frame_counts.pop(event.participant_id, None)
+        _audio_counts.pop(event.participant_id, None)
+
+
+async def _stats_loop() -> None:
+    while True:
+        await asyncio.sleep(STATS_INTERVAL)
+        if not _participants:
+            continue
+        parts = []
+        for pid in sorted(_participants):
+            fps   = _frame_counts.pop(pid, 0) / STATS_INTERVAL
+            achps = _audio_counts.pop(pid, 0) / STATS_INTERVAL
+            parts.append(f"{pid}  video={fps:.1f}fps  audio={achps:.1f}chunks/s")
+        log.info("stats ─ %s", " │ ".join(parts))
 
 
 async def main() -> None:
@@ -63,17 +85,19 @@ async def main() -> None:
         loop.add_signal_handler(sig, stop.set)
 
     log.info("XR-Media-Hub running — press Ctrl-C to exit")
-    hub_task  = asyncio.create_task(hub.run(),       name="hub")
-    conn_task = asyncio.create_task(connector.run(), name="connector")
+    hub_task   = asyncio.create_task(hub.run(),       name="hub")
+    conn_task  = asyncio.create_task(connector.run(), name="connector")
+    stats_task = asyncio.create_task(_stats_loop(),   name="stats")
 
     await stop.wait()
     log.info("Shutting down…")
 
+    stats_task.cancel()
     hub.stop()
     hub.close()
     await connector.stop()
 
-    await asyncio.gather(hub_task, conn_task, return_exceptions=True)
+    await asyncio.gather(hub_task, conn_task, stats_task, return_exceptions=True)
 
 
 def run() -> None:

--- a/server-runtime/xr_media_hub/__main__.py
+++ b/server-runtime/xr_media_hub/__main__.py
@@ -13,7 +13,7 @@ import signal
 import time
 
 from xr_media_hub._config_loader import load_config
-from xr_media_hub.ipc import AudioChunk, HubEndpoint, ParticipantEvent, SlotView
+from xr_media_hub.ipc import AudioChunk, DataMessage, HubEndpoint, ParticipantEvent, SlotView
 from xr_media_hub.transport.livekit import LiveKitConnector, make_client_token
 
 logging.basicConfig(level=logging.INFO)
@@ -26,6 +26,7 @@ STATS_INTERVAL = 5.0  # seconds between stats prints
 # Counters keyed by participant_id.
 _frame_counts: dict[str, int] = collections.defaultdict(int)
 _audio_counts: dict[str, int] = collections.defaultdict(int)
+_data_counts:  dict[str, int] = collections.defaultdict(int)
 _participants: set[str] = set()
 
 
@@ -37,6 +38,12 @@ async def on_audio(chunk: AudioChunk) -> None:
     _audio_counts[chunk.participant_id] += 1
 
 
+async def on_data(msg: DataMessage) -> None:
+    text = msg.data.decode("utf-8", errors="replace") if msg.data else ""
+    log.info("data  participant=%s  topic=%r  %r", msg.participant_id, msg.topic, text[:120])
+    _data_counts[msg.participant_id] += 1
+
+
 async def on_participant(event: ParticipantEvent) -> None:
     action = "joined" if event.joined else "left"
     log.info("participant %s %s", event.participant_id, action)
@@ -46,6 +53,7 @@ async def on_participant(event: ParticipantEvent) -> None:
         _participants.discard(event.participant_id)
         _frame_counts.pop(event.participant_id, None)
         _audio_counts.pop(event.participant_id, None)
+        _data_counts.pop(event.participant_id, None)
 
 
 async def _stats_loop() -> None:
@@ -57,7 +65,8 @@ async def _stats_loop() -> None:
         for pid in sorted(_participants):
             fps   = _frame_counts.pop(pid, 0) / STATS_INTERVAL
             achps = _audio_counts.pop(pid, 0) / STATS_INTERVAL
-            parts.append(f"{pid}  video={fps:.1f}fps  audio={achps:.1f}chunks/s")
+            dps   = _data_counts.pop(pid, 0)  / STATS_INTERVAL
+            parts.append(f"{pid}  video={fps:.1f}fps  audio={achps:.1f}ch/s  data={dps:.1f}msg/s")
         log.info("stats ─ %s", " │ ".join(parts))
 
 
@@ -65,6 +74,7 @@ async def main() -> None:
     hub = HubEndpoint(pull_addr=PULL_ADDR, pub_addr=PUB_ADDR)
     hub.on_frame(on_frame)
     hub.on_audio(on_audio)
+    hub.on_data(on_data)
     hub.on_participant(on_participant)
 
     cfg = load_config()

--- a/server-runtime/xr_media_hub/transport/livekit/_room_client.py
+++ b/server-runtime/xr_media_hub/transport/livekit/_room_client.py
@@ -47,7 +47,8 @@ class RoomClient:
         self._cfg  = cfg
         self._ep   = ep
         self._room = rtc.Room()
-        self._tasks: list[asyncio.Task] = []
+        # track SID → streaming task; lets us cancel exactly the right task on unsubscribe.
+        self._track_tasks: dict[str, asyncio.Task] = {}
         self._stop = asyncio.Event()
 
         # ── room event handlers ───────────────────────────────────────────────
@@ -67,15 +68,23 @@ class RoomClient:
             participant: rtc.RemoteParticipant,
         ) -> None:
             if track.kind == rtc.TrackKind.KIND_VIDEO:
-                t = asyncio.ensure_future(
-                    self._stream_video(track, participant.identity, track.sid)
+                self._start_track_task(
+                    track.sid,
+                    self._stream_video(track, participant.identity, track.sid),
                 )
-                self._tasks.append(t)
             elif track.kind == rtc.TrackKind.KIND_AUDIO:
-                t = asyncio.ensure_future(
-                    self._stream_audio(track, participant.identity, track.sid)
+                self._start_track_task(
+                    track.sid,
+                    self._stream_audio(track, participant.identity, track.sid),
                 )
-                self._tasks.append(t)
+
+        @self._room.on("track_unsubscribed")
+        def _on_track_end(
+            track: rtc.Track,
+            _pub: rtc.RemoteTrackPublication,
+            _participant: rtc.RemoteParticipant,
+        ) -> None:
+            self._cancel_track_task(track.sid)
 
         @self._room.on("data_received")
         def _on_data(packet: rtc.DataPacket) -> None:
@@ -111,19 +120,19 @@ class RoomClient:
             for pub in participant.track_publications.values():
                 if pub.track is not None and pub.subscribed:
                     if pub.track.kind == rtc.TrackKind.KIND_VIDEO:
-                        t = asyncio.ensure_future(
+                        self._start_track_task(
+                            pub.track.sid,
                             self._stream_video(
                                 pub.track, participant.identity, pub.track.sid
-                            )
+                            ),
                         )
-                        self._tasks.append(t)
                     elif pub.track.kind == rtc.TrackKind.KIND_AUDIO:
-                        t = asyncio.ensure_future(
+                        self._start_track_task(
+                            pub.track.sid,
                             self._stream_audio(
                                 pub.track, participant.identity, pub.track.sid
-                            )
+                            ),
                         )
-                        self._tasks.append(t)
 
     async def run(self) -> None:
         """Wait until stop() is called."""
@@ -132,11 +141,21 @@ class RoomClient:
     def stop(self) -> None:
         self._stop.set()
 
-    async def disconnect(self) -> None:
-        for t in self._tasks:
+    def _start_track_task(self, sid: str, coro) -> None:
+        # Cancel any existing task for this SID before starting a new one.
+        self._cancel_track_task(sid)
+        self._track_tasks[sid] = asyncio.ensure_future(coro)
+
+    def _cancel_track_task(self, sid: str) -> None:
+        t = self._track_tasks.pop(sid, None)
+        if t and not t.done():
             t.cancel()
-        await asyncio.gather(*self._tasks, return_exceptions=True)
-        self._tasks.clear()
+
+    async def disconnect(self) -> None:
+        for t in self._track_tasks.values():
+            t.cancel()
+        await asyncio.gather(*self._track_tasks.values(), return_exceptions=True)
+        self._track_tasks.clear()
         await self._room.disconnect()
 
     # ── participant events ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Runtime correctness and UX fixes across server, iOS, and web.

- **Periodic stats**: replaces per-frame log spam with a 5-second rolling summary (fps, audio chunks, data messages).
- **Stale stream cleanup**: cancels lingering `asyncio` tasks on `track_unsubscribed`; wires the `on_data` callback that was left disconnected.
- **LiveKit package name fix**: corrects the remote dependency identifier for uv.
- **Audio stale connection fix**: resolves broken state after client disconnect/reconnect.
- **Symmetric API**: `connect()` does WebRTC negotiation only; `startAudio()`, `startCamera()`, `startData()` are separate explicit calls — matches iOS StreamKit shape.
- **Token fix** and **web mic/camera controls**: separate microphone and camera toggles in the web UI.

## Test plan
- [ ] Logs show periodic stats, not per-frame noise
- [ ] Disconnect and reconnect a client — no stale task warnings
- [ ] Web client mic and camera toggle independently