### PR TITLE
feat: VLM agent sample, multi-camera, HTTPS, agent status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,21 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-04-21 — VLM agent sample added
+
+`agent-samples/vlm-agent/` — answers natural-language queries about live XR
+video using a locally-hosted vision-language model.
+**Model:** `nvidia/Cosmos-Reason1-7B` (NVIDIA Open Model License + Apache 2.0,
+commercial use permitted; ~16 GB VRAM at BF16). Architecture:
+`Qwen2_5_VLForConditionalGeneration` + `AutoProcessor` + `qwen-vl-utils`.
+**Protocol:** client sends `vlm.query` data message (raw text or
+`{"query":"…","track_id":"…"}`); agent replies on `vlm.response`.
+**Frame flow:** `on_frame()` tracks latest `FrameSignal` per (participant,
+track); on query, `request_frame(signal)` pulls a pixel copy, converts to PIL
+via numpy (I420/NV12/RGB24/RGBA/BGRA), then calls `_VlmBackend.infer()` in a
+thread pool so the asyncio loop is not blocked. Model is loaded lazily on the
+first query. Override model via `VLM_MODEL` env var.
+
 ### 2026-04-21 — Process management moved to `launcher/`
 
 `HubLauncher` lives in `launcher/xr_ai_launcher/`, not in `server-runtime`.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ VLM_MODEL=Qwen/Qwen2.5-VL-7B-Instruct uv run vlm_agent
 
 The agent replies on topic `vlm.response` with plain UTF-8 text.
 
-The model is loaded on the first query (~30–60 s). Subsequent queries are fast.
+The model is loaded at startup (~30–60 s). It is ready before the first query.
 
 ---
 
@@ -85,6 +85,28 @@ Useful for development or when running an agent in a separate terminal.
 Open `http://localhost:8080` in a browser. Leave **Token URL** blank to use the
 server's built-in `/token` endpoint, or paste the printed token directly.
 
+#### HTTPS (required for camera access from remote devices)
+
+Camera access in browsers is only permitted over `localhost` or HTTPS. When
+connecting from another device on the network, enable TLS in `xr_media_hub.yaml`:
+
+```yaml
+web_server_tls: true
+web_server_port: 8443   # conventional HTTPS alt-port (optional)
+```
+
+On first run a self-signed certificate is generated at
+`~/.local/share/xr-ai/web-server.crt`. To trust it:
+
+- **Chrome / Edge**: navigate to `https://<host>:8443`, click **Advanced →
+  Proceed to … (unsafe)**.
+- **Firefox**: click **Advanced → Accept the Risk and Continue**.
+- **iOS / Safari**: open the cert URL, follow the prompt to install the profile,
+  then enable it under **Settings → General → VPN & Device Management**.
+
+To use your own certificate, set `cert_file` and `key_file` in
+`xr_media_hub.yaml`.
+
 ---
 
 ### iOS / visionOS client
@@ -100,6 +122,42 @@ for full Xcode setup. Quick connection settings:
 
 The token is valid for 24 hours. To get a fresh one restart the server or call
 `GET http://<host>:8080/token?identity=<name>`.
+
+## Firewall
+
+The hub uses the following ports. Open them permanently if a firewall is active.
+
+| Port | Protocol | Purpose |
+|------|----------|---------|
+| 7880 | TCP | LiveKit WebSocket signaling |
+| 7881 | TCP | LiveKit WebRTC TCP fallback |
+| 7882 | UDP | LiveKit WebRTC UDP media |
+| 8080 | TCP | Web client / token server (HTTP) |
+| 8443 | TCP | Web client / token server (HTTPS, if enabled) |
+
+**Ubuntu / Debian (`ufw`)**
+
+```bash
+sudo ufw allow 7880/tcp
+sudo ufw allow 7881/tcp
+sudo ufw allow 7882/udp
+sudo ufw allow 8080/tcp
+sudo ufw allow 8443/tcp   # HTTPS only
+sudo ufw reload
+```
+
+**RHEL / Fedora / CentOS (`firewall-cmd`)**
+
+```bash
+sudo firewall-cmd --permanent --add-port=7880/tcp
+sudo firewall-cmd --permanent --add-port=7881/tcp
+sudo firewall-cmd --permanent --add-port=7882/udp
+sudo firewall-cmd --permanent --add-port=8080/tcp
+sudo firewall-cmd --permanent --add-port=8443/tcp   # HTTPS only
+sudo firewall-cmd --reload
+```
+
+---
 
 ## Design
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,33 @@ point `web_client_dir` at a different web client build.
 
 ---
 
+### VLM agent (vision-language queries over live video)
+
+Requires ~16 GB VRAM. Default model: `nvidia/Cosmos-Reason1-7B`
+(NVIDIA Open Model License + Apache 2.0 — commercial use permitted).
+
+```bash
+cd xr-ai/agent-samples/vlm-agent
+uv sync
+uv run vlm_agent
+```
+
+Override the model via environment variable:
+
+```bash
+VLM_MODEL=Qwen/Qwen2.5-VL-7B-Instruct uv run vlm_agent
+```
+
+**Client protocol** — send any data channel message (no specific topic required):
+- Raw UTF-8 text: `"What objects are on the table?"`
+- Or JSON: `{"query": "What objects are on the table?", "track_id": "optional"}`
+
+The agent replies on topic `vlm.response` with plain UTF-8 text.
+
+The model is loaded on the first query (~30–60 s). Subsequent queries are fast.
+
+---
+
 ### Hub only (server-runtime standalone)
 
 ```bash

--- a/agent-samples/vlm-agent/.gitignore
+++ b/agent-samples/vlm-agent/.gitignore
@@ -1,0 +1,2 @@
+# Downloaded model weights — large binary files, never commit
+models/

--- a/agent-samples/vlm-agent/pyproject.toml
+++ b/agent-samples/vlm-agent/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "vlm-agent"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "xr-media-hub",
+    "xr-ai-launcher",
+    "numpy>=1.24",
+    "Pillow>=10.0",
+    "torch>=2.2",
+    "torchvision>=0.17",
+    "transformers>=4.49",
+    "accelerate>=0.30",
+    "qwen-vl-utils>=0.0.8",
+    "hf-transfer>=0.1.4",
+]
+
+[tool.uv.sources]
+xr-media-hub   = { path = "../../server-runtime", editable = true }
+xr-ai-launcher = { path = "../../launcher",       editable = true }
+
+[project.scripts]
+vlm_agent = "vlm_agent.__main__:run"
+
+[tool.hatch.build.targets.wheel]
+packages = ["vlm_agent"]

--- a/agent-samples/vlm-agent/vlm_agent/__main__.py
+++ b/agent-samples/vlm-agent/vlm_agent/__main__.py
@@ -54,6 +54,11 @@ log = logging.getLogger("vlm_agent")
 _MODEL_ID    = os.environ.get("VLM_MODEL", "nvidia/Cosmos-Reason1-7B")
 # Models are cached inside this sample's directory, gitignored.
 _MODEL_CACHE = pathlib.Path(__file__).resolve().parents[1] / "models"
+
+# Qwen2.5-VL image token budget: 1 token per 28×28 px patch.
+# Large frames (e.g. 1920×1080) produce ~2500 tokens and push the model past
+# its context limit, triggering a CUDA device-side assert.  Cap to ~1 MP.
+_MAX_IMAGE_PIXELS = 1280 * 28 * 28   # ≈ 1 003 520 px  (~1002×1002)
 _HUB_PUB     = "ipc:///tmp/xr_hub_pub"
 _HUB_PUSH    = "ipc:///tmp/xr_hub_in"
 
@@ -135,14 +140,18 @@ class _VlmBackend:
                 device_map="auto",
                 cache_dir=str(_MODEL_CACHE),
             )
+            proc_kwargs = dict(
+                cache_dir=str(_MODEL_CACHE),
+                min_pixels=256 * 28 * 28,
+                max_pixels=_MAX_IMAGE_PIXELS,
+            )
             # Try offline first — avoids a network round-trip when weights are cached.
             try:
                 self._model = Qwen2_5_VLForConditionalGeneration.from_pretrained(
                     self._model_id, local_files_only=True, **kwargs,
                 ).eval()
                 self._processor = AutoProcessor.from_pretrained(
-                    self._model_id, local_files_only=True,
-                    cache_dir=str(_MODEL_CACHE),
+                    self._model_id, local_files_only=True, **proc_kwargs,
                 )
             except OSError:
                 log.info("Model not in cache — downloading %s", self._model_id)
@@ -150,7 +159,7 @@ class _VlmBackend:
                     self._model_id, **kwargs,
                 ).eval()
                 self._processor = AutoProcessor.from_pretrained(
-                    self._model_id, cache_dir=str(_MODEL_CACHE),
+                    self._model_id, **proc_kwargs,
                 )
             log.info("VLM ready on %s", next(self._model.parameters()).device)
 
@@ -159,6 +168,15 @@ class _VlmBackend:
         self._ensure_loaded()
         import torch
         from qwen_vl_utils import process_vision_info
+
+        # Resize before tokenisation — large frames (e.g. 1920×1080) exceed the
+        # model's context window and cause a CUDA device-side assert at runtime.
+        if image.width * image.height > _MAX_IMAGE_PIXELS:
+            scale = (_MAX_IMAGE_PIXELS / (image.width * image.height)) ** 0.5
+            image = image.resize(
+                (int(image.width * scale), int(image.height * scale)),
+                Image.LANCZOS,
+            )
 
         messages = [{"role": "user", "content": [
             {"type": "image", "image": image},
@@ -235,10 +253,11 @@ class VlmAgent:
 
         frame = await self._ep.request_frame(signal)
         if frame is None:
+            # Hub had no slot for this track yet — client can retry.
             await self._reply(pid, "Frame data unavailable — please retry.", msg.pts_us)
             return
 
-        image = _frame_to_pil(frame)
+        image = _frame_to_pil(frame)   # raises on unrecognised format → crash
         log.info("vlm  pid=%r  %dx%d  query=%r", pid, frame.width, frame.height, query[:60])
 
         loop   = asyncio.get_running_loop()

--- a/agent-samples/vlm-agent/vlm_agent/__main__.py
+++ b/agent-samples/vlm-agent/vlm_agent/__main__.py
@@ -293,6 +293,8 @@ class VlmAgent:
     # ── lifecycle ─────────────────────────────────────────────────────────────
 
     async def run(self) -> None:
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._vlm._ensure_loaded)
         await self._ep.run()
 
     def shutdown(self) -> None:

--- a/agent-samples/vlm-agent/vlm_agent/__main__.py
+++ b/agent-samples/vlm-agent/vlm_agent/__main__.py
@@ -1,0 +1,314 @@
+"""
+VLM agent for XR-Media-Hub.
+
+Starts the hub as a subprocess, connects via IPC, and answers natural-language
+queries about the live video feed from XR clients.
+
+Protocol
+--------
+Client → agent  (LiveKit data channel, any topic):
+    Raw UTF-8 text  OR  JSON  {"query": "…", "track_id": "optional"}
+
+Agent → client  (topic "vlm.response"):
+    Raw UTF-8 text — the model's answer
+
+Environment
+-----------
+    VLM_MODEL   HuggingFace model ID (default: nvidia/Cosmos-Reason1-7B)
+                Must be a Qwen2.5-VL-compatible model.
+                License: NVIDIA Open Model License + Apache 2.0 (commercial OK).
+                ~16 GB VRAM required at BF16; use device_map="auto" for multi-GPU.
+
+How to run (from agent-samples/vlm-agent/ or xr-ai/):
+    uv sync
+    uv run vlm_agent
+
+First-query note: the model is loaded on demand. The first vlm.query after
+startup will block for ~30–60 s while weights load from disk.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import pathlib
+import signal
+import threading
+
+# Must be set before huggingface_hub is imported — enables the Rust-based
+# parallel downloader (hf-transfer) which is ~5-10x faster than urllib.
+os.environ.setdefault("HF_HUB_ENABLE_HF_TRANSFER", "1")
+
+import numpy as np
+from PIL import Image
+
+from xr_ai_launcher import HubLauncher
+from xr_media_hub.ipc import ProcessorEndpoint
+from xr_media_hub.ipc._types import (
+    DataMessage, FrameData, FrameSignal, ParticipantEvent, PixelFormat,
+)
+
+log = logging.getLogger("vlm_agent")
+
+_MODEL_ID    = os.environ.get("VLM_MODEL", "nvidia/Cosmos-Reason1-7B")
+# Models are cached inside this sample's directory, gitignored.
+_MODEL_CACHE = pathlib.Path(__file__).resolve().parents[1] / "models"
+_HUB_PUB     = "ipc:///tmp/xr_hub_pub"
+_HUB_PUSH    = "ipc:///tmp/xr_hub_in"
+
+
+# ── pixel conversion ──────────────────────────────────────────────────────────
+
+def _yuv_to_rgb(Y: np.ndarray, U: np.ndarray, V: np.ndarray) -> Image.Image:
+    """BT.601 limited-range YCbCr → RGB. U/V must already be full-size (upsampled)."""
+    Y = Y.astype(np.float32) - 16.0
+    U = U.astype(np.float32) - 128.0
+    V = V.astype(np.float32) - 128.0
+    R = np.clip(1.164 * Y               + 1.596 * V, 0, 255)
+    G = np.clip(1.164 * Y - 0.392 * U  - 0.813 * V, 0, 255)
+    B = np.clip(1.164 * Y + 2.017 * U,              0, 255)
+    return Image.fromarray(np.stack([R, G, B], axis=-1).astype(np.uint8), "RGB")
+
+
+def _frame_to_pil(frame: FrameData) -> Image.Image:
+    w, h = frame.width, frame.height
+    arr  = np.frombuffer(frame.data, dtype=np.uint8)
+
+    if frame.fmt == PixelFormat.RGB24:
+        return Image.fromarray(arr.reshape(h, w, 3), "RGB")
+
+    if frame.fmt == PixelFormat.RGBA:
+        return Image.fromarray(arr.reshape(h, w, 4), "RGBA").convert("RGB")
+
+    if frame.fmt == PixelFormat.BGRA:
+        a = arr.reshape(h, w, 4)
+        return Image.fromarray(a[:, :, [2, 1, 0]], "RGB")
+
+    if frame.fmt == PixelFormat.I420:
+        y_end = w * h
+        uv_sz = (w // 2) * (h // 2)
+        Y = arr[:y_end].reshape(h, w)
+        U = arr[y_end : y_end + uv_sz].reshape(h // 2, w // 2).repeat(2, 0).repeat(2, 1)
+        V = arr[y_end + uv_sz :].reshape(h // 2, w // 2).repeat(2, 0).repeat(2, 1)
+        return _yuv_to_rgb(Y, U, V)
+
+    if frame.fmt == PixelFormat.NV12:
+        y_end = w * h
+        Y  = arr[:y_end].reshape(h, w)
+        uv = arr[y_end:].reshape(h // 2, w)
+        U  = uv[:, 0::2].repeat(2, 0).repeat(2, 1)
+        V  = uv[:, 1::2].repeat(2, 0).repeat(2, 1)
+        return _yuv_to_rgb(Y, U, V)
+
+    raise ValueError(f"Unsupported pixel format: {frame.fmt!r}")
+
+
+# ── VLM inference ─────────────────────────────────────────────────────────────
+
+class _VlmBackend:
+    """
+    Thread-safe lazy loader and inference runner for a Qwen2.5-VL model.
+
+    Model is loaded on the first call to infer() and reused for all subsequent
+    calls. Loading blocks the calling thread; use run_in_executor from asyncio.
+    """
+
+    def __init__(self, model_id: str) -> None:
+        self._model_id  = model_id
+        self._model     = None
+        self._processor = None
+        self._lock      = threading.Lock()
+
+    def _ensure_loaded(self) -> None:
+        if self._model is not None:
+            return
+        with self._lock:
+            if self._model is not None:
+                return
+            import torch
+            from transformers import AutoProcessor, Qwen2_5_VLForConditionalGeneration
+            _MODEL_CACHE.mkdir(parents=True, exist_ok=True)
+            log.info("Loading VLM %s  cache=%s", self._model_id, _MODEL_CACHE)
+            kwargs = dict(
+                torch_dtype=torch.bfloat16,
+                device_map="auto",
+                cache_dir=str(_MODEL_CACHE),
+            )
+            # Try offline first — avoids a network round-trip when weights are cached.
+            try:
+                self._model = Qwen2_5_VLForConditionalGeneration.from_pretrained(
+                    self._model_id, local_files_only=True, **kwargs,
+                ).eval()
+                self._processor = AutoProcessor.from_pretrained(
+                    self._model_id, local_files_only=True,
+                    cache_dir=str(_MODEL_CACHE),
+                )
+            except OSError:
+                log.info("Model not in cache — downloading %s", self._model_id)
+                self._model = Qwen2_5_VLForConditionalGeneration.from_pretrained(
+                    self._model_id, **kwargs,
+                ).eval()
+                self._processor = AutoProcessor.from_pretrained(
+                    self._model_id, cache_dir=str(_MODEL_CACHE),
+                )
+            log.info("VLM ready on %s", next(self._model.parameters()).device)
+
+    def infer(self, image: Image.Image, query: str) -> str:
+        """Synchronous inference. Call from a thread pool, not the event loop."""
+        self._ensure_loaded()
+        import torch
+        from qwen_vl_utils import process_vision_info
+
+        messages = [{"role": "user", "content": [
+            {"type": "image", "image": image},
+            {"type": "text",  "text":  query},
+        ]}]
+        text = self._processor.apply_chat_template(
+            messages, tokenize=False, add_generation_prompt=True,
+        )
+        image_inputs, video_inputs = process_vision_info(messages)
+        inputs = self._processor(
+            text=[text], images=image_inputs, videos=video_inputs,
+            padding=True, return_tensors="pt",
+        ).to(self._model.device)
+        with torch.inference_mode():
+            out_ids = self._model.generate(**inputs, max_new_tokens=512)
+        trimmed = out_ids[:, inputs.input_ids.shape[1]:]
+        return self._processor.batch_decode(trimmed, skip_special_tokens=True)[0]
+
+
+# ── agent ─────────────────────────────────────────────────────────────────────
+
+class VlmAgent:
+    """
+    Receives live video signals and on-demand VLM queries from XR clients.
+
+    Flow
+    ----
+    1. on_frame() keeps track of the latest FrameSignal per (participant, track).
+    2. on_data() — any data message is treated as a query (raw text or JSON):
+       a. request_frame(latest_signal)   — pixel copy from hub SHM
+       b. _frame_to_pil(frame)           — pixel format → PIL Image
+       c. _VlmBackend.infer()            — VLM inference in thread pool
+       d. send_return_data("vlm.response") → client data channel
+    """
+
+    def __init__(self) -> None:
+        self._ep = ProcessorEndpoint(sub_addr=_HUB_PUB, push_addr=_HUB_PUSH)
+        self._ep.on_frame(self._on_frame)
+        self._ep.on_data(self._on_data)
+        self._ep.on_participant(self._on_participant)
+
+        # (participant_id, track_id) → latest FrameSignal
+        self._latest: dict[tuple[str, str], FrameSignal] = {}
+        self._vlm = _VlmBackend(_MODEL_ID)
+
+    # ── callbacks ─────────────────────────────────────────────────────────────
+
+    async def _on_frame(self, signal: FrameSignal) -> None:
+        self._latest[(signal.participant_id, signal.track_id)] = signal
+
+    async def _on_data(self, msg: DataMessage) -> None:
+        # Accept raw text or {"query": "…", "track_id": "…"} — any topic.
+        query    = ""
+        track_id = None
+        try:
+            payload = json.loads(msg.data)
+            if isinstance(payload, dict):
+                query    = payload.get("query", "")
+                track_id = payload.get("track_id")
+            else:
+                query = str(payload)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            query = msg.data.decode(errors="replace")
+
+        if not query:
+            return
+
+        pid    = msg.participant_id
+        signal = self._pick_signal(pid, track_id)
+        if signal is None:
+            log.warning("vlm from %r — no video frame yet", pid)
+            await self._reply(pid, "No video frame available yet.", msg.pts_us)
+            return
+
+        frame = await self._ep.request_frame(signal)
+        if frame is None:
+            await self._reply(pid, "Frame data unavailable — please retry.", msg.pts_us)
+            return
+
+        image = _frame_to_pil(frame)
+        log.info("vlm  pid=%r  %dx%d  query=%r", pid, frame.width, frame.height, query[:60])
+
+        loop   = asyncio.get_running_loop()
+        answer = await loop.run_in_executor(None, self._vlm.infer, image, query)
+        log.info("vlm response  pid=%r  %d chars", pid, len(answer))
+        await self._reply(pid, answer, frame.pts_us)
+
+    async def _on_participant(self, event: ParticipantEvent) -> None:
+        if not event.joined:
+            keys = [k for k in self._latest if k[0] == event.participant_id]
+            for k in keys:
+                del self._latest[k]
+
+    # ── helpers ───────────────────────────────────────────────────────────────
+
+    def _pick_signal(self, pid: str, track_id: str | None) -> FrameSignal | None:
+        if track_id:
+            return self._latest.get((pid, track_id))
+        # Return whichever track arrived most recently (deterministic: sorted)
+        candidates = [(k, v) for k, v in self._latest.items() if k[0] == pid]
+        if not candidates:
+            return None
+        return max(candidates, key=lambda kv: kv[1].seq)[1]
+
+    async def _reply(self, pid: str, text: str, pts_us: int) -> None:
+        await self._ep.send_return_data(DataMessage(
+            participant_id=pid,
+            topic="vlm.response",
+            pts_us=pts_us,
+            data=text.encode(),
+        ))
+
+    # ── lifecycle ─────────────────────────────────────────────────────────────
+
+    async def run(self) -> None:
+        await self._ep.run()
+
+    def shutdown(self) -> None:
+        self._ep.stop()
+        self._ep.close()
+
+
+# ── entry point ───────────────────────────────────────────────────────────────
+
+async def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+    log.info("vlm-agent  model=%s", _MODEL_ID)
+
+    async with HubLauncher():
+        agent = VlmAgent()
+
+        loop = asyncio.get_running_loop()
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            loop.add_signal_handler(sig, agent.shutdown)
+
+        log.info("vlm-agent connecting  sub=%s  push=%s", _HUB_PUB, _HUB_PUSH)
+        try:
+            await agent.run()
+        finally:
+            agent.shutdown()
+
+    log.info("vlm-agent stopped")
+
+
+def run() -> None:
+    asyncio.run(main())
+
+
+if __name__ == "__main__":
+    run()

--- a/agent-samples/vlm-agent/vlm_agent/__main__.py
+++ b/agent-samples/vlm-agent/vlm_agent/__main__.py
@@ -260,10 +260,12 @@ class VlmAgent:
         image = _frame_to_pil(frame)   # raises on unrecognised format → crash
         log.info("vlm  pid=%r  %dx%d  query=%r", pid, frame.width, frame.height, query[:60])
 
+        await self._ep.set_status("processing", pid)
         loop   = asyncio.get_running_loop()
         answer = await loop.run_in_executor(None, self._vlm.infer, image, query)
         log.info("vlm response  pid=%r  %d chars", pid, len(answer))
         await self._reply(pid, answer, frame.pts_us)
+        await self._ep.set_status("idle", pid)
 
     async def _on_participant(self, event: ParticipantEvent) -> None:
         if not event.joined:

--- a/client-samples/web/App/app.js
+++ b/client-samples/web/App/app.js
@@ -89,6 +89,8 @@ const model = {
   cameras:          [],
   /** @type {string|null} */
   selectedCameraId: null,
+  /** @type {string|null} */
+  agentStatus: null,
   /** @type {Array<{id: string, text: string, timestamp: Date}>} */
   receivedMessages: [],
   /** @type {string|null} */
@@ -217,6 +219,24 @@ function render() {
     selectRow.style.display = 'none';
   }
 
+  // ── Agent status ───────────────────────────────────────────────────────────
+  const agentDot   = $('agent-status-dot');
+  const agentLabel = $('agent-status-label');
+
+  if (!isConnected) {
+    agentDot.className    = 'state-dot disconnected';
+    agentLabel.textContent = '—';
+  } else if (model.agentStatus === 'processing') {
+    agentDot.className    = 'state-dot connecting';  // orange pulse
+    agentLabel.textContent = 'Processing\u2026';
+  } else if (model.agentStatus === 'idle') {
+    agentDot.className    = 'state-dot connected';   // green
+    agentLabel.textContent = 'Idle';
+  } else {
+    agentDot.className    = 'state-dot disconnected';
+    agentLabel.textContent = 'Unknown';
+  }
+
   // ── Data channel ───────────────────────────────────────────────────────────
   $('ping-btn').disabled = !isConnected;
   $('send-btn').disabled = !isConnected || $('message-input').value.trim() === '';
@@ -313,7 +333,13 @@ async function connect() {
     if (state === ConnectionState.DISCONNECTED) {
       model.isAudioActive  = false;
       model.isCameraActive = false;
+      model.agentStatus    = null;
     }
+    render();
+  };
+
+  newSession.onAgentStatus = (status) => {
+    model.agentStatus = status;
     render();
   };
 

--- a/client-samples/web/App/app.js
+++ b/client-samples/web/App/app.js
@@ -21,6 +21,50 @@ import {
 } from '/StreamKit/index.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Camera enumeration
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Queries available video input devices and updates `model.cameras`.
+ * Labels are only populated after the user has granted camera permission;
+ * calling this again after the first `startCamera()` yields labelled entries.
+ *
+ * @returns {Promise<void>}
+ */
+async function enumerateCameras() {
+  if (!navigator.mediaDevices?.enumerateDevices) return;
+  try {
+    let devices = await navigator.mediaDevices.enumerateDevices();
+    let cameras = devices.filter(d => d.kind === 'videoinput');
+
+    // deviceId is an empty string until camera permission has been granted.
+    // Request a brief permission probe so we get real device IDs and labels.
+    if (cameras.length > 0 && !cameras.some(d => d.deviceId)) {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: false });
+        stream.getTracks().forEach(t => t.stop());
+        devices  = await navigator.mediaDevices.enumerateDevices();
+        cameras  = devices.filter(d => d.kind === 'videoinput');
+      } catch { /* permission denied — proceed with anonymous devices */ }
+    }
+
+    const list = cameras.map((d, i) => ({
+      deviceId: d.deviceId,
+      label:    d.label || `Camera ${i + 1}`,
+    }));
+
+    model.cameras = list;
+    // Preserve selection if it still exists; otherwise default to first device.
+    if (list.length > 0 && !list.some(c => c.deviceId === model.selectedCameraId)) {
+      model.selectedCameraId = list[0].deviceId;
+    }
+    render();
+  } catch {
+    // enumerateDevices not available — ignore.
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Model state  (mirrors AppModel.swift field-for-field)
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -41,6 +85,10 @@ const model = {
   connectionState: ConnectionState.DISCONNECTED,
   isAudioActive:   false,
   isCameraActive:  false,
+  /** @type {Array<{deviceId: string, label: string}>} */
+  cameras:          [],
+  /** @type {string|null} */
+  selectedCameraId: null,
   /** @type {Array<{id: string, text: string, timestamp: Date}>} */
   receivedMessages: [],
   /** @type {string|null} */
@@ -147,6 +195,26 @@ function render() {
     cameraBtn.className   = 'btn btn-secondary';
     cameraStatus.textContent = isConnected ? 'Idle' : 'Not connected';
     cameraStatus.className   = 'status-text status-idle';
+  }
+
+  // ── Camera selector (shown only when multiple cameras detected) ────────────
+  const selectRow = $('camera-select-row');
+  const camSelect = $('camera-select');
+
+  if (model.cameras.length > 1) {
+    selectRow.style.display = '';
+    // Rebuild options only when the list has changed.
+    const currentIds = [...camSelect.options].map(o => o.value).join(',');
+    const newIds     = model.cameras.map(c => c.deviceId).join(',');
+    if (currentIds !== newIds) {
+      camSelect.innerHTML = model.cameras
+        .map(c => `<option value="${escapeHtml(c.deviceId)}">${escapeHtml(c.label)}</option>`)
+        .join('');
+    }
+    camSelect.value    = model.selectedCameraId ?? '';
+    camSelect.disabled = model.isCameraActive;
+  } else {
+    selectRow.style.display = 'none';
   }
 
   // ── Data channel ───────────────────────────────────────────────────────────
@@ -326,8 +394,15 @@ async function stopAudio() {
  * @returns {Promise<void>}
  */
 async function startCamera() {
+  // Enumerate first (triggers permission prompt if needed) so the selector
+  // is populated with real device names before the camera goes active.
+  await enumerateCameras();
+
+  const cameraConfig = model.selectedCameraId
+    ? new CameraConfig({ deviceId: model.selectedCameraId })
+    : CameraConfig.default;
   try {
-    await model.session?.startCamera();
+    await model.session?.startCamera(cameraConfig);
     model.isCameraActive = true;
   } catch (err) {
     showError(err instanceof StreamError ? err.message : String(err));
@@ -415,6 +490,11 @@ function wireEvents() {
     } else {
       startAudio();
     }
+  });
+
+  // Camera selector
+  $('camera-select').addEventListener('change', (e) => {
+    model.selectedCameraId = e.target.value || null;
   });
 
   // Camera toggle

--- a/client-samples/web/StreamKit/Backends/LiveKit/LiveKitBackend.js
+++ b/client-samples/web/StreamKit/Backends/LiveKit/LiveKitBackend.js
@@ -220,13 +220,15 @@ export class LiveKitBackend {
   /**
    * Captures the local camera and publishes it to the room.
    *
-   * The `facingMode` is taken from `sessionConfig.camera.facing`, which is
-   * already a browser `getUserMedia` constraint value (`'user'`/`'environment'`).
+   * An optional `cameraConfig` overrides the config supplied at connect time.
+   * When `cameraConfig.deviceId` is set it takes precedence over `facingMode`,
+   * selecting the exact device returned by `enumerateDevices()`.
    *
+   * @param {import('../../Config/CameraConfig.js').CameraConfig} [cameraConfig]
    * @returns {Promise<void>}
    * @throws {StreamError} `cameraRequiresConnection` if not connected.
    */
-  async startCamera() {
+  async startCamera(cameraConfig) {
     if (!this.#room || this.#room.state !== 'connected') {
       throw StreamError.cameraRequiresConnection();
     }
@@ -234,8 +236,15 @@ export class LiveKitBackend {
     // Stop any previous video track first.
     await this.stopCamera();
 
-    const facingMode = this.#sessionConfig?.camera?.facing ?? 'user';
-    const track = await createLocalVideoTrack({ facingMode });
+    const config     = cameraConfig ?? this.#sessionConfig?.camera;
+    const deviceId   = config?.deviceId ?? null;
+    const facingMode = config?.facing   ?? 'user';
+
+    const constraints = deviceId
+      ? { deviceId: { exact: deviceId } }
+      : { facingMode };
+
+    const track = await createLocalVideoTrack(constraints);
     this.#videoTrack = track;
 
     await this.#room.localParticipant.publishTrack(track, {

--- a/client-samples/web/StreamKit/Backends/LiveKit/LiveKitBackend.js
+++ b/client-samples/web/StreamKit/Backends/LiveKit/LiveKitBackend.js
@@ -99,6 +99,17 @@ export class LiveKitBackend {
    */
   onDataReceived = null;
 
+  /**
+   * Called when an agent publishes a status update on the internal SDK channel.
+   * `StreamSession` assigns this before calling `connect()`.
+   *
+   * @type {((status: string) => void) | null}
+   */
+  onAgentStatus = null;
+
+  /** @type {string} Reserved LiveKit topic for internal SDK status messages. */
+  static #STATUS_TOPIC = '_agent.status';
+
   // ── Constructor ─────────────────────────────────────────────────────────────
 
   /**
@@ -166,8 +177,15 @@ export class LiveKitBackend {
       this.onConnectionStateChanged?.(mapState(lkState));
     });
 
-    room.on(RoomEvent.DataReceived, (payload /*, participant, kind, topic */) => {
-      // payload is already a Uint8Array per the LiveKit v2 API.
+    room.on(RoomEvent.DataReceived, (payload, _participant, _kind, topic) => {
+      // Intercept internal SDK messages; never forward them to the application.
+      if (topic === LiveKitBackend.#STATUS_TOPIC) {
+        try {
+          const { status } = JSON.parse(new TextDecoder().decode(payload));
+          if (status) this.onAgentStatus?.(status);
+        } catch { /* malformed — ignore */ }
+        return;
+      }
       this.onDataReceived?.(payload);
     });
 

--- a/client-samples/web/StreamKit/Config/CameraConfig.js
+++ b/client-samples/web/StreamKit/Config/CameraConfig.js
@@ -55,13 +55,23 @@ export class CameraConfig {
   #facing;
 
   /**
-   * @param {object}  [opts]
-   * @param {boolean} [opts.enabled=true]
-   * @param {string}  [opts.facing=CameraFacing.FRONT]
+   * Specific device ID from `navigator.mediaDevices.enumerateDevices()`.
+   * When set, takes precedence over `facing`.
+   *
+   * @type {string | null}
    */
-  constructor({ enabled = true, facing = CameraFacing.FRONT } = {}) {
-    this.#enabled = enabled;
-    this.#facing = facing;
+  #deviceId;
+
+  /**
+   * @param {object}       [opts]
+   * @param {boolean}      [opts.enabled=true]
+   * @param {string}       [opts.facing=CameraFacing.FRONT]
+   * @param {string|null}  [opts.deviceId=null]
+   */
+  constructor({ enabled = true, facing = CameraFacing.FRONT, deviceId = null } = {}) {
+    this.#enabled  = enabled;
+    this.#facing   = facing;
+    this.#deviceId = deviceId;
   }
 
   /** @returns {boolean} Whether the camera should be captured and streamed. */
@@ -76,6 +86,14 @@ export class CameraConfig {
    */
   get facing() { return this.#facing; }
   set facing(v) { this.#facing = v; }
+
+  /**
+   * Specific device ID. When set, overrides `facing`.
+   *
+   * @returns {string | null}
+   */
+  get deviceId() { return this.#deviceId; }
+  set deviceId(v) { this.#deviceId = v; }
 
   // -------------------------------------------------------------------------
   // Presets

--- a/client-samples/web/StreamKit/StreamSession.js
+++ b/client-samples/web/StreamKit/StreamSession.js
@@ -60,6 +60,14 @@ export class StreamSession {
    */
   onDataReceived = null;
 
+  /**
+   * Called when an agent publishes a status update.
+   * Common values: `"idle"`, `"processing"`.
+   *
+   * @type {((status: string) => void) | null}
+   */
+  onAgentStatus = null;
+
   // ── Constructor ─────────────────────────────────────────────────────────────
 
   /**
@@ -213,6 +221,10 @@ export class StreamSession {
 
     this.#backend.onDataReceived = (data) => {
       this.onDataReceived?.(data);
+    };
+
+    this.#backend.onAgentStatus = (status) => {
+      this.onAgentStatus?.(status);
     };
   }
 }

--- a/client-samples/web/StreamKit/StreamSession.js
+++ b/client-samples/web/StreamKit/StreamSession.js
@@ -157,8 +157,16 @@ export class StreamSession {
     await this.#backend.stopAudio();
   }
 
-  async startCamera() {
-    await this.#backend.startCamera();
+  /**
+   * Captures the local camera and publishes it.
+   *
+   * @param {import('./Config/CameraConfig.js').CameraConfig} [cameraConfig]
+   *   Optional override. When `cameraConfig.deviceId` is set the exact device
+   *   is selected; otherwise falls back to the `facingMode` from session config.
+   * @returns {Promise<void>}
+   */
+  async startCamera(cameraConfig) {
+    await this.#backend.startCamera(cameraConfig);
   }
 
   /**

--- a/client-samples/web/index.html
+++ b/client-samples/web/index.html
@@ -446,6 +446,20 @@
       </div>
     </section>
 
+    <!-- ── Agent section ────────────────────────────────────────────────── -->
+    <section class="section">
+      <h2 class="section-header">Agent</h2>
+      <div class="card">
+        <div class="labeled-row">
+          <span class="row-label">Status</span>
+          <div class="state-badge">
+            <span id="agent-status-dot" class="state-dot disconnected"></span>
+            <span id="agent-status-label">—</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <!-- ── Data channel section ───────────────────────────────────────── -->
     <section class="section">
       <h2 class="section-header">Data Channel</h2>

--- a/client-samples/web/index.html
+++ b/client-samples/web/index.html
@@ -208,6 +208,21 @@
 
     .text-input::placeholder { color: var(--secondary); }
 
+    /* ── Camera select ───────────────────────────────────────────────── */
+    .field-select {
+      flex: 1;
+      border: none;
+      outline: none;
+      font-family: var(--font);
+      font-size: 15px;
+      color: var(--label);
+      background: transparent;
+      cursor: pointer;
+      text-align: right;
+    }
+
+    .field-select:disabled { opacity: 0.4; cursor: default; }
+
     /* ── Camera + data rows with label + trailing content ─────────────── */
     .labeled-row {
       display: flex;
@@ -407,6 +422,12 @@
         <div class="labeled-row">
           <span class="row-label">Microphone</span>
           <span id="audio-status" class="status-text status-idle">Not connected</span>
+        </div>
+
+        <!-- Camera selector (hidden when only one camera is available) -->
+        <div id="camera-select-row" class="field-row" style="display:none">
+          <label class="field-label" for="camera-select">Camera</label>
+          <select id="camera-select" class="field-select"></select>
         </div>
 
         <!-- Camera toggle -->

--- a/server-runtime/pyproject.toml
+++ b/server-runtime/pyproject.toml
@@ -22,6 +22,8 @@ dependencies = [
     "numpy>=1.24",
     # Config file
     "pyyaml>=6.0",
+    # TLS certificate generation
+    "cryptography>=42.0",
 ]
 
 [project.scripts]

--- a/server-runtime/xr_media_hub/ipc/__init__.py
+++ b/server-runtime/xr_media_hub/ipc/__init__.py
@@ -27,7 +27,7 @@ from ._hub import (HubEndpoint,
                    TOPIC_VIDEO, TOPIC_VIDEO_DATA,
                    TOPIC_AUDIO, TOPIC_DATA, TOPIC_CONTROL,
                    TOPIC_RETURN_AUDIO, TOPIC_RETURN_DATA)
-from ._processor import ProcessorEndpoint
+from ._processor import ProcessorEndpoint, AGENT_STATUS_TOPIC
 from ._shm import ShmRingBuffer, SlotView
 from ._types import (AudioChunk, ConnectorRegistration, ControlMessage, DataMessage,
                      FrameData, FrameRequest, FrameSignal, MsgType, ParticipantEvent, PixelFormat)
@@ -65,4 +65,6 @@ __all__ = [
     "TOPIC_CONTROL",
     "TOPIC_RETURN_AUDIO",
     "TOPIC_RETURN_DATA",
+    # internal SDK channel topic
+    "AGENT_STATUS_TOPIC",
 ]

--- a/server-runtime/xr_media_hub/ipc/_processor.py
+++ b/server-runtime/xr_media_hub/ipc/_processor.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from typing import Awaitable, Callable
 
 import zmq
@@ -215,8 +216,12 @@ class ProcessorEndpoint:
     @staticmethod
     def _spawn(coro) -> None:
         t = asyncio.create_task(coro)
-        t.add_done_callback(lambda t: log.error("Callback raised: %s", t.exception())
-                            if not t.cancelled() and t.exception() else None)
+        def _on_done(t: asyncio.Task) -> None:
+            if not t.cancelled() and (exc := t.exception()):
+                log.critical("Unhandled error in processor callback — crashing",
+                             exc_info=exc)
+                os._exit(1)
+        t.add_done_callback(_on_done)
 
     # ── lifecycle ─────────────────────────────────────────────────────────────
 

--- a/server-runtime/xr_media_hub/ipc/_processor.py
+++ b/server-runtime/xr_media_hub/ipc/_processor.py
@@ -29,8 +29,10 @@ Video frame access is two-step:
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
+import time
 from typing import Awaitable, Callable
 
 import zmq
@@ -51,6 +53,9 @@ ParticipantCallback = Callable[[ParticipantEvent], Awaitable[None]]
 _DEFAULT_TOPICS: tuple[bytes, ...] = (
     b"video", b"video_data", b"audio", b"data", b"participant", b"control",
 )
+
+# Reserved topic for internal SDK status messages — not forwarded to app callbacks.
+AGENT_STATUS_TOPIC = "_agent.status"
 
 _FRAME_REQUEST_TIMEOUT = 1.0  # seconds before request_frame() gives up
 
@@ -123,6 +128,39 @@ class ProcessorEndpoint:
 
     async def send_return_audio(self, chunk: AudioChunk) -> None:
         await self._push.send(encode(MsgType.RETURN_AUDIO, chunk))
+
+    async def set_status(self, status: str,
+                         participant_id: str | None = None) -> None:
+        """
+        Publish agent status to connected clients via the internal SDK channel.
+
+        The status is delivered on the reserved LiveKit topic ``_agent.status``
+        and is intercepted client-side by the StreamKit SDK — it never surfaces
+        as a raw ``onDataReceived`` message.
+
+        Parameters
+        ----------
+        status :
+            Arbitrary status string.  Conventional values: ``"idle"``,
+            ``"processing"``.
+        participant_id :
+            Target participant.  If *None*, broadcasts to every participant
+            currently in ``connected_participants``.
+        """
+        payload = json.dumps({"status": status}).encode()
+        pts_us  = int(time.time() * 1_000_000)
+        targets = (
+            [participant_id]
+            if participant_id is not None
+            else list(self._participants)
+        )
+        for pid in targets:
+            await self.send_return_data(DataMessage(
+                participant_id=pid,
+                topic=AGENT_STATUS_TOPIC,
+                pts_us=pts_us,
+                data=payload,
+            ))
 
     async def request_frame(self, signal: FrameSignal,
                             timeout: float = _FRAME_REQUEST_TIMEOUT) -> FrameData | None:

--- a/server-runtime/xr_media_hub/ipc/_processor.py
+++ b/server-runtime/xr_media_hub/ipc/_processor.py
@@ -184,30 +184,39 @@ class ProcessorEndpoint:
     async def _dispatch(self, type_id: int, msg) -> None:
         if type_id == MsgType.FRAME_SIGNAL:
             for cb in self._frame_cbs:
-                await cb(msg)
+                self._spawn(cb(msg))
         elif type_id == MsgType.FRAME_DATA:
+            # Resolve pending request_frame() futures synchronously so they can
+            # proceed as soon as the event loop next runs their awaiting coroutine.
             key = (msg.participant_id, msg.track_id)
             waiters = self._pending.pop(key, [])
             for fut in waiters:
                 if not fut.done():
                     fut.set_result(msg)
             for cb in self._frame_data_cbs:
-                await cb(msg)
+                self._spawn(cb(msg))
         elif type_id == MsgType.AUDIO_CHUNK:
             for cb in self._audio_cbs:
-                await cb(msg)
+                self._spawn(cb(msg))
         elif type_id == MsgType.DATA_MESSAGE:
             for cb in self._data_cbs:
-                await cb(msg)
+                self._spawn(cb(msg))
         elif type_id == MsgType.PARTICIPANT_EVENT:
+            # Update participant set before spawning callbacks.
             if msg.joined:
                 self._participants.add(msg.participant_id)
             else:
                 self._participants.discard(msg.participant_id)
             for cb in self._participant_cbs:
-                await cb(msg)
+                self._spawn(cb(msg))
         else:
             log.debug("Unhandled message type %d on processor endpoint", type_id)
+
+    @staticmethod
+    def _spawn(coro) -> None:
+        t = asyncio.create_task(coro)
+        t.add_done_callback(lambda t: log.error("Callback raised: %s", t.exception())
+                            if not t.cancelled() and t.exception() else None)
 
     # ── lifecycle ─────────────────────────────────────────────────────────────
 

--- a/server-runtime/xr_media_hub/transport/livekit/_tls.py
+++ b/server-runtime/xr_media_hub/transport/livekit/_tls.py
@@ -1,0 +1,65 @@
+"""Auto-generate a self-signed TLS certificate for the web server."""
+from __future__ import annotations
+
+import datetime
+import ipaddress
+import pathlib
+import socket
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+_CERT_DIR  = pathlib.Path.home() / ".local" / "share" / "xr-ai"
+_CERT_FILE = _CERT_DIR / "web-server.crt"
+_KEY_FILE  = _CERT_DIR / "web-server.key"
+
+
+def ensure_self_signed_cert() -> tuple[str, str]:
+    """Return (cert_path, key_path), generating them once and reusing thereafter."""
+    _CERT_DIR.mkdir(parents=True, exist_ok=True)
+
+    if _CERT_FILE.exists() and _KEY_FILE.exists():
+        return str(_CERT_FILE), str(_KEY_FILE)
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+    hostname = socket.gethostname()
+    san: list[x509.GeneralName] = [
+        x509.DNSName("localhost"),
+        x509.DNSName(hostname),
+        x509.IPAddress(ipaddress.IPv4Address("127.0.0.1")),
+    ]
+    try:
+        local_ip = socket.gethostbyname(hostname)
+        if local_ip != "127.0.0.1":
+            san.append(x509.IPAddress(ipaddress.IPv4Address(local_ip)))
+    except OSError:
+        pass
+
+    now  = datetime.datetime.now(datetime.timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, hostname)]))
+        .issuer_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, hostname)]))
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + datetime.timedelta(days=3650))
+        .add_extension(x509.SubjectAlternativeName(san), critical=False)
+        .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+        .sign(key, hashes.SHA256())
+    )
+
+    _KEY_FILE.write_bytes(
+        key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.TraditionalOpenSSL,
+            serialization.NoEncryption(),
+        )
+    )
+    _KEY_FILE.chmod(0o600)
+    _CERT_FILE.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+
+    return str(_CERT_FILE), str(_KEY_FILE)

--- a/server-runtime/xr_media_hub/transport/livekit/_web_server.py
+++ b/server-runtime/xr_media_hub/transport/livekit/_web_server.py
@@ -19,6 +19,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from livekit.api import AccessToken, VideoGrants
 
+from ._tls import ensure_self_signed_cert
 from .config import LiveKitConnectorConfig
 
 log = logging.getLogger(__name__)
@@ -68,17 +69,30 @@ class WebServer:
 
     async def start(self) -> None:
         app = _build_app(self._cfg)
+
+        ssl_kwargs: dict = {}
+        scheme = "http"
+        if self._cfg.web_server_tls:
+            cert = self._cfg.cert_file or None
+            key  = self._cfg.key_file  or None
+            if not cert or not key:
+                cert, key = ensure_self_signed_cert()
+                log.info("TLS: using auto-generated self-signed cert  %s", cert)
+            ssl_kwargs = {"ssl_certfile": cert, "ssl_keyfile": key}
+            scheme = "https"
+
         uv_cfg = uvicorn.Config(
             app=app,
             host=self._cfg.web_server_host,
             port=self._cfg.web_server_port,
             log_level="warning",
+            **ssl_kwargs,
         )
         self._server = uvicorn.Server(uv_cfg)
         self._task = asyncio.create_task(self._serve_safe())
         log.info(
-            "Web server → http://%s:%d  client=%r",
-            self._cfg.web_server_host, self._cfg.web_server_port,
+            "Web server → %s://%s:%d  client=%r",
+            scheme, self._cfg.web_server_host, self._cfg.web_server_port,
             self._cfg.web_client_dir or "<no static dir>",
         )
 

--- a/server-runtime/xr_media_hub/transport/livekit/config.py
+++ b/server-runtime/xr_media_hub/transport/livekit/config.py
@@ -48,6 +48,10 @@ class LiveKitConnectorConfig:
     web_server_port:   int  = 8080
     # Absolute path to the web client directory. Set via xr_media_hub.yaml.
     web_client_dir:    str  = ""
+    # Enable HTTPS. A self-signed cert is auto-generated in
+    # ~/.local/share/xr-ai/ on first run. Supply cert_file/key_file to use
+    # your own certificate instead.
+    web_server_tls:    bool = False
 
     # ── Shared-memory ring buffer ──────────────────────────────────────────────
     shm_num_slots:       int = 10

--- a/xr_media_hub.yaml
+++ b/xr_media_hub.yaml
@@ -17,6 +17,10 @@ web_server_host:   "0.0.0.0"
 web_server_port:   8080
 # Path is relative to this file's directory.
 web_client_dir:    client-samples/web
+# Enable HTTPS with a self-signed certificate (auto-generated on first run at
+# ~/.local/share/xr-ai/web-server.crt).  Required for camera access when
+# connecting from a device other than localhost.
+# web_server_tls: true
 
 # ── Optional: token server (only needed for HTTPS/WSS proxy) ─────────────────
 enable_token_server: true


### PR DESCRIPTION
## Summary

Adds the VLM agent sample (Cosmos-Reason1-7B), multi-camera selection, TLS support, and a live agent status indicator.

**VLM agent** (`agent-samples/vlm-agent/`): uses `nvidia/Cosmos-Reason1-7B` (commercial-OK). Accepts data channel messages as vision queries, replies on `vlm.response`. Model loaded at startup (warm on first query). Frames capped at ~1 MP before tokenization to prevent CUDA context corruption from oversized vision token sequences. Retriable soft errors reply to client; inference failures crash via `os._exit(1)` (CUDA context corruption is unrecoverable).

**ProcessorEndpoint fix**: user callbacks dispatched as `asyncio` tasks — fixes the deadlock causing "Frame data unavailable" on every VLM query.

**Agent status channel**: `set_status("processing"|"idle")` sends on reserved topic `_agent.status`; routed through return-data path to LiveKit room. Web client shows a pulsing orange dot while processing, green when idle.

**Multi-camera**: `CameraConfig` gains `deviceId`; camera selector dropdown appears when multiple cameras are detected.

**HTTPS**: auto-generates a self-signed cert in `~/.local/share/xr-ai/` when `web_server_tls=true`. Required for camera access from non-localhost devices.

## Test plan
- [ ] VLM agent responds to data channel queries with vision answers
- [ ] Agent status dot updates during inference
- [ ] Camera selector appears when multiple cameras are available
- [ ] HTTPS web server works; camera access works on a remote device