### PR TITLE
feat(ai-services): add nemotron_omni vLLM launcher for Omni-30B-A3B-Reasoning

### DIFF
--- a/agent-samples/simple-vlm-example/pyproject.toml
+++ b/agent-samples/simple-vlm-example/pyproject.toml
@@ -11,6 +11,7 @@ version = "0.1.0"
 requires-python = ">=3.11,<3.13"
 dependencies = [
     "xr-ai-launcher",
+    "pyyaml>=6.0",
 ]
 
 [tool.uv.sources]

--- a/agent-samples/simple-vlm-example/simple_vlm_example.py
+++ b/agent-samples/simple-vlm-example/simple_vlm_example.py
@@ -21,22 +21,41 @@ How to run (from agent-samples/simple-vlm-example/):
 import asyncio
 from pathlib import Path
 
+import yaml
+
 from xr_ai_launcher import Process, ensure_credentials, run_stack
 
 _BASE = Path(__file__).resolve().parent
 
-PROCESSES = [
-    Process("hub",    "../../server-runtime",         "xr_media_hub"),
-    Process("vlm",    "../../ai-services/vlm-server", "vlm_server"),
-    Process("stt",    "../../ai-services/stt-server", "stt_server"),
-    Process("tts",    "../../ai-services/tts/piper",  "piper_tts_server"),
-    Process("worker", "worker",                       "simple_vlm_example_worker"),
-]
+
+def _build_processes() -> list[Process]:
+    # Read vlm_backend from the worker YAML so the orchestrator starts the
+    # matching AI service automatically.
+    worker_cfg: dict = {}
+    worker_yaml = _BASE / "simple_vlm_example_worker.yaml"
+    if worker_yaml.exists():
+        with open(worker_yaml) as f:
+            worker_cfg = yaml.safe_load(f) or {}
+
+    backend = worker_cfg.get("vlm_backend", "cosmos")
+    if backend == "omni":
+        vlm = Process("vlm", "../../ai-services/llm/nemotron_omni",
+                      "nemotron_omni_llm_server")
+    else:  # cosmos (default)
+        vlm = Process("vlm", "../../ai-services/vlm-server", "vlm_server")
+
+    return [
+        Process("hub",    "../../server-runtime",        "xr_media_hub"),
+        vlm,
+        Process("stt",    "../../ai-services/stt-server", "stt_server"),
+        Process("tts",    "../../ai-services/tts/piper",  "piper_tts_server"),
+        Process("worker", "worker",                       "simple_vlm_example_worker"),
+    ]
 
 
 def run() -> None:
     ensure_credentials("HF_TOKEN")
-    asyncio.run(run_stack(PROCESSES, _BASE))
+    asyncio.run(run_stack(_build_processes(), _BASE))
 
 
 if __name__ == "__main__":

--- a/agent-samples/simple-vlm-example/simple_vlm_example_worker.yaml
+++ b/agent-samples/simple-vlm-example/simple_vlm_example_worker.yaml
@@ -5,8 +5,18 @@
 # Auto-discovered by the launcher and passed as --config to the worker process.
 
 stt_server:  http://localhost:8103
-vlm_server:  http://localhost:8100
 tts_server:  http://localhost:8105   # piper_tts_server
+
+# VLM backend — controls which vision model the worker uses.
+# "cosmos" (default) → vlm-server (Cosmos-Reason1-7B) on port 8100
+# "omni"             → nemotron_omni (Nemotron-3-Nano-Omni-30B) on port 8108
+#
+# Changing this also changes which AI service the orchestrator launches.
+# The vlm_server and vlm_model_name keys below override the backend defaults
+# if you need to point at a non-standard port or served-model-name.
+vlm_backend: cosmos
+# vlm_server:     http://localhost:8100   # override default URL
+# vlm_model_name: vlm                     # override default model name
 
 # Sent to the VLM whenever the client posts the literal text "ping".
 default_prompt: "Describe what you see."

--- a/agent-samples/simple-vlm-example/worker/services.py
+++ b/agent-samples/simple-vlm-example/worker/services.py
@@ -38,10 +38,11 @@ class SttClient:
 class VlmClient:
     """OpenAI-compatible /v1/chat/completions client (SSE streaming)."""
 
-    def __init__(self, base_url: str) -> None:
+    def __init__(self, base_url: str, model_name: str = "vlm") -> None:
         base = base_url.rstrip("/")
         self.health_url = base + "/health"
         self.chat_url   = base + "/v1/chat/completions"
+        self._model     = model_name
 
     async def stream(
         self,
@@ -59,7 +60,7 @@ class VlmClient:
             {"type": "text",      "text": query},
         ]})
         payload = {
-            "model": "vlm",
+            "model": self._model,
             "stream": True,
             "messages": messages,
         }

--- a/agent-samples/simple-vlm-example/worker/simple_vlm_example_worker.py
+++ b/agent-samples/simple-vlm-example/worker/simple_vlm_example_worker.py
@@ -60,8 +60,20 @@ async def main(cfg: dict) -> None:
         format="%(asctime)s %(name)s %(levelname)s %(message)s",
     )
 
+    # VLM backend selection.
+    # "cosmos" → vlm-server on port 8100 (Cosmos-Reason1-7B, model="vlm")
+    # "omni"   → nemotron_omni on port 8108 (Nemotron-Omni-30B, model="llm")
+    backend = cfg.get("vlm_backend", "cosmos")
+    if backend == "omni":
+        vlm_default_url   = "http://localhost:8108"
+        vlm_default_model = "llm"
+    else:
+        vlm_default_url   = "http://localhost:8100"
+        vlm_default_model = "vlm"
+
     stt = SttClient(cfg.get("stt_server", "http://localhost:8103"))
-    vlm = VlmClient(cfg.get("vlm_server", "http://localhost:8100"))
+    vlm = VlmClient(cfg.get("vlm_server", vlm_default_url),
+                    model_name=cfg.get("vlm_model_name", vlm_default_model))
     tts = TtsClient(cfg.get("tts_server", "http://localhost:8105"))
     await wait_for_health({
         "STT": stt.health_url,

--- a/ai-services/llm/nemotron_omni/nemotron_omni_llm_server.yaml
+++ b/ai-services/llm/nemotron_omni/nemotron_omni_llm_server.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Nemotron-3-Nano-Omni — vLLM configuration.
+# Omni multimodal model supporting text + video input.
+# OpenAI-compatible API at http://localhost:8108/v1  (served-model-name: "llm")
+#
+# GPU auto-selection:
+#   Blackwell (SM100+) → model_blackwell  (NVFP4, --kv-cache-dtype fp8)
+#   Ada / Hopper       → model_ada        (FP8,   --kv-cache-dtype fp8)
+#   use_bf16: true     → model_bf16       (BF16,  no kv-cache quantisation)
+
+model_blackwell: nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4
+model_ada:       nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8
+model_bf16:      nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16
+
+# Set to true to force BF16 regardless of GPU (highest quality, most VRAM).
+use_bf16: false
+
+host: "0.0.0.0"
+port: 8108
+hf_token: ""
+
+# Weight cache — resolves relative to this YAML.
+model_cache: ../../models
+
+# Pin to a specific GPU (or comma-separated list for multi-GPU).
+# Unset to use all GPUs visible to the process.
+# cuda_visible_devices: "0"
+
+# vLLM knobs.
+max_num_seqs:           384
+tensor_parallel_size:   1
+max_model_len:          131072
+gpu_memory_utilization: 0.85
+enforce_eager:          false
+
+# Video input — controls how video frames are sampled and pruned.
+video_pruning_rate: 0.5   # fraction of redundant video tokens to drop
+video_fps:          2     # FPS for video sampling
+video_num_frames:   256   # max frames per video clip

--- a/ai-services/llm/nemotron_omni/nemotron_omni_llm_server/__init__.py
+++ b/ai-services/llm/nemotron_omni/nemotron_omni_llm_server/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/ai-services/llm/nemotron_omni/nemotron_omni_llm_server/__main__.py
+++ b/ai-services/llm/nemotron_omni/nemotron_omni_llm_server/__main__.py
@@ -62,6 +62,8 @@ def _gpu_compute_major() -> int:
         if out:
             return int(out[0].split(".")[0])
     except Exception:
+        # Detection is best-effort; if nvidia-smi is unavailable or parsing fails,
+        # fall back to 0 (unknown capability) so caller can select a safe default.
         pass
     return 0
 

--- a/ai-services/llm/nemotron_omni/nemotron_omni_llm_server/__main__.py
+++ b/ai-services/llm/nemotron_omni/nemotron_omni_llm_server/__main__.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+nemotron_omni_llm_server — vLLM launcher for Nemotron-3-Nano-Omni-30B-A3B-Reasoning.
+
+Omni multimodal model (text + video). Selects the weight quantisation based
+on GPU compute capability and execs into ``vllm serve``.
+
+Config keys (nemotron_omni_llm_server.yaml)
+-------------------------------------------
+    model_blackwell:          str    HF model ID for Blackwell (SM100+) — NVFP4.
+    model_ada:                str    HF model ID for Ada / Hopper / Ampere — FP8.
+    model_bf16:               str    HF model ID for BF16 (fallback / no quant).
+    use_bf16:                 bool   Force BF16 regardless of GPU (default: false).
+    host:                     str    Bind address (default: "0.0.0.0").
+    port:                     int    HTTP port (default: 8108).
+    served_model_name:        str    Name in /v1/models (default: "llm").
+    hf_token:                 str    HF token for gated models.
+    model_cache:              str    Weight cache, relative to this YAML.
+    max_num_seqs:             int    vLLM --max-num-seqs (default: 384).
+    tensor_parallel_size:     int    vLLM --tensor-parallel-size (default: 1).
+    max_model_len:            int    vLLM --max-model-len (default: 131072).
+    gpu_memory_utilization:   float  vLLM --gpu-memory-utilization (default: 0.85).
+    enforce_eager:            bool   Skip CUDA graph capture (default: false).
+    video_pruning_rate:       float  --video-pruning-rate (default: 0.5).
+    video_fps:                int    FPS for video input sampling (default: 2).
+    video_num_frames:         int    Max frames per video (default: 256).
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+_MODEL_BLACKWELL = "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4"
+_MODEL_ADA       = "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8"
+_MODEL_BF16      = "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16"
+
+_DEFAULT_PORT    = 8108
+_DEFAULT_HOST    = "0.0.0.0"
+_DEFAULT_SERVED  = "llm"
+_DEFAULT_SEQS    = 384
+_DEFAULT_TP      = 1
+_DEFAULT_CTX     = 131072
+_DEFAULT_GPU_MEM = 0.85
+_DEFAULT_EAGER   = False
+_DEFAULT_PRUNE   = 0.5
+_DEFAULT_FPS     = 2
+_DEFAULT_FRAMES  = 256
+
+
+def _gpu_compute_major() -> int:
+    try:
+        out = subprocess.check_output(
+            ["nvidia-smi", "--query-gpu=compute_cap", "--format=csv,noheader,nounits"],
+            text=True, stderr=subprocess.DEVNULL,
+        ).strip().splitlines()
+        if out:
+            return int(out[0].split(".")[0])
+    except Exception:
+        pass
+    return 0
+
+
+def _resolve_model_cache(cfg: dict, yaml_dir: Path) -> Path:
+    raw = cfg.get("model_cache", "../../models")
+    p = Path(raw)
+    if not p.is_absolute():
+        p = (yaml_dir / p).resolve()
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def run() -> None:
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
+
+    p = argparse.ArgumentParser(add_help=False)
+    p.add_argument("--config", type=Path, default=None)
+    ns, _ = p.parse_known_args()
+
+    cfg: dict = {}
+    yaml_dir = Path.cwd()
+    if ns.config and ns.config.exists():
+        yaml_dir = ns.config.parent.resolve()
+        with open(ns.config) as f:
+            cfg = yaml.safe_load(f) or {}
+
+    # Model selection
+    if cfg.get("use_bf16", False):
+        model = cfg.get("model_bf16", _MODEL_BF16)
+        use_kv_fp8 = False
+        print(f"[nemotron_omni] use_bf16=true → {model}", flush=True)
+    else:
+        major = _gpu_compute_major()
+        if major >= 10:
+            model = cfg.get("model_blackwell", _MODEL_BLACKWELL)
+            use_kv_fp8 = True
+            print(f"[nemotron_omni] Blackwell (SM{major}0) → {model}", flush=True)
+        else:
+            model = cfg.get("model_ada", _MODEL_ADA)
+            use_kv_fp8 = True
+            arch = f"SM{major}0" if major > 0 else "unknown GPU"
+            print(f"[nemotron_omni] Pre-Blackwell ({arch}) → {model}", flush=True)
+
+    host          = cfg.get("host",                 _DEFAULT_HOST)
+    port          = int(cfg.get("port",             _DEFAULT_PORT))
+    served_name   = cfg.get("served_model_name",    _DEFAULT_SERVED)
+    max_seqs      = int(cfg.get("max_num_seqs",     _DEFAULT_SEQS))
+    tp_size       = int(cfg.get("tensor_parallel_size", _DEFAULT_TP))
+    max_ctx       = int(cfg.get("max_model_len",    _DEFAULT_CTX))
+    gpu_mem       = float(cfg.get("gpu_memory_utilization", _DEFAULT_GPU_MEM))
+    enforce_eager = bool(cfg.get("enforce_eager",   _DEFAULT_EAGER))
+    prune_rate    = float(cfg.get("video_pruning_rate", _DEFAULT_PRUNE))
+    video_fps     = int(cfg.get("video_fps",        _DEFAULT_FPS))
+    video_frames  = int(cfg.get("video_num_frames", _DEFAULT_FRAMES))
+
+    if cuda_devices := cfg.get("cuda_visible_devices"):
+        os.environ["CUDA_VISIBLE_DEVICES"] = str(cuda_devices)
+
+    model_cache = _resolve_model_cache(cfg, yaml_dir)
+    if hf_token := (cfg.get("hf_token") or os.environ.get("HF_TOKEN", "")):
+        os.environ["HF_TOKEN"] = hf_token
+    os.environ.setdefault("HF_HUB_ENABLE_HF_TRANSFER", "1")
+    os.environ["HF_HOME"] = str(model_cache)
+
+    media_io_kwargs = json.dumps({"video": {"fps": video_fps, "num_frames": video_frames}})
+
+    argv = [
+        "vllm", "serve", model,
+        "--served-model-name", served_name,
+        "--host", host,
+        "--port", str(port),
+        "--trust-remote-code",
+        "--max-num-seqs", str(max_seqs),
+        "--tensor-parallel-size", str(tp_size),
+        "--max-model-len", str(max_ctx),
+        "--gpu-memory-utilization", str(gpu_mem),
+        "--video-pruning-rate", str(prune_rate),
+        "--allowed-local-media-path", "/",
+        "--media-io-kwargs", media_io_kwargs,
+        "--reasoning-parser", "nemotron_v3",
+        "--enable-auto-tool-choice",
+        "--tool-call-parser", "qwen3_coder",
+    ]
+    if use_kv_fp8:
+        argv.extend(["--kv-cache-dtype", "fp8"])
+    if enforce_eager:
+        argv.append("--enforce-eager")
+
+    print(f"[nemotron_omni] Launching vLLM  http://{host}:{port}/v1  model={model}", flush=True)
+    os.execvp(argv[0], argv)
+
+
+if __name__ == "__main__":
+    run()

--- a/ai-services/llm/nemotron_omni/pyproject.toml
+++ b/ai-services/llm/nemotron_omni/pyproject.toml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "nemotron-omni-llm-server"
+version = "0.1.0"
+requires-python = ">=3.11,<3.13"
+dependencies = [
+    "vllm>=0.8.0",
+    "pyyaml>=6.0",
+    "hf-transfer>=0.1.4",
+]
+
+[project.scripts]
+nemotron_omni_llm_server = "nemotron_omni_llm_server.__main__:run"
+
+[tool.hatch.build.targets.wheel]
+packages = ["nemotron_omni_llm_server"]


### PR DESCRIPTION
## Summary

New `ai-services/llm/nemotron_omni/` service for the Nemotron-3-Nano-Omni-30B-A3B-Reasoning multimodal models (text + video input, reasoning, tool calling).

## Model selection

| GPU | Model | KV cache |
|---|---|---|
| Blackwell (SM100+) | NVFP4 | fp8 |
| Ada / Hopper | FP8 | fp8 |
| `use_bf16: true` | BF16 | auto |

## Key flags (vs other Nemotron services)

```bash
--reasoning-parser nemotron_v3          # different from nano_v3
--video-pruning-rate 0.5
--allowed-local-media-path /
--media-io-kwargs '{"video": {"fps": 2, "num_frames": 256}}'
--max-model-len 131072                  # 128k context
--max-num-seqs 384
--kv-cache-dtype fp8                    # NVFP4 and FP8 only; omitted for BF16
```

## Usage

```bash
uv run nemotron_omni_llm_server --config nemotron_omni_llm_server.yaml
```

API at `http://localhost:8108/v1`, served as `model: "llm"`.

## Test plan

- [ ] Service starts on Ada GPU, selects FP8 variant
- [ ] Service starts on Blackwell GPU, selects NVFP4 variant
- [ ] `use_bf16: true` selects BF16 and omits `--kv-cache-dtype fp8`
- [ ] `cuda_visible_devices` key correctly sets `CUDA_VISIBLE_DEVICES`

🤖 Generated with [Claude Code](https://claude.com/claude-code)