### PR TITLE
docs(readme): update sample VRAM estimates for vLLM-backed stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ endpoint and no local GPU is required for the agent or hub.
 
 | Sample | Local VRAM needed |
 |---|---|
-| simple-vlm-example | ~16 GB |
-| xr-render-demo | ~17 GB |
+| simple-vlm-example | ~23 GB |
+| xr-render-demo | ~70 GB |
 | Hub only | none |
 
 **Software**


### PR DESCRIPTION
The in-process transformers backends were replaced by vLLM (gpu_memory_ utilization defaults to 0.85), and xr-render-demo now bundles a 30B-class LLM alongside the VLM and rendering — the previous estimates predated both.

- simple-vlm-example: ~16 GB -> ~23 GB
- xr-render-demo:     ~17 GB -> ~70 GB