### PR TITLE
fix(ai-services): gate /health on model readiness in all custom servers

### DIFF
--- a/ai-services/stt-server/stt_server/__main__.py
+++ b/ai-services/stt-server/stt_server/__main__.py
@@ -75,6 +75,10 @@ class _AsrBackend:
             self._model = model
             print("[stt_server] ASR model ready.")
 
+    @property
+    def ready(self) -> bool:
+        return self._model is not None
+
     def transcribe(self, audio_path: str) -> str:
         """Synchronous. Call from a thread pool."""
         self._ensure_loaded()
@@ -101,6 +105,9 @@ def _build_app(cfg: dict, model_cache: Path):
 
     @app.get("/health")
     def health():
+        if not backend.ready:
+            from fastapi import HTTPException
+            raise HTTPException(status_code=503, detail="model not loaded")
         return {"status": "ok"}
 
     @app.get("/v1/models")

--- a/ai-services/tts/magpie/magpie_tts_server/__main__.py
+++ b/ai-services/tts/magpie/magpie_tts_server/__main__.py
@@ -80,6 +80,10 @@ class _TtsBackend:
             self._model = model
             print("[magpie_tts_server] TTS model ready.")
 
+    @property
+    def ready(self) -> bool:
+        return self._model is not None
+
     def synthesize(self, text: str) -> bytes:
         """Synthesize text → WAV bytes. Synchronous — call from a thread pool."""
         import io as _io
@@ -124,6 +128,9 @@ def _build_app(cfg: dict, model_cache: Path):
 
     @app.get("/health")
     def health():
+        if not backend.ready:
+            from fastapi import HTTPException
+            raise HTTPException(status_code=503, detail="model not loaded")
         return {"status": "ok"}
 
     @app.get("/v1/models")

--- a/ai-services/tts/piper/piper_tts_server/__main__.py
+++ b/ai-services/tts/piper/piper_tts_server/__main__.py
@@ -110,6 +110,10 @@ class _PiperBackend:
                   f"sample_rate={self._voice.config.sample_rate}")
 
     @property
+    def ready(self) -> bool:
+        return self._voice is not None
+
+    @property
     def sample_rate(self) -> int:
         self._ensure_loaded()
         return self._voice.config.sample_rate
@@ -145,6 +149,9 @@ def _build_app(cfg: dict, model_cache: Path):
 
     @app.get("/health")
     def health():
+        if not backend.ready:
+            from fastapi import HTTPException
+            raise HTTPException(status_code=503, detail="model not loaded")
         return {"status": "ok"}
 
     @app.get("/v1/models")


### PR DESCRIPTION
## Summary

The custom AI service servers (STT, Piper TTS, Magpie TTS) returned `200 {"status": "ok"}` from `/health` unconditionally. While weights are loaded before `uvicorn.serve()` today (so there is no actual gap), the health endpoint should explicitly check the model state so the guarantee is structural, not just a consequence of startup ordering.

## Change

Added a `ready` property to each backend class that reflects the internal loading flag:

```python
@property
def ready(self) -> bool:
    return self._model is not None  # or self._voice for Piper
```

Health endpoint now returns `503` when not ready:

```python
@app.get("/health")
def health():
    if not backend.ready:
        raise HTTPException(status_code=503, detail="model not loaded")
    return {"status": "ok"}
```

## Scope

| Service | Change |
|---|---|
| `stt-server` | `_AsrBackend.ready` + health gate |
| `tts/piper` | `_PiperBackend.ready` + health gate |
| `tts/magpie` | `_MagpieTtsBackend.ready` + health gate |
| vLLM services | No change — vLLM's native `/health` only returns 200 after model load |

🤖 Generated with [Claude Code](https://claude.com/claude-code)