### PR TITLE
fix(web): enumerate cameras on connect; default to VOICE_PROCESSING

### DIFF
--- a/client-samples/web/App/app.js
+++ b/client-samples/web/App/app.js
@@ -80,7 +80,7 @@ const model = {
   identity:       'web-client',
 
   // Media settings
-  audioMode:      MicrophoneMode.RAW,
+  audioMode:      MicrophoneMode.VOICE_PROCESSING,
 
   // Live state
   /** @type {StreamSession|null} */
@@ -216,7 +216,7 @@ function render() {
   const selectRow = $('camera-select-row');
   const camSelect = $('camera-select');
 
-  if (model.cameras.length > 1) {
+  if (model.cameras.length >= 1) {
     selectRow.style.display = '';
     // Rebuild options only when the list has changed.
     const currentIds = [...camSelect.options].map(o => o.value).join(',');
@@ -343,7 +343,11 @@ async function connect() {
   // Wire callbacks before connecting (mirrors iOS ordering).
   newSession.onConnectionStateChanged = (state) => {
     model.connectionState = state;
-    if (state === ConnectionState.DISCONNECTED) {
+    if (state === ConnectionState.CONNECTED) {
+      // Enumerate cameras on connect so the selector is populated before the
+      // user starts the camera for the first time.
+      enumerateCameras();
+    } else if (state === ConnectionState.DISCONNECTED) {
       model.isAudioActive  = false;
       model.isCameraActive = false;
       model.agentStatus    = null;


### PR DESCRIPTION
## Summary

Two web client fixes.

### Camera selection before first start

`enumerateCameras()` was only called inside `startCamera()`, so `model.cameras` was always empty and the selector hidden until after the first camera start. Now called when the session reaches `CONNECTED` — the browser permission prompt fires at a natural moment (just joined the session) and the selector is ready before the user touches the camera button.

Also changed the show condition from `> 1` to `>= 1` so users can confirm which device is selected even when only one camera is detected.

### Voice mode default

`audioMode` defaulted to `MicrophoneMode.RAW` (no DSP). Changed to `VOICE_PROCESSING`. On the web, `VOICE_PROCESSING` and `SOFTWARE_PROCESSING` both map to the same WebRTC constraints (`echoCancellation`, `noiseSuppression`, `autoGainControl` all true), so voice processing is always "available" — no feature detection needed.

## Test plan

- [ ] Connect to a session — browser prompts for camera permission, selector is populated immediately
- [ ] Select a different camera before clicking "Start Camera" — correct device is used
- [ ] Microphone starts with echo cancellation active by default (verify via audio quality)
- [ ] Switching mode in the dropdown still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)