### PR TITLE
fix(web): stop camera on RECONNECTING to sync state with fresh server

### DIFF
--- a/client-samples/web/App/app.js
+++ b/client-samples/web/App/app.js
@@ -347,6 +347,12 @@ async function connect() {
       model.isAudioActive  = false;
       model.isCameraActive = false;
       model.agentStatus    = null;
+    } else if (state === ConnectionState.RECONNECTING) {
+      // Stop the camera when the connection drops so the server and client
+      // both start from a known-off state after reconnect. The server starts
+      // fresh with _camera_on=false; if the camera stayed "on" here the UI
+      // and server would be out of sync until the next clientControl message.
+      if (model.isCameraActive) stopCamera();
     }
     render();
   };


### PR DESCRIPTION
## Summary

When the server restarts, the agent initialises `_camera_on = false`, but the web client's `isCameraActive` may still be `true` while LiveKit is in the `RECONNECTING` state. When the connection is restored the UI shows the camera as active but the server has no record of it — they're out of sync until the next `clientControl` message.

## Fix

Stop the camera in `onConnectionStateChanged` when the state transitions to `RECONNECTING`. Both sides are then at a known-off state after reconnect, and the server will issue `startCamera` via `clientControl` when the next query needs a frame.

## Test plan

- [ ] Quit the server while the camera is on
- [ ] Verify the browser stops the camera (light goes off) when `RECONNECTING` fires
- [ ] Restart the server — client reconnects with camera off on both sides
- [ ] Ask a question — `startCamera` is received, camera starts cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)