### PR TITLE
Add compatibility for BYO enterprise license for visionOS camera

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,11 @@ xcuserdata/
 .build/
 livekit-client-sdk-swift/
 
+# Apple visionOS Enterprise API license — per-team file, never commit
+# Issued from developer.apple.com to the team account holder; expires yearly.
+# Required at runtime for com.apple.developer.arkit.main-camera-access.allow.
+**/Enterprise.license
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -736,6 +736,28 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-05-01 — visionOS Enterprise license bundling
+
+Apple Vision Pro main-camera passthrough
+(`com.apple.developer.arkit.main-camera-access.allow`) requires the entitlement
+signed into the binary **and** a per-team `Enterprise.license` file bundled
+into the `.app`. Without the license the API is a silent no-op
+(`CameraVideoFormat.supportedVideoFormats(...)` returns `[]`, LiveKit AR camera
+publish fails with `LiveKitError.invalidState`). visionOS auto-loads the file
+from the app bundle.
+
+The license file is per-team and Apple's terms restrict redistribution, so it
+is gitignored (`**/Enterprise.license`) rather than committed. A placeholder
+`App/Enterprise.license.sample` documents the path for new contributors. An
+Xcode "Copy Enterprise.license" build phase copies the file into the `.app`
+at build time; if missing, the build succeeds with a warning and the camera
+path no-ops at runtime (audio + data + simulator GIF feed are unaffected).
+Symlinks at the expected path are supported and still gitignored.
+
+The sample's display name (`StreamKitSample`) is intentionally decoupled from
+its Bundle ID (`com.nvidia.xr-ai-example`) so a fork that renames the Bundle
+ID still ships under the same on-device app name.
+
 ### 2026-04-30 — Unified MCP IDs: identity sidecars, live vs recorded splits, transcript source_id
 
 The MCP servers had two consistency gaps: (1) `list_*` tools returned

--- a/client-samples/ios-visionos/App/AppModel.swift
+++ b/client-samples/ios-visionos/App/AppModel.swift
@@ -5,6 +5,10 @@ import Foundation
 import Observation
 import StreamKit
 
+#if os(visionOS)
+import ARKit
+#endif
+
 // MARK: - AppModel
 
 /// Observable state shared across the sample app.
@@ -20,26 +24,87 @@ final class AppModel {
     var immersiveSpaceIsOpen = false
     #endif
 
-    // MARK: - Connection settings
+    // MARK: - Connection settings (persisted across launches via UserDefaults)
 
-    var host: String = "192.168.1.100"
-    var port: String = "7880"
-    var secure: Bool = false
+    var host: String = AppModel.defaults.string(forKey: Keys.host) ?? "192.168.1.100" {
+        didSet { AppModel.defaults.set(host, forKey: Keys.host) }
+    }
+    var port: String = AppModel.defaults.string(forKey: Keys.port) ?? "7880" {
+        didSet { AppModel.defaults.set(port, forKey: Keys.port) }
+    }
+    // Default `false`: `bool(forKey:)` returns `false` for missing keys.
+    // To change the default to `true`, switch to `object(forKey:) as? Bool ?? true`.
+    var secure: Bool = AppModel.defaults.bool(forKey: Keys.secure) {
+        didSet { AppModel.defaults.set(secure, forKey: Keys.secure) }
+    }
+    /// Bearer token bypass — intentionally not persisted.
     var token: String = ""
-    var tokenServerURL: String = ""
-    var identity: String = "ios-client"
+    var tokenServerURL: String = AppModel.defaults.string(forKey: Keys.tokenServerURL) ?? "" {
+        didSet { AppModel.defaults.set(tokenServerURL, forKey: Keys.tokenServerURL) }
+    }
+    var identity: String = AppModel.defaults.string(forKey: Keys.identity) ?? "ios-client" {
+        didSet { AppModel.defaults.set(identity, forKey: Keys.identity) }
+    }
 
-    // MARK: - Audio settings
+    // MARK: - Audio settings (persisted)
 
-    var audioMode: AudioConfig.MicrophoneMode = .voiceProcessing
+    var audioMode: AudioConfig.MicrophoneMode = AppModel.loadAudioMode() {
+        didSet { AppModel.defaults.set(AppModel.encode(audioMode), forKey: Keys.audioMode) }
+    }
 
-    // MARK: - Camera settings
+    // MARK: - Camera settings (persisted)
 
-    var cameraPosition: CameraConfig.Position = .front
+    var cameraPosition: CameraConfig.Position = AppModel.loadCameraPosition() {
+        didSet { AppModel.defaults.set(AppModel.encode(cameraPosition), forKey: Keys.cameraPosition) }
+    }
     /// When `true`, ``clientControl`` startCamera/stopCamera messages from
     /// the agent are honoured.  When `false` (default — always-on), they are
     /// ignored and the camera button is the sole control.
-    var cameraOnDemand: Bool = false
+    /// (Default `false`; see note on `secure` for `bool(forKey:)` semantics.)
+    var cameraOnDemand: Bool = AppModel.defaults.bool(forKey: Keys.cameraOnDemand) {
+        didSet { AppModel.defaults.set(cameraOnDemand, forKey: Keys.cameraOnDemand) }
+    }
+
+    // MARK: - Persistence helpers
+
+    private static let defaults = UserDefaults.standard
+
+    private enum Keys {
+        static let host           = "settings.host"
+        static let port           = "settings.port"
+        static let secure         = "settings.secure"
+        static let tokenServerURL = "settings.tokenServerURL"
+        static let identity       = "settings.identity"
+        static let audioMode      = "settings.audioMode"
+        static let cameraPosition = "settings.cameraPosition"
+        static let cameraOnDemand = "settings.cameraOnDemand"
+    }
+
+    private static func encode(_ mode: AudioConfig.MicrophoneMode) -> String {
+        switch mode {
+        case .voiceProcessing:    return "voiceProcessing"
+        case .softwareProcessing: return "softwareProcessing"
+        case .raw:                return "raw"
+        case .disabled:           return "disabled"
+        }
+    }
+    private static func loadAudioMode() -> AudioConfig.MicrophoneMode {
+        switch defaults.string(forKey: Keys.audioMode) {
+        case "softwareProcessing": return .softwareProcessing
+        case "raw":                return .raw
+        case "disabled":           return .disabled
+        default:                   return .voiceProcessing
+        }
+    }
+    private static func encode(_ pos: CameraConfig.Position) -> String {
+        switch pos {
+        case .front: return "front"
+        case .back:  return "back"
+        }
+    }
+    private static func loadCameraPosition() -> CameraConfig.Position {
+        defaults.string(forKey: Keys.cameraPosition) == "back" ? .back : .front
+    }
 
     // MARK: - Live state
 
@@ -167,10 +232,30 @@ final class AppModel {
     // MARK: - Camera
 
     func startCamera() async {
+        #if os(visionOS)
+        // Surface a friendly message when main-camera access is permanently
+        // denied. Without this probe the user sees `LiveKitError.deviceAccessDenied`
+        // from StreamKit's internal ARCameraCapturer.
+        let result = await ARKitSession().requestAuthorization(for: [.cameraAccess])
+        guard result[.cameraAccess] == .allowed else {
+            lastError = "Main camera access was not granted. Enable it in Settings → Apps → StreamKitSample."
+            return
+        }
+        #endif
+
         do {
             try await session?.startCamera(config: CameraConfig(position: cameraPosition))
             isCameraActive = true
         } catch {
+            #if DEBUG
+            // `error.localizedDescription` strips domain/code/underlying cause.
+            let ns = error as NSError
+            print("startCamera failed: \(type(of: error)) \(ns.domain) #\(ns.code) — \(error)")
+            print("  userInfo: \(ns.userInfo)")
+            if let underlying = ns.userInfo[NSUnderlyingErrorKey] as? NSError {
+                print("  underlying: \(underlying.domain) #\(underlying.code) — \(underlying.userInfo)")
+            }
+            #endif
             lastError = error.localizedDescription
         }
     }

--- a/client-samples/ios-visionos/App/ContentView.swift
+++ b/client-samples/ios-visionos/App/ContentView.swift
@@ -74,6 +74,7 @@ struct ContentView: View {
             if model.connectionState == .disconnected {
                 TextField("Host / IP", text: $m.host)
                     .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
                     #if os(iOS)
                     .keyboardType(.decimalPad)
                     #endif
@@ -87,6 +88,7 @@ struct ContentView: View {
 
                 TextField("Token server URL (e.g. http://host/token)", text: $m.tokenServerURL)
                     .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
                     .onSubmit {}
                     #if os(iOS)
                     .keyboardType(.URL)
@@ -94,6 +96,7 @@ struct ContentView: View {
 
                 TextField("Identity", text: $m.identity)
                     .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
                     .onSubmit {}
 
                 Button(model.isConnecting ? "Connecting…" : "Connect") {

--- a/client-samples/ios-visionos/App/Enterprise.license.sample
+++ b/client-samples/ios-visionos/App/Enterprise.license.sample
@@ -1,0 +1,25 @@
+This file is a placeholder showing where the real Enterprise.license belongs.
+
+The Apple Vision Pro main camera (com.apple.developer.arkit.main-camera-access.allow)
+requires a per-team enterprise license file at runtime. Without it the camera
+APIs are silent no-ops, even when the entitlement is signed and authorization
+is granted.
+
+To enable main camera access:
+
+1. Request the Main Camera Access entitlement from Apple at:
+   https://developer.apple.com/contact/   (Distribution → Enterprise APIs)
+   Apple issues your team a `.license` file (CMS-signed plist; ~450 bytes).
+
+2. Place it at this path with the real filename:
+       client-samples/ios-visionos/App/Enterprise.license
+   The `**/Enterprise.license` rule in the repo `.gitignore` keeps it out
+   of git so it cannot be accidentally committed.
+
+3. Build & run. The Xcode build phase "Copy Enterprise.license" copies the
+   file into StreamKitSample.app/Enterprise.license; visionOS auto-loads it
+   from the app bundle.
+
+If the file is absent, the build still succeeds with a warning and every
+feature except main-camera passthrough works (audio, data channel, simulator
+GIF feed, etc.).

--- a/client-samples/ios-visionos/App/Info.plist
+++ b/client-samples/ios-visionos/App/Info.plist
@@ -31,7 +31,7 @@
 	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>Used to stream the camera feed.</string>
-	<key>NSEnterpriseMCAMUsageDescription</key>
+	<key>NSMainCameraUsageDescription</key>
 	<string>Used to stream the main passthrough camera via ARKit.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Used to stream microphone audio.</string>

--- a/client-samples/ios-visionos/README.md
+++ b/client-samples/ios-visionos/README.md
@@ -123,19 +123,12 @@ entitlement.
 > and is unchanged. `UserDefaults` are keyed by Bundle ID, so saved settings
 > reset on first launch after a rename.
 
-#### Requesting the entitlement (one-time, per Apple team)
-
-1. <https://developer.apple.com/contact/> → Distribution → Enterprise APIs →
-   request **Main Camera Access** (`com.apple.developer.arkit.main-camera-access.allow`).
-   Apple issues a team-wide license valid for any Bundle ID your team signs.
-   License expires yearly.
-2. In the developer portal, enable **Main Camera Access** on the App ID.
-
 #### Bundling `Enterprise.license`
 
-The license is per-team and Apple's terms restrict redistribution, so it is
-**gitignored** (`**/Enterprise.license`) and never committed. A placeholder at
-`App/Enterprise.license.sample` documents the location.
+The Enterprise license is issued by Apple, per team. Apple's terms restrict
+redistribution, so it is **gitignored** (`**/Enterprise.license`) and never
+committed. A placeholder at `App/Enterprise.license.sample` documents the
+location.
 
 Place your team's license at:
 

--- a/client-samples/ios-visionos/README.md
+++ b/client-samples/ios-visionos/README.md
@@ -95,47 +95,67 @@ target's **Info** tab):
 <key>NSCameraUsageDescription</key>
 <string>Used to stream the camera feed.</string>
 
-<!-- visionOS passthrough camera — requires Apple enterprise entitlement -->
-<key>NSEnterpriseMCAMUsageDescription</key>
+<!-- visionOS passthrough camera — requires Apple enterprise entitlement (see §6) -->
+<key>NSMainCameraUsageDescription</key>
 <string>Used to stream the main passthrough camera via ARKit.</string>
 ```
 
-### 6. Entitlements file (visionOS passthrough camera — device only)
+### 6. visionOS passthrough camera — device only
 
-> **Enterprise license required.**  
-> Access to the Apple Vision Pro main passthrough camera is an Apple enterprise API.
-> You must request the entitlement from Apple before it will work on a physical device.
-> All other features — audio, data channel, and the visionOS simulator — work without it.
+Access to the Apple Vision Pro main passthrough camera is an Apple **enterprise** API.
+Two things are required; without both the camera APIs are silent no-ops at
+runtime (`CameraVideoFormat.supportedVideoFormats(...)` returns `[]`). All
+other features — audio, data channel, and the visionOS simulator — work
+without any of this.
 
-#### Requesting the entitlement
+| # | What | Where |
+|---|---|---|
+| 1 | Entitlement key in the signed binary | `App/StreamKitSample.entitlements` declares `com.apple.developer.arkit.main-camera-access.allow`; wired in via the project's `CODE_SIGN_ENTITLEMENTS` build setting |
+| 2 | The team's `Enterprise.license` bundled into the `.app` | See below |
 
-1. Visit <https://developer.apple.com/contact/request/visionos-enterprise-api/> and
-   submit a request for the **Main Camera Access** enterprise entitlement.
-2. Apple will review your use case and, if approved, add the entitlement to your
-   App ID in the developer portal.
-3. Regenerate your provisioning profile after it is granted.
+Xcode's automatic signing works for development builds. App Store / TestFlight
+distribution requires a manually-issued provisioning profile that grants the
+entitlement.
 
-#### Adding it to the project
+> **Bundle ID note**: this sample's Bundle ID is `com.nvidia.xr-ai-example`.
+> If you fork it, change the ID under Signing & Capabilities to one your team
+> owns. The display name (`StreamKitSample`) is independent of the Bundle ID
+> and is unchanged. `UserDefaults` are keyed by Bundle ID, so saved settings
+> reset on first launch after a rename.
 
-An entitlements file is already provided at `App/StreamKitSample.entitlements`:
+#### Requesting the entitlement (one-time, per Apple team)
 
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>com.apple.developer.arkit.main-camera-access.allow</key>
-    <true/>
-</dict>
-</plist>
+1. <https://developer.apple.com/contact/> → Distribution → Enterprise APIs →
+   request **Main Camera Access** (`com.apple.developer.arkit.main-camera-access.allow`).
+   Apple issues a team-wide license valid for any Bundle ID your team signs.
+   License expires yearly.
+2. In the developer portal, enable **Main Camera Access** on the App ID.
+
+#### Bundling `Enterprise.license`
+
+The license is per-team and Apple's terms restrict redistribution, so it is
+**gitignored** (`**/Enterprise.license`) and never committed. A placeholder at
+`App/Enterprise.license.sample` documents the location.
+
+Place your team's license at:
+
+```
+client-samples/ios-visionos/App/Enterprise.license
 ```
 
-Verify that **Build Settings → Code Signing Entitlements** for the visionOS target
-points at this file. Without a matching provisioning profile from Apple the build will
-succeed but `startCamera()` will throw an access-denied error at runtime on device.
+A "Copy Enterprise.license" build phase copies it into the `.app` at build
+time; visionOS auto-loads it from the bundle. If the file is missing, the
+build still succeeds with a warning and every feature except main-camera
+passthrough works.
 
-The visionOS simulator does **not** require this entitlement and will always use the
+If you prefer to keep the file outside the repo, symlink it (the gitignore
+rule still matches):
+
+```bash
+ln -s ~/wherever/Enterprise.license client-samples/ios-visionos/App/Enterprise.license
+```
+
+The visionOS simulator does **not** require any of this and will always use the
 GIF-based camera feed regardless.
 
 ### 7. Build and run

--- a/client-samples/ios-visionos/StreamKitSample.xcodeproj/project.pbxproj
+++ b/client-samples/ios-visionos/StreamKitSample.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 				AA000100000000000000EE01 /* Sources */,
 				AA000100000000000000EE02 /* Frameworks */,
 				AA000100000000000000EE03 /* Resources */,
+				AA000100000000000000EE04 /* Copy Enterprise.license */,
 			);
 			buildRules = (
 			);
@@ -145,6 +146,30 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		AA000100000000000000EE04 /* Copy Enterprise.license */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/App/Enterprise.license",
+			);
+			name = "Copy Enterprise.license";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/Enterprise.license",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/bash;
+			shellScript = "# Bundle App/Enterprise.license into the .app for the\n# com.apple.developer.arkit.main-camera-access.allow entitlement. The file is\n# per-team and gitignored. See client-samples/ios-visionos/README.md.\n\nset -e\n\nLICENSE_PATH=\"$SRCROOT/App/Enterprise.license\"\nDEST=\"$BUILT_PRODUCTS_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/Enterprise.license\"\n\nif [ -f \"$LICENSE_PATH\" ]; then\n    mkdir -p \"$BUILT_PRODUCTS_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH\"\n    cp -f \"$LICENSE_PATH\" \"$DEST\"\nelse\n    rm -f \"$DEST\"\n    echo \"warning: Enterprise.license not found at $LICENSE_PATH \u2014 main camera access will be a no-op at runtime. See README.\"\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		AA000100000000000000EE01 /* Sources */ = {
@@ -300,8 +325,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.nvidia.StreamKitSample;
-				"PRODUCT_BUNDLE_IDENTIFIER[sdk=xros*]" = com.nvidia.streamkitsample;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.nvidia.xr-ai-example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -328,8 +352,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.nvidia.StreamKitSample;
-				"PRODUCT_BUNDLE_IDENTIFIER[sdk=xros*]" = com.nvidia.streamkitsample;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.nvidia.xr-ai-example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/client-samples/ios-visionos/StreamKitSample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/client-samples/ios-visionos/StreamKitSample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,42 @@
+{
+  "originHash" : "8cf0a46a405a91a6e03fdb9955e92e284a2b298c977b6fe852aac1d002dd4446",
+  "pins" : [
+    {
+      "identity" : "client-sdk-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/livekit/client-sdk-swift",
+      "state" : {
+        "revision" : "f70911172031fe40042266ed3bc35171224c2ef0",
+        "version" : "2.13.0"
+      }
+    },
+    {
+      "identity" : "livekit-uniffi-xcframework",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/livekit/livekit-uniffi-xcframework.git",
+      "state" : {
+        "revision" : "61229f4032131311b997ddb1bc1cb8f5afbe30c8",
+        "version" : "0.0.5"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "81558271e243f8f47dfe8e9fdd55f3c2b5413f68",
+        "version" : "1.37.0"
+      }
+    },
+    {
+      "identity" : "webrtc-xcframework",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/livekit/webrtc-xcframework.git",
+      "state" : {
+        "revision" : "f6017e189972b86f90e0ec406b1629828bc75748",
+        "version" : "144.7559.3"
+      }
+    }
+  ],
+  "version" : 3
+}


### PR DESCRIPTION
This adds support for visionOS camera. Developers need to add their own enterprise license to use it, but then it will work. A sample license file is included to document the location.

The client also now persists connection settings between launches.