### PR TITLE
docs(xr-render-demo): LOVR build-from-source for DGX Spark

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,11 @@ On first run the orchestrator automatically downloads LOVR v0.18.0 to
 `deps/lovr/` inside the repo and builds the web vendor bundle (requires npm
 and network access). Both steps are skipped on subsequent runs.
 
+**DGX Spark (aarch64):** LOVR does not publish a prebuilt aarch64 Linux
+binary, so the auto-download is not available — build LOVR from source and
+export `LOVR_BIN`. See
+[`docs/troubleshooting.md`](docs/troubleshooting.md#dgx-spark--lovr-auto-download-is-not-supported).
+
 To use a custom LOVR build instead:
 
 ```bash

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -26,6 +26,41 @@ sudo apt install python3-dev
 
 This applies to the `xr-render-demo/yaml/spark/` profile.
 
+### DGX Spark — LOVR auto-download is not supported
+
+**Symptom:** `uv run xr_render_demo` exits at startup with:
+
+```
+xr-render-demo: LOVR auto-download is not supported on linux/aarch64.
+```
+
+**Cause:** upstream LOVR releases do not ship a prebuilt aarch64 Linux binary,
+so the orchestrator cannot fetch one. Build LOVR from source on the Spark and
+point `LOVR_BIN` at it.
+
+**Fix:**
+
+```bash
+sudo apt install -y cmake build-essential \
+                    libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
+                    libcurl4-openssl-dev libx11-xcb-dev
+
+git clone --recursive https://github.com/bjornbytes/lovr.git ~/lovr
+cd ~/lovr
+mkdir build && cd build
+cmake ..
+make -j$(nproc)
+
+export LOVR_BIN=~/lovr/build/bin/lovr
+```
+
+`export LOVR_BIN=…` only lasts for the current shell. To make it permanent,
+append the line to `~/.bashrc`, or set `lovr_bin: ~/lovr/build/bin/lovr` in
+`agent-mcp-servers/render-mcp/render_mcp.yaml` instead.
+
+If `git clone` was run without `--recursive`, run
+`git submodule update --init --recursive` inside `~/lovr` before `cmake ..`.
+
 ### Blackwell GPUs (B200, RTX PRO 6000) — VLM fails to start
 
 **Symptom:** the VLM server logs FlashInfer or NVFP4 kernel errors and never


### PR DESCRIPTION
## Summary

- LOVR does not publish a prebuilt aarch64 Linux binary, so on DGX Spark the xr-render-demo orchestrator exits with `LOVR auto-download is not supported on linux/aarch64`.
- Add a troubleshooting entry with the cleaned-up build recipe (apt deps, recursive clone, cmake/make) and how to expose `LOVR_BIN` (env var or `render_mcp.yaml`).
- Add a short Spark callout in the README quickstart pointing at the new troubleshooting section.

## Test plan

- [x] Read-through on GitHub: anchor link from README resolves to the new troubleshooting section.
- [x] On a DGX Spark, follow the recipe end-to-end: apt deps install, `git clone --recursive`, `cmake ..`, `make -j$(nproc)` produce `~/lovr/build/bin/lovr`.
- [x] `export LOVR_BIN=~/lovr/build/bin/lovr && uv run xr_render_demo` launches without the auto-download error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)