### PR TITLE
feat(ai-services): add llm-server (pure-text LLM inference)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,7 @@ OpenAI SDK client or plain `httpx` / `requests`.
 | Server | Command | Port | Model | Backend |
 |---|---|---|---|---|
 | `ai-services/vlm-server/` | `vlm_server` | 8100 | Cosmos-Reason1-7B | transformers in-process |
+| `ai-services/llm-server/` | `llm_server` | 8101 | Mistral-NeMo-Minitron-8B-Instruct | transformers in-process |
 | `ai-services/stt-server/` | `stt_server` | 8103 | parakeet-tdt-0.6b-v3 | NeMo ASR in-process |
 | `ai-services/tts-server/` | `tts_server` | 8104 | magpie_tts_multilingual_357m | NeMo TTS in-process |
 
@@ -143,6 +144,7 @@ servers).  Each YAML configures `model_cache` — resolved relative to the YAML 
 PROCESSES = [
     Process("hub",    "../../server-runtime",          "xr_media_hub"),
     Process("vlm",    "../../ai-services/vlm-server",  "vlm_server"),   # ← add as needed
+    Process("llm",    "../../ai-services/llm-server",  "llm_server"),
     Process("stt",    "../../ai-services/stt-server",  "stt_server"),
     Process("tts",    "../../ai-services/tts-server",  "tts_server"),
     Process("worker", "worker",                        "my_agent_worker"),
@@ -153,6 +155,7 @@ PROCESSES = [
 
 ```bash
 cp ../../ai-services/vlm-server/vlm_server.yaml ./vlm_server.yaml
+cp ../../ai-services/llm-server/llm_server.yaml ./llm_server.yaml
 cp ../../ai-services/stt-server/stt_server.yaml ./stt_server.yaml
 cp ../../ai-services/tts-server/tts_server.yaml ./tts_server.yaml
 ```
@@ -192,12 +195,25 @@ async with httpx.AsyncClient() as client:
         ]}]},
     )
     answer = resp.json()["choices"][0]["message"]["content"]
+
+# LLM — POST JSON (pure-text chat completion)
+async with httpx.AsyncClient() as client:
+    resp = await client.post(
+        "http://localhost:8101/v1/chat/completions",
+        json={"model": "llm", "messages": [
+            {"role": "user", "content": "Say OK"},
+        ], "max_tokens": 16},
+    )
+    answer = resp.json()["choices"][0]["message"]["content"]
 ```
 
 ### Notes
 
 - **vlm-server** loads Cosmos-Reason1-7B in-process via HuggingFace transformers.
   Model warms up at startup; strips `<think>…</think>` blocks automatically.
+- **llm-server** loads Mistral-NeMo-Minitron-8B-Instruct in-process via HuggingFace
+  transformers. Pure-text `/v1/chat/completions` only; default stop list handles
+  Minitron's `<extra_id_*>` chat-template tokens. Swap models via `llm_server.yaml`.
 - **stt-server** loads parakeet-tdt-0.6b-v3 via NeMo ASR in-process.
   English-only; `language` / `temperature` form fields are accepted but ignored.
 - **tts-server** loads magpie_tts_multilingual_357m via NeMo TTS in-process.
@@ -566,6 +582,34 @@ but LiveKit itself always runs over plain WebSocket (`ws://`).  This means:
 Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
+
+### 2026-04-28 — llm-server added (pure-text LLM)
+
+Fourth AI inference server added under `ai-services/llm-server/`, filling the
+pure-text LLM gap alongside the existing VLM / STT / TTS servers.
+
+- **Model**: `nvidia/Mistral-NeMo-Minitron-8B-Instruct` (HuggingFace causal LM,
+  ~16 GB VRAM at BF16) loaded in-process via `AutoModelForCausalLM` +
+  `AutoTokenizer`. Any `AutoModelForCausalLM`-compatible HF model works — swap
+  by editing `llm_server.yaml` (`model`, `max_new_tokens`, `dtype`, `stop`).
+- **API**: OpenAI-compatible `GET /health`, `GET /v1/models`,
+  `POST /v1/chat/completions` on default port **8101** (avoiding the VLM 8100
+  and the STT/TTS 8103/8104 slots). Pure-text messages only — multi-modal
+  content blocks are flattened to text (non-`text` blocks are dropped).
+- **No strict Pydantic schema** on the request body — the endpoint parses
+  raw JSON. This sidesteps FastAPI/Pydantic v2 ForwardRef issues with
+  closure-defined models and tolerates the many optional fields OpenAI
+  clients send (`n`, `frequency_penalty`, `seed`, `reasoning_effort`, …).
+- **Stop handling**: the request's `stop` list is honored; if absent, the
+  YAML's `stop` default is used. For Minitron-8B this defaults to
+  `["<extra_id_1>", "<extra_id_0>"]` so chat-template tokens don't leak
+  into replies. A `StringStopCriteria` hook also halts generation mid-stream
+  once a stop string appears in decoded output.
+- **Threading**: blocking `generate()` runs in the default thread pool
+  executor via `loop.run_in_executor` so the asyncio loop is never blocked.
+  The backend is loaded lazily under a lock (warmed at startup from `_run`).
+- **No continuous batching.** Single-user voice-agent workloads only; for
+  higher concurrency swap in vLLM behind the same HTTP contract.
 
 ### 2026-04-24 — AI inference servers added; NVIDIA models; shared model cache
 

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -65,6 +65,16 @@ tts-server  (tts-server/)
     └── hf-transfer >=0.1.4
     └── pyyaml >=6.0
     Model: nvidia/magpie_tts_multilingual_357m (NeMo TTS, in-process)
+
+llm-server  (llm-server/)
+    └── torch >=2.2
+    └── transformers >=4.49
+    └── accelerate >=0.30
+    └── fastapi >=0.111
+    └── uvicorn[standard] >=0.29
+    └── hf-transfer >=0.1.4
+    └── pyyaml >=6.0
+    Model: nvidia/Mistral-NeMo-Minitron-8B-Instruct (HuggingFace transformers, in-process)
 ```
 
 ---
@@ -74,6 +84,7 @@ tts-server  (tts-server/)
 | Server | Package | Command | Default port | Model | Backend |
 |---|---|---|---|---|---|
 | `vlm-server/` | `vlm-server` | `vlm_server` | 8100 | Cosmos-Reason1-7B | transformers in-process |
+| `llm-server/` | `llm-server` | `llm_server` | 8101 | Mistral-NeMo-Minitron-8B-Instruct | transformers in-process |
 | `stt-server/` | `stt-server` | `stt_server` | 8103 | parakeet-tdt-0.6b-v3 | NeMo ASR in-process |
 | `tts-server/` | `tts-server` | `tts_server` | 8104 | magpie_tts_multilingual_357m | NeMo TTS in-process |
 

--- a/ai-services/llm-server/README.md
+++ b/ai-services/llm-server/README.md
@@ -1,0 +1,72 @@
+# llm-server
+
+OpenAI-compatible LLM HTTP server using HuggingFace transformers.
+
+Default model: `nvidia/Mistral-NeMo-Minitron-8B-Instruct` (~16 GB at BF16).
+
+## Quickstart
+
+```bash
+cd ai-services/llm-server
+uv sync
+uv run llm_server --config llm_server.yaml
+```
+
+First run downloads weights (~16 GB) to the `models/` cache.
+
+## Endpoints
+
+| Endpoint                  | Method | Description                        |
+|---------------------------|--------|------------------------------------|
+| `/health`                 | GET    | Health check (`{"status": "ok"}`)  |
+| `/v1/models`              | GET    | List available models              |
+| `/v1/chat/completions`    | POST   | Chat completion (OpenAI-compatible)|
+
+## Config keys (`llm_server.yaml`)
+
+| Key             | Type       | Default                                  | Description                                    |
+|-----------------|------------|------------------------------------------|------------------------------------------------|
+| `model`         | str        | (required)                               | HuggingFace model ID                           |
+| `port`          | int        | `8101`                                   | HTTP port                                      |
+| `host`          | str        | `0.0.0.0`                                | Bind address                                   |
+| `hf_token`      | str        | `""`                                     | HuggingFace token (for gated models)           |
+| `system_prompt` | str        | `""`                                     | Optional system prompt prepended to all requests |
+| `max_new_tokens`| int        | `1024`                                   | Max tokens to generate                         |
+| `model_cache`   | str        | `../models`                              | Weight cache path (relative to YAML)           |
+| `dtype`         | str        | `bfloat16`                               | Torch dtype (`bfloat16`, `float16`, `float32`) |
+| `stop`          | list[str]  | `["<extra_id_1>", "<extra_id_0>"]`       | Default stop sequences (if request omits stop) |
+
+## Example curl
+
+```bash
+# Health check
+curl http://localhost:8101/health
+
+# Chat completion
+curl -X POST http://localhost:8101/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "llm",
+    "messages": [{"role": "user", "content": "Say OK"}],
+    "max_tokens": 16
+  }'
+```
+
+## Swap models
+
+Edit `llm_server.yaml`:
+
+```yaml
+model: nvidia/Nemotron-H-4B-Instruct-128K
+```
+
+Any HuggingFace `AutoModelForCausalLM`-compatible model works. Adjust
+`max_new_tokens`, `dtype`, and `stop` as needed for the new model.
+
+## Notes
+
+- **No continuous batching.** FastAPI + raw transformers is simpler but slower
+  under load than vLLM. For single-user voice agents, this is fine.
+- **First-run download** goes to the shared `models/` cache.
+- **Minitron-8B's chat template** emits `<extra_id_1>` as turn boundaries;
+  the default `stop` list handles this so replies don't leak template tokens.

--- a/ai-services/llm-server/llm_server.yaml
+++ b/ai-services/llm-server/llm_server.yaml
@@ -1,0 +1,20 @@
+# llm-server reference configuration.
+# `model_cache: ../../models` resolves to the shared weight cache at the repo
+# root (xr-ai/models/) regardless of whether this YAML is invoked from here
+# or copied into a sample directory — so all four inference servers share
+# one cache. See AGENTS.md "AI inference servers" section.
+
+model: nvidia/Mistral-NeMo-Minitron-8B-Instruct
+port: 8101
+host: 0.0.0.0
+hf_token: ""
+system_prompt: ""
+max_new_tokens: 1024
+model_cache: ../../models
+dtype: bfloat16
+
+# Default stop sequences for Minitron-8B's chat template.
+# Applied server-side if the request doesn't provide its own stop list.
+stop:
+  - "<extra_id_1>"
+  - "<extra_id_0>"

--- a/ai-services/llm-server/llm_server/__main__.py
+++ b/ai-services/llm-server/llm_server/__main__.py
@@ -1,0 +1,347 @@
+"""
+llm_server — OpenAI-compatible LLM HTTP server.
+
+Loads nvidia/Mistral-NeMo-Minitron-8B-Instruct (or any HuggingFace causal LM)
+in-process and serves an OpenAI-compatible API:
+
+    POST /v1/chat/completions   (pure-text messages)
+    GET  /v1/models
+
+Accepts --config <path>.yaml (auto-passed by xr-ai-launcher).
+
+Config keys
+-----------
+    model:          str    HuggingFace model ID (required)
+    port:           int    HTTP port (default: 8101)
+    host:           str    Bind address (default: "0.0.0.0")
+    hf_token:       str    HuggingFace token for gated models
+    system_prompt:  str    Optional system prompt prepended to every request
+    model_cache:    str    HuggingFace weight cache path.  Resolved relative to
+                           this YAML file's directory.  Default: ../models
+    max_new_tokens: int    Max tokens to generate (default: 1024)
+    dtype:          str    Torch dtype (default: bfloat16)
+    stop:           list   Default stop sequences applied if request omits stop
+"""
+import argparse
+import asyncio
+import os
+import sys
+import threading
+import uuid
+from pathlib import Path
+
+import yaml
+
+_DEFAULT_PORT = 8101
+_DEFAULT_TOKENS = 1024
+_DEFAULT_STOP = ["<extra_id_1>", "<extra_id_0>"]
+
+
+def _resolve_model_cache(cfg: dict, yaml_dir: Path) -> Path:
+    raw = cfg.get("model_cache", "../models")
+    p = Path(raw)
+    if not p.is_absolute():
+        p = (yaml_dir / p).resolve()
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def _get_torch_dtype(dtype_str: str):
+    import torch
+    mapping = {
+        "bfloat16": torch.bfloat16,
+        "float16": torch.float16,
+        "float32": torch.float32,
+    }
+    return mapping.get(dtype_str, torch.bfloat16)
+
+
+class _StopStringCriteria:
+    """StoppingCriteria that checks decoded text for stop strings."""
+
+    def __init__(self, tokenizer, stop_strings: list[str], prompt_length: int):
+        self.tokenizer = tokenizer
+        self.stop_strings = stop_strings
+        self.prompt_length = prompt_length
+
+    def __call__(self, input_ids, scores, **kwargs) -> bool:
+        generated_ids = input_ids[0, self.prompt_length:]
+        text = self.tokenizer.decode(generated_ids, skip_special_tokens=False)
+        return any(stop in text for stop in self.stop_strings)
+
+
+class _LlmBackend:
+    """Thread-safe lazy loader for AutoModelForCausalLM models."""
+
+    def __init__(
+        self,
+        model_id: str,
+        system_prompt: str,
+        model_cache: Path,
+        dtype_str: str,
+        default_stop: list[str],
+    ) -> None:
+        self._model_id = model_id
+        self._system_prompt = system_prompt
+        self._model_cache = model_cache
+        self._dtype_str = dtype_str
+        self._default_stop = default_stop
+        self._model = None
+        self._tokenizer = None
+        self._lock = threading.Lock()
+
+    def _ensure_loaded(self) -> None:
+        if self._model is not None:
+            return
+        with self._lock:
+            if self._model is not None:
+                return
+            import torch
+            from transformers import AutoModelForCausalLM, AutoTokenizer
+
+            self._model_cache.mkdir(parents=True, exist_ok=True)
+            cache = str(self._model_cache)
+            dtype = _get_torch_dtype(self._dtype_str)
+
+            print(f"[llm_server] Loading {self._model_id}  cache={cache}  dtype={self._dtype_str}")
+            try:
+                self._tokenizer = AutoTokenizer.from_pretrained(
+                    self._model_id, cache_dir=cache, local_files_only=True,
+                )
+                self._model = AutoModelForCausalLM.from_pretrained(
+                    self._model_id,
+                    torch_dtype=dtype,
+                    device_map="auto",
+                    cache_dir=cache,
+                    local_files_only=True,
+                ).eval()
+            except OSError:
+                print(f"[llm_server] Downloading {self._model_id}…")
+                self._tokenizer = AutoTokenizer.from_pretrained(
+                    self._model_id, cache_dir=cache,
+                )
+                self._model = AutoModelForCausalLM.from_pretrained(
+                    self._model_id,
+                    torch_dtype=dtype,
+                    device_map="auto",
+                    cache_dir=cache,
+                ).eval()
+
+            dev = next(self._model.parameters()).device
+            print(f"[llm_server] Model ready on {dev}")
+
+    def infer(
+        self,
+        messages: list[dict],
+        max_new_tokens: int,
+        temperature: float,
+        top_p: float,
+        stop: list[str] | None,
+    ) -> str:
+        """Synchronous inference. Call from a thread pool."""
+        import torch
+        from transformers import StoppingCriteria, StoppingCriteriaList
+
+        self._ensure_loaded()
+
+        full_messages = list(messages)
+        if self._system_prompt:
+            full_messages = [{"role": "system", "content": self._system_prompt}] + full_messages
+
+        prompt = self._tokenizer.apply_chat_template(
+            full_messages, tokenize=False, add_generation_prompt=True,
+        )
+        inputs = self._tokenizer(prompt, return_tensors="pt").to(self._model.device)
+        prompt_length = inputs.input_ids.shape[1]
+
+        stop_strings = stop if stop else self._default_stop
+        stopping_criteria = StoppingCriteriaList()
+
+        class StringStopCriteria(StoppingCriteria):
+            def __init__(inner_self, tokenizer, stops, plen):
+                inner_self.tokenizer = tokenizer
+                inner_self.stops = stops
+                inner_self.plen = plen
+
+            def __call__(inner_self, input_ids, scores, **kwargs) -> bool:
+                gen_ids = input_ids[0, inner_self.plen:]
+                text = inner_self.tokenizer.decode(gen_ids, skip_special_tokens=False)
+                return any(s in text for s in inner_self.stops)
+
+        if stop_strings:
+            stopping_criteria.append(
+                StringStopCriteria(self._tokenizer, stop_strings, prompt_length)
+            )
+
+        do_sample = temperature > 0
+        gen_kwargs = dict(
+            **inputs,
+            max_new_tokens=max_new_tokens,
+            do_sample=do_sample,
+            pad_token_id=self._tokenizer.eos_token_id,
+            stopping_criteria=stopping_criteria,
+        )
+        if do_sample:
+            gen_kwargs["temperature"] = temperature
+            gen_kwargs["top_p"] = top_p
+
+        with torch.inference_mode():
+            output_ids = self._model.generate(**gen_kwargs)
+
+        generated_ids = output_ids[0, prompt_length:]
+        text = self._tokenizer.decode(generated_ids, skip_special_tokens=True)
+
+        for stop_str in stop_strings:
+            if stop_str in text:
+                text = text.split(stop_str)[0]
+
+        return text.strip()
+
+
+def _build_app(cfg: dict, model_cache: Path):
+    from fastapi import FastAPI, Request
+
+    model_id = cfg["model"]
+    system_prompt = cfg.get("system_prompt", "").strip()
+    max_new_tokens = int(cfg.get("max_new_tokens", _DEFAULT_TOKENS))
+    dtype_str = cfg.get("dtype", "bfloat16")
+    default_stop = cfg.get("stop", _DEFAULT_STOP)
+
+    backend = _LlmBackend(model_id, system_prompt, model_cache, dtype_str, default_stop)
+
+    app = FastAPI(title="LLM Server", version="0.1.0")
+
+    @app.get("/health")
+    def health():
+        return {"status": "ok"}
+
+    @app.get("/v1/models")
+    def list_models():
+        return {
+            "object": "list",
+            "data": [{"id": model_id, "object": "model", "owned_by": "local"}],
+        }
+
+    @app.post("/v1/chat/completions")
+    async def chat_completions(request: Request):
+        # Parse the raw JSON body directly. We deliberately avoid a strict
+        # Pydantic schema here because OpenAI-compatible clients (LangChain,
+        # openai-python, etc.) send many optional fields (n, frequency_penalty,
+        # presence_penalty, seed, logprobs, reasoning_effort, service_tier,
+        # etc.) that we don't care about. Pydantic v2 + FastAPI's schema
+        # builder also has trouble with strict models defined inside a
+        # function closure (ForwardRef "not fully defined" errors during
+        # OpenAPI schema generation), which surfaced as 422 "req missing"
+        # for every request — see issue history. This free-form approach
+        # sidesteps both problems.
+        try:
+            body = await request.json()
+        except Exception as exc:
+            from fastapi import HTTPException
+            raise HTTPException(status_code=400, detail=f"invalid JSON body: {exc}")
+
+        messages = body.get("messages")
+        if not isinstance(messages, list) or not messages:
+            from fastapi import HTTPException
+            raise HTTPException(status_code=400, detail="messages must be a non-empty list")
+
+        messages_dict = []
+        for m in messages:
+            if not isinstance(m, dict):
+                continue
+            role = m.get("role", "user")
+            content = m.get("content", "")
+            if not isinstance(content, str):
+                # Content may be a list of blocks (text/image) in OpenAI spec;
+                # this server is text-only, so concatenate any text blocks.
+                if isinstance(content, list):
+                    content = "".join(
+                        b.get("text", "") for b in content
+                        if isinstance(b, dict) and b.get("type") == "text"
+                    )
+                else:
+                    content = str(content)
+            messages_dict.append({"role": role, "content": content})
+
+        max_tokens = int(body.get("max_tokens", max_new_tokens))
+        temperature = float(body.get("temperature", 0.0))
+        top_p = float(body.get("top_p", 1.0))
+        stop = body.get("stop")
+        if isinstance(stop, str):
+            stop = [stop]
+
+        loop = asyncio.get_running_loop()
+        answer = await loop.run_in_executor(
+            None,
+            backend.infer,
+            messages_dict,
+            max_tokens,
+            temperature,
+            top_p,
+            stop,
+        )
+
+        return {
+            "id": f"chatcmpl-{uuid.uuid4().hex[:12]}",
+            "object": "chat.completion",
+            "model": model_id,
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": answer},
+                "finish_reason": "stop",
+            }],
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+        }
+
+    return app, backend
+
+
+async def _run(cfg: dict, yaml_dir: Path) -> None:
+    import uvicorn
+
+    if not cfg.get("model"):
+        print("[llm_server] 'model' is required in config", file=sys.stderr)
+        sys.exit(1)
+
+    model_cache = _resolve_model_cache(cfg, yaml_dir)
+
+    if hf_token := (cfg.get("hf_token") or os.environ.get("HF_TOKEN", "")):
+        os.environ["HF_TOKEN"] = hf_token
+    os.environ.setdefault("HF_HUB_ENABLE_HF_TRANSFER", "1")
+
+    port = int(cfg.get("port", _DEFAULT_PORT))
+    host = cfg.get("host", "0.0.0.0")
+
+    app, backend = _build_app(cfg, model_cache)
+
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, backend._ensure_loaded)
+
+    config = uvicorn.Config(app, host=host, port=port, log_level="warning")
+    server = uvicorn.Server(config)
+
+    print(f"[llm_server] Ready  →  http://localhost:{port}/v1")
+    await server.serve()
+    print("[llm_server] Stopped.")
+
+
+def run() -> None:
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
+
+    p = argparse.ArgumentParser(add_help=False)
+    p.add_argument("--config", type=Path, default=None)
+    ns, _ = p.parse_known_args()
+
+    cfg: dict = {}
+    yaml_dir = Path.cwd()
+    if ns.config and ns.config.exists():
+        yaml_dir = ns.config.parent.resolve()
+        with open(ns.config) as f:
+            cfg = yaml.safe_load(f) or {}
+
+    asyncio.run(_run(cfg, yaml_dir))
+
+
+if __name__ == "__main__":
+    run()

--- a/ai-services/llm-server/pyproject.toml
+++ b/ai-services/llm-server/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "llm-server"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "torch>=2.2",
+    "transformers>=4.49",
+    "accelerate>=0.30",
+    "fastapi>=0.111",
+    "uvicorn[standard]>=0.29",
+    "hf-transfer>=0.1.4",
+    "pyyaml>=6.0",
+]
+
+[project.scripts]
+llm_server = "llm_server.__main__:run"
+
+[tool.hatch.build.targets.wheel]
+packages = ["llm_server"]


### PR DESCRIPTION
Adds ai-services/llm-server/ — a fourth OpenAI-compatible HTTP inference server for pure-text chat completion, filling the LLM slot alongside the existing VLM / STT / TTS services.

- Default model: nvidia/Mistral-NeMo-Minitron-8B-Instruct loaded in-process via HuggingFace AutoModelForCausalLM + AutoTokenizer (BF16, ~16 GB VRAM). Any AutoModelForCausalLM-compatible HF model works; swap via YAML.
- Endpoints: GET /health, GET /v1/models, POST /v1/chat/completions on default port 8101. Raw-JSON body parsing (no strict Pydantic schema) so the full range of optional OpenAI client fields is tolerated and FastAPI/Pydantic v2 ForwardRef issues from closure-defined models are avoided.
- Stop handling: request-level stop list honored; falls back to the YAML default (Minitron's <extra_id_1>/<extra_id_0> chat-template tokens) so replies don't leak template markers. A StringStopCriteria halts generation mid-stream once any stop string appears in decoded output.
- Blocking generate() runs in the default thread pool executor via loop.run_in_executor — asyncio loop is never blocked. Backend is lazy-loaded under a lock and warmed up at startup.
- Shared model cache at xr-ai/models/ (resolved relative to the YAML), matching the other ai-services.

Docs updated in the same commit (per DEPENDENCIES.md + AGENTS.md rules):
- DEPENDENCIES.md: add llm-server package entry and table row.
- AGENTS.md: add llm-server to the AI inference servers table, sample orchestrator PROCESSES example, YAML copy snippet, httpx usage example, notes bullet, and a dated change-log entry with rationale.

Made-with: Cursor