### PR TITLE
chore(sonar): exclude by-design parallel clusters from CPD

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,3 +3,17 @@
 
 sonar.projectKey=SW-Cloud_XR_XR-AI_xr-ai
 sonar.qualitygate.wait=true
+
+# CPD (duplication) exclusions — files that are intentionally parallel
+# by design. Each LLM/TTS backend, sample agent, MCP server, and web
+# demo is an independent unit sharing a templated scaffold; collapsing
+# them would couple unrelated services and undermine the
+# sample-as-template use case. Real duplication elsewhere
+# (server-runtime/, tests/, xr_ai_agent/, etc.) is still detected.
+sonar.cpd.exclusions=\
+    ai-services/llm/*/**, \
+    ai-services/tts/*/**, \
+    ai-services/vlm-server/**, \
+    agent-samples/*/**, \
+    agent-mcp-servers/*/**, \
+    client-samples/web*/**


### PR DESCRIPTION
Most of the project's reported duplication comes from intentionally parallel files: alternative LLM/TTS backends, sample agents, MCP servers, and web demos all share a templated scaffold by design. Collapsing them would couple unrelated services and undermine their use as standalone templates.

Add sonar.cpd.exclusions covering those clusters. Real duplication in server-runtime/, tests/, xr_ai_agent/, and the Android sample is still detected — _web_server.py vs _token_server.py is the next refactor target.