### PR TITLE
port: machine-specific fixes from xr-ai@005682507f (shm, llm, launcher)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+.claudelearnings
+
 # AI model weights — every models/ subtree is gitignored; only .gitkeep is tracked
 **/models/**
 !**/models/.gitkeep

--- a/agent-sdk/xr_ai_agent/_shm.py
+++ b/agent-sdk/xr_ai_agent/_shm.py
@@ -167,7 +167,12 @@ class ShmRingBuffer:
 
     def close(self) -> None:
         self._buf.release()
-        self._shm.close()
+        try:
+            self._shm.close()
+        except BufferError:
+            # A SlotView memoryview is still live (unreleased slot during abnormal
+            # shutdown).  The OS reclaims the segment once all views are GC'd.
+            pass
 
     def unlink(self) -> None:
         """Remove the underlying shared memory segment. Call once from the owner (Hub)."""

--- a/ai-services/llm/nemotron3_nano/README.md
+++ b/ai-services/llm/nemotron3_nano/README.md
@@ -105,7 +105,7 @@ Edit `nemotron3_nano_llm_server.yaml`:
 
 ```yaml
 model: nvidia/Nemotron-Nano-3-30B-A3B          # BF16 unquantized
-# model: nvidia/Nemotron-Nano-3-30B-A3B-FP8    # FP8 (Hopper-compatible)
+# model: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8    # FP8 (Hopper-compatible)
 ```
 
 Any NVIDIA Nemotron-3 family variant works because they share the same chat

--- a/ai-services/llm/nemotron3_nano/nemotron3_nano_llm_server.yaml
+++ b/ai-services/llm/nemotron3_nano/nemotron3_nano_llm_server.yaml
@@ -13,7 +13,7 @@
 # actual answer in message.content is never polluted — this is what keeps
 # voice TTS from reading the reasoning aloud.
 
-model: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4
+model: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8
 
 host: "0.0.0.0"
 port: 8107
@@ -24,19 +24,20 @@ hf_token: ""
 # ai-services write their weights).
 model_cache: ../../models
 
-# vLLM server knobs.  Defaults are conservative for single-GPU Blackwell
-# (B200 192GB or RTX PRO 6000 96GB) running one concurrent voice agent.
+# vLLM server knobs.
+#
+# On Blackwell (B200 / RTX PRO 6000 96 GB): NVFP4 weights ~20 GB; keep
+# gpu_memory_utilization at 0.6 to share the single GPU with vlm-server
+# (~14 GB) and stt-server (~1.5 GB).
+#
+# On Ada Lovelace (RTX 6000 Ada 48 GB): FP8 weights ~30 GB; run the LLM
+# on a dedicated GPU and keep the vlm-server + stt-server on the second GPU.
+# With LLM alone on a 48 GB card, 0.85 (~41 GB) gives ~11 GB for KV cache.
 max_num_seqs:         8
 tensor_parallel_size: 1
 max_model_len:        32768
 
-# Fraction of total GPU memory vLLM reserves at startup (weights + KV
-# cache + activations).  vLLM's own default is 0.92 — we lower it to
-# 0.6 because this LLM shares the GPU with vlm-server (Cosmos-Reason1-7B,
-# ~14 GB BF16) and stt-server (parakeet, ~1.5 GB) in the
-# pipecat-nat-nemotron3nano sample.  Bump back toward 0.85-0.92 if you
-# run this service on a dedicated GPU with no other tenants.
-gpu_memory_utilization: 0.6
+gpu_memory_utilization: 0.85
 
 # Skip CUDA graph capture + FlashInfer MoE autotune at startup.  For
 # NemotronH-30B-A3B-NVFP4 those two phases are silent (no log output)

--- a/ai-services/llm/nemotron3_nano/nemotron3_nano_llm_server/__main__.py
+++ b/ai-services/llm/nemotron3_nano/nemotron3_nano_llm_server/__main__.py
@@ -123,6 +123,60 @@ def _ensure_reasoning_parser(model_cache: Path) -> Path:
     return path
 
 
+def _clear_stale_flashinfer_cache(correct_cuda_home: str) -> None:
+    """Delete FlashInfer JIT cache dirs whose build.ninja uses a different nvcc.
+
+    FlashInfer generates a build.ninja with the nvcc path baked in.  If a
+    previous run used the wrong nvcc (e.g. /usr/bin/nvcc = CUDA 11.5) and
+    compilation failed, the stale build.ninja persists and ninja keeps using it
+    even after CUDA_HOME is corrected.  This function removes those dirs so
+    FlashInfer regenerates them with the correct nvcc on the next start.
+
+    Safe to call on every startup: a no-op once the cache was compiled with
+    the right nvcc (correct_nvcc will be present in the new build.ninja).
+    """
+    import shutil
+    correct_nvcc = (Path(correct_cuda_home) / "bin" / "nvcc").as_posix().encode()
+    fi_cache = Path.home() / ".cache" / "flashinfer"
+    if not fi_cache.exists():
+        return
+    cleared = 0
+    for ninja_path in fi_cache.rglob("build.ninja"):
+        try:
+            content = ninja_path.read_bytes()
+        except OSError:
+            continue
+        if b"/bin/nvcc" in content and correct_nvcc not in content:
+            shutil.rmtree(ninja_path.parent, ignore_errors=True)
+            cleared += 1
+    if cleared:
+        print(
+            f"[nemotron3_nano_llm_server] Cleared {cleared} stale FlashInfer JIT "
+            f"cache dir(s) (wrong nvcc — will recompile on first inference)",
+            flush=True,
+        )
+
+
+def _cuda_compute_capability() -> str:
+    """Return 'major.minor' for the first visible CUDA device, or '?.?' on error."""
+    try:
+        import torch
+        major, minor = torch.cuda.get_device_capability(0)
+        return f"{major}.{minor}"
+    except Exception:
+        return "?.?"
+
+
+def _is_blackwell() -> bool:
+    """Return True if the first CUDA device is Blackwell (SM100, compute cap >= 10.0)."""
+    try:
+        import torch
+        major, _ = torch.cuda.get_device_capability(0)
+        return major >= 10
+    except Exception:
+        return False
+
+
 def run() -> None:
     sys.stdout.reconfigure(line_buffering=True)
     sys.stderr.reconfigure(line_buffering=True)
@@ -159,12 +213,43 @@ def run() -> None:
     # alongside the llama_nemotron download, not in ~/.cache/huggingface.
     os.environ["HF_HOME"] = str(model_cache)
 
-    # Blackwell FP4 MoE kernels via FlashInfer — required to unlock the
-    # NVFP4 quantization's efficiency; on non-Blackwell hardware vLLM will
-    # either fall back silently (emulated FP4, slower) or refuse to start
-    # depending on the FlashInfer build.
-    os.environ["VLLM_USE_FLASHINFER_MOE_FP4"] = "1"
-    os.environ["VLLM_FLASHINFER_MOE_BACKEND"] = "throughput"
+    # FlashInfer uses CUDA_HOME to find nvcc for JIT kernel compilation.
+    # PyTorch's cpp_extension sets it to /usr, which resolves to /usr/bin/nvcc
+    # (CUDA 11.5 on this system) — too old to compile SM89 (Ada, added in 11.8).
+    # Prefer a versioned installation that matches the PyTorch CUDA build.
+    _CUDA_HOME_CANDIDATES = [
+        "/usr/local/cuda-13.0",
+        "/usr/local/cuda-13",
+        "/usr/local/cuda-12.6",
+        "/usr/local/cuda-12",
+        "/usr/local/cuda",
+    ]
+    for _cuda_home in _CUDA_HOME_CANDIDATES:
+        if (Path(_cuda_home) / "bin" / "nvcc").exists():
+            os.environ["CUDA_HOME"] = _cuda_home
+            print(
+                f"[nemotron3_nano_llm_server] CUDA_HOME → {_cuda_home} "
+                "(overrides /usr to avoid CUDA 11.5 nvcc for FlashInfer JIT)",
+                flush=True,
+            )
+            _clear_stale_flashinfer_cache(_cuda_home)
+            break
+
+    # NVFP4 FlashInfer MoE kernels only work on Blackwell (SM100+).
+    # On Ada / Hopper / Ampere, setting these env vars causes vLLM to crash
+    # with "kernel does not support current device cuda".  Detect the
+    # compute capability at runtime and skip them on pre-Blackwell GPUs.
+    if _is_blackwell():
+        os.environ["VLLM_USE_FLASHINFER_MOE_FP4"] = "1"
+        os.environ["VLLM_FLASHINFER_MOE_BACKEND"] = "throughput"
+    else:
+        cc = _cuda_compute_capability()
+        print(
+            f"[nemotron3_nano_llm_server] GPU compute capability {cc} — "
+            "skipping NVFP4 FlashInfer env vars (Blackwell/SM100+ required). "
+            "Using FP8 model variant instead.",
+            flush=True,
+        )
 
     parser_path = _ensure_reasoning_parser(model_cache)
 
@@ -178,12 +263,19 @@ def run() -> None:
         "--tool-call-parser", "qwen3_coder",
         "--reasoning-parser-plugin", str(parser_path),
         "--reasoning-parser", "nano_v3",
-        "--kv-cache-dtype", "fp8",
         "--max-num-seqs", str(max_num_seqs),
         "--tensor-parallel-size", str(tp_size),
         "--max-model-len", str(max_model_len),
         "--gpu-memory-utilization", str(gpu_mem_util),
     ]
+    if _is_blackwell():
+        # FP8 KV cache requires FlashInfer to JIT-compile for the target SM via
+        # the system nvcc.  On Ada (SM89) the system CUDA toolkit is often older
+        # than 11.8 and nvcc rejects compute_89, crashing at startup.  Blackwell
+        # (SM100) ships with a recent toolkit and the compiled wheels, so this is
+        # safe there.  On Ada, vLLM defaults to auto (BF16 KV cache), which is
+        # correct and avoids any JIT compilation.
+        argv.extend(["--kv-cache-dtype", "fp8"])
     if enforce_eager:
         argv.append("--enforce-eager")
 

--- a/launcher/xr_ai_launcher/_project.py
+++ b/launcher/xr_ai_launcher/_project.py
@@ -16,13 +16,25 @@ from ._processes import ManagedProcess
 
 
 @asynccontextmanager
-async def ProjectLauncher(project: str | Path, command: str, *args: str, name: str | None = None):
+async def ProjectLauncher(
+    project: str | Path,
+    command: str,
+    *args: str,
+    name: str | None = None,
+    gpu: str | None = None,
+):
     """
     Run *command* inside *project*'s isolated venv via ``uv run --project``.
     Falls back to ``sys.executable -m <command>`` if uv is not on PATH.
 
     *name* is the label used in log output (the prefix on every forwarded
     line). When omitted it defaults to the trailing component of *command*.
+
+    *gpu* pins the process to specific device(s) by setting
+    ``CUDA_VISIBLE_DEVICES`` in the child environment.  Pass a device index
+    string (``"0"``, ``"1"``, ``"0,1"``) or omit to inherit the parent's
+    visibility.  This is the only GPU-selection mechanism; no YAML key is
+    read.
 
     Yields the underlying ``asyncio.subprocess.Process`` so callers can
     ``await proc.wait()`` or inspect ``proc.returncode``.
@@ -33,14 +45,17 @@ async def ProjectLauncher(project: str | Path, command: str, *args: str, name: s
     project = Path(project).resolve()
     if name is None:
         name = command.rsplit(".", 1)[-1]
-    env: dict[str, str] | None = None
+
+    # Always build an explicit env dict so we can safely inject env vars.
+    # Drop VIRTUAL_ENV to prevent uv from warning about an active-venv mismatch.
+    env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
+    if gpu is not None:
+        env["CUDA_VISIBLE_DEVICES"] = gpu
 
     if shutil.which("uv"):
         cmd = ["uv", "run", "--project", str(project), command, *args]
-        # Drop any inherited VIRTUAL_ENV so uv doesn't warn about a mismatch
-        # between the parent shell's active venv and *project*'s own.
-        env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
     else:
         cmd = [sys.executable, "-m", command, *args]
+
     async with ManagedProcess(name, cmd, env=env) as proc:
         yield proc

--- a/launcher/xr_ai_launcher/_stack.py
+++ b/launcher/xr_ai_launcher/_stack.py
@@ -41,6 +41,8 @@ class Process:
     name    — label used in log output.
     project — path to the uv project (relative to the sample root, or absolute).
     command — entry-point script to run inside the project's venv.
+    gpu     — optional CUDA_VISIBLE_DEVICES value (e.g. "0", "1", "0,1").
+              Omit to inherit the parent's GPU visibility.
 
     Config convention: ``run_stack`` looks for ``<command>.yaml`` in the
     sample root and passes it as ``--config <abs-path>`` if it exists.
@@ -49,6 +51,7 @@ class Process:
     name:    str
     project: str | Path
     command: str
+    gpu:     str | None = None
 
 
 def _config_args(command: str, base: Path) -> list[str]:
@@ -73,7 +76,7 @@ async def StackLauncher(processes: Sequence[Process], base: Path):
             project = (base / p.project).resolve()
             extra   = _config_args(p.command, base)
             proc    = await stack.enter_async_context(
-                ProjectLauncher(project, p.command, *extra, name=p.name)
+                ProjectLauncher(project, p.command, *extra, name=p.name, gpu=p.gpu)
             )
             procs[p.name] = proc
         yield procs


### PR DESCRIPTION
## Summary

Ports the non-nat-agent changes from commit 005682507f04a99a8ac195537ae556c7918661ce on the xr-ai dev repo to this branch.

- **shm** (`agent-sdk/xr_ai_agent/_shm.py`): catch `BufferError` in `ShmRingBuffer.close()` when a `SlotView` memoryview is still live during abnormal shutdown; the OS reclaims the segment once all views are GC'd
- **llm / nemotron3_nano** (`ai-services/llm/nemotron3_nano/`):
  - Detect GPU compute capability at startup; skip NVFP4 FlashInfer env vars and `--kv-cache-dtype fp8` on pre-Blackwell (Ada/SM89) where the system nvcc is too old to compile SM89 kernels
  - Switch default model to FP8 variant (`NVIDIA-Nemotron-3-Nano-30B-A3B-FP8`) for Ada Lovelace compatibility
  - Add `CUDA_HOME` override logic to prefer a versioned CUDA installation over `/usr/bin/nvcc` (CUDA 11.5) for FlashInfer JIT
  - Add `_clear_stale_flashinfer_cache()` to remove stale `build.ninja` entries that reference the wrong nvcc
  - Update `gpu_memory_utilization` to 0.85 for dedicated-GPU Ada setups; update YAML comments to document per-architecture guidance
- **launcher** (`launcher/xr_ai_launcher/`):
  - Add `gpu: str | None = None` field to `Process` dataclass and `gpu=` parameter to `ProjectLauncher`; sets `CUDA_VISIBLE_DEVICES` in the child env to pin a service to a specific GPU
  - Always build an explicit env dict (not just when uv is present) so `CUDA_VISIBLE_DEVICES` injection works regardless of how the child is launched
- **gitignore**: exclude `.claudelearnings/`

## Test plan

- [x] `cd tests && uv run pytest -v` — 38/38 pass (no regression)
- [x] Verify nemotron3_nano server starts on Ada Lovelace (RTX 6000 Ada) without crashing on `--kv-cache-dtype fp8` or NVFP4 FlashInfer env vars
- [x] Verify launcher `gpu=` field correctly sets `CUDA_VISIBLE_DEVICES` in child processes

🤖 Generated with [Claude Code](https://claude.com/claude-code)