### PR TITLE
feat(mcp): add vlm-mcp; update video-mcp to get_frame_from_time API + PyNvVideoCodec 2.x

### DIFF
--- a/agent-mcp-servers/video-mcp/video_mcp_server.yaml
+++ b/agent-mcp-servers/video-mcp/video_mcp_server.yaml
@@ -8,8 +8,9 @@
 # in xr_media_hub.yaml — the server reads chunk files directly from disk.
 #
 # hub_pub / hub_push are the hub IPC sockets used to fetch live frames
-# (the `get_latest_frame` tool). They must match the hub's PUB / PULL
-# bindings. Defaults below match xr_media_hub's defaults.
+# (the `get_frame_from_time(..., second_ago=0)` tool). They must match
+# the hub's PUB / PULL bindings. Defaults below match xr_media_hub's
+# defaults.
 #
 # MCP endpoint: http://localhost:8210/mcp  (StreamableHTTP transport)
 

--- a/agent-mcp-servers/video-mcp/video_mcp_server/__main__.py
+++ b/agent-mcp-servers/video-mcp/video_mcp_server/__main__.py
@@ -11,13 +11,14 @@ Two data paths:
 
 * **Historical chunks** — reads the H.264 Annex B chunks the hub recorder
   writes to (tmpfs by default). Used by ``query_video``,
-  ``get_video_stats``, ``list_recorded_participants``,
-  ``get_frame_at_time``.
+  ``get_video_stats``, ``list_recorded_participants``, and
+  ``get_frame_from_time`` when ``second_ago > 0``.
 
 * **Live frames** — connects to the hub as a ``ProcessorEndpoint``,
   tracks the most recent ``FrameSignal`` per participant, and pulls
   pixels on demand via ``request_frame``. Used by
-  ``list_live_participants`` and ``get_latest_frame``.
+  ``list_live_participants`` and ``get_frame_from_time`` when
+  ``second_ago == 0``.
 
 All tools accept and return raw LiveKit identities; sanitization happens
 internally for filesystem paths and is recovered via ``.identity``
@@ -38,14 +39,15 @@ Tools (FastMCP, mounted at /mcp)
       Concatenate H.264 chunks overlapping the window, write to a file,
       return the path. Result is raw H.264 starting with an IDR.
 
-  get_latest_frame(participant_id) → dict
-      Fetch the most recent frame the hub has for *participant_id*,
-      encode to PNG, return the file path. Uses the live IPC path —
-      independent of disk chunk timing.
-
-  get_frame_at_time(participant_id, timestamp_us) → dict
-      Decode the chunk covering *timestamp_us*, pick the frame closest
-      to that timestamp, encode to PNG, return the file path.
+  get_frame_from_time(participant_id, second_ago, reference_time_us=0) → dict
+      Frame at ``anchor − second_ago s`` where the anchor is either the
+      wall clock (``reference_time_us = 0``, default) or an explicit
+      Unix-microseconds timestamp. The anchored mode (typical for LLM
+      agents that pass the user's speech timestamp) always reads from
+      the recorded NVENC chunk store and decodes via NVDEC; only the
+      unanchored ``second_ago = 0`` short-circuits to the live IPC path.
+      Returns a PNG file path. Replaces the deprecated
+      ``get_latest_frame`` and ``get_frame_at_time`` tools.
 
 Config (video_mcp_server.yaml)
 ───────────────────────────────
@@ -60,9 +62,11 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import ctypes
 import json
 import logging
 import pathlib
+import time
 
 import numpy as np
 import uvicorn
@@ -311,6 +315,22 @@ def _save_png(rgb: np.ndarray, out_path: pathlib.Path) -> None:
 
 # ── H.264 decode (PyNvVideoCodec) ────────────────────────────────────────────
 
+def _decoded_frame_to_nv12(frame) -> np.ndarray:
+    """Copy a ``DecodedFrame`` (host memory, NV12) into an owned numpy array.
+
+    PyNvVideoCodec 2.x ``DecodedFrame`` no longer implements the numpy
+    array interface, so ``np.array(frame, copy=True)`` returns an opaque
+    object array. Read the host-memory plane pointer via
+    ``GetPtrToPlane(0)`` and copy the bytes out as a contiguous uint8
+    buffer of shape ``(H*3//2, W)`` — the canonical NV12 layout the
+    encoder also consumes.
+    """
+    nbytes = frame.shape[0] * frame.shape[1]
+    buf_t  = ctypes.c_uint8 * nbytes
+    view   = buf_t.from_address(frame.GetPtrToPlane(0))
+    return np.ctypeslib.as_array(view).reshape(frame.shape).copy()
+
+
 def _decode_chunk_to_nv12_frames(annex_b: bytes, gpu_id: int = 0) -> list[np.ndarray]:
     """Decode an H.264 Annex B chunk into a list of NV12 numpy arrays.
 
@@ -319,15 +339,34 @@ def _decode_chunk_to_nv12_frames(annex_b: bytes, gpu_id: int = 0) -> list[np.nda
     fallback.
     """
     import PyNvVideoCodec as nvc
+    # PyNvVideoCodec >= 2.x dropped the string-form ``codec=`` argument and
+    # the raw-bytes form of ``Decode``. Pass the ``cudaVideoCodec`` enum
+    # and wrap the bitstream in a ``PacketData`` whose ``bsl_data`` points
+    # into a numpy buffer that outlives the call.
     decoder = nvc.CreateDecoder(
-        gpuid=gpu_id, codec="h264", cudacontext=0, cudastream=0,
+        gpuid=gpu_id, codec=nvc.cudaVideoCodec.H264, cudacontext=0, cudastream=0,
         usedevicememory=False,
     )
+
+    src = np.frombuffer(annex_b, dtype=np.uint8)
+    pkt = nvc.PacketData()
+    pkt.bsl      = int(src.size)
+    pkt.bsl_data = int(src.ctypes.data)
+
     frames: list[np.ndarray] = []
-    for frame in decoder.Decode(annex_b):
-        # `frame` exposes the NumPy buffer protocol; copy out so it
-        # outlives the decoder's internal slot.
-        frames.append(np.array(frame, copy=True))
+    for f in decoder.Decode(pkt):
+        frames.append(_decoded_frame_to_nv12(f))
+
+    # NVDEC keeps the last few frames in its reorder buffer until it sees
+    # an end-of-stream marker. Without this drain pass we silently drop
+    # ~7 of 30 frames per chunk.
+    eos = nvc.PacketData()
+    eos.bsl         = 0
+    eos.bsl_data    = 0
+    eos.decode_flag = int(nvc.VideoPacketFlag.ENDOFSTREAM)
+    for f in decoder.Decode(eos):
+        frames.append(_decoded_frame_to_nv12(f))
+
     return frames
 
 
@@ -346,7 +385,8 @@ def build_mcp(
     def list_live_participants() -> list[str]:
         """Return raw participant identities currently connected to the
         hub. Drawn from the live IPC roster — these are the only pids
-        for which ``get_latest_frame`` will return a frame."""
+        for which ``get_frame_from_time(..., second_ago=0)`` will return
+        a live frame."""
         return sorted(provider.connected_participants())
 
     @mcp.tool()
@@ -392,48 +432,105 @@ def build_mcp(
                 "start_us": start_us, "end_us": end_us}
 
     @mcp.tool()
-    async def get_latest_frame(participant_id: str) -> dict:
+    async def get_frame_from_time(
+        participant_id:    str,
+        second_ago:        int,
+        reference_time_us: int = 0,
+    ) -> dict:
         """
-        Fetch the most recent frame the hub has for *participant_id*,
-        encode to PNG, return the file path.
+        Retrieve a camera frame for *participant_id* near a chosen instant in
+        time, encode to PNG, and return the file path.
 
-        Keys: path, width, height, timestamp_us, track_id.
-        Returns an error dict if no live frame is available yet.
-        """
-        frame = await provider.fetch_latest(participant_id)
-        if frame is None:
-            return {"error": f"No live frame available for {participant_id!r}"}
-        try:
-            rgb = _frame_to_rgb(frame.data, frame.width, frame.height, frame.fmt)
-        except ValueError as exc:
-            return {"error": str(exc)}
-        safe     = _safe_name(participant_id)
-        out_path = out_dir / f"{safe}_latest_{frame.pts_us}.png"
-        _save_png(rgb, out_path)
-        log.info("get_latest_frame  pid=%r  %dx%d  ts=%d → %s",
-                 participant_id, frame.width, frame.height, frame.pts_us, out_path)
-        return {
-            "path":         str(out_path),
-            "width":        frame.width,
-            "height":       frame.height,
-            "timestamp_us": frame.pts_us,
-            "track_id":     frame.track_id,
-        }
+        Time anchor
+        -----------
+        ``reference_time_us`` is the "now" anchor in Unix microseconds. The
+        target instant is ``anchor - second_ago * 1_000_000``.
 
-    @mcp.tool()
-    def get_frame_at_time(participant_id: str, timestamp_us: int) -> dict:
-        """
-        Decode the H.264 chunk covering *timestamp_us* (Unix µs) for
-        *participant_id*, pick the frame closest to that timestamp,
-        encode to PNG, return the file path.
+        - ``reference_time_us = 0`` (omitted) ⇒ anchor = wall clock
+          ``time.time()``. With ``second_ago = 0`` you get the latest live
+          IPC frame; with ``second_ago > 0`` a recorded chunk near
+          ``now - N s``.
 
-        Keys: path, width, height, timestamp_us (the actual frame ts,
-        approximated by linear interpolation within the chunk), chunk_path.
-        Returns an error dict if no chunks cover the request.
+        - ``reference_time_us > 0`` ⇒ anchor = that timestamp. ALL lookups
+          go through the recorded-chunk path (live IPC is bypassed) so the
+          returned frame matches the user's reference frame in time, not
+          the wall clock at the moment this tool fires.
+
+        Why the anchor matters
+        ----------------------
+        LLM thinking + STT finalisation introduce 5-15 s of delay between
+        the user speaking and this tool being called. Without an anchor,
+        ``second_ago = 0`` returns a frame from "now" — i.e. seconds AFTER
+        the user finished asking. Workers that know when the user spoke
+        should pass that timestamp here.
+
+        Parameters
+        ----------
+        participant_id
+            Raw LiveKit identity; same value as in the hub's IPC roster.
+        second_ago
+            Seconds before the anchor. ``0`` means at the anchor; positive
+            means in the past relative to it. Negative values are an error.
+        reference_time_us
+            Optional Unix-microseconds anchor. ``0`` (default) means use
+            the wall clock and (for ``second_ago = 0``) the live IPC frame.
+
+        Returns
+        -------
+        dict
+            Keys: ``path``, ``width``, ``height``, ``timestamp_us`` (Unix
+            µs of the actual frame returned), ``second_ago`` (echoes the
+            request), ``actual_second_ago`` (how many seconds before the
+            wall clock the returned frame actually is — useful for
+            telemetry; may be negative if the chunk is newer than the
+            anchor).
+
+        Returns ``{"error": "..."}`` when no frame is available
+        (participant not connected for live, or recording disabled /
+        requested time outside the eviction window for chunk lookup).
         """
-        found = store.find_chunk_at(participant_id, timestamp_us)
+        if second_ago < 0:
+            return {"error": f"second_ago must be >= 0, got {second_ago}"}
+        if reference_time_us < 0:
+            return {"error": f"reference_time_us must be >= 0, got {reference_time_us}"}
+
+        now_us    = int(time.time() * 1_000_000)
+        anchor_us = reference_time_us if reference_time_us > 0 else now_us
+
+        # Live IPC path is taken ONLY when the caller wants "right now,
+        # wall clock" — i.e. no anchor provided AND no past offset. As
+        # soon as the caller anchors to an explicit timestamp (typically
+        # the user's speech time), we always go through the recorded
+        # chunk store so the returned frame matches that instant rather
+        # than the wall clock at tool-fire time.
+        if reference_time_us == 0 and second_ago == 0:
+            frame = await provider.fetch_latest(participant_id)
+            if frame is None:
+                return {"error": f"No live frame available for {participant_id!r}"}
+            try:
+                rgb = _frame_to_rgb(frame.data, frame.width, frame.height, frame.fmt)
+            except ValueError as exc:
+                return {"error": str(exc)}
+            safe     = _safe_name(participant_id)
+            out_path = out_dir / f"{safe}_ago0_{frame.pts_us}.png"
+            _save_png(rgb, out_path)
+            actual = (now_us - frame.pts_us) / 1_000_000
+            log.info("get_frame_from_time(0)  pid=%r  %dx%d  ts=%d (~%.2fs ago, live) → %s",
+                     participant_id, frame.width, frame.height, frame.pts_us, actual, out_path)
+            return {
+                "path":              str(out_path),
+                "width":             frame.width,
+                "height":            frame.height,
+                "timestamp_us":      frame.pts_us,
+                "second_ago":        0,
+                "actual_second_ago": actual,
+            }
+
+        # Anchored chunk lookup.
+        target_us = anchor_us - second_ago * 1_000_000
+        found = store.find_chunk_at(participant_id, target_us)
         if found is None:
-            return {"error": f"No video chunks recorded for {participant_id!r}"}
+            return {"error": f"No recorded video for {participant_id!r}. Recording may be disabled."}
         chunk_path, meta = found
         try:
             frames = _decode_chunk_to_nv12_frames(chunk_path.read_bytes(), gpu_id=gpu_id)
@@ -450,33 +547,40 @@ def build_mcp(
         height_nv  = frames[0].shape[0]
         height     = int(meta.get("height", height_nv * 2 // 3))
 
-        # Linear interpolation: which frame index is closest to ts_us?
         if num_frames <= 1 or end_us <= start_us:
             idx = 0
         else:
-            ratio = (timestamp_us - start_us) / (end_us - start_us)
+            ratio = (target_us - start_us) / (end_us - start_us)
             idx   = max(0, min(num_frames - 1, round(ratio * (num_frames - 1))))
         idx = min(idx, len(frames) - 1)
 
         nv12     = frames[idx]
         rgb      = _nv12_to_rgb(nv12, width, height)
         safe     = _safe_name(participant_id)
-        out_path = out_dir / f"{safe}_at_{timestamp_us}.png"
+        out_path = out_dir / f"{safe}_ago{second_ago}_{target_us}.png"
         _save_png(rgb, out_path)
 
-        # Approximate frame timestamp (uniform spacing inside the chunk).
-        frame_ts = (
+        frame_ts  = (
             start_us + idx * (end_us - start_us) // max(num_frames - 1, 1)
             if num_frames > 1 else start_us
         )
-        log.info("get_frame_at_time  pid=%r  ts=%d  frame=%d/%d → %s",
-                 participant_id, timestamp_us, idx, num_frames, out_path)
+        actual    = (now_us - frame_ts)    / 1_000_000
+        anchored  = bool(reference_time_us > 0)
+        anchor_dt = (now_us - anchor_us)   / 1_000_000 if anchored else 0.0
+        log.info(
+            "get_frame_from_time(%d)  pid=%r  ts=%d (~%.2fs ago wall, anchored=%s%s)"
+            "  frame=%d/%d → %s",
+            second_ago, participant_id, frame_ts, actual,
+            anchored, f", anchor={anchor_dt:.2f}s ago" if anchored else "",
+            idx, num_frames, out_path,
+        )
         return {
-            "path":         str(out_path),
-            "width":        width,
-            "height":       height,
-            "timestamp_us": frame_ts,
-            "chunk_path":   str(chunk_path),
+            "path":              str(out_path),
+            "width":             width,
+            "height":            height,
+            "timestamp_us":      frame_ts,
+            "second_ago":        second_ago,
+            "actual_second_ago": actual,
         }
 
     return mcp

--- a/agent-mcp-servers/vlm-mcp/pyproject.toml
+++ b/agent-mcp-servers/vlm-mcp/pyproject.toml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "vlm-mcp-server"
+version = "0.1.0"
+requires-python = ">=3.11,<3.13"
+dependencies = [
+    "uvicorn[standard]>=0.29",
+    "fastmcp>=0.4",
+    "pyyaml>=6.0",
+    "httpx>=0.27",
+    "Pillow>=10.0",
+]
+
+[project.scripts]
+vlm_mcp_server = "vlm_mcp_server.__main__:run"
+
+[tool.hatch.build.targets.wheel]
+packages = ["vlm_mcp_server"]

--- a/agent-mcp-servers/vlm-mcp/vlm_mcp_server.yaml
+++ b/agent-mcp-servers/vlm-mcp/vlm_mcp_server.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# VLM MCP server reference configuration.
+# Copy to your agent sample root as vlm_mcp_server.yaml and edit.
+#
+# This server is a pure FastMCP wrapper around vlm-server (ai-services/vlm-server/).
+# It exposes one MCP tool — ask_image(question, image_path) — that reads a local
+# image file and POSTs it to vlm-server's OpenAI-compatible chat-completions
+# endpoint. There is no hub IPC subscription and no `xr-ai-agent` dependency.
+#
+# The MCP endpoint is served at http://<host>:<port>/mcp via StreamableHTTP.
+# Use the URL WITHOUT a trailing slash — Starlette's strict path matching
+# replies with 307 redirect on /mcp/, which NAT's streamable-http MCP client
+# treats as an error.
+
+host:                  0.0.0.0
+port:                  8220
+
+# URL of the vlm-server (ai-services/vlm-server/). The MCP tool forwards the
+# loaded image + the LLM's question to this service over HTTP.
+vlm_server:            http://localhost:8100
+
+# httpx timeout applied to each POST /v1/chat/completions call to vlm-server.
+vlm_request_timeout_s: 60.0

--- a/agent-mcp-servers/vlm-mcp/vlm_mcp_server/__init__.py
+++ b/agent-mcp-servers/vlm-mcp/vlm_mcp_server/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from .__main__ import VlmClient, build_mcp
+
+__all__ = ["VlmClient", "build_mcp"]

--- a/agent-mcp-servers/vlm-mcp/vlm_mcp_server/__main__.py
+++ b/agent-mcp-servers/vlm-mcp/vlm_mcp_server/__main__.py
@@ -1,0 +1,260 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+VLM MCP server.
+
+Pure FastMCP — one tool at /mcp on port 8220. There are no REST endpoints,
+no hub IPC subscription, and no `xr-ai-agent` runtime dependency.
+
+The single tool ``ask_image(question, image_path)`` reads a local PNG path,
+encodes it as a JPEG data URL, and POSTs to vlm-server's OpenAI-compatible
+``/v1/chat/completions`` endpoint. The model's answer is returned verbatim.
+
+Typical two-step agent flow
+───────────────────────────
+1. Call ``video_mcp.get_frame_from_time(participant_id, second_ago=0)``
+   (or ``second_ago=N`` for a frame from N seconds ago) to obtain a PNG
+   path on the local filesystem.
+2. Pass that path straight into ``ask_image`` along with your question.
+
+vlm-mcp itself knows nothing about participants, the hub, or the frame
+source — it just reads a file and forwards it to the VLM.
+
+Tool (FastMCP, mounted at /mcp)
+────────────────────────────────
+  ask_image(question, image_path) → str
+      Send the local image at *image_path* and *question* to vlm-server
+      and return the answer text. Reads the file synchronously inside an
+      executor; the asyncio loop is never blocked.
+
+Config (vlm_mcp_server.yaml)
+────────────────────────────
+    host:                 0.0.0.0
+    port:                 8220
+    vlm_server:           http://localhost:8100
+    vlm_request_timeout_s: 60.0
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import io
+import logging
+import pathlib
+from contextlib import asynccontextmanager
+
+import httpx
+import uvicorn
+import yaml
+from fastmcp import FastMCP
+from PIL import Image
+
+log = logging.getLogger("vlm_mcp_server")
+
+
+# ── VLM HTTP client ───────────────────────────────────────────────────────────
+
+class VlmClient:
+    """Thin async client for vlm-server's OpenAI-compatible chat endpoint."""
+
+    def __init__(self, base_url: str, timeout: float) -> None:
+        self._url = base_url.rstrip("/") + "/v1/chat/completions"
+        self._client = httpx.AsyncClient(timeout=timeout)
+
+    async def ask(self, image_data_url: str, question: str) -> str:
+        payload = {
+            "model": "vlm",
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": image_data_url}},
+                    {"type": "text", "text": question},
+                ],
+            }],
+        }
+        resp = await self._client.post(self._url, json=payload)
+        resp.raise_for_status()
+        return resp.json()["choices"][0]["message"]["content"]
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+
+# ── image helpers ─────────────────────────────────────────────────────────────
+
+def _load_jpeg_data_url(image_path: str, quality: int = 85) -> str:
+    """Open *image_path*, convert to RGB, encode as a JPEG data URL.
+
+    Runs synchronously — caller is expected to invoke via
+    ``loop.run_in_executor`` to keep the asyncio loop responsive.
+    """
+    with Image.open(image_path) as img:
+        img = img.convert("RGB")
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG", quality=quality)
+    b64 = base64.b64encode(buf.getvalue()).decode("ascii")
+    return f"data:image/jpeg;base64,{b64}"
+
+
+# ── FastMCP build ─────────────────────────────────────────────────────────────
+
+def build_mcp(vlm: VlmClient) -> FastMCP:
+    """Return a FastMCP server with the single ``ask_image`` tool bound."""
+    mcp = FastMCP("vlm-mcp")
+
+    @mcp.tool()
+    async def ask_image(question: str, image_path: str) -> str:
+        """
+        Ask the vision-language model a question about a local image file.
+
+        This is the primary tool for any task that requires visual understanding
+        of the XR scene: describing what the user sees, reading text on screen,
+        identifying objects, checking UI state, answering user questions about
+        their environment, and so on.
+
+        Typical usage pattern
+        ---------------------
+        Step 1 — acquire a frame::
+
+            frame = video_mcp.get_frame_from_time(
+                participant_id="alice",
+                second_ago=0,            # live frame (what the user sees right now)
+                # second_ago=3,          # frame from 3 seconds ago
+                # reference_time_us=..., # pass the user's speech timestamp to avoid
+                #                        # LLM-thinking delay shifting the frame
+            )
+            # frame["path"] is an absolute path to a PNG on the local filesystem
+
+        Step 2 — ask the VLM::
+
+            answer = vlm_mcp.ask_image(
+                question="What objects are on the table?",
+                image_path=frame["path"],
+            )
+
+        Good ``question`` values
+        -------------------------
+        - The user's exact words:  "what is that?"
+        - A rephrasing:            "Describe what the user is looking at."
+        - A specific sub-question: "What text appears on the whiteboard?"
+        - A follow-up:             "List every distinct color visible in the scene."
+        - Counting:                "How many people are in the frame?"
+        - Spatial:                 "Is there anything in the top-left corner?"
+
+        Parameters
+        ----------
+        question
+            Free-form natural-language question or instruction for the VLM.
+            The model receives both the image and this text in the same turn.
+        image_path
+            Absolute path to a local image file (PNG or JPEG). Typically the
+            ``path`` value returned by ``video_mcp.get_frame_from_time``.
+            The file is read from disk and sent to vlm-server as a
+            base64-encoded JPEG (quality 85).
+
+        Returns
+        -------
+        str
+            The VLM's answer, trimmed of leading/trailing whitespace.
+            On error (file not found, server unreachable, etc.) returns a
+            human-readable error string starting with ``"ask_image: ..."``.
+
+        Notes
+        -----
+        - Image I/O runs in a thread pool so the asyncio event loop is never
+          blocked even for large frames.
+        - The tool does NOT maintain conversation history. Each call is
+          independent; pass relevant context in ``question`` if needed.
+        - vlm-server must be running at the ``vlm_server`` URL configured in
+          ``vlm_mcp_server.yaml`` (default: http://localhost:8100).
+        """
+        if not image_path:
+            return "ask_image: image_path is empty — call video_mcp.get_frame_from_time first."
+        path = pathlib.Path(image_path)
+        if not path.exists():
+            return f"ask_image: file not found at {image_path!r}."
+
+        loop = asyncio.get_running_loop()
+        try:
+            data_url = await loop.run_in_executor(None, _load_jpeg_data_url, str(path))
+        except Exception as exc:
+            log.exception("ask_image: failed to load %s", image_path)
+            return f"ask_image: failed to read image at {image_path!r}: {exc}"
+
+        try:
+            answer = await vlm.ask(data_url, question)
+        except httpx.HTTPError as exc:
+            log.exception("ask_image: vlm-server HTTP error")
+            return f"ask_image: vlm-server request failed: {exc}"
+
+        log.info(
+            "ask_image  q=%r  image=%s  -> %d chars",
+            question[:80], path.name, len(answer),
+        )
+        return answer.strip()
+
+    return mcp
+
+
+# ── server ────────────────────────────────────────────────────────────────────
+
+async def _serve(cfg: dict) -> None:
+    host                  = cfg.get("host", "0.0.0.0")
+    port                  = int(cfg.get("port", 8220))
+    vlm_server            = cfg.get("vlm_server", "http://localhost:8100")
+    vlm_request_timeout_s = float(cfg.get("vlm_request_timeout_s", 60.0))
+
+    vlm = VlmClient(vlm_server, timeout=vlm_request_timeout_s)
+    mcp = build_mcp(vlm)
+    app = mcp.http_app(path="/mcp")
+
+    @asynccontextmanager
+    async def _lifespan(_app):
+        try:
+            yield
+        finally:
+            await vlm.close()
+
+    # FastMCP installs its own lifespan on the returned ASGI app; chain ours
+    # so the VLM client is closed cleanly when uvicorn shuts down.
+    base_lifespan = app.router.lifespan_context
+
+    @asynccontextmanager
+    async def _combined(_app):
+        async with base_lifespan(_app):
+            async with _lifespan(_app):
+                yield
+
+    app.router.lifespan_context = _combined
+
+    config = uvicorn.Config(app, host=host, port=port, log_level="warning")
+    server = uvicorn.Server(config)
+
+    log.info(
+        "vlm-mcp-server  port=%d  vlm_server=%s  timeout=%.1fs",
+        port, vlm_server, vlm_request_timeout_s,
+    )
+    await server.serve()
+
+
+def run() -> None:
+    p = argparse.ArgumentParser(add_help=False)
+    p.add_argument("--config", type=pathlib.Path, default=None)
+    ns, _ = p.parse_known_args()
+
+    cfg: dict = {}
+    if ns.config and ns.config.exists():
+        with open(ns.config) as f:
+            cfg = yaml.safe_load(f) or {}
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+    asyncio.run(_serve(cfg))
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary

- **vlm-mcp** (new server): wraps `vlm-server` as an MCP tool so agents can ask visual questions about local image files with a single `ask_image(question, image_path)` call. No hub IPC or `xr-ai-agent` dependency.
- **video-mcp**: replaces the two separate `get_latest_frame` / `get_frame_at_time` tools with a unified `get_frame_from_time` API; updates H.264 decoding for PyNvVideoCodec 2.x.

## video-mcp changes

### `get_frame_from_time` unified tool
Replaces `get_latest_frame` and `get_frame_at_time`. The new signature:
```python
get_frame_from_time(participant_id, second_ago, reference_time_us=0)
```
- `second_ago=0, reference_time_us=0` → live IPC frame (same as old `get_latest_frame`)
- `second_ago=N` → chunk N seconds before the wall clock
- `reference_time_us=<speech_ts_us>` → anchor to the user's speech timestamp, bypassing the 5–15 s LLM-thinking delay that made wall-clock lookups return frames from after the user finished speaking

### PyNvVideoCodec 2.x decode path
- `codec=nvc.cudaVideoCodec.H264` enum instead of the dropped string form
- Bitstream wrapped in `PacketData` with `bsl_data` pointer into a numpy buffer
- EOS drain pass (`VideoPacketFlag.ENDOFSTREAM`) recovers ~7 trailing frames per chunk that NVDEC held in its reorder buffer
- New `_decoded_frame_to_nv12` helper reads host-memory plane via `ctypes` since 2.x dropped the numpy buffer protocol on `DecodedFrame`

The TOCTOU-safe `self._root = recordings_dir.resolve()` from the security branch is preserved (upstream uses per-call `.resolve()`).

## vlm-mcp (new)

Single tool: `ask_image(question, image_path)`

**Typical two-step agent flow:**
```
frame = video_mcp.get_frame_from_time(participant_id="alice", second_ago=0)
answer = vlm_mcp.ask_image(question="What is on the table?", image_path=frame["path"])
```

The tool docstring is written specifically for LLM agent consumption — includes the two-step usage pattern, example questions, parameter semantics, and the error return convention.

## Test plan

- [ ] `cd tests && uv run pytest -v` — 38/38 pass (verified locally)
- [ ] Verify `get_frame_from_time(second_ago=0)` returns a live frame on a running hub
- [ ] Verify `get_frame_from_time(second_ago=5, reference_time_us=<ts>)` decodes from the recorded chunk store at the expected timestamp
- [ ] Verify `vlm_mcp_server` starts and responds to `ask_image` with a valid PNG path

🤖 Generated with [Claude Code](https://claude.com/claude-code)