### PR TITLE
refactor(livekit): extract shared /rtc proxy helpers

### DIFF
--- a/server-runtime/xr_media_hub/transport/livekit/_lk_proxy.py
+++ b/server-runtime/xr_media_hub/transport/livekit/_lk_proxy.py
@@ -91,4 +91,6 @@ async def pump_rtc_ws(client_ws: WebSocket, lk_internal_ws: str) -> None:
         try:
             await client_ws.close()
         except Exception:
+            # Best-effort cleanup: client may already be closed/disconnected.
+            # Intentionally ignore close-time errors in shutdown path.
             pass

--- a/server-runtime/xr_media_hub/transport/livekit/_lk_proxy.py
+++ b/server-runtime/xr_media_hub/transport/livekit/_lk_proxy.py
@@ -69,8 +69,10 @@ async def pump_rtc_ws(client_ws: WebSocket, lk_internal_ws: str) -> None:
                             await lk_ws.send(msg["bytes"])
                         elif msg.get("text"):
                             await lk_ws.send(msg["text"])
-                except Exception:
-                    pass
+                except Exception as exc:
+                    # Client-side receive/send can fail during normal disconnect
+                    # races; keep teardown best-effort but retain debug visibility.
+                    log.debug("WS proxy /rtc c2l ended with error: %s", exc)
                 finally:
                     await lk_ws.close()
 

--- a/server-runtime/xr_media_hub/transport/livekit/_lk_proxy.py
+++ b/server-runtime/xr_media_hub/transport/livekit/_lk_proxy.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Shared LiveKit proxy helpers used by both the standalone web server
+(``_web_server.py``) and the token server (``_token_server.py``).
+
+Both expose the same /rtc surface to browser/headset clients —
+``GET /rtc/validate`` over HTTP and ``WS /rtc`` for signaling — so a
+TLS-terminating front can reach a plaintext LiveKit signaling port
+without mixed-content errors. The HTTP shells differ; the LiveKit-
+facing proxy logic does not.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import httpx
+import websockets
+from fastapi import Request, WebSocket
+from fastapi.responses import Response
+
+log = logging.getLogger(__name__)
+
+
+async def proxy_validate(
+    client: httpx.AsyncClient,
+    lk_internal_http: str,
+    request: Request,
+) -> Response:
+    """Forward ``GET /rtc/validate?<qs>`` to LiveKit's internal HTTP."""
+    qs = str(request.url.query)
+    r = await client.get(f"{lk_internal_http}/rtc/validate?{qs}")
+    return Response(
+        content=r.content,
+        status_code=r.status_code,
+        media_type=r.headers.get("content-type", "text/plain"),
+    )
+
+
+async def pump_rtc_ws(client_ws: WebSocket, lk_internal_ws: str) -> None:
+    """Bidirectional WebSocket pump between *client_ws* and LiveKit signaling.
+
+    Same-origin /rtc proxy: lets browser clients on TLS pages reach a plain
+    LiveKit signaling port without the mixed-content error.
+    """
+    qs = client_ws.scope.get("query_string", b"").decode()
+    target = f"{lk_internal_ws}/rtc?{qs}"
+    await client_ws.accept()
+    try:
+        async with websockets.connect(target, max_size=None) as lk_ws:
+
+            async def c2l() -> None:
+                try:
+                    while True:
+                        msg = await client_ws.receive()
+                        msg_type = msg.get("type")
+                        if msg_type == "websocket.disconnect":
+                            break
+                        # Only websocket.receive carries data — any other
+                        # event type (lifespan ack, ping/pong) shouldn't
+                        # land here, but skip explicitly so a future ASGI
+                        # change doesn't accidentally forward control
+                        # frames upstream as bogus payload.
+                        if msg_type != "websocket.receive":
+                            continue
+                        if msg.get("bytes"):
+                            await lk_ws.send(msg["bytes"])
+                        elif msg.get("text"):
+                            await lk_ws.send(msg["text"])
+                except Exception:
+                    pass
+                finally:
+                    await lk_ws.close()
+
+            async def l2c() -> None:
+                try:
+                    async for frame in lk_ws:
+                        if isinstance(frame, bytes):
+                            await client_ws.send_bytes(frame)
+                        else:
+                            await client_ws.send_text(frame)
+                except Exception:
+                    pass
+
+            await asyncio.gather(c2l(), l2c(), return_exceptions=True)
+    except Exception as exc:
+        log.debug("WS proxy /rtc error: %s", exc)
+    finally:
+        try:
+            await client_ws.close()
+        except Exception:
+            pass

--- a/server-runtime/xr_media_hub/transport/livekit/_lk_proxy.py
+++ b/server-runtime/xr_media_hub/transport/livekit/_lk_proxy.py
@@ -82,6 +82,9 @@ async def pump_rtc_ws(client_ws: WebSocket, lk_internal_ws: str) -> None:
                         else:
                             await client_ws.send_text(frame)
                 except Exception:
+                    # Either side closing the websocket during teardown can
+                    # raise here; suppression is intentional to let shutdown
+                    # complete without noisy expected-disconnect errors.
                     pass
 
             await asyncio.gather(c2l(), l2c(), return_exceptions=True)

--- a/server-runtime/xr_media_hub/transport/livekit/_token.py
+++ b/server-runtime/xr_media_hub/transport/livekit/_token.py
@@ -14,7 +14,7 @@ from .config import LiveKitConnectorConfig
 def make_client_token(
     cfg: LiveKitConnectorConfig,
     identity: str = "client",
-    ttl: int = 3600 * 24,   # 24 h — long enough for dev
+    ttl: int | None = 3600 * 24,   # 24 h — long enough for dev; None → SDK default
 ) -> str:
     """
     Generate a signed LiveKit JWT for a browser or mobile client.
@@ -24,12 +24,16 @@ def make_client_token(
 
         token = make_client_token(cfg, identity="alice")
         # hand token + ws://10.x.x.x:7880 to the browser client
+
+    Pass ``ttl=None`` to skip the explicit lifetime and use the LiveKit SDK's
+    default token TTL — used by short-lived per-session web tokens.
     """
-    return (
+    builder = (
         AccessToken(cfg.api_key, cfg.api_secret)
         .with_identity(identity)
         .with_name(identity)
         .with_grants(VideoGrants(room_join=True, room=cfg.room_name))
-        .with_ttl(timedelta(seconds=ttl))
-        .to_jwt()
     )
+    if ttl is not None:
+        builder = builder.with_ttl(timedelta(seconds=ttl))
+    return builder.to_jwt()

--- a/server-runtime/xr_media_hub/transport/livekit/_token_server.py
+++ b/server-runtime/xr_media_hub/transport/livekit/_token_server.py
@@ -19,12 +19,12 @@ import logging
 
 import httpx
 import uvicorn
-import websockets
 from fastapi import FastAPI, Query, Request, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import Response
-from livekit.api import AccessToken, VideoGrants
 
+from . import _lk_proxy
+from ._token import make_client_token
 from .config import LiveKitConnectorConfig
 
 log = logging.getLogger(__name__)
@@ -44,67 +44,17 @@ def build_app(cfg: LiveKitConnectorConfig) -> FastAPI:
 
     @app.get("/token")
     async def get_token(identity: str = Query(default="browser-user")) -> dict:
-        token = (
-            AccessToken(cfg.api_key, cfg.api_secret)
-            .with_identity(identity)
-            .with_name(identity)
-            .with_grants(VideoGrants(room_join=True, room=cfg.room_name))
-            .to_jwt()
-        )
+        token = make_client_token(cfg, identity=identity, ttl=None)
         return {"token": token, "room": cfg.room_name, "url": cfg.token_server_url}
 
     @app.get("/rtc/validate")
     async def rtc_validate(request: Request) -> Response:
-        qs = str(request.url.query)
         async with httpx.AsyncClient() as client:
-            r = await client.get(f"{lk_internal_http}/rtc/validate?{qs}")
-        return Response(
-            content=r.content,
-            status_code=r.status_code,
-            media_type=r.headers.get("content-type", "text/plain"),
-        )
+            return await _lk_proxy.proxy_validate(client, lk_internal_http, request)
 
     @app.websocket("/rtc")
     async def rtc_ws_proxy(client_ws: WebSocket) -> None:
-        qs = client_ws.scope.get("query_string", b"").decode()
-        target = f"{lk_internal_ws}/rtc?{qs}"
-        await client_ws.accept()
-        try:
-            async with websockets.connect(target, max_size=None) as lk_ws:
-
-                async def c2l() -> None:
-                    try:
-                        while True:
-                            msg = await client_ws.receive()
-                            if msg["type"] == "websocket.disconnect":
-                                break
-                            if msg.get("bytes"):
-                                await lk_ws.send(msg["bytes"])
-                            elif msg.get("text"):
-                                await lk_ws.send(msg["text"])
-                    except Exception:
-                        pass
-                    finally:
-                        await lk_ws.close()
-
-                async def l2c() -> None:
-                    try:
-                        async for frame in lk_ws:
-                            if isinstance(frame, bytes):
-                                await client_ws.send_bytes(frame)
-                            else:
-                                await client_ws.send_text(frame)
-                    except Exception:
-                        pass
-
-                await asyncio.gather(c2l(), l2c(), return_exceptions=True)
-        except Exception as exc:
-            log.debug("WS proxy /rtc error: %s", exc)
-        finally:
-            try:
-                await client_ws.close()
-            except Exception:
-                pass
+        await _lk_proxy.pump_rtc_ws(client_ws, lk_internal_ws)
 
     if cfg.browser_dir:
         from fastapi.staticfiles import StaticFiles

--- a/server-runtime/xr_media_hub/transport/livekit/_web_server.py
+++ b/server-runtime/xr_media_hub/transport/livekit/_web_server.py
@@ -26,14 +26,14 @@ import logging
 
 import httpx
 import uvicorn
-import websockets
 from fastapi import FastAPI, Query, Request, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import Response
 from fastapi.staticfiles import StaticFiles
-from livekit.api import AccessToken, VideoGrants
 
+from . import _lk_proxy
 from ._tls import ensure_self_signed_cert
+from ._token import make_client_token
 from .config import LiveKitConnectorConfig
 
 log = logging.getLogger(__name__)
@@ -69,13 +69,7 @@ def _build_app(cfg: LiveKitConnectorConfig) -> FastAPI:
             lk_url = f"wss://{host}:{cfg.web_server_port}"
         else:
             lk_url = f"ws://{host}:{cfg.lk_port_ws}"
-        token = (
-            AccessToken(cfg.api_key, cfg.api_secret)
-            .with_identity(identity)
-            .with_name(identity)
-            .with_grants(VideoGrants(room_join=True, room=cfg.room_name))
-            .to_jwt()
-        )
+        token = make_client_token(cfg, identity=identity, ttl=None)
         return {"token": token, "room": cfg.room_name, "url": lk_url}
 
     # ── LiveKit signaling proxy (only useful when web_server_tls is true) ────
@@ -83,63 +77,11 @@ def _build_app(cfg: LiveKitConnectorConfig) -> FastAPI:
 
     @app.get("/rtc/validate")
     async def rtc_validate(request: Request) -> Response:
-        qs = str(request.url.query)
-        r = await proxy_client.get(f"{lk_internal_http}/rtc/validate?{qs}")
-        return Response(
-            content=r.content,
-            status_code=r.status_code,
-            media_type=r.headers.get("content-type", "text/plain"),
-        )
+        return await _lk_proxy.proxy_validate(proxy_client, lk_internal_http, request)
 
     @app.websocket("/rtc")
     async def rtc_ws_proxy(client_ws: WebSocket) -> None:
-        qs = client_ws.scope.get("query_string", b"").decode()
-        target = f"{lk_internal_ws}/rtc?{qs}"
-        await client_ws.accept()
-        try:
-            async with websockets.connect(target, max_size=None) as lk_ws:
-
-                async def c2l() -> None:
-                    try:
-                        while True:
-                            msg = await client_ws.receive()
-                            msg_type = msg.get("type")
-                            if msg_type == "websocket.disconnect":
-                                break
-                            # Only websocket.receive carries data — any other
-                            # event type (lifespan ack, ping/pong) shouldn't
-                            # land here, but skip explicitly so a future ASGI
-                            # change doesn't accidentally forward control
-                            # frames upstream as bogus payload.
-                            if msg_type != "websocket.receive":
-                                continue
-                            if msg.get("bytes"):
-                                await lk_ws.send(msg["bytes"])
-                            elif msg.get("text"):
-                                await lk_ws.send(msg["text"])
-                    except Exception:
-                        pass
-                    finally:
-                        await lk_ws.close()
-
-                async def l2c() -> None:
-                    try:
-                        async for frame in lk_ws:
-                            if isinstance(frame, bytes):
-                                await client_ws.send_bytes(frame)
-                            else:
-                                await client_ws.send_text(frame)
-                    except Exception:
-                        pass
-
-                await asyncio.gather(c2l(), l2c(), return_exceptions=True)
-        except Exception as exc:
-            log.debug("WS proxy /rtc error: %s", exc)
-        finally:
-            try:
-                await client_ws.close()
-            except Exception:
-                pass
+        await _lk_proxy.pump_rtc_ws(client_ws, lk_internal_ws)
 
     # StaticFiles asserts scope["type"] == "http" and crashes on WebSocket upgrades.
     # Catch any remaining WebSocket paths and close them before the mount sees them.


### PR DESCRIPTION
This is to resolve SonarQube duplicated code issue.

_web_server.py and _token_server.py duplicated ~50 lines of LiveKit-facing logic (the /token JWT issuer, /rtc/validate HTTP proxy, and /rtc WebSocket pump). Both servers expose the same proxy surface to browser clients with slightly different HTTP shells; only the shells differ.

Extract:
- _lk_proxy.proxy_validate(client, base, request) — /rtc/validate
- _lk_proxy.pump_rtc_ws(client_ws, lk_internal_ws) — /rtc WS pump
- _token.make_client_token(cfg, identity, ttl=None) — accepts None to skip the explicit TTL, used by both web servers (preserving prior LiveKit-default-TTL behavior).

The defensive `msg_type != "websocket.receive"` guard from _web_server.py is now applied uniformly via _lk_proxy. Public API (LiveKitConnector / make_client_token) and existing TTL behavior for non-web callers (24h default) are unchanged.

Closes the SonarQube duplication finding on _web_server.py (47.9%).