### PR TITLE
feat(client-samples): rebrand UI titles to NVIDIA XR-AI

### DIFF
--- a/client-samples/android/app/src/main/java/com/nvidia/xrai/streamkitsample/MainActivity.kt
+++ b/client-samples/android/app/src/main/java/com/nvidia/xrai/streamkitsample/MainActivity.kt
@@ -140,7 +140,7 @@ private fun StreamKitSampleApp(vm: AppViewModel = viewModel()) {
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(
-                title = { Text("StreamKit Sample", style = MaterialTheme.typography.titleLarge) },
+                title = { Text("NVIDIA XR-AI Sample", style = MaterialTheme.typography.titleLarge) },
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = ColorPageBg,
                 ),

--- a/client-samples/android/app/src/main/res/values/strings.xml
+++ b/client-samples/android/app/src/main/res/values/strings.xml
@@ -6,5 +6,5 @@
 -->
 
 <resources>
-    <string name="app_name">StreamKit Sample</string>
+    <string name="app_name">NVIDIA XR-AI Sample</string>
 </resources>

--- a/client-samples/ios-visionos/App/ContentView.swift
+++ b/client-samples/ios-visionos/App/ContentView.swift
@@ -27,7 +27,7 @@ struct ContentView: View {
                     messagesSection
                 }
             }
-            .navigationTitle("StreamKit Sample")
+            .navigationTitle("NVIDIA XR-AI Sample")
             #if os(iOS)
             .navigationBarTitleDisplayMode(.large)
             .scrollDismissesKeyboard(.interactively)

--- a/client-samples/web/index.html
+++ b/client-samples/web/index.html
@@ -9,7 +9,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>StreamKit Sample</title>
+  <title>NVIDIA XR-AI Sample</title>
 
   <!-- Both bundles served same-origin from /vendor/ so the page works on
        headsets / offline LANs. Produced by client-samples/web-xr-build/build.sh. -->
@@ -364,7 +364,7 @@
 
 <body>
   <div class="page-content">
-    <h1 class="page-title">StreamKit Sample</h1>
+    <h1 class="page-title">NVIDIA XR-AI Sample</h1>
 
     <!-- ── Connection section ─────────────────────────────────────────── -->
     <section class="section">


### PR DESCRIPTION
## Summary

- Updates the user-visible app title in each client sample from **StreamKit Sample** to **NVIDIA XR-AI Sample**
- Affected surfaces: web `<title>` + `<h1>`, Android app name string resource + TopAppBar title, iOS/visionOS navigation title
- No code identifiers, module names, or internal strings were changed

## Test plan

- [ ] Web: open `client-samples/web/index.html` in a browser — confirm tab title and page heading show "NVIDIA XR-AI Sample"
- [ ] Android: build and run the app — confirm launcher label and top bar title show "NVIDIA XR-AI Sample"
- [ ] iOS/visionOS: build and run — confirm navigation bar title shows "NVIDIA XR-AI Sample"

🤖 Generated with [Claude Code](https://claude.com/claude-code)