### PR TITLE
feat(ai-services): add Docker Model Runner variants and nemotron-omni vLLM service

### DIFF
--- a/ai-services/llm/nemotron3_nano_docker/nemotron3_nano_docker_llm_server.yaml
+++ b/ai-services/llm/nemotron3_nano_docker/nemotron3_nano_docker_llm_server.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Nemotron-3-Nano tool-calling LLM — Docker Model Runner variant.
+# Replaces nemotron3_nano_llm_server (vLLM) with Docker Model Runner.
+#
+# API endpoint: http://localhost:12434/engines/llama.cpp/v1
+# Model name in API requests: the selected model image (e.g. model_ada below).
+#
+# GPU auto-selection:
+#   Blackwell (SM100+)  → model_blackwell  (NVFP4, ~20 GB VRAM)
+#   Ada / Hopper / etc. → model_ada        (FP8,   ~30 GB VRAM)
+#   Any (use_small)     → model_small      (FP8,   ~10 GB VRAM)
+
+use_small: false
+
+model_blackwell: hf.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4
+model_ada:       hf.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8
+model_small:     hf.co/nvidia/NVIDIA-Nemotron-Nano-9B-v2-FP8

--- a/ai-services/llm/nemotron3_nano_docker/nemotron3_nano_docker_llm_server/__init__.py
+++ b/ai-services/llm/nemotron3_nano_docker/nemotron3_nano_docker_llm_server/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/ai-services/llm/nemotron3_nano_docker/nemotron3_nano_docker_llm_server/__main__.py
+++ b/ai-services/llm/nemotron3_nano_docker/nemotron3_nano_docker_llm_server/__main__.py
@@ -37,6 +37,29 @@ _MODEL_ADA       = "hf.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8"
 _MODEL_SMALL     = "hf.co/nvidia/NVIDIA-Nemotron-Nano-9B-v2-FP8"
 
 
+def _require_docker_model_runner() -> None:
+    """Exit with a clear message if the Docker Model Runner plugin is not installed."""
+    result = subprocess.run(
+        ["docker", "model", "version"],
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        print(
+            "[nemotron3_nano_docker] ERROR: Docker Model Runner plugin not found.\n"
+            "\n"
+            "Install it on Linux:\n"
+            "  sudo apt-get install docker-model-plugin\n"
+            "\n"
+            "Or follow the official guide:\n"
+            "  https://docs.docker.com/model-runner/\n"
+            "\n"
+            "Alternatively, use the vLLM-based service instead:\n"
+            "  ai-services/llm/nemotron3_nano/",
+            flush=True,
+        )
+        sys.exit(1)
+
+
 def _gpu_compute_major() -> int:
     try:
         out = subprocess.check_output(
@@ -62,6 +85,8 @@ def run() -> None:
     if ns.config and ns.config.exists():
         with open(ns.config) as f:
             cfg = yaml.safe_load(f) or {}
+
+    _require_docker_model_runner()
 
     if cfg.get("use_small", False):
         model = cfg.get("model_small", _MODEL_SMALL)

--- a/ai-services/llm/nemotron3_nano_docker/nemotron3_nano_docker_llm_server/__main__.py
+++ b/ai-services/llm/nemotron3_nano_docker/nemotron3_nano_docker_llm_server/__main__.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+nemotron3_nano_docker_llm_server — Docker Model Runner launcher for the
+Nemotron-3-Nano tool-calling LLM.
+
+Drop-in replacement for nemotron3_nano_llm_server that uses Docker Model
+Runner instead of vLLM.  Selects the model variant based on GPU compute
+capability, pulls it, then execs into ``docker model run``.
+
+API endpoint (Docker Model Runner):
+    http://localhost:12434/engines/llama.cpp/v1
+
+Use this model name in OpenAI API requests (the selected variant):
+    hf.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8         (Ada/Hopper)
+    hf.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4       (Blackwell)
+    hf.co/nvidia/NVIDIA-Nemotron-Nano-9B-v2-FP8             (use_small)
+
+Config keys (nemotron3_nano_docker_llm_server.yaml)
+----------------------------------------------------
+    model_blackwell: str   Model image for Blackwell GPUs (SM100+).
+    model_ada:       str   Model image for Ada / Hopper / Ampere.
+    model_small:     str   9B variant — low VRAM or development use.
+    use_small:       bool  Always use model_small regardless of GPU (default: false).
+"""
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+_MODEL_BLACKWELL = "hf.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4"
+_MODEL_ADA       = "hf.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8"
+_MODEL_SMALL     = "hf.co/nvidia/NVIDIA-Nemotron-Nano-9B-v2-FP8"
+
+
+def _gpu_compute_major() -> int:
+    try:
+        out = subprocess.check_output(
+            ["nvidia-smi", "--query-gpu=compute_cap", "--format=csv,noheader,nounits"],
+            text=True, stderr=subprocess.DEVNULL,
+        ).strip().splitlines()
+        if out:
+            return int(out[0].split(".")[0])
+    except Exception:
+        pass
+    return 0
+
+
+def run() -> None:
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
+
+    p = argparse.ArgumentParser(add_help=False)
+    p.add_argument("--config", type=Path, default=None)
+    ns, _ = p.parse_known_args()
+
+    cfg: dict = {}
+    if ns.config and ns.config.exists():
+        with open(ns.config) as f:
+            cfg = yaml.safe_load(f) or {}
+
+    if cfg.get("use_small", False):
+        model = cfg.get("model_small", _MODEL_SMALL)
+        print(f"[nemotron3_nano_docker] use_small=true → {model}", flush=True)
+    else:
+        major = _gpu_compute_major()
+        if major >= 10:
+            model = cfg.get("model_blackwell", _MODEL_BLACKWELL)
+            print(f"[nemotron3_nano_docker] Blackwell (SM{major}0) → {model}", flush=True)
+        else:
+            model = cfg.get("model_ada", _MODEL_ADA)
+            arch  = f"SM{major}0" if major > 0 else "unknown GPU"
+            print(f"[nemotron3_nano_docker] Pre-Blackwell ({arch}) → {model}", flush=True)
+
+    print(f"[nemotron3_nano_docker] Pulling {model}…", flush=True)
+    subprocess.run(["docker", "model", "pull", model], check=True)
+
+    print(
+        "[nemotron3_nano_docker] Starting Docker Model Runner — "
+        "API: http://localhost:12434/engines/llama.cpp/v1",
+        flush=True,
+    )
+    os.execvp("docker", ["docker", "model", "run", model])
+
+
+if __name__ == "__main__":
+    run()

--- a/ai-services/llm/nemotron3_nano_docker/pyproject.toml
+++ b/ai-services/llm/nemotron3_nano_docker/pyproject.toml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "nemotron3-nano-docker-llm-server"
+version = "0.1.0"
+requires-python = ">=3.11,<3.13"
+dependencies = [
+    # Model weights are pulled and served via Docker Model Runner.
+    # No vLLM or HuggingFace download dependencies needed.
+    "pyyaml>=6.0",
+]
+
+[project.scripts]
+nemotron3_nano_docker_llm_server = "nemotron3_nano_docker_llm_server.__main__:run"
+
+[tool.hatch.build.targets.wheel]
+packages = ["nemotron3_nano_docker_llm_server"]

--- a/ai-services/llm/nemotron_omni/nemotron_omni_llm_server.yaml
+++ b/ai-services/llm/nemotron_omni/nemotron_omni_llm_server.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Nemotron-3-Nano-Omni conversational / voice-entry LLM — vLLM configuration.
+# OpenAI-compatible API at http://localhost:8107/v1  (served-model-name: "llm")
+#
+# Model is auto-selected based on GPU compute capability:
+#   Blackwell (SM100+)  → model_blackwell  (NVFP4, ~20 GB VRAM)
+#   Ada / Hopper / etc. → model_ada        (FP8,   ~30 GB VRAM)
+#
+# This service is the real-time voice entry point. Workers should set their
+# llm_server to http://localhost:8107/v1 and use model: "llm".
+
+model_blackwell: nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4
+model_ada:       nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8
+
+host: "0.0.0.0"
+port: 8107
+
+# HuggingFace token — not required for these models (Apache 2.0 + NVIDIA Open
+# Model License, no gating). Leave empty.
+hf_token: ""
+
+# Weight + reasoning-parser cache, relative to this YAML.
+model_cache: ../../models
+
+# vLLM knobs — tune based on available VRAM and co-tenants.
+max_num_seqs:         8
+tensor_parallel_size: 1
+max_model_len:        32768
+gpu_memory_utilization: 0.85
+
+# Skip CUDA graph capture on first start (3-8 min for MoE + Mamba-2 layers).
+# Set to false for maximum throughput once startup time is acceptable.
+enforce_eager: true

--- a/ai-services/llm/nemotron_omni/nemotron_omni_llm_server/__init__.py
+++ b/ai-services/llm/nemotron_omni/nemotron_omni_llm_server/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/ai-services/llm/nemotron_omni/nemotron_omni_llm_server/__main__.py
+++ b/ai-services/llm/nemotron_omni/nemotron_omni_llm_server/__main__.py
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+nemotron_omni_llm_server — vLLM launcher for the Nemotron-3-Nano-Omni
+real-time conversational / voice-entry LLM.
+
+Selects the FP8 or NVFP4 model variant based on GPU compute capability,
+downloads the nano_v3 reasoning-parser plugin once, and execs into
+``vllm serve`` so the launcher owns the subprocess.
+
+Config keys (nemotron_omni_llm_server.yaml)
+-------------------------------------------
+    model_blackwell:         str    HuggingFace model ID for Blackwell (SM100+).
+    model_ada:               str    HuggingFace model ID for Ada / Hopper / Ampere.
+    host:                    str    Bind address (default: "0.0.0.0").
+    port:                    int    HTTP port (default: 8107).
+    hf_token:                str    HuggingFace token (leave empty — model is ungated).
+    model_cache:             str    Weight + plugin cache dir, relative to this YAML.
+    max_num_seqs:            int    vLLM --max-num-seqs (default: 8).
+    tensor_parallel_size:    int    vLLM --tensor-parallel-size (default: 1).
+    max_model_len:           int    vLLM --max-model-len (default: 32768).
+    gpu_memory_utilization:  float  vLLM --gpu-memory-utilization (default: 0.85).
+    enforce_eager:           bool   Skip CUDA graph capture (default: true).
+    parser_url:              str    URL to fetch nano_v3_reasoning_parser.py.
+                                    Defaults to the NVFP4 model's HuggingFace page.
+"""
+import argparse
+import os
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+
+import yaml
+
+_MODEL_BLACKWELL = "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4"
+_MODEL_ADA       = "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8"
+
+_DEFAULT_PORT      = 8107
+_DEFAULT_HOST      = "0.0.0.0"
+_DEFAULT_SEQS      = 8
+_DEFAULT_TP        = 1
+_DEFAULT_CTX       = 32768
+_DEFAULT_GPU_MEM   = 0.85
+_DEFAULT_EAGER     = True
+
+_PARSER_FILENAME = "nano_v3_reasoning_parser.py"
+# Shared across the Nemotron-3-Nano family; hosted on the NVFP4 model page.
+_PARSER_URL_DEFAULT = (
+    "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4"
+    f"/resolve/main/{_PARSER_FILENAME}"
+)
+
+
+def _gpu_compute_major() -> int:
+    """Return the compute-capability major version of GPU 0 via nvidia-smi."""
+    try:
+        out = subprocess.check_output(
+            ["nvidia-smi", "--query-gpu=compute_cap", "--format=csv,noheader,nounits"],
+            text=True, stderr=subprocess.DEVNULL,
+        ).strip().splitlines()
+        if out:
+            return int(out[0].split(".")[0])
+    except Exception:
+        pass
+    return 0
+
+
+def _resolve_model_cache(cfg: dict, yaml_dir: Path) -> Path:
+    raw = cfg.get("model_cache", "../../models")
+    p = Path(raw)
+    if not p.is_absolute():
+        p = (yaml_dir / p).resolve()
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def _ensure_reasoning_parser(model_cache: Path, url: str) -> Path:
+    path = model_cache / _PARSER_FILENAME
+    if not path.exists():
+        print(f"[nemotron_omni] Downloading {_PARSER_FILENAME}…", flush=True)
+        try:
+            with urllib.request.urlopen(url) as resp:
+                path.write_bytes(resp.read())
+        except Exception as exc:
+            raise RuntimeError(f"Failed to download reasoning parser from {url}: {exc}") from exc
+    return path
+
+
+def run() -> None:
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
+
+    p = argparse.ArgumentParser(add_help=False)
+    p.add_argument("--config", type=Path, default=None)
+    ns, _ = p.parse_known_args()
+
+    cfg: dict = {}
+    yaml_dir = Path.cwd()
+    if ns.config and ns.config.exists():
+        yaml_dir = ns.config.parent.resolve()
+        with open(ns.config) as f:
+            cfg = yaml.safe_load(f) or {}
+
+    major = _gpu_compute_major()
+    if major >= 10:
+        model = cfg.get("model_blackwell", _MODEL_BLACKWELL)
+        print(f"[nemotron_omni] Blackwell (SM{major}0) → {model}", flush=True)
+    else:
+        model = cfg.get("model_ada", _MODEL_ADA)
+        arch  = f"SM{major}0" if major > 0 else "unknown GPU"
+        print(f"[nemotron_omni] Pre-Blackwell ({arch}) → {model}", flush=True)
+
+    host         = cfg.get("host", _DEFAULT_HOST)
+    port         = int(cfg.get("port", _DEFAULT_PORT))
+    max_seqs     = int(cfg.get("max_num_seqs", _DEFAULT_SEQS))
+    tp_size      = int(cfg.get("tensor_parallel_size", _DEFAULT_TP))
+    max_ctx      = int(cfg.get("max_model_len", _DEFAULT_CTX))
+    gpu_mem      = float(cfg.get("gpu_memory_utilization", _DEFAULT_GPU_MEM))
+    enforce_eager = bool(cfg.get("enforce_eager", _DEFAULT_EAGER))
+    parser_url   = cfg.get("parser_url", _PARSER_URL_DEFAULT)
+
+    model_cache = _resolve_model_cache(cfg, yaml_dir)
+
+    if hf_token := (cfg.get("hf_token") or os.environ.get("HF_TOKEN", "")):
+        os.environ["HF_TOKEN"] = hf_token
+    os.environ.setdefault("HF_HUB_ENABLE_HF_TRANSFER", "1")
+    os.environ["HF_HOME"] = str(model_cache)
+
+    # NVFP4 FlashInfer MoE kernels are Blackwell-only.
+    if major >= 10 and "NVFP4" in model:
+        os.environ["VLLM_USE_FLASHINFER_MOE_FP4"] = "1"
+        os.environ["VLLM_FLASHINFER_MOE_BACKEND"]  = "throughput"
+
+    parser_path = _ensure_reasoning_parser(model_cache, parser_url)
+
+    argv = [
+        "vllm", "serve", model,
+        "--served-model-name", "llm",
+        "--host", host,
+        "--port", str(port),
+        "--trust-remote-code",
+        "--enable-auto-tool-choice",
+        "--tool-call-parser", "qwen3_coder",
+        "--reasoning-parser-plugin", str(parser_path),
+        "--reasoning-parser", "nano_v3",
+        "--max-num-seqs", str(max_seqs),
+        "--tensor-parallel-size", str(tp_size),
+        "--max-model-len", str(max_ctx),
+        "--gpu-memory-utilization", str(gpu_mem),
+    ]
+    if major >= 10:
+        argv.extend(["--kv-cache-dtype", "fp8"])
+    if enforce_eager:
+        argv.append("--enforce-eager")
+
+    print(
+        f"[nemotron_omni] Launching vLLM  http://{host}:{port}/v1  model={model}",
+        flush=True,
+    )
+    os.execvp(argv[0], argv)
+
+
+if __name__ == "__main__":
+    run()

--- a/ai-services/llm/nemotron_omni/pyproject.toml
+++ b/ai-services/llm/nemotron_omni/pyproject.toml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "nemotron-omni-llm-server"
+version = "0.1.0"
+requires-python = ">=3.11,<3.13"
+dependencies = [
+    # vLLM provides the OpenAI-compatible HTTP server, the Qwen3-coder
+    # tool-call parser, and the nano_v3 reasoning parser plugin.
+    "vllm>=0.12.0",
+    "pyyaml>=6.0",
+    "hf-transfer>=0.1.4",
+]
+
+[project.scripts]
+nemotron_omni_llm_server = "nemotron_omni_llm_server.__main__:run"
+
+[tool.hatch.build.targets.wheel]
+packages = ["nemotron_omni_llm_server"]

--- a/ai-services/vlm-server-docker/pyproject.toml
+++ b/ai-services/vlm-server-docker/pyproject.toml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "vlm-server-docker"
+version = "0.1.0"
+requires-python = ">=3.11,<3.13"
+dependencies = [
+    # Model weights are pulled and served via Docker Model Runner.
+    "pyyaml>=6.0",
+]
+
+[project.scripts]
+vlm_server_docker = "vlm_server_docker.__main__:run"
+
+[tool.hatch.build.targets.wheel]
+packages = ["vlm_server_docker"]

--- a/ai-services/vlm-server-docker/vlm_server_docker.yaml
+++ b/ai-services/vlm-server-docker/vlm_server_docker.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# VLM server — Docker Model Runner variant.
+# Replaces vlm_server (transformers in-process) with Docker Model Runner.
+#
+# API endpoint: http://localhost:12434/engines/llama.cpp/v1
+# Model name in API requests: the value of `model` below.
+#
+# To use this with vlm-mcp, set vlm_mcp_server.yaml to:
+#   vlm_server:     http://localhost:12434/engines/llama.cpp
+#   vlm_model_name: hf.co/nvidia/Cosmos-Reason1-7B
+
+model: hf.co/nvidia/Cosmos-Reason1-7B

--- a/ai-services/vlm-server-docker/vlm_server_docker/__init__.py
+++ b/ai-services/vlm-server-docker/vlm_server_docker/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/ai-services/vlm-server-docker/vlm_server_docker/__main__.py
+++ b/ai-services/vlm-server-docker/vlm_server_docker/__main__.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+vlm_server_docker — Docker Model Runner launcher for Cosmos-Reason1-7B.
+
+Drop-in replacement for vlm_server (transformers in-process) that uses
+Docker Model Runner instead.  Pulls the model then execs into
+``docker model run``.
+
+API endpoint (Docker Model Runner):
+    http://localhost:12434/engines/llama.cpp/v1
+
+Use this model name in OpenAI API requests:
+    hf.co/nvidia/Cosmos-Reason1-7B  (or whatever model: is set to below)
+
+Config keys (vlm_server_docker.yaml)
+--------------------------------------
+    model: str   Docker Model Runner image (default: hf.co/nvidia/Cosmos-Reason1-7B).
+"""
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+_DEFAULT_MODEL = "hf.co/nvidia/Cosmos-Reason1-7B"
+
+
+def run() -> None:
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
+
+    p = argparse.ArgumentParser(add_help=False)
+    p.add_argument("--config", type=Path, default=None)
+    ns, _ = p.parse_known_args()
+
+    cfg: dict = {}
+    if ns.config and ns.config.exists():
+        with open(ns.config) as f:
+            cfg = yaml.safe_load(f) or {}
+
+    model = cfg.get("model", _DEFAULT_MODEL)
+
+    print(f"[vlm_server_docker] Pulling {model}…", flush=True)
+    subprocess.run(["docker", "model", "pull", model], check=True)
+
+    print(
+        "[vlm_server_docker] Starting Docker Model Runner — "
+        "API: http://localhost:12434/engines/llama.cpp/v1",
+        flush=True,
+    )
+    os.execvp("docker", ["docker", "model", "run", model])
+
+
+if __name__ == "__main__":
+    run()

--- a/ai-services/vlm-server-docker/vlm_server_docker/__main__.py
+++ b/ai-services/vlm-server-docker/vlm_server_docker/__main__.py
@@ -29,6 +29,29 @@ import yaml
 _DEFAULT_MODEL = "hf.co/nvidia/Cosmos-Reason1-7B"
 
 
+def _require_docker_model_runner() -> None:
+    """Exit with a clear message if the Docker Model Runner plugin is not installed."""
+    result = subprocess.run(
+        ["docker", "model", "version"],
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        print(
+            "[vlm_server_docker] ERROR: Docker Model Runner plugin not found.\n"
+            "\n"
+            "Install it on Linux:\n"
+            "  sudo apt-get install docker-model-plugin\n"
+            "\n"
+            "Or follow the official guide:\n"
+            "  https://docs.docker.com/model-runner/\n"
+            "\n"
+            "Alternatively, use the in-process VLM server:\n"
+            "  ai-services/vlm-server/",
+            flush=True,
+        )
+        sys.exit(1)
+
+
 def run() -> None:
     sys.stdout.reconfigure(line_buffering=True)
     sys.stderr.reconfigure(line_buffering=True)
@@ -41,6 +64,8 @@ def run() -> None:
     if ns.config and ns.config.exists():
         with open(ns.config) as f:
             cfg = yaml.safe_load(f) or {}
+
+    _require_docker_model_runner()
 
     model = cfg.get("model", _DEFAULT_MODEL)
 

--- a/scripts/test_nemotron3_nano_docker.py
+++ b/scripts/test_nemotron3_nano_docker.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""
+Manual test: nemotron3_nano_docker_llm_server (Docker Model Runner).
+
+Launches the service via `uv run`, waits for it to be ready, runs tests,
+then stops it.  No manual `docker model run` needed.
+
+Usage:
+    python3 scripts/test_nemotron3_nano_docker.py
+
+    # Override repo root if needed:
+    REPO=/path/to/xr-ai python3 ...
+
+    # Use the small 9B model (faster for quick testing):
+    USE_SMALL=1 python3 ...
+"""
+import atexit
+import json
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+REPO = Path(os.environ.get("REPO", str(Path(__file__).resolve().parents[1])))
+PROJECT  = REPO / "ai-services/llm/nemotron3_nano_docker"
+COMMAND  = "nemotron3_nano_docker_llm_server"
+CONFIG   = PROJECT / f"{COMMAND}.yaml"
+
+BASE_URL = "http://localhost:12434/engines/llama.cpp/v1"
+TIMEOUT  = int(os.environ.get("TIMEOUT", "300"))
+
+GREEN  = "\033[92m"
+RED    = "\033[91m"
+YELLOW = "\033[93m"
+RESET  = "\033[0m"
+
+_proc: subprocess.Popen | None = None
+
+
+def _stop():
+    if _proc and _proc.poll() is None:
+        print("\n[teardown] Stopping service…")
+        _proc.terminate()
+        try:
+            _proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            _proc.kill()
+
+atexit.register(_stop)
+
+
+def start_service():
+    global _proc
+    # Override use_small via a temp config if requested.
+    if os.environ.get("USE_SMALL"):
+        import yaml
+        base = yaml.safe_load(CONFIG.read_text()) if CONFIG.exists() else {}
+        base["use_small"] = True
+        tmp = tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w")
+        yaml.dump(base, tmp)
+        tmp.flush()
+        cfg_path = tmp.name
+    else:
+        cfg_path = str(CONFIG)
+
+    cmd = ["uv", "run", "--project", str(PROJECT), COMMAND, "--config", cfg_path]
+    print(f"[start] {' '.join(cmd)}")
+    _proc = subprocess.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr)
+
+
+def wait_ready() -> bool:
+    print(f"Waiting for Docker Model Runner at {BASE_URL} (up to {TIMEOUT}s)…")
+    deadline = time.time() + TIMEOUT
+    while time.time() < deadline:
+        if _proc and _proc.poll() is not None:
+            print(f"{RED}Service process exited early (rc={_proc.returncode}){RESET}")
+            return False
+        try:
+            urllib.request.urlopen(f"{BASE_URL}/models", timeout=3)
+            print(f"{GREEN}Ready.{RESET}")
+            return True
+        except Exception:
+            time.sleep(3)
+    return False
+
+
+def _post(body: dict, model: str) -> dict:
+    data = json.dumps({**body, "model": model}).encode()
+    req  = urllib.request.Request(
+        f"{BASE_URL}/chat/completions", data=data,
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=120) as r:
+        return json.loads(r.read())
+
+
+def get_loaded_model() -> str:
+    """Return the first loaded model name from the runner."""
+    with urllib.request.urlopen(f"{BASE_URL}/models", timeout=5) as r:
+        data = json.loads(r.read())
+    models = [m["id"] for m in data.get("data", [])]
+    if not models:
+        raise RuntimeError("No models loaded in Docker Model Runner")
+    return models[0]
+
+
+def test_plain_chat(model: str):
+    print(f"\n{YELLOW}── Test 1: plain chat ──{RESET}")
+    resp = _post({
+        "messages": [{"role": "user", "content": "Say exactly: hello world"}],
+        "max_tokens": 32,
+    }, model)
+    content = resp["choices"][0]["message"]["content"]
+    print(f"Response: {content!r}")
+    assert "hello" in content.lower(), f"Expected 'hello', got: {content!r}"
+    print(f"{GREEN}PASS{RESET}")
+
+
+def test_tool_call(model: str):
+    print(f"\n{YELLOW}── Test 2: tool calling ──{RESET}")
+    tools = [{
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get current weather for a city",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string"},
+                    "unit":     {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                },
+                "required": ["location"],
+            },
+        },
+    }]
+    resp = _post({
+        "messages": [{"role": "user", "content": "What's the weather in Tokyo?"}],
+        "tools":    tools,
+        "max_tokens": 128,
+    }, model)
+    msg    = resp["choices"][0]["message"]
+    reason = resp["choices"][0]["finish_reason"]
+    print(f"finish_reason: {reason}")
+    if reason == "tool_calls" and msg.get("tool_calls"):
+        call = msg["tool_calls"][0]["function"]
+        args = json.loads(call["arguments"])
+        print(f"{GREEN}PASS{RESET} — called {call['name']}({args})")
+    else:
+        content = msg.get("content", "")
+        print(f"{YELLOW}WARN{RESET} — answered conversationally: {content!r}")
+        print("  (acceptable; small models sometimes answer directly)")
+
+
+def test_reasoning(model: str):
+    print(f"\n{YELLOW}── Test 3: arithmetic (checks correctness) ──{RESET}")
+    resp = _post({
+        "messages": [{"role": "user", "content": "What is 17 * 23? Just the number."}],
+        "max_tokens": 32,
+    }, model)
+    content = resp["choices"][0]["message"].get("content", "")
+    reasoning = resp["choices"][0]["message"].get("reasoning_content", "")
+    print(f"content:   {content!r}")
+    print(f"reasoning: {reasoning[:80]!r}")
+    assert "391" in content or "391" in reasoning, \
+        f"Expected 391 in response, got: {content!r}"
+    print(f"{GREEN}PASS{RESET}")
+
+
+def main():
+    if not PROJECT.exists():
+        print(f"{RED}Service not found at {PROJECT}{RESET}")
+        print(f"Check REPO env var (currently: {REPO})")
+        sys.exit(1)
+
+    start_service()
+
+    if not wait_ready():
+        print(f"{RED}Service did not become ready in {TIMEOUT}s.{RESET}")
+        sys.exit(1)
+
+    model = get_loaded_model()
+    print(f"Testing model: {model}\n")
+
+    test_plain_chat(model)
+    test_tool_call(model)
+    test_reasoning(model)
+
+    print(f"\n{GREEN}All tests complete.{RESET}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_nemotron3_nano_docker.py
+++ b/scripts/test_nemotron3_nano_docker.py
@@ -54,7 +54,26 @@ def _stop():
 atexit.register(_stop)
 
 
+
+def _check_docker_model_runner():
+    """Fail fast with install instructions if the plugin is missing."""
+    import shutil
+    if not shutil.which("docker"):
+        print(f"{RED}docker not found on PATH.{RESET}")
+        sys.exit(1)
+    result = subprocess.run(["docker", "model", "version"], capture_output=True)
+    if result.returncode != 0:
+        print(f"{RED}Docker Model Runner plugin not installed.{RESET}")
+        print()
+        print("Install on Linux:")
+        print("  sudo apt-get install docker-model-plugin")
+        print()
+        print("Official guide: https://docs.docker.com/model-runner/")
+        sys.exit(1)
+
+
 def start_service():
+    _check_docker_model_runner()
     global _proc
     # Override use_small via a temp config if requested.
     if os.environ.get("USE_SMALL"):

--- a/scripts/test_nemotron3_nano_docker.py
+++ b/scripts/test_nemotron3_nano_docker.py
@@ -93,18 +93,25 @@ def start_service():
 
 
 def wait_ready() -> bool:
-    print(f"Waiting for Docker Model Runner at {BASE_URL} (up to {TIMEOUT}s)…")
+    # Two-phase wait:
+    #   1. Docker Model Runner daemon starts (endpoint responds but models list is empty).
+    #   2. docker model pull + docker model run completes (model appears in the list).
+    # We wait for phase 2 — an empty models list means the pull is still in progress.
+    print(f"Waiting for model to load at {BASE_URL} (up to {TIMEOUT}s — pull may take a while)…")
     deadline = time.time() + TIMEOUT
     while time.time() < deadline:
         if _proc and _proc.poll() is not None:
             print(f"{RED}Service process exited early (rc={_proc.returncode}){RESET}")
             return False
         try:
-            urllib.request.urlopen(f"{BASE_URL}/models", timeout=3)
-            print(f"{GREEN}Ready.{RESET}")
-            return True
+            with urllib.request.urlopen(f"{BASE_URL}/models", timeout=3) as r:
+                data = json.loads(r.read())
+            if data.get("data"):
+                print(f"{GREEN}Ready — model loaded.{RESET}")
+                return True
         except Exception:
-            time.sleep(3)
+            pass
+        time.sleep(5)
     return False
 
 

--- a/scripts/test_nemotron_omni.py
+++ b/scripts/test_nemotron_omni.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""
+Manual test: nemotron_omni_llm_server (vLLM voice/conversational entry point).
+
+Launches the service via `uv run`, waits for vLLM to finish loading weights,
+runs tests, then stops it.
+
+Usage:
+    python3 scripts/test_nemotron_omni.py
+
+    # Override repo root if needed:
+    REPO=/path/to/xr-ai python3 ...
+
+NOTE: vLLM weight loading takes several minutes on first run.
+      TIMEOUT defaults to 600s (10 min) to accommodate this.
+"""
+import atexit
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+REPO = Path(os.environ.get("REPO", str(Path(__file__).resolve().parents[1])))
+PROJECT = REPO / "ai-services/llm/nemotron_omni"
+COMMAND = "nemotron_omni_llm_server"
+CONFIG  = PROJECT / f"{COMMAND}.yaml"
+
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:8107")
+# nemotron_omni serves as "llm" via --served-model-name
+MODEL    = "llm"
+TIMEOUT  = int(os.environ.get("TIMEOUT", "600"))
+
+GREEN  = "\033[92m"
+RED    = "\033[91m"
+YELLOW = "\033[93m"
+RESET  = "\033[0m"
+
+_proc: subprocess.Popen | None = None
+
+
+def _stop():
+    if _proc and _proc.poll() is None:
+        print("\n[teardown] Stopping vLLM service…")
+        _proc.terminate()
+        try:
+            _proc.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            _proc.kill()
+
+atexit.register(_stop)
+
+
+def start_service():
+    global _proc
+    cmd = ["uv", "run", "--project", str(PROJECT), COMMAND, "--config", str(CONFIG)]
+    print(f"[start] {' '.join(cmd)}")
+    _proc = subprocess.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr)
+
+
+def wait_ready() -> bool:
+    print(f"Waiting for vLLM at {BASE_URL}/v1 (up to {TIMEOUT}s — weight load takes a few minutes)…")
+    deadline = time.time() + TIMEOUT
+    while time.time() < deadline:
+        if _proc and _proc.poll() is not None:
+            print(f"{RED}Service process exited early (rc={_proc.returncode}){RESET}")
+            return False
+        try:
+            urllib.request.urlopen(f"{BASE_URL}/v1/models", timeout=3)
+            print(f"{GREEN}Ready.{RESET}")
+            return True
+        except Exception:
+            time.sleep(5)
+    return False
+
+
+def _post(body: dict) -> dict:
+    data = json.dumps({**body, "model": MODEL}).encode()
+    req  = urllib.request.Request(
+        f"{BASE_URL}/v1/chat/completions", data=data,
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=120) as r:
+        return json.loads(r.read())
+
+
+def test_plain_chat():
+    print(f"\n{YELLOW}── Test 1: plain conversational response ──{RESET}")
+    resp = _post({
+        "messages": [{"role": "user", "content": "Say exactly: hello world"}],
+        "max_tokens": 32,
+    })
+    content = resp["choices"][0]["message"]["content"]
+    print(f"Response: {content!r}")
+    assert "hello" in content.lower(), f"Expected 'hello', got: {content!r}"
+    print(f"{GREEN}PASS{RESET}")
+
+
+def test_reasoning_not_in_content():
+    print(f"\n{YELLOW}── Test 2: <think> not leaked into content (TTS safety) ──{RESET}")
+    resp = _post({
+        "messages": [{"role": "user", "content": "What is 17 * 23? Think step by step."}],
+        "max_tokens": 512,
+    })
+    msg       = resp["choices"][0]["message"]
+    content   = msg.get("content", "")
+    reasoning = msg.get("reasoning_content", "")
+    print(f"content:          {content!r}")
+    print(f"reasoning_content:{reasoning[:80]!r}{'…' if len(reasoning) > 80 else ''}")
+    assert "<think>" not in content, \
+        f"<think> block leaked into content — TTS would read it aloud!\n{content!r}"
+    assert "391" in content or "391" in reasoning, \
+        f"Expected 391 (17×23), got: {content!r}"
+    print(f"{GREEN}PASS{RESET}")
+
+
+def test_tool_call():
+    print(f"\n{YELLOW}── Test 3: tool calling ──{RESET}")
+    tools = [{
+        "type": "function",
+        "function": {
+            "name": "get_scene_description",
+            "description": "Describe what the XR user is currently looking at",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "detail_level": {
+                        "type": "string",
+                        "enum": ["brief", "detailed"],
+                    },
+                },
+                "required": ["detail_level"],
+            },
+        },
+    }]
+    resp = _post({
+        "messages": [{"role": "user",
+                      "content": "Can you describe what I'm looking at in detail?"}],
+        "tools":    tools,
+        "max_tokens": 128,
+    })
+    msg    = resp["choices"][0]["message"]
+    reason = resp["choices"][0]["finish_reason"]
+    print(f"finish_reason: {reason}")
+    if reason == "tool_calls" and msg.get("tool_calls"):
+        call = msg["tool_calls"][0]["function"]
+        args = json.loads(call["arguments"])
+        print(f"{GREEN}PASS{RESET} — called {call['name']}({args})")
+    else:
+        print(f"{YELLOW}WARN{RESET} — answered conversationally: {msg.get('content','')!r}")
+        print("  (acceptable; model may not always choose to call the tool)")
+
+
+def test_multi_turn():
+    print(f"\n{YELLOW}── Test 4: multi-turn memory ──{RESET}")
+    resp = _post({
+        "messages": [
+            {"role": "user",      "content": "My name is Alex."},
+            {"role": "assistant", "content": "Nice to meet you, Alex!"},
+            {"role": "user",      "content": "What's my name?"},
+        ],
+        "max_tokens": 32,
+    })
+    content = resp["choices"][0]["message"]["content"]
+    print(f"Response: {content!r}")
+    assert "alex" in content.lower(), \
+        f"Expected model to recall 'Alex', got: {content!r}"
+    print(f"{GREEN}PASS{RESET}")
+
+
+def main():
+    if not PROJECT.exists():
+        print(f"{RED}Service not found at {PROJECT}{RESET}")
+        print(f"Check REPO env var (currently: {REPO})")
+        sys.exit(1)
+
+    start_service()
+
+    if not wait_ready():
+        print(f"{RED}Service did not become ready in {TIMEOUT}s.{RESET}")
+        sys.exit(1)
+
+    test_plain_chat()
+    test_reasoning_not_in_content()
+    test_tool_call()
+    test_multi_turn()
+
+    print(f"\n{GREEN}All tests complete.{RESET}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_vlm_server_docker.py
+++ b/scripts/test_vlm_server_docker.py
@@ -77,18 +77,25 @@ def start_service():
 
 
 def wait_ready() -> bool:
-    print(f"Waiting for Docker Model Runner at {BASE_URL} (up to {TIMEOUT}s)…")
+    # Two-phase wait:
+    #   1. Docker Model Runner daemon starts (endpoint responds but models list is empty).
+    #   2. docker model pull + docker model run completes (model appears in the list).
+    # We wait for phase 2 — an empty models list means the pull is still in progress.
+    print(f"Waiting for model to load at {BASE_URL} (up to {TIMEOUT}s — pull may take a while)…")
     deadline = time.time() + TIMEOUT
     while time.time() < deadline:
         if _proc and _proc.poll() is not None:
             print(f"{RED}Service process exited early (rc={_proc.returncode}){RESET}")
             return False
         try:
-            urllib.request.urlopen(f"{BASE_URL}/models", timeout=3)
-            print(f"{GREEN}Ready.{RESET}")
-            return True
+            with urllib.request.urlopen(f"{BASE_URL}/models", timeout=3) as r:
+                data = json.loads(r.read())
+            if data.get("data"):
+                print(f"{GREEN}Ready — model loaded.{RESET}")
+                return True
         except Exception:
-            time.sleep(3)
+            pass
+        time.sleep(5)
     return False
 
 

--- a/scripts/test_vlm_server_docker.py
+++ b/scripts/test_vlm_server_docker.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""
+Manual test: vlm_server_docker (Cosmos-Reason1-7B via Docker Model Runner).
+
+Launches the service via `uv run`, waits for it to be ready, runs tests,
+then stops it.  No manual `docker model run` needed.
+
+Usage:
+    python3 scripts/test_vlm_server_docker.py
+
+    # Override repo root if needed:
+    REPO=/path/to/xr-ai python3 ...
+"""
+import atexit
+import base64
+import io
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+REPO = Path(os.environ.get("REPO", str(Path(__file__).resolve().parents[1])))
+PROJECT = REPO / "ai-services/vlm-server-docker"
+COMMAND = "vlm_server_docker"
+CONFIG  = PROJECT / f"{COMMAND}.yaml"
+
+BASE_URL = "http://localhost:12434/engines/llama.cpp/v1"
+TIMEOUT  = int(os.environ.get("TIMEOUT", "300"))
+
+GREEN  = "\033[92m"
+RED    = "\033[91m"
+YELLOW = "\033[93m"
+RESET  = "\033[0m"
+
+_proc: subprocess.Popen | None = None
+
+
+def _stop():
+    if _proc and _proc.poll() is None:
+        print("\n[teardown] Stopping service…")
+        _proc.terminate()
+        try:
+            _proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            _proc.kill()
+
+atexit.register(_stop)
+
+
+def start_service():
+    global _proc
+    cmd = ["uv", "run", "--project", str(PROJECT), COMMAND, "--config", str(CONFIG)]
+    print(f"[start] {' '.join(cmd)}")
+    _proc = subprocess.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr)
+
+
+def wait_ready() -> bool:
+    print(f"Waiting for Docker Model Runner at {BASE_URL} (up to {TIMEOUT}s)…")
+    deadline = time.time() + TIMEOUT
+    while time.time() < deadline:
+        if _proc and _proc.poll() is not None:
+            print(f"{RED}Service process exited early (rc={_proc.returncode}){RESET}")
+            return False
+        try:
+            urllib.request.urlopen(f"{BASE_URL}/models", timeout=3)
+            print(f"{GREEN}Ready.{RESET}")
+            return True
+        except Exception:
+            time.sleep(3)
+    return False
+
+
+def _post(body: dict, model: str) -> dict:
+    data = json.dumps({**body, "model": model}).encode()
+    req  = urllib.request.Request(
+        f"{BASE_URL}/chat/completions", data=data,
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=120) as r:
+        return json.loads(r.read())
+
+
+def get_loaded_model() -> str:
+    with urllib.request.urlopen(f"{BASE_URL}/models", timeout=5) as r:
+        data = json.loads(r.read())
+    models = [m["id"] for m in data.get("data", [])]
+    if not models:
+        raise RuntimeError("No models loaded in Docker Model Runner")
+    return models[0]
+
+
+def _solid_color_jpeg(r: int, g: int, b: int) -> str:
+    """Tiny solid-color image as a JPEG data URL. Uses PIL if available."""
+    try:
+        from PIL import Image
+        img = Image.new("RGB", (64, 64), (r, g, b))
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG")
+        b64 = base64.b64encode(buf.getvalue()).decode()
+    except ImportError:
+        # Minimal valid JPEG fallback (ignores color, but gets us a valid image)
+        raw = bytes([
+            0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01,
+            0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0xFF, 0xDB, 0x00, 0x43,
+            0x00, 0x08, 0x06, 0x06, 0x07, 0x06, 0x05, 0x08, 0x07, 0x07, 0x07, 0x09,
+            0x09, 0x08, 0x0A, 0x0C, 0x14, 0x0D, 0x0C, 0x0B, 0x0B, 0x0C, 0x19, 0x12,
+            0x13, 0x0F, 0x14, 0x1D, 0x1A, 0x1F, 0x1E, 0x1D, 0x1A, 0x1C, 0x1C, 0x20,
+            0x24, 0x2E, 0x27, 0x20, 0x22, 0x2C, 0x23, 0x1C, 0x1C, 0x28, 0x37, 0x29,
+            0x2C, 0x30, 0x31, 0x34, 0x34, 0x34, 0x1F, 0x27, 0x39, 0x3D, 0x38, 0x32,
+            0x3C, 0x2E, 0x33, 0x34, 0x32, 0xFF, 0xC0, 0x00, 0x0B, 0x08, 0x00, 0x01,
+            0x00, 0x01, 0x01, 0x01, 0x11, 0x00, 0xFF, 0xC4, 0x00, 0x1F, 0x00, 0x00,
+            0x01, 0x05, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+            0x09, 0x0A, 0x0B, 0xFF, 0xDA, 0x00, 0x08, 0x01, 0x01, 0x00, 0x00, 0x3F,
+            0x00, 0xF5, 0x7F, 0xFF, 0xD9,
+        ])
+        b64 = base64.b64encode(raw).decode()
+    return f"data:image/jpeg;base64,{b64}"
+
+
+def test_text_only(model: str):
+    print(f"\n{YELLOW}── Test 1: text-only prompt ──{RESET}")
+    resp = _post({
+        "messages": [{"role": "user", "content": "What is 2 + 2? Answer with just the number."}],
+        "max_tokens": 16,
+    }, model)
+    content = resp["choices"][0]["message"]["content"].strip()
+    print(f"Response: {content!r}")
+    assert "4" in content, f"Expected '4', got: {content!r}"
+    print(f"{GREEN}PASS{RESET}")
+
+
+def test_image_color(model: str):
+    print(f"\n{YELLOW}── Test 2: image description (solid red 64×64) ──{RESET}")
+    data_url = _solid_color_jpeg(255, 0, 0)
+    resp = _post({
+        "messages": [{
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": data_url}},
+                {"type": "text", "text": "What color is this image? One word."},
+            ],
+        }],
+        "max_tokens": 16,
+    }, model)
+    content = resp["choices"][0]["message"]["content"].strip()
+    print(f"Response: {content!r}")
+    assert "red" in content.lower(), f"Expected 'red', got: {content!r}"
+    print(f"{GREEN}PASS{RESET}")
+
+
+def test_image_reasoning(model: str):
+    print(f"\n{YELLOW}── Test 3: image + reasoning (blue 64×64) ──{RESET}")
+    data_url = _solid_color_jpeg(0, 0, 200)
+    resp = _post({
+        "messages": [{
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": data_url}},
+                {"type": "text",
+                 "text": "What primary color do you see? Think before answering."},
+            ],
+        }],
+        "max_tokens": 256,
+    }, model)
+    msg       = resp["choices"][0]["message"]
+    content   = msg.get("content", "")
+    reasoning = msg.get("reasoning_content", "")
+    print(f"content:   {content!r}")
+    print(f"reasoning: {reasoning[:100]!r}{'…' if len(reasoning) > 100 else ''}")
+    assert "blue" in content.lower() or "blue" in reasoning.lower(), \
+        f"Expected 'blue', got: {content!r}"
+    print(f"{GREEN}PASS{RESET}")
+
+
+def main():
+    if not PROJECT.exists():
+        print(f"{RED}Service not found at {PROJECT}{RESET}")
+        print(f"Check REPO env var (currently: {REPO})")
+        sys.exit(1)
+
+    start_service()
+
+    if not wait_ready():
+        print(f"{RED}Service did not become ready in {TIMEOUT}s.{RESET}")
+        sys.exit(1)
+
+    model = get_loaded_model()
+    print(f"Testing model: {model}\n")
+
+    test_text_only(model)
+    test_image_color(model)
+    test_image_reasoning(model)
+
+    print(f"\n{GREEN}All tests complete.{RESET}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_vlm_server_docker.py
+++ b/scripts/test_vlm_server_docker.py
@@ -50,7 +50,26 @@ def _stop():
 atexit.register(_stop)
 
 
+
+def _check_docker_model_runner():
+    """Fail fast with install instructions if the plugin is missing."""
+    import shutil
+    if not shutil.which("docker"):
+        print(f"{RED}docker not found on PATH.{RESET}")
+        sys.exit(1)
+    result = subprocess.run(["docker", "model", "version"], capture_output=True)
+    if result.returncode != 0:
+        print(f"{RED}Docker Model Runner plugin not installed.{RESET}")
+        print()
+        print("Install on Linux:")
+        print("  sudo apt-get install docker-model-plugin")
+        print()
+        print("Official guide: https://docs.docker.com/model-runner/")
+        sys.exit(1)
+
+
 def start_service():
+    _check_docker_model_runner()
     global _proc
     cmd = ["uv", "run", "--project", str(PROJECT), COMMAND, "--config", str(CONFIG)]
     print(f"[start] {' '.join(cmd)}")


### PR DESCRIPTION
## Summary

Adds three new services alongside the originals — no existing examples need to change.

| Service | Type | Notes |
|---|---|---|
| `nemotron3_nano_docker` | Docker Model Runner | Tool-calling LLM; replaces vLLM shim when using Docker Model Runner |
| `vlm-server-docker` | Docker Model Runner | Cosmos-Reason1-7B VLM; replaces transformers in-process |
| `nemotron_omni` | vLLM | New voice/conversational entry point (Omni reasoning model) |

## nemotron3_nano_docker

Drops all ~260 lines of CUDA/FlashInfer/HuggingFace workarounds from the vLLM variant. Selects model via `nvidia-smi`:
- Blackwell (SM100+) → `hf.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4`
- Ada/Hopper → `hf.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8`
- `use_small: true` → `hf.co/nvidia/NVIDIA-Nemotron-Nano-9B-v2-FP8`

API: `http://localhost:12434/engines/llama.cpp/v1`

## vlm-server-docker

Replaces the 400-line transformers/FastAPI server with a ~45-line launcher. `docker model pull` + `docker model run hf.co/nvidia/Cosmos-Reason1-7B`.

To use with vlm-mcp, update `vlm_mcp_server.yaml`:
```yaml
vlm_server:     http://localhost:12434/engines/llama.cpp
vlm_model_name: hf.co/nvidia/Cosmos-Reason1-7B
```

## nemotron_omni

Clean vLLM shim for `Nemotron-3-Nano-Omni-30B-A3B-Reasoning-{FP8,NVFP4}` on port 8107. Same architecture as the existing nemotron3_nano vLLM service but without the machine-specific workarounds. Serves as `model: "llm"` so workers don't need changes.

## Test plan

Test scripts at `/tmp/xr-ai-tests/` (not committed):
- [ ] `python3 test_nemotron3_nano_docker.py` — plain chat, tool call, reasoning extraction
- [ ] `python3 test_vlm_server_docker.py` — text-only, image color, image+reasoning
- [ ] `python3 test_nemotron_omni.py` — chat, reasoning not in content (TTS safety), tools, multi-turn
- [ ] Existing agent samples run unchanged against originals

🤖 Generated with [Claude Code](https://claude.com/claude-code)