### PR TITLE
feat(launcher): parallel process groups; fix agent noise and clarification spam

### DIFF
--- a/agent-mcp-servers/video-mcp/video_mcp_server/__main__.py
+++ b/agent-mcp-servers/video-mcp/video_mcp_server/__main__.py
@@ -667,7 +667,7 @@ async def _serve(cfg: dict, ready_file: pathlib.Path | None = None) -> None:
 
     ep_task = asyncio.create_task(ep.run(), name="video_mcp_processor")
     log.info("video-mcp-server  recordings_dir=%s  port=%d  hub_pub=%s",
-             recordings_dir, port, hub_pub)
+             recordings_dir_raw, port, hub_pub)
     if ready_file:
         ready_file.touch()
     try:

--- a/agent-samples/xr-render-demo/main.py
+++ b/agent-samples/xr-render-demo/main.py
@@ -39,7 +39,7 @@ import sys
 import urllib.request
 from pathlib import Path
 
-from xr_ai_launcher import Process, run_stack
+from xr_ai_launcher import Parallel, Process, run_stack
 
 _BASE = Path(__file__).resolve().parent
 
@@ -132,6 +132,7 @@ _AI      = f"yaml/{_GPU_CFG}"
 # runs with the full GPU free.  The compiled kernels are cached after the
 # first run.  On ADA, nemotron3_nano is pinned to cuda:1 so this order has
 # no downside there either.
+# fmt: off
 PROCESSES = [
     Process("hub",        "../../server-runtime",                 "xr_media_hub",
             config="yaml/xr_media_hub.yaml"),
@@ -157,6 +158,38 @@ PROCESSES = [
     Process("worker",     "worker",                               "xr_render_demo_worker",
             config="yaml/xr_render_demo_worker.yaml"),
 ]
+# fmt: on
+
+# Parallel launch (re-enable once serial debugging is complete):
+# PROCESSES = [
+#     Process("hub",     "../../server-runtime",  "xr_media_hub",
+#             config="yaml/xr_media_hub.yaml"),
+#     Process("cloudxr", "../../cloudxr-runtime", "cloudxr_runtime",
+#             config="yaml/cloudxr_runtime.yaml"),
+#     Parallel([
+#         Process("stt",       "../../ai-services/stt-server",         "stt_server",
+#                 config=f"{_AI}/stt_server.yaml"),
+#         Process("tts",       "../../ai-services/tts/piper",          "piper_tts_server",
+#                 config=f"{_AI}/piper_tts_server.yaml"),
+#         Process("agent-llm", "../../ai-services/llm/nemotron3_nano", "nemotron3_nano_llm_server",
+#                 config=f"{_AI}/nemotron3_nano_llm_server.yaml"),
+#         Process("vlm",       "../../ai-services/vlm-server",         "vlm_server",
+#                 config=f"{_AI}/vlm_server.yaml"),
+#         Process("llm",       "../../ai-services/llm/llama_nemotron", "llama_nemotron_llm_server",
+#                 config=f"{_AI}/llama_nemotron_llm_server.yaml"),
+#     ]),
+#     Parallel([
+#         Process("vlm-mcp",    "../../agent-mcp-servers/vlm-mcp",    "vlm_mcp_server",
+#                 config="yaml/vlm_mcp_server.yaml"),
+#         Process("video-mcp",  "../../agent-mcp-servers/video-mcp",  "video_mcp_server",
+#                 config="yaml/video_mcp_server.yaml"),
+#         Process("render-mcp", "../../agent-mcp-servers/render-mcp", "render_mcp"),
+#         Process("oxr-mcp",    "../../agent-mcp-servers/oxr-mcp",    "oxr_mcp_server",
+#                 config="yaml/oxr_mcp_server.yaml"),
+#     ]),
+#     Process("worker", "worker", "xr_render_demo_worker",
+#             config="yaml/xr_render_demo_worker.yaml"),
+# ]
 
 # Match an uncommented `lovr_bin:` line with a non-empty value.
 _LOVR_BIN_LINE = re.compile(r"^\s*lovr_bin\s*:\s*\S")

--- a/agent-samples/xr-render-demo/worker/processors.py
+++ b/agent-samples/xr-render-demo/worker/processors.py
@@ -251,13 +251,13 @@ class SttProcessor(FrameProcessor):
         finally:
             self._stt_busy = False
         if not text:
-            log.info("STT returned empty (%.1fs audio) — VAD may have caught noise", dur_s)
+            log.debug("STT returned empty (%.1fs audio) — VAD may have caught noise", dur_s)
             return
         log.info("transcript: %r", text)
         _trace_log.info("USER  %s", text)
         lower = text.lower().strip().rstrip(string.punctuation).strip()
         if _is_filler(lower):
-            log.info("filler — skipping")
+            log.debug("filler — skipping")
             return
         await self.push_frame(
             TranscriptionFrame(text=text, user_id="", timestamp=str(_now_us())),
@@ -379,10 +379,6 @@ class RenderSceneProcessor(FrameProcessor):
             if ack and ack_pid:
                 await self._send(ack_pid, ack, topic=_AGENT_PROGRESS_TOPIC)
                 if needs_thinking:
-                    # Speak the ack only when thinking is on — that's when the
-                    # user has to wait 5-10 s and needs to know we heard them.
-                    # For fast (non-thinking) turns the real response arrives
-                    # within ~1 s so speaking an ack would just add noise.
                     await self.push_frame(TextFrame(text=ack), FrameDirection.DOWNSTREAM)
 
             # Start a "still working" timer — fires if reasoning takes >5s.

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker.py
@@ -137,7 +137,10 @@ def _build_prompt(render_tools: list, oxr_tools: list,
         "4. SIZE in metres — radius for spheres, half-edge for boxes:\n"
         "   tiny=0.05  small=0.08  default=0.1  medium=0.2  large=0.5  huge=1.0\n"
         "   Resize: new_size = current_size × factor  (e.g. '3× bigger' → ×3, 'half' → ×0.5)\n"
-        "5. After completing the task respond with ONE short sentence confirming what was done.\n"
+        "5. NEVER ask the user for clarification. If a detail is missing, pick a sensible default "
+        "and act immediately: unspecified type → white sphere; unspecified position → 1.5 m ahead; "
+        "unspecified color → white; unspecified size → default (0.1 m).\n"
+        "6. After completing the task respond with ONE short sentence confirming what was done.\n"
     )
 
 

--- a/launcher/xr_ai_launcher/__init__.py
+++ b/launcher/xr_ai_launcher/__init__.py
@@ -2,20 +2,24 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-xr-ai-launcher — sequential process management for the xr-ai stack.
+xr-ai-launcher — process management for the xr-ai stack.
 
 Intentionally stdlib-only so it can be added to any sample without pulling
 in the dependency chain of the processes it manages.
 
 Typical usage::
 
-    from xr_ai_launcher import Process, run_stack
+    from xr_ai_launcher import Parallel, Process, run_stack
 
     _BASE = Path(__file__).resolve().parent
 
     PROCESSES = [
         Process("hub",    "../../server-runtime", "xr_media_hub"),
-        Process("worker", "worker",               "my_agent_worker"),
+        Parallel([
+            Process("stt", "../../ai-services/stt-server", "stt_server"),
+            Process("tts", "../../ai-services/tts/piper",  "piper_tts_server"),
+        ]),
+        Process("worker", "worker", "my_agent_worker"),
     ]
 
     def run() -> None:
@@ -25,11 +29,11 @@ Typical usage::
 from ._cloudxr_env import XR_RUNTIME_VAR, load_cloudxr_env
 from ._credentials import ensure_credentials, load_credentials
 from ._processes import ManagedProcess
-from ._stack import Process, run_stack
+from ._stack import Parallel, Process, run_stack
 
 __all__ = [
     "XR_RUNTIME_VAR", "load_cloudxr_env",
     "ensure_credentials", "load_credentials",
     "ManagedProcess",
-    "Process", "run_stack",
+    "Parallel", "Process", "run_stack",
 ]

--- a/launcher/xr_ai_launcher/_stack.py
+++ b/launcher/xr_ai_launcher/_stack.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Sequential stack launcher with per-process readiness files.
+Stack launcher with per-process readiness files.
 
 Design
 ------
@@ -10,8 +10,15 @@ Every launchable sub-project is self-describing: it exposes an entry-point
 command and accepts ``--config <path>.yaml`` (auto-discovered) and
 ``--ready-file <path>`` (injected by the launcher).
 
-Processes start **one at a time** in declaration order.  For each process
-the launcher:
+The stack is declared as a sequence of ``Process`` or ``Parallel`` items:
+
+* ``Process`` — started alone; the launcher waits for it to signal ready
+  before moving on.
+* ``Parallel([p1, p2, ...])`` — all processes in the group are started at
+  once; the launcher waits for *every* member to signal ready before the
+  next item in the sequence begins.
+
+For each process the launcher:
 
   1. Resolves the project directory and YAML config from the sample root.
   2. Spawns ``uv run --project <dir> <command> --config <yaml> --ready-file <f>``.
@@ -36,7 +43,7 @@ import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Sequence
+from typing import Sequence, Union
 
 from ._credentials import load_credentials
 
@@ -62,6 +69,29 @@ class Process:
     command: str
     config:  str | Path | None = None
     gpu:     str | None = None
+
+
+@dataclass(frozen=True)
+class Parallel:
+    """
+    A group of processes that start simultaneously.
+
+    The launcher spawns every member at once and waits for *all* of them to
+    signal readiness before advancing to the next item in the stack sequence.
+    If any member exits before signaling ready the launcher shuts everything
+    down, just as it would for a serial process.
+
+    Example::
+
+        Parallel([
+            Process("stt", "../../ai-services/stt-server", "stt_server"),
+            Process("tts", "../../ai-services/tts/piper",  "piper_tts_server"),
+        ])
+    """
+    processes: tuple[Process, ...]
+
+    def __init__(self, processes: Sequence[Process]) -> None:
+        object.__setattr__(self, "processes", tuple(processes))
 
 
 # ── subprocess helpers ─────────────────────────────────────────────────────────
@@ -125,6 +155,33 @@ def _wait_ready(name: str, ready_file: Path, proc: subprocess.Popen) -> None:
         time.sleep(0.5)
 
 
+_ReadyEntry = tuple[str, Path, subprocess.Popen]
+
+def _wait_ready_parallel(group: list[_ReadyEntry]) -> None:
+    """Wait for all processes in *group* concurrently; raise if any fails."""
+    failed: list[SystemExit] = []
+    lock = threading.Lock()
+
+    def _one(name: str, ready_file: Path, proc: subprocess.Popen) -> None:
+        try:
+            _wait_ready(name, ready_file, proc)
+        except SystemExit as exc:
+            with lock:
+                failed.append(exc)
+
+    threads = [
+        threading.Thread(target=_one, args=entry, daemon=True)
+        for entry in group
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    if failed:
+        raise failed[0]
+
+
 # ── monitor + shutdown ─────────────────────────────────────────────────────────
 
 def _monitor(procs: dict[str, subprocess.Popen]) -> None:
@@ -186,10 +243,14 @@ def _shutdown(procs: dict[str, subprocess.Popen]) -> None:
 
 # ── public API ─────────────────────────────────────────────────────────────────
 
-def run_stack(processes: Sequence[Process], base: Path) -> None:
+def run_stack(processes: Sequence[Union[Process, Parallel]], base: Path) -> None:
     """
-    Start *processes* sequentially, waiting for each to signal readiness
-    before launching the next.
+    Start *processes* in declaration order, waiting for each item to signal
+    readiness before advancing to the next.
+
+    Each item is either a single ``Process`` (started and awaited alone) or a
+    ``Parallel`` group (all members started at once; the launcher waits for
+    *every* member before moving on).
 
     Each process receives ``--ready-file <path>``.  When fully initialized
     it must ``Path(ready_file).touch()`` to signal the launcher.  Progress
@@ -207,7 +268,11 @@ def run_stack(processes: Sequence[Process], base: Path) -> None:
         PROCESSES = [
             Process("hub",    "../../server-runtime", "xr_media_hub",
                     config="yaml/xr_media_hub.yaml"),
-            Process("worker", "worker",               "my_worker",
+            Parallel([
+                Process("stt", "../../ai-services/stt-server", "stt_server"),
+                Process("tts", "../../ai-services/tts/piper",  "piper_tts_server"),
+            ]),
+            Process("worker", "worker", "my_worker",
                     config="yaml/my_worker.yaml"),
         ]
 
@@ -221,10 +286,20 @@ def run_stack(processes: Sequence[Process], base: Path) -> None:
     with tempfile.TemporaryDirectory(prefix="xr-ai-") as _tmpdir:
         tmpdir = Path(_tmpdir)
         try:
-            for proc in processes:
-                ready_file = tmpdir / f"{proc.name}.ready"
-                launched[proc.name] = _spawn(proc, base, ready_file)
-                _wait_ready(proc.name, ready_file, launched[proc.name])
+            for item in processes:
+                if isinstance(item, Parallel):
+                    group: list[_ReadyEntry] = []
+                    for proc in item.processes:
+                        ready_file = tmpdir / f"{proc.name}.ready"
+                        launched[proc.name] = _spawn(proc, base, ready_file)
+                        group.append((proc.name, ready_file, launched[proc.name]))
+                    names = ", ".join(p.name for p in item.processes)
+                    print(f"  [parallel] starting: {names}", flush=True)
+                    _wait_ready_parallel(group)
+                else:
+                    ready_file = tmpdir / f"{item.name}.ready"
+                    launched[item.name] = _spawn(item, base, ready_file)
+                    _wait_ready(item.name, ready_file, launched[item.name])
 
             print("\n  All processes ready.\n", flush=True)
             _monitor(launched)


### PR DESCRIPTION
## Summary

- **launcher**: adds `Parallel([...])` group type — processes within a group start simultaneously and the launcher waits for all members to be ready before advancing. Serial launch is unchanged; the xr-render-demo `PROCESSES` list has the parallel version commented out for debugging.
- **video-mcp**: fixes `NameError: recordings_dir` → `recordings_dir_raw` in log call (crashed the stack on startup).
- **xr-render-demo worker**: adds prompt rule to never ask clarifying questions — act immediately with sensible defaults (white sphere, 1.5 m ahead, etc.) instead of stalling with "I need to know what and where".
- **processors**: demotes empty-STT and filler-skip log lines from `INFO` to `DEBUG` to stop noise bursts spamming the console.

## Test plan

- [x] Serial launch still works (default path, Parallel block commented out)
- [ ] Uncomment Parallel block in `main.py` and verify AI services + MCP servers start concurrently
- [x] Confirm video-mcp no longer crashes on startup
- [x] Verify agent responds immediately to vague commands ("add an object") with a default white sphere
- [x] Verify noise bursts no longer produce INFO log spam

🤖 Generated with [Claude Code](https://claude.com/claude-code)