### PR TITLE
feat(agent-mcp-servers): multi-primitive scene API; LLM-friendly pose; vlm-mcp path note

### DIFF
--- a/agent-mcp-servers/oxr-mcp/oxr_mcp_server/__main__.py
+++ b/agent-mcp-servers/oxr-mcp/oxr_mcp_server/__main__.py
@@ -6,28 +6,32 @@ oxr-mcp — OpenXR tracking MCP adapter.
 
 Pure FastMCP. Opens a SECOND OpenXR session against CloudXR in headless mode
 (XR_MND_HEADLESS) so the rendering OpenXR client (e.g. LOVR via render-mcp)
-keeps full ownership of frame submission while we read pose. Both sessions
-co-exist because the headless one never submits frames.
+keeps full ownership of frame submission while we read pose.
 
 Tools (FastMCP, mounted at /mcp)
 ────────────────────────────────
   get_head_pose() → dict
-      ``{is_valid, position, orientation, ts, error?}``. Position is metres
-      in world space (OpenXR Y-up); orientation is a unit quaternion
-      (qx, qy, qz, qw). ``is_valid: false`` (with optional ``error`` reason)
-      until tracking is established — callers should retry rather than
-      treat it as a hard failure.
+      LLM-friendly pose with derived spatial vectors — no raw quaternions.
+      Fields: is_valid, position {x,y,z}, forward {x,y,z}, right {x,y,z},
+      up {x,y,z}, yaw_deg, pitch_deg, ts.
+
+  position_ahead(distance) → dict {x,y,z}
+      World position 'distance' metres along the user's gaze direction.
+
+  position_relative(forward, right, up) → dict {x,y,z}
+      Convert head-relative offsets (metres) to world-space position.
+      forward>0 = ahead, right>0 = right, up>0 = above eye level.
 
   get_health() → dict
-      ``{status, session_open, open_attempts, last_open_error}``.
+      {status, session_open, open_attempts, last_open_error}.
 
-Pose is fetched fresh per request via xrLocateSpace; no background polling,
-no staleness.
+Pose is fetched fresh per request via xrLocateSpace; no background polling.
 """
 from __future__ import annotations
 
 import argparse
 import asyncio
+import math
 import logging
 import sys
 import threading
@@ -51,6 +55,23 @@ from xr_ai_launcher import (
 log = logging.getLogger("oxr_mcp_server")
 
 _DEFAULT_YAML = Path(__file__).resolve().parent.parent / "oxr_mcp_server.yaml"
+
+
+# ── Quaternion helpers ────────────────────────────────────────────────────────
+
+def _rotate_vec(
+    q: tuple[float, float, float, float],
+    v: tuple[float, float, float],
+) -> tuple[float, float, float]:
+    """Rotate vector *v* by unit quaternion *q* = (qx, qy, qz, qw)."""
+    qx, qy, qz, qw = q
+    vx, vy, vz = v
+    tx = 2.0 * (qy * vz - qz * vy)
+    ty = 2.0 * (qz * vx - qx * vz)
+    tz = 2.0 * (qx * vy - qy * vx)
+    return (vx + qw * tx + qy * tz - qz * ty,
+            vy + qw * ty + qz * tx - qx * tz,
+            vz + qw * tz + qx * ty - qy * tx)
 
 
 # ── Config ─────────────────────────────────────────────────────────────────────
@@ -174,35 +195,57 @@ class PoseSource:
                 self._oxr_session = None
 
     def get_pose(self) -> dict:
-        """Pose snapshot. Returns ``is_valid=False`` (with optional ``error``)
-        when the session can't open yet, so callers can distinguish "no pose
-        yet" from a real failure."""
+        """Pose snapshot with derived spatial vectors — no raw quaternions.
+
+        Returns ``is_valid=False`` (with optional ``error``) when the session
+        can't open yet so callers can distinguish "not ready" from failure.
+        """
         with self._lock:
             if self._dev_session is None:
                 err = self._try_open()
                 if err is not None:
                     return {
-                        "is_valid":    False,
-                        "position":    [0.0, 0.0, 0.0],
-                        "orientation": [0.0, 0.0, 0.0, 1.0],
-                        "ts":          int(time.time() * 1000),
-                        "error":       f"session_not_ready: {err}",
+                        "is_valid":  False,
+                        "position":  {"x": 0.0, "y": 1.6, "z": 0.0},
+                        "forward":   {"x": 0.0, "y": 0.0, "z": -1.0},
+                        "right":     {"x": 1.0, "y": 0.0, "z": 0.0},
+                        "up":        {"x": 0.0, "y": 1.0, "z": 0.0},
+                        "yaw_deg":   0.0,
+                        "pitch_deg": 0.0,
+                        "ts":        int(time.time() * 1000),
+                        "error":     f"session_not_ready: {err}",
                     }
             self._dev_session.update()
             tracked = self._tracker.get_head(self._dev_session)
             data = tracked.data
             pose = data.pose
-            return {
-                "is_valid":    bool(data.is_valid),
-                "position":    [float(pose.position.x),
-                                float(pose.position.y),
-                                float(pose.position.z)],
-                "orientation": [float(pose.orientation.x),
-                                float(pose.orientation.y),
-                                float(pose.orientation.z),
-                                float(pose.orientation.w)],
-                "ts":          int(time.time() * 1000),
-            }
+            px = float(pose.position.x)
+            py = float(pose.position.y)
+            pz = float(pose.position.z)
+            qx = float(pose.orientation.x)
+            qy = float(pose.orientation.y)
+            qz = float(pose.orientation.z)
+            qw = float(pose.orientation.w)
+
+        fwd = _rotate_vec((qx, qy, qz, qw), (0.0,  0.0, -1.0))
+        rgt = _rotate_vec((qx, qy, qz, qw), (1.0,  0.0,  0.0))
+        up  = _rotate_vec((qx, qy, qz, qw), (0.0,  1.0,  0.0))
+        yaw   = math.degrees(math.atan2(
+            2.0 * (qw * qy + qx * qz),
+            1.0 - 2.0 * (qy * qy + qz * qz)))
+        pitch = math.degrees(math.asin(
+            max(-1.0, min(1.0, 2.0 * (qw * qx - qy * qz)))))
+
+        return {
+            "is_valid":  bool(data.is_valid),
+            "position":  {"x": round(px, 3), "y": round(py, 3), "z": round(pz, 3)},
+            "forward":   {"x": round(fwd[0], 3), "y": round(fwd[1], 3), "z": round(fwd[2], 3)},
+            "right":     {"x": round(rgt[0], 3), "y": round(rgt[1], 3), "z": round(rgt[2], 3)},
+            "up":        {"x": round(up[0],  3), "y": round(up[1],  3), "z": round(up[2],  3)},
+            "yaw_deg":   round(yaw,   1),
+            "pitch_deg": round(pitch, 1),
+            "ts":        int(time.time() * 1000),
+        }
 
 
 # ── MCP tool surface ──────────────────────────────────────────────────────────
@@ -212,32 +255,84 @@ def build_mcp(source: PoseSource) -> FastMCP:
 
     @mcp.tool()
     async def get_head_pose() -> dict:
-        """
-        Return the user's current head pose as observed by CloudXR.
+        """Return the user's head position and orientation as human-readable vectors.
 
-        Result shape::
+        Fields (all world-space, OpenXR Y-up, +x right, +y up, -z forward):
+          is_valid  — False until tracking is established; retry, don't fail hard
+          position  — {x, y, z} head position in metres
+          forward   — {x, y, z} unit vector in the direction the user is looking
+          right     — {x, y, z} unit vector pointing to the user's right
+          up        — {x, y, z} unit vector pointing up from the user's head
+          yaw_deg   — horizontal rotation in degrees (0 = facing -z, 90 = facing +x)
+          pitch_deg — vertical tilt in degrees (positive = looking up)
+          ts        — ms since Unix epoch
 
-            {
-              "is_valid":    bool,
-              "position":    [x, y, z],         # metres, world-space
-              "orientation": [qx, qy, qz, qw],  # unit quaternion
-              "ts":          <ms since Unix epoch>,
-              "error":       str                # ONLY on failure paths
-            }
-
-        Coordinate convention is OpenXR's right-handed Y-up world: +x right,
-        +y up, -z forward. ``is_valid`` is False when the headset has not
-        yet established tracking (CloudXR still spinning up, or headset off).
-        Treat that as "wait and retry", not a hard failure — the optional
-        ``error`` field carries a short reason string.
+        No raw quaternions — use forward/right/up for spatial reasoning.
         """
         return await asyncio.get_running_loop().run_in_executor(None, source.get_pose)
 
     @mcp.tool()
+    async def position_ahead(distance: float = 1.5) -> dict:
+        """Compute the world position *distance* metres in front of the user.
+
+        Use for: "in front of me", "where I'm looking", "ahead of me".
+
+        Returns {x, y, z} world-space position, or {error: "pose unavailable"} if
+        tracking is not yet established — in that case do not use any position
+        values; retry after a short delay.
+        """
+        pose = await asyncio.get_running_loop().run_in_executor(None, source.get_pose)
+        if not pose.get("is_valid"):
+            return {"error": "pose unavailable"}
+        p = pose["position"]
+        f = pose["forward"]
+        return {
+            "x": round(p["x"] + f["x"] * distance, 3),
+            "y": round(p["y"] + f["y"] * distance, 3),
+            "z": round(p["z"] + f["z"] * distance, 3),
+        }
+
+    @mcp.tool()
+    async def position_relative(
+        forward: float = 0.0,
+        right:   float = 0.0,
+        up:      float = 0.0,
+    ) -> dict:
+        """Compute a world position from head-relative offsets (metres).
+
+        forward > 0 = in front of user   (use for "ahead", "in front of me")
+        forward < 0 = behind user
+        right   > 0 = to the user's right
+        right   < 0 = to the user's left
+        up      > 0 = above eye level
+        up      < 0 = below eye level
+
+        Examples:
+          "1m to my right"   → right=1.0
+          "2m ahead and left"→ forward=2.0, right=-0.5
+          "at arm's length"  → forward=0.7
+
+        Returns {x, y, z} world-space position, or {error: "pose unavailable"} if
+        tracking is not yet established — do not use any position values in
+        that case; retry after a short delay.
+        """
+        pose = await asyncio.get_running_loop().run_in_executor(None, source.get_pose)
+        if not pose.get("is_valid"):
+            return {"error": "pose unavailable"}
+        p = pose["position"]
+        f = pose["forward"]
+        r = pose["right"]
+        u = pose["up"]
+        return {
+            "x": round(p["x"] + f["x"]*forward + r["x"]*right + u["x"]*up, 3),
+            "y": round(p["y"] + f["y"]*forward + r["y"]*right + u["y"]*up, 3),
+            "z": round(p["z"] + f["z"]*forward + r["z"]*right + u["z"]*up, 3),
+        }
+
+    @mcp.tool()
     async def get_health() -> dict:
         """Server status. ``session_open`` is True once the headless OpenXR
-        session has been established — typically once the first ``get_head_pose``
-        call after the streaming client connects."""
+        session has been established."""
         return source.health_snapshot()
 
     return mcp

--- a/agent-mcp-servers/render-mcp/render_mcp/__main__.py
+++ b/agent-mcp-servers/render-mcp/render_mcp/__main__.py
@@ -2,16 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-render-mcp — OpenXR rendering MCP adapter.
+render-mcp — generic OpenXR rendering MCP adapter.
 
-Spawns LOVR (the OpenXR rendering app) on demand and forwards scene ops to
-it as msgpack over ZMQ PUSH (``scene_socket``).
+Manages a scene of typed 3D primitives and forwards state changes to LOVR
+(the OpenXR rendering app) as msgpack over ZMQ PUSH (``scene_socket``).
 
-  POST /sphere/radius   {"value": F}        per-audio-chunk volume → radius
   /mcp/start_xr                              spawn LOVR (idempotent)
-  /mcp/set_sphere_color(r, g, b)             RGB floats in [0, 1]
-  /mcp/set_sphere_position(x, y, z)          world-space, metres (OpenXR Y-up)
-  /mcp/reset_sphere                          restore default colour + position
+  /mcp/add_primitive(...)                    add a new primitive; returns assigned id
+  /mcp/update_primitive(id, ...)             partially update an existing primitive
+  /mcp/remove_primitive(id)                  remove a primitive from the scene
+  /mcp/get_scene_state                       current state of all scene objects
   /mcp/get_health                            {status, lovr_started, spawn_error, render_drops}
 
 LOVR can't be spawned at process start because CloudXR returns
@@ -38,9 +38,7 @@ import uvicorn
 import yaml
 import zmq
 import zmq.asyncio
-from fastapi import FastAPI
 from fastmcp import FastMCP
-from pydantic import BaseModel
 
 from xr_ai_launcher import (
     ManagedProcess,
@@ -130,11 +128,16 @@ def _find_bundled_libzmq() -> Path | None:
     return None
 
 
-# ── Sphere dispatcher ─────────────────────────────────────────────────────────
+# ── Scene dispatcher ──────────────────────────────────────────────────────────
 
-class SphereDispatcher:
-    """ZMQ PUSH to LOVR + the LOVR child lifecycle. All tools funnel through
-    ``forward(op, value)``; ops are dropped until ``start_lovr_once`` has run."""
+class SceneDispatcher:
+    """ZMQ PUSH to LOVR + LOVR child lifecycle + in-memory scene state.
+
+    Scene state is mirrored in ``_objects`` so ``get_scene_state()`` answers
+    immediately without a round-trip to LOVR. All scene mutations go through
+    ``add`` / ``update`` / ``remove`` for state bookkeeping and then through
+    ``forward()`` to push the op to LOVR.
+    """
 
     def __init__(self, cfg: Config, stack: contextlib.AsyncExitStack) -> None:
         self._cfg   = cfg
@@ -142,19 +145,23 @@ class SphereDispatcher:
 
         ctx = zmq.asyncio.Context.instance()
         self._push: zmq.asyncio.Socket = ctx.socket(zmq.PUSH)
-        # 8 = enough headroom for a single LLM-round-trip burst (colour +
-        # position + radius), small enough that anything beyond a burst is
-        # correctly classified as a stall and dropped via NOBLOCK.
-        self._push.setsockopt(zmq.SNDHWM, 8)
+        # 8 = enough headroom for a single LLM-round-trip burst, small enough
+        # that anything beyond a burst is dropped via NOBLOCK rather than queued.
+        # 256 = room for ~5 s of 50 Hz scale messages while LOVR starts up,
+        # plus command messages. The old value of 8 let scale messages crowd
+        # out scene.add before LOVR connected.
+        self._push.setsockopt(zmq.SNDHWM, 256)
         self._push.bind(cfg.scene_socket)
         log.info("render-mcp: bound PUSH on %s", cfg.scene_socket)
 
         self._lovr_started: bool = False
         self._spawn_lock: asyncio.Lock = asyncio.Lock()
         self._render_drops: int = 0
-        # Set once on a terminal cloudxr-readiness timeout so retries fail
-        # fast instead of re-running the multi-minute wait.
         self._spawn_error: str | None = None
+
+        # Scene state: { id → { type, position, color, scale } }
+        self._objects: dict[str, dict] = {}
+        self._id_counters: dict[str, int] = {}
 
     async def start_lovr_once(self) -> dict:
         """Spawn LOVR if not already running. Idempotent. Failures are cached."""
@@ -203,13 +210,73 @@ class SphereDispatcher:
 
             async def _watch() -> None:
                 rc = await lovr_proc.wait()
-                log.warning("render-mcp: LOVR child exited (rc=%s)", rc)
+                log.warning("render-mcp: LOVR child exited (rc=%s) — "
+                            "resetting lovr_started so next start_xr respawns it", rc)
+                self._lovr_started = False
 
             asyncio.create_task(_watch(), name="lovr-watch")
 
             self._lovr_started = True
             log.info("render-mcp: LOVR spawned (xr.start handled)")
+            # Resync current scene state into LOVR's ZMQ receive buffer so any
+            # previously-added primitives survive a LOVR restart.
+            await self._resync_scene()
             return {"status": "started"}
+
+    async def _resync_scene(self) -> None:
+        """Push scene.add for every known primitive into LOVR's ZMQ buffer.
+        Called after LOVR (re)starts so primitives added in a previous session
+        are visible immediately when LOVR connects."""
+        for obj_id, obj in list(self._objects.items()):
+            pos = obj["position"]
+            col = obj["color"]
+            await self.forward("scene.add", {
+                "id":       obj_id,
+                "type":     obj["type"],
+                "position": [pos["x"], pos["y"], pos["z"]],
+                "color":    [col["r"], col["g"], col["b"]],
+                "size":    obj["size"],
+            })
+            log.info("render-mcp: resync  id=%s", obj_id)
+
+    # ── scene state ───────────────────────────────────────────────────────────
+
+    def _make_id(self, prim_type: str) -> str:
+        n = self._id_counters.get(prim_type, 0)
+        self._id_counters[prim_type] = n + 1
+        return f"{prim_type}-{n}"
+
+    def add(self, prim_type: str, position: dict, color: dict,
+            size: float) -> str:
+        """Add a new object; return its server-assigned id."""
+        obj_id = self._make_id(prim_type)
+        self._objects[obj_id] = {
+            "type":     prim_type,
+            "position": dict(position),
+            "color":    dict(color),
+            "size":     size,
+        }
+        return obj_id
+
+    def get_object(self, obj_id: str) -> dict | None:
+        """Return the stored object for *obj_id*, or None if not found."""
+        return self._objects.get(obj_id)
+
+    def update(self, obj_id: str, props: dict) -> bool:
+        """Partially merge *props* into an existing object. Returns False if
+        the id is unknown."""
+        obj = self._objects.get(obj_id)
+        if obj is None:
+            return False
+        for k, v in props.items():
+            if isinstance(v, dict) and isinstance(obj.get(k), dict):
+                obj[k].update(v)
+            else:
+                obj[k] = v
+        return True
+
+    def remove(self, obj_id: str) -> bool:
+        return self._objects.pop(obj_id, None) is not None
 
     def health_snapshot(self) -> dict:
         return {
@@ -219,13 +286,21 @@ class SphereDispatcher:
             "render_drops": self._render_drops,
         }
 
+    def scene_snapshot(self) -> dict:
+        return {
+            "objects": [{"id": obj_id, **obj} for obj_id, obj in self._objects.items()]
+        }
+
+    # ── wire ──────────────────────────────────────────────────────────────────
+
     async def forward(self, op: str, value: Any) -> dict:
-        """msgpack-encode ``{op, value}`` and PUSH to LOVR. Drops until xr.start."""
+        """msgpack-encode ``{op, value}`` and PUSH to LOVR. Drops until
+        ``start_xr`` has succeeded."""
         if not self._lovr_started:
             self._render_drops += 1
             if self._render_drops % 200 == 1:
                 log.debug(
-                    "render-mcp: dropping render op %r (LOVR not started yet) — drops=%d",
+                    "render-mcp: dropping op %r (LOVR not started) — drops=%d",
                     op, self._render_drops,
                 )
             return {"ok": False, "reason": "not_started"}
@@ -244,22 +319,19 @@ class SphereDispatcher:
 
 # ── MCP tool surface ──────────────────────────────────────────────────────────
 
-def build_mcp(disp: SphereDispatcher) -> FastMCP:
+def build_mcp(disp: SceneDispatcher) -> FastMCP:
     mcp = FastMCP("render-mcp")
 
     @mcp.tool()
     async def start_xr() -> dict:
-        """
-        Spawn LOVR (the OpenXR rendering app) if it hasn't been started.
+        """Spawn LOVR (the OpenXR rendering app) if it hasn't been started.
 
-        Idempotent — calling again after success returns
-        ``{"status": "already_started"}``. Returns immediately; the
-        cloudxr-runtime readiness wait + LOVR launch happen in a background
-        task. Poll ``get_health`` until ``lovr_started`` flips before sending
-        render ops you can't tolerate dropping.
+        Idempotent — returns ``{"status": "already_started"}`` if already up.
+        Returns immediately; the CloudXR readiness wait and LOVR launch run in
+        a background task. Poll ``get_health`` until ``lovr_started`` flips
+        before sending scene ops you can't tolerate dropping.
 
-        Failure (cloudxr never became ready) is cached: every subsequent
-        call returns the same error rather than re-running the wait.
+        Terminal failures are cached so retries fail fast.
         """
         snap = disp.health_snapshot()
         if snap["lovr_started"]:
@@ -277,20 +349,152 @@ def build_mcp(disp: SphereDispatcher) -> FastMCP:
         return {"status": "starting"}
 
     @mcp.tool()
-    async def set_sphere_color(r: float, g: float, b: float) -> dict:
-        """Set sphere RGB. Components in [0, 1]."""
-        return await disp.forward("sphere.color", [float(r), float(g), float(b)])
+    async def add_primitive(
+        prim_type: str,
+        x: float = 0.0, y: float = 1.6, z: float = -1.5,
+        r: float = 0.2, g: float = 0.9, b: float = 1.0,
+        size: float = 0.1,
+    ) -> dict:
+        """Add a new primitive to the scene. Returns its server-assigned id.
+
+        Supported types: sphere, box (others fall back to sphere).
+        Position is world-space metres (OpenXR Y-up).
+        size is in METRES: radius for spheres, edge half-length for boxes.
+          0.05 m = 5 cm (tiny)   0.1 m = 10 cm (default)
+          0.3 m = 30 cm          1.0 m = 1 metre (large)
+
+        COLOR — ALWAYS specify all three components together, never partial:
+          red    r=1, g=0, b=0      green   r=0, g=0.8, b=0
+          blue   r=0, g=0.4, b=1    yellow  r=1, g=1,   b=0
+          white  r=1, g=1,   b=1    orange  r=1, g=0.5, b=0
+          cyan   r=0, g=0.9, b=1    purple  r=0.6, g=0, b=1
+        Omitting any of r/g/b uses the default (0.2/0.9/1.0 = cyan).
+        Example: 'red sphere' → r=1.0, g=0.0, b=0.0  (all three required)
+
+        Examples:
+          "add a red sphere"     prim_type="sphere", r=1, g=0, b=0
+          "add a green cube"     prim_type="box",    r=0, g=0.8, b=0
+          "add a blue sphere"    prim_type="sphere", r=0, g=0.4, b=1
+        """
+        position = {"x": float(x), "y": float(y), "z": float(z)}
+        color    = {"r": float(r), "g": float(g), "b": float(b)}
+        obj_id   = disp.add(prim_type, position, color, float(size))
+        result   = await disp.forward("scene.add", {
+            "id": obj_id, "type": prim_type,
+            "position": [x, y, z],
+            "color":    [r, g, b],
+            "size":     size,
+        })
+        log.info("render-mcp: add_primitive id=%s type=%s", obj_id, prim_type)
+        return {"id": obj_id, **result}
 
     @mcp.tool()
-    async def set_sphere_position(x: float, y: float, z: float) -> dict:
-        """Set sphere world-space position in metres (OpenXR Y-up; default
-        anchor is (0, 1.6, -1.5) — head height, 1.5 m in front of origin)."""
-        return await disp.forward("sphere.position", [float(x), float(y), float(z)])
+    async def update_primitive(
+        obj_id: str,
+        prim_type: str | None = None,
+        x: float | None = None, y: float | None = None, z: float | None = None,
+        r: float | None = None, g: float | None = None, b: float | None = None,
+        size: float | None = None,
+    ) -> dict:
+        """Update one or more properties of an existing primitive (partial update).
+
+        Only the fields you pass change; omitted fields keep their current values.
+        All coordinates are world-space metres (OpenXR Y-up).
+
+        TYPE CHANGE: pass prim_type="box" or prim_type="sphere" to convert a
+        primitive to a different shape while keeping its position, color, and size.
+          "change the sphere to a cube" → obj_id=<id>, prim_type="box"
+          "convert the box to a sphere" → obj_id=<id>, prim_type="sphere"
+
+        COLOR: when changing color, ALWAYS pass all three of r, g, b together.
+          "make it red"   → r=1.0, g=0.0, b=0.0  (all three required)
+          "make it green" → r=0.0, g=0.8, b=0.0
+
+        Examples:
+          "change to a cube"       obj_id=<id>, prim_type="box"
+          "make it red"            obj_id=<id>, r=1.0, g=0.0, b=0.0
+          "move it up 1m"          obj_id=<id>, y=<current_y + 1.0>
+          "make it twice as big"   obj_id=<id>, size=<current_size * 2>
+        """
+        obj = disp.get_object(obj_id)
+        if obj is None:
+            return {"ok": False, "reason": "not_found"}
+
+        # Apply scalar-property updates first.
+        props: dict = {}
+        if any(v is not None for v in (x, y, z)):
+            props["position"] = {k: v for k, v in (("x", x), ("y", y), ("z", z)) if v is not None}
+        if any(v is not None for v in (r, g, b)):
+            props["color"] = {k: v for k, v in (("r", r), ("g", g), ("b", b)) if v is not None}
+        if size is not None:
+            props["size"] = float(size)
+        if props:
+            disp.update(obj_id, props)
+
+        if prim_type is not None and prim_type != obj["type"]:
+            # Type change: remove old, re-add with new type preserving merged state.
+            merged = disp.get_object(obj_id)
+            p, c = merged["position"], merged["color"]
+            disp.remove(obj_id)
+            await disp.forward("scene.remove", {"id": obj_id})
+            new_id = disp.add(prim_type, p, c, merged["size"])
+            result = await disp.forward("scene.add", {
+                "id": new_id, "type": prim_type,
+                "position": [p["x"], p["y"], p["z"]],
+                "color":    [c["r"], c["g"], c["b"]],
+                "size":     merged["size"],
+            })
+            log.info("render-mcp: type change %s → %s  new_id=%s", obj_id, prim_type, new_id)
+            return {"ok": result.get("ok", True), "new_id": new_id}
+
+        if not props:
+            return {"ok": True}   # no-op
+
+        # Build wire payload for property-only updates.
+        obj  = disp.get_object(obj_id)
+        wire: dict = {"id": obj_id}
+        if "position" in props:
+            p = obj["position"]
+            wire["position"] = [p["x"], p["y"], p["z"]]
+        if "color" in props:
+            c = obj["color"]
+            wire["color"] = [c["r"], c["g"], c["b"]]
+        if "size" in props:
+            wire["size"] = obj["size"]
+        return await disp.forward("scene.update", wire)
 
     @mcp.tool()
-    async def reset_sphere() -> dict:
-        """Restore default sphere colour + position. Radius keeps tracking voice."""
-        return await disp.forward("sphere.reset", None)
+    async def remove_primitive(obj_id: str) -> dict:
+        """Remove a primitive from the scene by id.
+
+        Example: "remove the sphere" → obj_id=<id from get_scene_state>
+        """
+        if not disp.remove(obj_id):
+            return {"ok": False, "reason": "not_found"}
+        return await disp.forward("scene.remove", {"id": obj_id})
+
+    @mcp.tool()
+    async def get_scene_state() -> dict:
+        """Return the current state of all scene objects.
+
+        Response shape::
+
+            {
+              "objects": [
+                {
+                  "id":       "<string>",
+                  "type":     "<string>",
+                  "position": {"x": float, "y": float, "z": float},
+                  "color":    {"r": float, "g": float, "b": float},
+                  "size":    float
+                },
+                ...
+              ]
+            }
+
+        All coordinates are world-space metres (OpenXR Y-up).
+        """
+        return disp.scene_snapshot()
 
     @mcp.tool()
     async def get_health() -> dict:
@@ -301,26 +505,9 @@ def build_mcp(disp: SphereDispatcher) -> FastMCP:
     return mcp
 
 
-# ── Streaming HTTP route ──────────────────────────────────────────────────────
-
-class _RadiusBody(BaseModel):
-    value: float
-
-
-def build_app(disp: SphereDispatcher) -> FastAPI:
-    """FastAPI app hosting POST /sphere/radius plus the FastMCP tool
-    surface mounted at /mcp. The outer app inherits the inner FastMCP
-    app's lifespan so its session-store startup hooks run."""
-    mcp_app = build_mcp(disp).http_app(path="/mcp")
-    app = FastAPI(title="render-mcp", docs_url=None, redoc_url=None,
-                  lifespan=mcp_app.lifespan)
-
-    @app.post("/sphere/radius")
-    async def sphere_radius(body: _RadiusBody) -> dict:
-        return await disp.forward("sphere.radius", body.value)
-
-    app.mount("/", mcp_app)
-    return app
+def build_app(disp: SceneDispatcher):
+    """Pure FastMCP app — no REST routes, all ops via MCP tools."""
+    return build_mcp(disp).http_app(path="/mcp")
 
 
 # ── Entry point ───────────────────────────────────────────────────────────────
@@ -335,12 +522,12 @@ async def _serve(cfg: Config) -> None:
         log.warning("render-mcp: no bundled libzmq found — LOVR will try the system copy")
 
     async with contextlib.AsyncExitStack() as stack:
-        disp = SphereDispatcher(cfg, stack)
+        disp = SceneDispatcher(cfg, stack)
         try:
             app = build_app(disp)
             uv_cfg = uvicorn.Config(app, host=cfg.host, port=cfg.port, log_level="warning")
             server = uvicorn.Server(uv_cfg)
-            log.info("render-mcp  http=/sphere/radius  mcp=/mcp  port=%d  scene_socket=%s",
+            log.info("render-mcp  mcp=/mcp  port=%d  scene_socket=%s",
                      cfg.port, cfg.scene_socket)
             await server.serve()
         finally:

--- a/agent-mcp-servers/render-mcp/xr_app/main.lua
+++ b/agent-mcp-servers/render-mcp/xr_app/main.lua
@@ -1,53 +1,28 @@
--- render-mcp scene.
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- render-mcp scene — generic primitive renderer.
 --
--- Renders a sphere at a fixed world-space position, whose appearance is driven
--- by scene commands arriving from render-mcp (Python) over a ZMQ PULL socket.
---
--- Wire format: msgpack-encoded Lua tables. Recognised ops:
---   { op = "sphere.radius",   value = <number, metres>   }   -- voice-loudness driven
---   { op = "sphere.color",    value = { r, g, b }        }   -- 0..1 floats; speech-driven
---   { op = "sphere.position", value = { x, y, z }        }   -- world-space metres; LLM-driven
---   { op = "sphere.reset"                                 }   -- return colour + position to defaults
---
--- Bridge endpoint comes from the RENDER_SCENE_SOCKET env var (set by render-mcp
--- before it spawns LOVR); a sensible default is used if unset so the file still
--- runs standalone for offline tweaking.
+-- Wire ops (msgpack-encoded tables):
+--   { op="scene.add",    value={ id, type, position={x,y,z}, color={r,g,b}, scale } }
+--   { op="scene.update", value={ id, [position=…], [color=…], [scale=…] } }
+--   { op="scene.remove", value={ id } }
+--   { op="scene.scale",  value={ id, scale } }    -- high-frequency audio path
 
 print("[render-mcp-scene] main.lua: top of file")
 
 local zmq = require("lib.zmq")
 local mp  = require("lib.msgpack")
-print("[render-mcp-scene] main.lua: lib.zmq + lib.msgpack loaded")
+print("[render-mcp-scene] lib.zmq + lib.msgpack loaded")
 
 -- ── Scene state ───────────────────────────────────────────────────────────────
 
--- Target radius is what render-mcp tells us we should be at; current radius
--- tracks it with a soft-follow lerp so the visual stays smooth even when
--- commands arrive in bursts.
-local target_radius  = 0.05
-local current_radius = target_radius
+local primitives      = {}
+local scale_warned    = {}   -- set of ids for which the "unknown scale" warning was printed
 
--- Defaults — the canonical look of the sphere at session start. ``sphere.reset``
--- restores these. Keep colour and position in module-local tables so the reset
--- op doesn't need to know magic numbers.
-local DEFAULT_COLOR = { 0.2, 0.9, 1.0 }   -- pleasant cyan
-local DEFAULT_POS   = { 0.0, 1.6, -1.5 }
-
--- Same dual-state pattern for colour: the agent emits discrete colour
--- commands (e.g. on STT match), and we ease toward the target so the change
--- looks like a wash rather than a flash.
-local target_color  = { DEFAULT_COLOR[1], DEFAULT_COLOR[2], DEFAULT_COLOR[3] }
-local current_color = { target_color[1], target_color[2], target_color[3] }
-
--- Same dual-state pattern for position. Default anchors the sphere at roughly
--- head-height, 1.5 m in front of the origin so a default-posed headset sees it
--- on first connect.
-local target_pos  = { DEFAULT_POS[1], DEFAULT_POS[2], DEFAULT_POS[3] }
-local current_pos = { target_pos[1], target_pos[2], target_pos[3] }
-
-local radius_lerp = 8.0    -- how fast current_radius follows target_radius
-local color_lerp  = 6.0    -- how fast current_color  follows target_color
-local pos_lerp    = 6.0    -- how fast current_pos    follows target_pos
+local pos_lerp   = 6.0
+local color_lerp = 6.0
+local scale_lerp = 8.0
 
 -- ── IPC ───────────────────────────────────────────────────────────────────────
 
@@ -55,58 +30,129 @@ local socket_addr = os.getenv("RENDER_SCENE_SOCKET") or "ipc:///tmp/xr_render_sc
 local scene_sock  = nil
 local recv_err    = nil
 
--- Try to connect to the scene bridge.  We keep running even if this fails so
--- the sphere still renders at its default size (makes offline debugging sane).
 local ok, err = pcall(function()
     scene_sock = zmq.new_pull_socket(socket_addr)
 end)
 if not ok then
     recv_err = tostring(err)
-    print(string.format("[render-mcp-scene] warning: %s", recv_err))
+    print("[render-mcp-scene] ZMQ error: " .. recv_err)
+end
+
+-- ── Helpers ───────────────────────────────────────────────────────────────────
+
+local function lerp(a, b, k) return a + (b - a) * k end
+
+local function read_vec3(v, dx, dy, dz)
+    return tonumber(v and (v[1] or v.x)) or dx,
+           tonumber(v and (v[2] or v.y)) or dy,
+           tonumber(v and (v[3] or v.z)) or dz
+end
+
+local function make_primitive(ptype, px, py, pz, cr, cg, cb, scale)
+    return {
+        type          = ptype or "sphere",
+        target_pos    = { px, py, pz },
+        current_pos   = { px, py, pz },
+        target_color  = { cr, cg, cb },
+        current_color = { cr, cg, cb },
+        target_scale  = scale,
+        current_scale = scale,
+    }
+end
+
+local function count_primitives()
+    local n = 0
+    for _ in pairs(primitives) do n = n + 1 end
+    return n
+end
+
+-- ── Op handlers ───────────────────────────────────────────────────────────────
+
+local function handle_scene_add(v)
+    local id = v.id
+    if not id then
+        print("[render-mcp-scene] scene.add: missing id — dropping")
+        return
+    end
+    local ptype      = v.type or "sphere"
+    local px, py, pz = read_vec3(v.position, 0, 1.6, -1.5)
+    local cr, cg, cb = read_vec3(v.color, 0.2, 0.9, 1.0)
+    local size       = tonumber(v.size) or 0.1
+    primitives[id]   = make_primitive(ptype, px, py, pz, cr, cg, cb, size)
+    scale_warned[id] = nil   -- clear so the id can warn again if it goes missing
+    print(string.format(
+        "[render-mcp-scene] scene.add  id=%s type=%s pos=(%.2f,%.2f,%.2f) color=(%.2f,%.2f,%.2f) size=%.3fm  total=%d",
+        id, ptype, px, py, pz, cr, cg, cb, size, count_primitives()))
+end
+
+local function handle_scene_update(v)
+    local id  = v.id
+    local obj = id and primitives[id]
+    if not obj then
+        print(string.format("[render-mcp-scene] scene.update: unknown id=%s", tostring(id)))
+        return
+    end
+    local changed = {}
+    if v.position then
+        local px, py, pz = read_vec3(v.position, obj.target_pos[1], obj.target_pos[2], obj.target_pos[3])
+        obj.target_pos[1], obj.target_pos[2], obj.target_pos[3] = px, py, pz
+        changed[#changed+1] = string.format("pos=(%.2f,%.2f,%.2f)", px, py, pz)
+    end
+    if v.color then
+        local cr, cg, cb = read_vec3(v.color, obj.target_color[1], obj.target_color[2], obj.target_color[3])
+        obj.target_color[1], obj.target_color[2], obj.target_color[3] = cr, cg, cb
+        changed[#changed+1] = string.format("color=(%.2f,%.2f,%.2f)", cr, cg, cb)
+    end
+    if v.size then
+        local s = tonumber(v.size)
+        if s then
+            obj.target_scale = s
+            changed[#changed+1] = string.format("size=%.3fm", s)
+        end
+    end
+    print(string.format("[render-mcp-scene] scene.update id=%s  %s",
+                        id, #changed > 0 and table.concat(changed, "  ") or "(nothing changed)"))
+end
+
+local function handle_scene_remove(v)
+    local id = v.id
+    if id and primitives[id] then
+        primitives[id] = nil
+        print(string.format("[render-mcp-scene] scene.remove id=%s  remaining=%d", id, count_primitives()))
+    elseif id then
+        print(string.format("[render-mcp-scene] scene.remove: unknown id=%s", id))
+    end
+end
+
+local function handle_scene_scale(v)
+    local id  = v.id
+    local obj = id and primitives[id]
+    if obj then
+        local s = tonumber(v.size)
+        if s then obj.target_scale = s end
+    elseif id and not scale_warned[id] then
+        -- Log exactly once per unknown id so it doesn't drown other output.
+        scale_warned[id] = true
+        print(string.format("[render-mcp-scene] scene.scale: unknown id=%s (logged once)", tostring(id)))
+    end
 end
 
 -- ── LOVR callbacks ────────────────────────────────────────────────────────────
 
 function lovr.load()
-    -- alpha=0 so the OpenXR runtime composites our framebuffer over the real
-    -- environment (passthrough on a real headset, transparent over the page
-    -- under IWER) instead of filling the void with black. Requires both:
-    --   1) WebXR client requests immersive-ar (so CloudXR exposes ALPHA_BLEND)
-    --   2) we explicitly opt into passthrough below — LOVR otherwise picks
-    --      blendModes[0], which on CloudXR is OPAQUE.
-    lovr.graphics.setBackgroundColor(0.0, 0.0, 0.0, 0.0)
+    lovr.graphics.setBackgroundColor(0, 0, 0, 0)
     lovr.headset.setClipDistance(0.1, 256.0)
-    print(string.format("[render-mcp-scene] listening on %s", socket_addr))
-    -- Confirm OpenXR session actually came up. A printed `isActive=false` here
-    -- means LOVR fell back to the desktop simulator (boot.lua:150-155), which
-    -- means CloudXR never sees any frames — that's the failure mode we hit.
+    print("[render-mcp-scene] lovr.load  socket=" .. socket_addr)
+
     local ok_a, active = pcall(lovr.headset.isActive)
     local ok_d, name   = pcall(lovr.headset.getDriver)
-    local ok_s, w, h   = pcall(lovr.headset.getDisplayDimensions)
-    print(string.format(
-        "[render-mcp-scene] headset: active=%s driver=%s display=%s",
+    print(string.format("[render-mcp-scene] headset: active=%s driver=%s",
         ok_a and tostring(active) or "<err>",
-        ok_d and tostring(name)   or "<err>",
-        ok_s and string.format("%sx%s", tostring(w), tostring(h)) or "<err>"
-    ))
+        ok_d and tostring(name)   or "<err>"))
 
-    -- Enumerate + opt into passthrough. Logging both makes it obvious in the
-    -- terminal whether the runtime advertised ALPHA_BLEND at all (problem on
-    -- the WebXR/CloudXR side) vs. advertised it but rejected our request
-    -- (problem on the LOVR/Vulkan side).
-    local ok_m, modes = pcall(lovr.headset.getPassthroughModes)
-    if ok_m and type(modes) == "table" then
-        local parts = {}
-        for k, v in pairs(modes) do parts[#parts + 1] = string.format("%s=%s", k, tostring(v)) end
-        print("[render-mcp-scene] passthrough modes: " .. table.concat(parts, " "))
-    else
-        print("[render-mcp-scene] passthrough modes: <err>")
-    end
     local ok_p, applied = pcall(lovr.headset.setPassthrough, "blend")
-    print(string.format(
-        "[render-mcp-scene] setPassthrough('blend') ok=%s result=%s active=%s",
-        tostring(ok_p), tostring(applied), tostring(lovr.headset.getPassthrough())
-    ))
+    print(string.format("[render-mcp-scene] setPassthrough('blend') ok=%s applied=%s",
+        tostring(ok_p), tostring(applied)))
 end
 
 local function drain_commands()
@@ -114,75 +160,91 @@ local function drain_commands()
     while true do
         local raw = scene_sock:recv_nonblocking()
         if not raw then break end
+
         local okd, decoded = pcall(mp.decode, raw)
-        if not okd or type(decoded) ~= "table" then goto continue end
+        if not okd then
+            print("[render-mcp-scene] msgpack decode error: " .. tostring(decoded))
+            goto continue
+        end
+        if type(decoded) ~= "table" then
+            print("[render-mcp-scene] unexpected message type: " .. type(decoded))
+            goto continue
+        end
 
-        if decoded.op == "sphere.radius" then
-            local v = tonumber(decoded.value)
-            if v then target_radius = v end
+        local op = decoded.op
+        local v  = decoded.value or {}
 
-        elseif decoded.op == "sphere.color" then
-            local v = decoded.value
-            -- Accept arrays {r,g,b} (msgpack-pythonic) and tables {r=…,g=…,b=…}.
-            local r = tonumber(v and (v[1] or v.r))
-            local g = tonumber(v and (v[2] or v.g))
-            local b = tonumber(v and (v[3] or v.b))
-            if r and g and b then
-                target_color[1] = r
-                target_color[2] = g
-                target_color[3] = b
-            end
+        -- Wrap each handler in pcall so one bad message can't crash lovr.update.
+        local ok_h, herr
+        if     op == "scene.add"    then ok_h, herr = pcall(handle_scene_add,    v)
+        elseif op == "scene.update" then ok_h, herr = pcall(handle_scene_update, v)
+        elseif op == "scene.remove" then ok_h, herr = pcall(handle_scene_remove, v)
+        elseif op == "scene.scale"  then ok_h, herr = pcall(handle_scene_scale,  v)
+        elseif op ~= nil then
+            print("[render-mcp-scene] unknown op=" .. tostring(op))
+        else
+            print("[render-mcp-scene] message missing 'op' field")
+        end
 
-        elseif decoded.op == "sphere.position" then
-            local v = decoded.value
-            -- Same dual-shape acceptance as sphere.color.
-            local x = tonumber(v and (v[1] or v.x))
-            local y = tonumber(v and (v[2] or v.y))
-            local z = tonumber(v and (v[3] or v.z))
-            if x and y and z then
-                target_pos[1] = x
-                target_pos[2] = y
-                target_pos[3] = z
-            end
-
-        elseif decoded.op == "sphere.reset" then
-            -- Restore colour + position to their session-start values. Radius
-            -- isn't reset because it's recomputed every audio chunk anyway —
-            -- it'll converge on its own once the user goes silent.
-            target_color[1], target_color[2], target_color[3] =
-                DEFAULT_COLOR[1], DEFAULT_COLOR[2], DEFAULT_COLOR[3]
-            target_pos[1], target_pos[2], target_pos[3] =
-                DEFAULT_POS[1], DEFAULT_POS[2], DEFAULT_POS[3]
+        if ok_h == false then
+            print(string.format("[render-mcp-scene] handler error (op=%s): %s",
+                                tostring(op), tostring(herr)))
         end
 
         ::continue::
     end
 end
 
+local heartbeat_t = 0.0
+
 function lovr.update(dt)
     drain_commands()
 
-    -- Smooth the radius a touch so we don't get stutter when commands drop.
-    current_radius = current_radius + (target_radius - current_radius) * math.min(1.0, radius_lerp * dt)
-
+    local ks = math.min(1.0, scale_lerp * dt)
     local kc = math.min(1.0, color_lerp * dt)
-    current_color[1] = current_color[1] + (target_color[1] - current_color[1]) * kc
-    current_color[2] = current_color[2] + (target_color[2] - current_color[2]) * kc
-    current_color[3] = current_color[3] + (target_color[3] - current_color[3]) * kc
+    local kp = math.min(1.0, pos_lerp   * dt)
 
-    local kp = math.min(1.0, pos_lerp * dt)
-    current_pos[1] = current_pos[1] + (target_pos[1] - current_pos[1]) * kp
-    current_pos[2] = current_pos[2] + (target_pos[2] - current_pos[2]) * kp
-    current_pos[3] = current_pos[3] + (target_pos[3] - current_pos[3]) * kp
+    for _, obj in pairs(primitives) do
+        obj.current_scale    = lerp(obj.current_scale,    obj.target_scale,    ks)
+        obj.current_color[1] = lerp(obj.current_color[1], obj.target_color[1], kc)
+        obj.current_color[2] = lerp(obj.current_color[2], obj.target_color[2], kc)
+        obj.current_color[3] = lerp(obj.current_color[3], obj.target_color[3], kc)
+        obj.current_pos[1]   = lerp(obj.current_pos[1],   obj.target_pos[1],   kp)
+        obj.current_pos[2]   = lerp(obj.current_pos[2],   obj.target_pos[2],   kp)
+        obj.current_pos[3]   = lerp(obj.current_pos[3],   obj.target_pos[3],   kp)
+    end
+
+    heartbeat_t = heartbeat_t + dt
+    if heartbeat_t >= 5.0 then
+        heartbeat_t = 0.0
+        local n = count_primitives()
+        if n == 0 then
+            print("[render-mcp-scene] heartbeat: scene empty")
+        else
+            for id, obj in pairs(primitives) do
+                print(string.format(
+                    "[render-mcp-scene] heartbeat: id=%s type=%s pos=(%.2f,%.2f,%.2f) size=%.3fm",
+                    id, obj.type,
+                    obj.current_pos[1], obj.current_pos[2], obj.current_pos[3],
+                    obj.current_scale))
+            end
+        end
+    end
 end
 
 function lovr.draw(pass)
-    pass:setColor(current_color[1], current_color[2], current_color[3], 0.95)
-    pass:sphere(current_pos[1], current_pos[2], current_pos[3], current_radius)
+    for _, obj in pairs(primitives) do
+        pass:setColor(obj.current_color[1], obj.current_color[2], obj.current_color[3], 0.95)
+        local p, s = obj.current_pos, obj.current_scale
+        if obj.type == "box" then
+            pass:box(p[1], p[2], p[3], s, s, s)
+        else
+            pass:sphere(p[1], p[2], p[3], s)
+        end
+    end
     pass:setColor(1, 1, 1, 1)
-
     if recv_err then
-        pass:text("render-mcp: " .. recv_err, 0, 2.0, -1.2, 0.06)
+        pass:text("ZMQ error: " .. recv_err, 0, 2.0, -1.2, 0.06)
     end
 end
 

--- a/agent-mcp-servers/vlm-mcp/vlm_mcp_server/__main__.py
+++ b/agent-mcp-servers/vlm-mcp/vlm_mcp_server/__main__.py
@@ -172,6 +172,9 @@ def build_mcp(vlm: VlmClient) -> FastMCP:
 
         Notes
         -----
+        - ``image_path`` MUST be the ``path`` value returned by a prior call to
+          ``get_frame_from_time`` or ``get_latest_frame``.  Never invent or guess
+          a path — the tool will return an error and the task will fail.
         - Image I/O runs in a thread pool so the asyncio event loop is never
           blocked even for large frames.
         - The tool does NOT maintain conversation history. Each call is


### PR DESCRIPTION
## Summary

Changes to `oxr-mcp`, `render-mcp`, `xr_app/main.lua`, and `vlm-mcp`. No changes to samples or other packages — those come in separate PRs.

---

## oxr-mcp

**LLM-friendly pose output.** `get_head_pose()` now returns human-readable spatial vectors instead of raw quaternions:
- `forward`, `right`, `up` unit vectors for direct spatial math
- `yaw_deg` / `pitch_deg` for heading description
- `position` as `{x, y, z}` dict

**Two new placement tools:**
- `position_ahead(distance)` — world position N metres in the gaze direction
- `position_relative(forward, right, up)` — world position from head-relative offsets

**Error return fix:** `position_ahead` / `position_relative` previously returned `{"error": ..., "x": 0.0, "y": 1.6, "z": -1.5}` — the fallback coordinates could be used by an LLM without checking the error key. Now returns `{"error": "pose unavailable"}` only.

---

## render-mcp

**Multi-primitive scene API** replacing the single-sphere model:

| Old | New |
|---|---|
| `set_sphere_color(r,g,b)` | `add_primitive(prim_type, x,y,z, r,g,b, size)` |
| `set_sphere_position(x,y,z)` | `update_primitive(obj_id, ...)` |
| `reset_sphere()` | `remove_primitive(obj_id)` |
| — | `get_scene_state()` |

`SceneDispatcher` (renamed from `SphereDispatcher`) mirrors the scene in `_objects` for instant state queries, syncs primitives back to LOVR after a restart, and resets `_lovr_started` on child exit so `start_xr` correctly respawns LOVR.

ZMQ SNDHWM bumped 8→256 so high-frequency scale messages don't crowd out `scene.add` before LOVR connects.

Removed stale `POST /primitive/{id}/scale` REST route from the module docstring (FastAPI was removed; `build_app` is now pure FastMCP).

**Code quality:** renamed `id`/`type` local variables that shadowed Python builtins → `obj_id`/`prim_type`; added `get_object()` public accessor so `update_primitive` no longer reaches into `_objects` directly.

---

## xr_app/main.lua

Full rewrite for multi-primitive rendering. `primitives` table keyed by id, `scene.add/update/remove/scale` wire ops, per-handler `pcall` for fault isolation, heartbeat log every 5 s. Added SPDX header.

---

## vlm-mcp

Docstring note warning the LLM never to invent an `image_path` — it must come from `get_frame_from_time`.

## Test plan

- [ ] `add_primitive` + `get_scene_state` round-trip
- [ ] `update_primitive` partial update (position only, color only, type change)
- [ ] `remove_primitive` removes from state and from LOVR
- [ ] LOVR restart → `_resync_scene` restores all primitives
- [ ] `position_ahead` / `position_relative` return error-only dict when pose is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)