### PR TITLE
fix(transcript-mcp): surface path validation as local before sink

### DIFF
--- a/agent-mcp-servers/transcript-mcp/transcript_mcp_server/__main__.py
+++ b/agent-mcp-servers/transcript-mcp/transcript_mcp_server/__main__.py
@@ -127,14 +127,16 @@ class TranscriptStore:
         if canonical_jsonl.exists():
             if canonical_ident.exists():
                 if canonical_ident.read_text(encoding="utf-8").strip() == source_id.strip():
-                    return self._check(canonical_jsonl)
+                    jsonl = self._check(canonical_jsonl)
+                    return jsonl
             elif source_id == safe:
-                return self._check(canonical_jsonl)
+                jsonl = self._check(canonical_jsonl)
+                return jsonl
         # Slow path: scan sidecars.
         for ident in sorted(self._dir.glob("*.identity")):
             if ident.read_text(encoding="utf-8").strip() == source_id.strip():
-                jsonl = ident.with_suffix(".jsonl")
-                return self._check(jsonl) if jsonl.exists() else None
+                jsonl = self._check(ident.with_suffix(".jsonl"))
+                return jsonl if jsonl.exists() else None
         return None
 
     # ── operations ───────────────────────────────────────────────────

--- a/agent-mcp-servers/transcript-mcp/transcript_mcp_server/__main__.py
+++ b/agent-mcp-servers/transcript-mcp/transcript_mcp_server/__main__.py
@@ -83,11 +83,14 @@ class TranscriptStore:
     def __init__(self, transcripts_dir: str) -> None:
         self._dir = pathlib.Path(transcripts_dir)
         self._dir.mkdir(parents=True, exist_ok=True)
+        # Resolve once at construction so the safe root can't be swapped
+        # for a symlink (TOCTOU) between subsequent _check calls.
+        self._root = self._dir.resolve()
 
     # ── path resolution ──────────────────────────────────────────────
 
     def _check(self, path: pathlib.Path) -> pathlib.Path:
-        if not path.resolve().is_relative_to(self._dir.resolve()):
+        if not path.resolve().is_relative_to(self._root):
             raise ValueError(f"Path escapes transcript directory: {path}")
         return path
 

--- a/agent-mcp-servers/video-mcp/video_mcp_server/__main__.py
+++ b/agent-mcp-servers/video-mcp/video_mcp_server/__main__.py
@@ -88,10 +88,12 @@ def _safe_name(s: str) -> str:
 
 class ChunkStore:
     def __init__(self, recordings_dir: pathlib.Path) -> None:
-        self._root = recordings_dir
+        # Resolve once at construction so the safe root can't be swapped
+        # for a symlink (TOCTOU) between subsequent _check calls.
+        self._root = recordings_dir.resolve()
 
     def _check(self, path: pathlib.Path) -> pathlib.Path:
-        if not path.resolve().is_relative_to(self._root.resolve()):
+        if not path.resolve().is_relative_to(self._root):
             raise ValueError(f"Path escapes recordings directory: {path}")
         return path
 


### PR DESCRIPTION
In _resolve_existing, hoist self._check(...) into a jsonl local right before each return. For the slow path, validate the constructed path before .exists() rather than after, so the sanitizer sits on the data-flow path SonarQube traces into the sink.