### PR TITLE
fix(web): remove remote-audio muting on local speech

### DIFF
--- a/client-samples/web/StreamKit/Backends/LiveKit/LiveKitBackend.js
+++ b/client-samples/web/StreamKit/Backends/LiveKit/LiveKitBackend.js
@@ -215,17 +215,6 @@ export class LiveKitBackend {
       }
     });
 
-    // Mute remote audio while the local participant is speaking so the browser's
-    // AEC pipeline doesn't suppress the user's voice as if it were echo.  Without
-    // this, when echo cancellation is enabled the agent's outgoing audio can mask
-    // the user's barge-in, making it impossible for the STT to detect "stop".
-    room.on(RoomEvent.ActiveSpeakersChanged, (speakers) => {
-      const localSpeaking = speakers.some(p => p === room.localParticipant);
-      for (const el of this.#audioElements.values()) {
-        el.muted = localSpeaking;
-      }
-    });
-
     // ── Connect ───────────────────────────────────────────────────────────────
     await room.connect(wsURL, token);
   }


### PR DESCRIPTION
## Summary

- Removes the `ActiveSpeakersChanged` listener in `LiveKitBackend.js` that was muting all remote `<audio>` elements whenever the local participant was detected as speaking.

## Problem

The mute-on-speak logic was intended to prevent the browser's AEC pipeline from suppressing the user's barge-in. In practice the muting window is triggered by the local participant's speech activity detector and stays open for the full duration of the utterance — which can overlap with the agent's own outgoing audio, cutting the LLM's spoken response mid-sentence.

## Why it's safe to remove

The browser's built-in WebRTC AEC and VAD already handle echo suppression without application-level muting. Removing the handler lets the agent's audio play through uninterrupted regardless of local speaking state.

## Test plan

- [ ] Start a session; verify the agent's audio is not cut off while the user is speaking
- [ ] Verify barge-in still works (user speaking interrupts the agent via the STT/VAD pipeline, not the mute toggle)

> **Note:** If AEC echo bleed becomes a problem on specific hardware/browser combos, a better approach would be volume ducking (lower gain rather than hard mute) or relying on the STT server's VAD to gate processing rather than the client's speaker-detection event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)