### PR TITLE
chore: AGENTS.md + echo-agent build fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,11 +31,19 @@ processes automatically. No separate server launch step.
 ## Adding a new sample
 
 1. Create `agent-samples/<name>/` with its own `pyproject.toml`.
-2. Add `xr-ai-launcher @ ../../launcher` as a dependency.
-3. Add `[tool.hatch.metadata] allow-direct-references = true` — hatchling requires
-   this for any path (`@ ../..`) dependency.
-4. Wrap `main()` with `async with HubLauncher():` to start the full stack.
-5. Update `README.md` — architecture table and quickstart section.
+2. Declare local dependencies by name in `[project.dependencies]` and resolve
+   them with `[tool.uv.sources]` — **not** with inline `@ ../../path` syntax,
+   which breaks at wheel build time:
+   ```toml
+   [project]
+   dependencies = ["xr-media-hub", "xr-ai-launcher"]
+
+   [tool.uv.sources]
+   xr-media-hub  = { path = "../../server-runtime", editable = true }
+   xr-ai-launcher = { path = "../../launcher",      editable = true }
+   ```
+3. Wrap `main()` with `async with HubLauncher():` to start the full stack.
+4. Update `README.md` — architecture table and quickstart section.
 
 ## Adding a new managed process type
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,10 @@ processes automatically. No separate server launch step.
 
 1. Create `agent-samples/<name>/` with its own `pyproject.toml`.
 2. Add `xr-ai-launcher @ ../../launcher` as a dependency.
-3. Wrap `main()` with `async with HubLauncher():` to start the full stack.
-4. Update `README.md` — architecture table and quickstart section.
+3. Add `[tool.hatch.metadata] allow-direct-references = true` — hatchling requires
+   this for any path (`@ ../..`) dependency.
+4. Wrap `main()` with `async with HubLauncher():` to start the full stack.
+5. Update `README.md` — architecture table and quickstart section.
 
 ## Adding a new managed process type
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,121 @@
+# xr-ai — Working Conventions
+
+Guidelines for developers and AI assistants working in this repo.
+
+## Architecture
+
+```
+client-samples/     # Platform clients (Android, iOS/visionOS, Web)
+server-runtime/     # XR-Media-Hub core + LiveKit transport
+launcher/           # stdlib-only process manager (used by samples)
+agent-mcp-servers/  # MCP adapters: oxr, render, client, xr-media
+agent-samples/      # End-to-end agent demos
+docs/               # Design docs
+```
+
+Key design decisions:
+- **XR-Media-Hub** is transport-agnostic at its IPC boundary. Agents connect via IPC only.
+- **LiveKit** is an internal transport detail — not exposed to the agent layer.
+- MCP servers are the agent's only interface to XR data and rendering.
+- No API keys or tokens in source files — use env vars or `xr_media_hub.yaml`.
+
+## Process model
+
+Every sample is self-contained: running it starts the hub and all required
+processes automatically. No separate server launch step.
+
+- `xr_media_hub` always runs as its own process — never embedded in-process.
+- Process management lives in `launcher/`, not inside any process it manages.
+- Agents connect to the hub via IPC (`xr_media_hub.ipc.ProcessorEndpoint`).
+
+## Adding a new sample
+
+1. Create `agent-samples/<name>/` with its own `pyproject.toml`.
+2. Add `xr-ai-launcher @ ../../launcher` as a dependency.
+3. Wrap `main()` with `async with HubLauncher():` to start the full stack.
+4. Update `README.md` — architecture table and quickstart section.
+
+## Adding a new managed process type
+
+Add `launcher/xr_ai_launcher/_<name>.py` following the pattern in `_hub.py`.
+Use `ManagedProcess` as the base. Export from `__init__.py`.
+
+## Documentation rule
+
+**Update `README.md` (and relevant sub-repo docs) in the same task as the code
+change.** A change is not done until the docs reflect it. This applies to: new
+packages, changed entry points, new quickstart flows, renamed commands, new
+config files.
+
+## Dependency discipline
+
+- `launcher/` has zero runtime dependencies — stdlib only. Keep it that way.
+- Samples depend on `xr-media-hub` (IPC types) + `xr-ai-launcher` (launch) only.
+- Don't add abstractions until needed by two concrete use-cases.
+
+## Config
+
+`xr_media_hub.yaml` at the repo root is the primary config. Paths inside it
+resolve relative to the file's location. `HubLauncher` finds it automatically
+by searching upward from CWD.
+
+---
+
+## Decisions & change log
+
+Significant decisions, in reverse-chronological order. Update this whenever a
+non-trivial architectural or design decision is made so the rationale is
+preserved and not re-litigated.
+
+### 2026-04-21 — Process management moved to `launcher/`
+
+`HubLauncher` lives in `launcher/xr_ai_launcher/`, not in `server-runtime`.
+**Why:** process management should not be part of the processes it manages.
+The launcher will eventually start MCP servers, CloudXR runtime, and other
+components — keeping it separate keeps dependency chains lean and the boundary
+clean. `launcher/` has zero runtime dependencies (stdlib only).
+
+### 2026-04-21 — `AgentEndpoint` + `ConsumerEndpoint` → `ProcessorEndpoint`
+
+`ipc/_agent.py` and `ipc/_consumer.py` are deleted. Both are replaced by a
+single `ProcessorEndpoint` in `ipc/_processor.py`.
+**Why:** `ConsumerEndpoint` was unused scaffolding; `AgentEndpoint` was too
+narrow a name (the endpoint suits analytics, recording, etc. — not just agents).
+`ProcessorEndpoint` auto-maintains `connected_participants: frozenset[str]` so
+processors always know who is present without manual event tracking.
+
+### 2026-04-21 — Agent return path through hub
+
+Agents push `RETURN_DATA`/`RETURN_AUDIO` on the hub's PULL socket.
+The hub's `_dispatch` routes them to `send_return_data`/`send_return_audio`,
+which PUBs them on `return_data.<pid>` / `return_audio.<pid>` topics.
+The `ConnectorEndpoint` SUBs these topics and calls registered callbacks
+→ `RoomClient` → LiveKit → client.
+**Why:** closes the loop so agents can send audio and data back to participants.
+
+### 2026-04-21 — Echo-agent sample added
+
+`agent-samples/echo-agent/` — echoes audio back to the originating participant
+and sends a JSON stats ping (`topic="agent.stats"`) every 5 s to each
+connected participant. Demonstrates `ProcessorEndpoint` usage end-to-end.
+
+### 2026-04-20 — Track task management keyed by track SID
+
+`RoomClient._track_tasks` changed from `list[Task]` to `dict[str, Task]`
+keyed by track SID. A `track_unsubscribed` handler cancels the exact task.
+**Why:** without this, stop/start camera caused a new streaming task to start
+while the old one kept running, doubling (then tripling) fps counts.
+
+### 2026-04-20 — Audio format: float32 on the wire, int16 in LiveKit
+
+LiveKit delivers audio as int16 PCM. The hub's IPC layer (`AudioChunk`) uses
+float32 LE interleaved. Conversion happens in `_room_client.py`:
+- Inbound: `int16 / 32768.0 → float32`
+- Outbound (return audio): `clip(float32, -1, 1) * 32767 → int16`
+
+### 2026-04-20 — `xr_media_hub.yaml` config file
+
+Flat YAML at repo root. Fields map 1:1 to `LiveKitConnectorConfig` dataclass.
+Relative paths (e.g. `web_client_dir`) resolve relative to the YAML file's
+own directory, not CWD. `HubLauncher` searches upward from CWD to find it
+automatically.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,36 +1,7 @@
 # xr-ai — Claude Working Instructions
 
-## Project Overview
+Read `AGENTS.md` before making any changes. It is the authoritative source for
+architecture, process model, conventions, and documentation rules.
 
-Agentic AI for XR (Extended Reality), built on CloudXR ecosystem.
-XR-Media-Hub is the primary server runtime; LiveKit is the internal transport layer.
-
-## Architecture
-
-```
-client-samples/        # Platform clients (Android, iOS/visionOS, Web)
-server-runtime/        # XR-Media-Hub core + LiveKit transport
-agent-mcp-servers/     # MCP adapters: oxr, render, client, xr-media
-agent-samples/         # E2E agent demos (Pipecat + NAI, Pipecat + LLM)
-docs/                  # Design docs
-```
-
-## Key Design Decisions
-
-- **XR-Media-Hub** is transport-agnostic at its IPC boundary. AI frameworks connect via IPC only.
-- **LiveKit** is the internal transport between clients and the hub. It is an implementation detail — not exposed to the agent layer.
-- MCP servers are the agent's only interface to XR data and rendering.
-- No API keys or tokens in source; use env vars or secret stores.
-
-## Module Conventions
-
-- `server-runtime/xr_media_hub/ipc/` — client-side and server-side IPC endpoints
-- `server-runtime/xr_media_hub/transport/livekit/` — LiveKit connector (internal)
-- Each `agent-mcp-servers/<name>/` is an independent MCP server process
-- Client samples wrap LiveKit SDK with a thin, platform-neutral API surface
-
-## Coding Norms
-
-- Prefer clarity over cleverness — XR code runs on constrained hardware.
-- Note latency / memory budget constraints in commit messages when touching inference code.
-- Don't add abstractions until needed by two concrete use-cases.
+Sub-repos may have their own `CLAUDE.md` with module-specific context — read
+those before working inside them.

--- a/agent-samples/echo-agent/pyproject.toml
+++ b/agent-samples/echo-agent/pyproject.toml
@@ -15,5 +15,8 @@ dependencies = [
 [project.scripts]
 echo_agent = "echo_agent.__main__:run"
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
 [tool.hatch.build.targets.wheel]
 packages = ["echo_agent"]

--- a/agent-samples/echo-agent/pyproject.toml
+++ b/agent-samples/echo-agent/pyproject.toml
@@ -7,16 +7,17 @@ name = "echo-agent"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
-    "xr-media-hub @ ../../server-runtime",
-    "xr-ai-launcher @ ../../launcher",
+    "xr-media-hub",
+    "xr-ai-launcher",
     "numpy>=1.24",
 ]
 
+[tool.uv.sources]
+xr-media-hub = { path = "../../server-runtime", editable = true }
+xr-ai-launcher = { path = "../../launcher", editable = true }
+
 [project.scripts]
 echo_agent = "echo_agent.__main__:run"
-
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["echo_agent"]


### PR DESCRIPTION
## Summary

Establishes `AGENTS.md` as the single authoritative reference for architecture, conventions, and decisions — and fixes echo-agent Python packaging.

**AGENTS.md**: architecture overview, IPC topology, process model, dependency discipline, and a decisions log (ProcessorEndpoint rename, launcher separation, return audio path, track task fix, config format). `CLAUDE.md` trimmed to a pointer.

**Echo-agent build fixes**:
- `tool.hatch.metadata.allow-direct-references = true` required for path dependencies at wheel build time.
- Switched from inline `@ ../../path` syntax (fails at build time) to `[tool.uv.sources]` table (resolves relative to `pyproject.toml` at sync time).
- Both fixes documented in AGENTS.md to prevent recurrence.

## Test plan
- [ ] `uv sync` in `agent-samples/echo-agent/` succeeds without errors
- [ ] `uv run echo-agent` still works after packaging fix