### PR TITLE
fix(logging): quieter stack output, prominent per-run log banner, captured container logs

### DIFF
--- a/agent-samples/xr-render-demo/main.py
+++ b/agent-samples/xr-render-demo/main.py
@@ -37,7 +37,6 @@ import re
 import shutil
 import subprocess
 import sys
-import time
 import urllib.request
 from pathlib import Path
 
@@ -278,31 +277,14 @@ def _ensure_web_vendor() -> None:
             f"    cd {build_sh.parent} && ./build.sh\n"
         )
 
-    # Capture build.sh output to a sibling file in the per-run log dir so
-    # the wrapper terminal stays quiet on the happy path. On failure, dump
-    # the captured output to stderr so the user can see the error inline.
-    log_root = Path(os.environ.get("XR_AI_LOG_ROOT", "/tmp"))
-    log_dir = log_root / (
-        f"log_{os.environ['XR_AI_LOG_NAMESPACE']}_{os.environ['XR_AI_LOG_TIMESTAMP']}"
-    )
-    log_dir.mkdir(parents=True, exist_ok=True)
-    build_log = log_dir / "web-vendor-build.log"
-
-    logger.info("Building web vendor bundle (~10 s) → {}", build_log)
-    t0 = time.monotonic()
-    with open(build_log, "wb") as fh:
-        result = subprocess.run(
-            [str(build_sh)], cwd=str(build_sh.parent),
-            stdout=fh, stderr=fh,
-        )
-    elapsed = time.monotonic() - t0
+    logger.info("Web vendor bundle not found — running build.sh: {}", build_sh)
+    result = subprocess.run([str(build_sh)], cwd=str(build_sh.parent))
     if result.returncode != 0:
-        sys.stderr.write(build_log.read_text(errors="replace"))
         sys.exit(
-            f"\n  [setup] build.sh failed (exit {result.returncode}, {elapsed:.1f}s).\n"
-            f"  Full log: {build_log}\n"
+            f"\n  [setup] build.sh failed (exit {result.returncode}).\n"
+            f"  Check the output above, then re-run.\n"
         )
-    logger.info("Web vendor bundle ready ({:.1f}s)", elapsed)
+    logger.info("Web vendor bundle ready")
 
 
 # ── Model cleanup (--stop) ────────────────────────────────────────────────────

--- a/agent-samples/xr-render-demo/main.py
+++ b/agent-samples/xr-render-demo/main.py
@@ -37,6 +37,7 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 import urllib.request
 from pathlib import Path
 
@@ -277,14 +278,31 @@ def _ensure_web_vendor() -> None:
             f"    cd {build_sh.parent} && ./build.sh\n"
         )
 
-    logger.info("Web vendor bundle not found — running build.sh: {}", build_sh)
-    result = subprocess.run([str(build_sh)], cwd=str(build_sh.parent))
-    if result.returncode != 0:
-        sys.exit(
-            f"\n  [setup] build.sh failed (exit {result.returncode}).\n"
-            f"  Check the output above, then re-run.\n"
+    # Capture build.sh output to a sibling file in the per-run log dir so
+    # the wrapper terminal stays quiet on the happy path. On failure, dump
+    # the captured output to stderr so the user can see the error inline.
+    log_root = Path(os.environ.get("XR_AI_LOG_ROOT", "/tmp"))
+    log_dir = log_root / (
+        f"log_{os.environ['XR_AI_LOG_NAMESPACE']}_{os.environ['XR_AI_LOG_TIMESTAMP']}"
+    )
+    log_dir.mkdir(parents=True, exist_ok=True)
+    build_log = log_dir / "web-vendor-build.log"
+
+    logger.info("Building web vendor bundle (~10 s) → {}", build_log)
+    t0 = time.monotonic()
+    with open(build_log, "wb") as fh:
+        result = subprocess.run(
+            [str(build_sh)], cwd=str(build_sh.parent),
+            stdout=fh, stderr=fh,
         )
-    logger.info("Web vendor bundle ready")
+    elapsed = time.monotonic() - t0
+    if result.returncode != 0:
+        sys.stderr.write(build_log.read_text(errors="replace"))
+        sys.exit(
+            f"\n  [setup] build.sh failed (exit {result.returncode}, {elapsed:.1f}s).\n"
+            f"  Full log: {build_log}\n"
+        )
+    logger.info("Web vendor bundle ready ({:.1f}s)", elapsed)
 
 
 # ── Model cleanup (--stop) ────────────────────────────────────────────────────

--- a/ai-services/stt-server/stt_server/__main__.py
+++ b/ai-services/stt-server/stt_server/__main__.py
@@ -27,7 +27,19 @@ import os
 import sys
 import tempfile
 import threading
+import warnings
 from pathlib import Path
+
+# Silence verbose third-party startup chatter that floods the launcher's
+# terminal and the per-run log file. Set before any import that pulls in
+# NeMo (which reads NEMO_LOGGING_LEVEL at import time), numexpr (reads
+# NUMEXPR_MAX_THREADS), or pydub (whose import-time ffmpeg probe emits a
+# RuntimeWarning). Users can override any of these via the env.
+os.environ.setdefault("NEMO_LOGGING_LEVEL",  "ERROR")
+os.environ.setdefault("NUMEXPR_MAX_THREADS", "16")
+warnings.filterwarnings(
+    "ignore", message="Couldn't find ffmpeg or avconv", category=RuntimeWarning,
+)
 
 import yaml
 from loguru import logger

--- a/cloudxr-runtime/cloudxr_runtime/__main__.py
+++ b/cloudxr-runtime/cloudxr_runtime/__main__.py
@@ -98,18 +98,23 @@ async def _run(cfg: dict, ready_file: Path | None = None) -> None:
         if not ready:
             if stop.done():
                 return  # cancelled by signal — clean exit
-            if not runtime_proc.is_alive() and runtime_proc.exitcode != 0:
+            native_log = latest_runtime_log() or logs_dir
+            if not runtime_proc.is_alive():
+                # Process exited before signaling ready. exitcode may be None
+                # for a tick after termination — treat that as a failure too.
+                rc = runtime_proc.exitcode
                 logger.error(
-                    "CloudXR runtime exited (code {}).\n"
-                    "  Check for leftover containers: docker ps --filter name=cloudxr\n"
-                    "  Native log: {}",
-                    runtime_proc.exitcode, latest_runtime_log() or logs_dir,
+                    "CloudXR runtime exited (rc={}) before signaling ready.\n"
+                    "  Native log: {}\n"
+                    "  Leftover containers: docker ps --filter name=cloudxr",
+                    rc if rc is not None else "?", native_log,
                 )
-                sys.exit(runtime_proc.exitcode or 1)
+                sys.exit(rc or 1)
             logger.error(
-                "CloudXR runtime did not become ready within 120 s.\n"
+                "CloudXR runtime did not become ready within 120 s "
+                "(process still alive — readiness lock file missing).\n"
                 "  Native log: {}",
-                latest_runtime_log() or logs_dir,
+                native_log,
             )
             sys.exit(1)
 

--- a/cloudxr-runtime/cloudxr_runtime/__main__.py
+++ b/cloudxr-runtime/cloudxr_runtime/__main__.py
@@ -52,7 +52,7 @@ async def _wait_with_progress(
         if lock_file.exists():
             return True
         if elapsed > 0 and elapsed % 10 == 0:
-            logger.info("[{}s] still waiting for CloudXR runtime…", elapsed)
+            logger.debug("[{}s] still waiting for CloudXR runtime…", elapsed)
         await asyncio.sleep(1)
         elapsed += 1
     return False

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -121,6 +121,46 @@ The orchestrator's `load_credentials()` injects `NGC_API_KEY` into the
 environment before each wrapper runs; the docker backend uses it to run
 `docker login nvcr.io --password-stdin` when no existing auth is found.
 
+### `vllm_backend: docker` — wrapper exits with `vLLM exited before /health became reachable`
+
+**Symptom:** the launcher reports
+
+```
+[<service>] vLLM exited before /health became reachable
+[<service>] exited (rc=1) before signaling ready
+```
+
+and the per-run log file under `/tmp/log_<sample>_<timestamp>/<service>.log`
+contains only wrapper messages — nothing from inside the container.
+
+**Health probe** — confirm vLLM never reached the `/health` endpoint:
+
+```bash
+curl -fsS http://127.0.0.1:8107/health   # nemotron3_nano (agent-llm)
+curl -fsS http://127.0.0.1:8100/health   # vlm_server
+curl -fsS http://127.0.0.1:8106/health   # llama_nemotron (llm)
+```
+
+**Container post-mortem** — the wrapper now streams `docker logs -f` into the
+per-run log file, so on the next run the actual vLLM error lands next to the
+wrapper messages. To inspect manually:
+
+```bash
+docker ps -a --filter name=xr-ai-vllm-
+docker logs --tail=200 <container-name>
+```
+
+**Cause:** vLLM crashed during startup — common reasons: model weights
+missing/inaccessible in the bind-mounted `model_cache`, GPU not visible to
+the container (`nvidia-container-cli` / `--gpus`), HF token missing for a
+gated model, or a reasoning-parser plugin file that is not present inside
+the container.
+
+**Fix:** read the container logs (the next run captures them automatically),
+address the root cause shown there, and retry. If the container was
+auto-removed by `--rm` before you could check, the next failed run will
+have the streamed output in the loguru log file — just re-run.
+
 ### `vllm_backend: docker` — `docker run` fails with `could not select device driver`
 
 **Symptom:** `docker run` exits with a message mentioning `nvidia-container-cli`

--- a/server-runtime/xr_media_hub/__main__.py
+++ b/server-runtime/xr_media_hub/__main__.py
@@ -81,7 +81,7 @@ async def _stats_loop() -> None:
             achps = _audio_counts.pop(pid, 0) / STATS_INTERVAL
             dps   = _data_counts.pop(pid, 0)  / STATS_INTERVAL
             parts.append(f"{pid}  video={fps:.1f}fps  audio={achps:.1f}ch/s  data={dps:.1f}msg/s")
-        logger.info("stats ─ {}", " │ ".join(parts))
+        logger.debug("stats ─ {}", " │ ".join(parts))
 
 
 async def main(ready_file: Path | None = None) -> None:

--- a/utils/xr-ai-launcher/xr_ai_launcher/_cloudxr_env.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/_cloudxr_env.py
@@ -41,5 +41,5 @@ def load_cloudxr_env(path: Path) -> None:
                (val.startswith("'") and val.endswith("'")):
                 val = val[1:-1]
             os.environ[key] = val
-    log.info("cloudxr env sourced from %s  (%s=%s)",
-             path, XR_RUNTIME_VAR, os.environ.get(XR_RUNTIME_VAR, "<missing>"))
+    log.debug("cloudxr env sourced from %s  (%s=%s)",
+              path, XR_RUNTIME_VAR, os.environ.get(XR_RUNTIME_VAR, "<missing>"))

--- a/utils/xr-ai-launcher/xr_ai_launcher/_processes.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/_processes.py
@@ -36,7 +36,7 @@ async def ManagedProcess(name: str, cmd: list[str], cwd: Path | None = None,
     *env*, if given, replaces the child's environment entirely; otherwise
     the child inherits the parent's.
     """
-    log.info("[%s] starting: %s", name, " ".join(cmd))
+    log.debug("[%s] starting: %s", name, " ".join(cmd))
     proc = await asyncio.create_subprocess_exec(
         *cmd,
         cwd=cwd,
@@ -44,7 +44,7 @@ async def ManagedProcess(name: str, cmd: list[str], cwd: Path | None = None,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
-    log.info("[%s] pid=%d", name, proc.pid)
+    log.debug("[%s] pid=%d", name, proc.pid)
 
     prefix = f"[{name}]"
     pipe_tasks = [
@@ -56,7 +56,7 @@ async def ManagedProcess(name: str, cmd: list[str], cwd: Path | None = None,
         yield proc
     finally:
         if proc.returncode is None:
-            log.info("[%s] stopping (pid=%d)…", name, proc.pid)
+            log.debug("[%s] stopping (pid=%d)…", name, proc.pid)
             proc.terminate()
             try:
                 await asyncio.wait_for(proc.wait(), timeout=_STOP_TIMEOUT)
@@ -67,4 +67,4 @@ async def ManagedProcess(name: str, cmd: list[str], cwd: Path | None = None,
         for t in pipe_tasks:
             t.cancel()
         await asyncio.gather(*pipe_tasks, return_exceptions=True)
-        log.info("[%s] stopped (returncode=%s)", name, proc.returncode)
+        log.debug("[%s] stopped (returncode=%s)", name, proc.returncode)

--- a/utils/xr-ai-launcher/xr_ai_launcher/_stack.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/_stack.py
@@ -157,7 +157,7 @@ def _wait_ready(name: str, ready_file: Path, proc: subprocess.Popen) -> None:
             raise SystemExit(1)
 
         if elapsed - last_report >= _READY_INTERVAL:
-            log.info("[%s] waiting... (%.0fs)", name, elapsed)
+            log.debug("[%s] waiting... (%.0fs)", name, elapsed)
             last_report = elapsed
 
         time.sleep(0.5)

--- a/utils/xr-ai-launcher/xr_ai_launcher/_stack.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/_stack.py
@@ -114,7 +114,8 @@ def _spawn(proc: Process, base: Path, ready_file: Path) -> subprocess.Popen:
     project = (base / proc.project).resolve()
 
     if shutil.which("uv"):
-        cmd: list[str] = ["uv", "run", "--project", str(project), proc.command]
+        # --quiet drops "Installed/Uninstalled N package" pre-run chatter.
+        cmd: list[str] = ["uv", "run", "--quiet", "--project", str(project), proc.command]
     else:
         cmd = [sys.executable, "-m", proc.command]
 

--- a/utils/xr-ai-logging/xr_ai_logging/__init__.py
+++ b/utils/xr-ai-logging/xr_ai_logging/__init__.py
@@ -119,6 +119,10 @@ def setup_logging(name: str, *, namespace: str | None = None) -> Path:
     """
     verbose = _is_verbose()
 
+    # First call in a run (orchestrator) doesn't have the stamp env var yet —
+    # subprocesses inherit it. Used below to surface the log dir once.
+    is_first_call = "XR_AI_LOG_TIMESTAMP" not in os.environ
+
     stamp = os.environ.get("XR_AI_LOG_TIMESTAMP") or time.strftime(
         "%Y-%m-%d_%H-%M-%S",
     )
@@ -164,4 +168,8 @@ def setup_logging(name: str, *, namespace: str | None = None) -> Path:
         "logging initialised  name={}  namespace={}  verbose={}  file={}",
         name, ns, verbose, log_file,
     )
+    if is_first_call:
+        # Single banner from the orchestrator so the user knows where every
+        # subprocess log file for this run will live.
+        logger.info("logs → {}", log_dir)
     return log_file

--- a/utils/xr-ai-logging/xr_ai_logging/__init__.py
+++ b/utils/xr-ai-logging/xr_ai_logging/__init__.py
@@ -160,7 +160,7 @@ def setup_logging(name: str, *, namespace: str | None = None) -> Path:
     for noisy in _NOISY_LOGGERS:
         logging.getLogger(noisy).setLevel(logging.WARNING)
 
-    logger.info(
+    logger.debug(
         "logging initialised  name={}  namespace={}  verbose={}  file={}",
         name, ns, verbose, log_file,
     )

--- a/utils/xr-ai-logging/xr_ai_logging/__init__.py
+++ b/utils/xr-ai-logging/xr_ai_logging/__init__.py
@@ -50,16 +50,20 @@ __all__ = ["setup_logging"]
 
 _DEFAULT_LOG_ROOT = Path("/tmp")
 
-# Stdlib loggers that emit a lot of low-value INFO/DEBUG noise. Pinned to
-# WARNING so they don't drown the rest of the stream even in verbose mode.
-# ``mcp.server.lowlevel.server`` emits one INFO per inbound tool call; the
-# worker already logs the user-visible side via ``tool call`` / ``tool result``.
-_NOISY_LOGGERS = (
-    "httpx",
-    "httpcore",
-    "urllib3",
-    "asyncio",
-    "mcp.server.lowlevel.server",
+# Stdlib loggers that emit low-value INFO/DEBUG noise. Each entry is a
+# ``(logger_name, level)`` pair. ``mcp.server.lowlevel.server`` emits one
+# INFO per inbound tool call; the worker already logs the user-visible side
+# via ``tool call`` / ``tool result``. ``nv_one_logger`` is NeMo's telemetry
+# stub — even its WARNINGs (no exporter configured, default error strategy)
+# are not actionable for inference, so it's pinned to ERROR.
+_NOISY_LOGGERS: tuple[tuple[str, int], ...] = (
+    ("httpx",                      logging.WARNING),
+    ("httpcore",                   logging.WARNING),
+    ("urllib3",                    logging.WARNING),
+    ("asyncio",                    logging.WARNING),
+    ("mcp.server.lowlevel.server", logging.WARNING),
+    ("numexpr.utils",              logging.WARNING),
+    ("nv_one_logger",              logging.ERROR),
 )
 
 _TRUTHY = {"1", "true", "debug", "yes", "on"}
@@ -161,15 +165,28 @@ def setup_logging(name: str, *, namespace: str | None = None) -> Path:
     )
 
     logging.basicConfig(handlers=[_InterceptHandler()], level=0, force=True)
-    for noisy in _NOISY_LOGGERS:
-        logging.getLogger(noisy).setLevel(logging.WARNING)
+    for noisy_name, noisy_level in _NOISY_LOGGERS:
+        logging.getLogger(noisy_name).setLevel(noisy_level)
 
     logger.debug(
         "logging initialised  name={}  namespace={}  verbose={}  file={}",
         name, ns, verbose, log_file,
     )
     if is_first_call:
-        # Single banner from the orchestrator so the user knows where every
-        # subprocess log file for this run will live.
-        logger.info("logs → {}", log_dir)
+        # Multi-line banner via raw stderr so the path stands out among the
+        # loguru-formatted lines that follow. The dim-grey ANSI is a TTY-only
+        # nudge — it degrades to plain text when piped to a file.
+        _print_log_dir_banner(log_dir)
     return log_file
+
+
+def _print_log_dir_banner(log_dir: Path) -> None:
+    bar = "─" * 78
+    is_tty = sys.stderr.isatty()
+    on  = "\x1b[1;36m" if is_tty else ""   # bright cyan, bold
+    dim = "\x1b[2m"    if is_tty else ""
+    off = "\x1b[0m"    if is_tty else ""
+    print(f"\n{dim}{bar}{off}",                                file=sys.stderr, flush=True)
+    print(f"  {on}Per-run logs:{off}  {log_dir}",              file=sys.stderr, flush=True)
+    print(f"  {dim}Tail all:      tail -F {log_dir}/*.log{off}", file=sys.stderr, flush=True)
+    print(f"{dim}{bar}{off}\n",                                file=sys.stderr, flush=True)

--- a/utils/xr-ai-logging/xr_ai_logging/__init__.py
+++ b/utils/xr-ai-logging/xr_ai_logging/__init__.py
@@ -186,7 +186,11 @@ def _print_log_dir_banner(log_dir: Path) -> None:
     on  = "\x1b[1;36m" if is_tty else ""   # bright cyan, bold
     dim = "\x1b[2m"    if is_tty else ""
     off = "\x1b[0m"    if is_tty else ""
-    print(f"\n{dim}{bar}{off}",                                file=sys.stderr, flush=True)
-    print(f"  {on}Per-run logs:{off}  {log_dir}",              file=sys.stderr, flush=True)
+    print(f"\n{dim}{bar}{off}",                                  file=sys.stderr, flush=True)
+    print(f"  {on}Per-run logs:{off}  {log_dir}",                file=sys.stderr, flush=True)
+    print(f"  {dim}<name>.log         one per stack process (hub, stt, agent-llm, worker, …){off}",
+                                                                 file=sys.stderr, flush=True)
+    print(f"  {dim}xr-ai-vllm-*.log   vLLM container output (vllm_backend: docker only){off}",
+                                                                 file=sys.stderr, flush=True)
     print(f"  {dim}Tail all:      tail -F {log_dir}/*.log{off}", file=sys.stderr, flush=True)
-    print(f"{dim}{bar}{off}\n",                                file=sys.stderr, flush=True)
+    print(f"{dim}{bar}{off}\n",                                  file=sys.stderr, flush=True)

--- a/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
@@ -220,6 +220,67 @@ def _maybe_ngc_login(image: str) -> None:
         )
 
 
+# ── log forwarding ──────────────────────────────────────────────────────────
+
+
+def _start_log_streamer(container_name: str) -> subprocess.Popen | None:
+    """Tail container stdout/stderr into the wrapper so loguru captures it.
+
+    `docker run -d` does not pipe container output back to the parent — the
+    wrapper sees only the container id. Without this streamer the per-run log
+    file shows wrapper messages only, and any startup failure inside vLLM is
+    invisible after `--rm` removes the container. `docker logs -f` reads from
+    the daemon's log driver, so it replays from container start regardless of
+    when we attach.
+    """
+    try:
+        return subprocess.Popen(
+            ["docker", "logs", "-f", container_name],
+            # stdout/stderr inherited → launcher prefixes them with [<name>]
+            # and the loguru stdlib bridge writes them to the per-run log file.
+        )
+    except FileNotFoundError:
+        return None
+
+
+def _stop_log_streamer(proc: subprocess.Popen | None) -> None:
+    if proc is None or proc.poll() is not None:
+        return
+    proc.terminate()
+    try:
+        proc.wait(timeout=2)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            pass
+
+
+def _dump_recent_logs(container_name: str, n: int = 200) -> None:
+    """Dump the last *n* lines of container logs through `log.error`.
+
+    Belt-and-suspenders against the small race between `docker run -d`
+    returning and the streamer attaching, and against the container being
+    removed before the streamer flushes. Best-effort: if the container is
+    already gone, this is a no-op.
+    """
+    try:
+        out = subprocess.run(
+            ["docker", "logs", "--tail", str(n), container_name],
+            capture_output=True, text=True, check=False,
+        )
+    except FileNotFoundError:
+        return
+    blob = (out.stdout or "") + (out.stderr or "")
+    if not blob.strip():
+        return
+    log.error("---- last %d lines of `docker logs %s` ----", n, container_name)
+    for line in blob.splitlines():
+        log.error("[%s] %s", container_name, line)
+    log.error("---- end of container logs ----")
+
+
 # ── run flow ────────────────────────────────────────────────────────────────
 
 
@@ -300,26 +361,38 @@ def run(
     else:
         proc = None
 
-    _lifecycle.wait_until_healthy(
-        health_url,
-        is_alive=lambda: (proc is None or proc.poll() is None)
-        and container_running(container_name),
-    )
+    log_streamer = _start_log_streamer(container_name) if persistent else None
+    try:
+        _lifecycle.wait_until_healthy(
+            health_url,
+            is_alive=lambda: (proc is None or proc.poll() is None)
+            and container_running(container_name),
+        )
+    except SystemExit:
+        # Give the streamer a beat to flush, then dump the tail explicitly in
+        # case the streamer attached late or the container is already gone.
+        time.sleep(0.5)
+        _dump_recent_logs(container_name)
+        _stop_log_streamer(log_streamer)
+        raise
 
     log.info("Ready  →  http://localhost:%d/v1  (docker: %s)", port, container_name)
     if ready_file:
         ready_file.touch()
 
-    if persistent:
-        # Persistence parity with pip mode: wrapper exits cleanly without
-        # touching the container; cleanup happens via stop_persistent_servers.
-        _lifecycle.idle_until_stopped(health_url, log_prefix)
-    else:
-        assert proc is not None
-        rc = proc.wait()
-        # Foreground container is auto-removed by --rm; nothing else to clean up.
-        if rc != 0:
-            sys.exit(rc)
+    try:
+        if persistent:
+            # Persistence parity with pip mode: wrapper exits cleanly without
+            # touching the container; cleanup happens via stop_persistent_servers.
+            _lifecycle.idle_until_stopped(health_url, log_prefix)
+        else:
+            assert proc is not None
+            rc = proc.wait()
+            # Foreground container is auto-removed by --rm; nothing else to clean up.
+            if rc != 0:
+                sys.exit(rc)
+    finally:
+        _stop_log_streamer(log_streamer)
 
 
 # ── port → pid (used by the docker-aware stop helper for the pip fallback) ──

--- a/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
@@ -211,7 +211,7 @@ def _maybe_ngc_login(image: str) -> None:
         return
     if result.returncode == 0:
         _LOGIN_DONE.add(registry)
-        log.info("docker login %s succeeded via NGC_API_KEY", registry)
+        log.debug("docker login %s succeeded via NGC_API_KEY", registry)
     else:
         log.warning(
             "docker login %s failed: %s — pull may fail",
@@ -223,24 +223,55 @@ def _maybe_ngc_login(image: str) -> None:
 # ── log forwarding ──────────────────────────────────────────────────────────
 
 
-def _start_log_streamer(container_name: str) -> subprocess.Popen | None:
-    """Tail container stdout/stderr into the wrapper so loguru captures it.
+def _container_log_path(container_name: str) -> Path:
+    """Sibling log file inside the per-run xr-ai-logging directory.
 
-    `docker run -d` does not pipe container output back to the parent — the
-    wrapper sees only the container id. Without this streamer the per-run log
-    file shows wrapper messages only, and any startup failure inside vLLM is
-    invisible after `--rm` removes the container. `docker logs -f` reads from
-    the daemon's log driver, so it replays from container start regardless of
-    when we attach.
+    Reads ``XR_AI_LOG_NAMESPACE`` / ``XR_AI_LOG_TIMESTAMP`` / ``XR_AI_LOG_ROOT``
+    stamped by ``setup_logging`` so the container log lands next to the
+    wrapper's own log. Falls back to ``XR_AI_LOG_ROOT`` (or ``/tmp``) when
+    the env vars are absent (e.g. running this module outside a stack).
     """
+    ns    = os.environ.get("XR_AI_LOG_NAMESPACE")
+    stamp = os.environ.get("XR_AI_LOG_TIMESTAMP")
+    root  = Path(os.environ.get("XR_AI_LOG_ROOT", "/tmp"))
+    if ns and stamp:
+        log_dir = root / f"log_{ns}_{stamp}"
+    else:
+        log_dir = root
+    log_dir.mkdir(parents=True, exist_ok=True)
+    return log_dir / f"{container_name}.log"
+
+
+def _start_log_streamer(container_name: str) -> tuple[subprocess.Popen | None, Path | None]:
+    """Stream container stdout/stderr to a sibling file (not to the terminal).
+
+    `docker run -d` does not pipe container output back to the parent and
+    `--rm` deletes the container on exit, so without this streamer a
+    startup failure leaves no trace. The streamer writes directly to a
+    file fd so the launcher's stdout forwarder (and the wrapper's loguru
+    sinks) stay quiet — the user reads the container log on demand via
+    ``tail -f``. ``docker logs -f`` replays from container start, so a
+    fast crash is still captured.
+    """
+    log_path = _container_log_path(container_name)
     try:
-        return subprocess.Popen(
-            ["docker", "logs", "-f", container_name],
-            # stdout/stderr inherited → launcher prefixes them with [<name>]
-            # and the loguru stdlib bridge writes them to the per-run log file.
+        out_fd = open(log_path, "ab", buffering=0)
+    except OSError as exc:
+        log.warning("vllm_docker: could not open %s for streaming: %s", log_path, exc)
+        return None, None
+    try:
+        proc = subprocess.Popen(
+            # -t prefixes each line with the daemon-side RFC3339 timestamp so
+            # the file is searchable without going through loguru.
+            ["docker", "logs", "-f", "-t", container_name],
+            stdout=out_fd, stderr=out_fd,
         )
     except FileNotFoundError:
-        return None
+        out_fd.close()
+        return None, None
+    out_fd.close()  # the child holds its own dup'd fd
+    log.info("container logs → %s", log_path)
+    return proc, log_path
 
 
 def _stop_log_streamer(proc: subprocess.Popen | None) -> None:
@@ -257,28 +288,32 @@ def _stop_log_streamer(proc: subprocess.Popen | None) -> None:
             pass
 
 
-def _dump_recent_logs(container_name: str, n: int = 200) -> None:
-    """Dump the last *n* lines of container logs through `log.error`.
+def _append_post_mortem(container_name: str, log_path: Path | None, n: int = 200) -> None:
+    """Append `docker logs --tail` to the container log file as a fallback.
 
-    Belt-and-suspenders against the small race between `docker run -d`
-    returning and the streamer attaching, and against the container being
-    removed before the streamer flushes. Best-effort: if the container is
-    already gone, this is a no-op.
+    Covers the small race where the streamer attaches just after the
+    container starts producing output, or where the container exited
+    before the streamer's process opened its connection to the daemon.
+    Best-effort — silent on any I/O error.
     """
+    target = log_path or _container_log_path(container_name)
     try:
-        out = subprocess.run(
+        result = subprocess.run(
             ["docker", "logs", "--tail", str(n), container_name],
-            capture_output=True, text=True, check=False,
+            capture_output=True, check=False,
         )
     except FileNotFoundError:
         return
-    blob = (out.stdout or "") + (out.stderr or "")
+    blob = (result.stdout or b"") + (result.stderr or b"")
     if not blob.strip():
         return
-    log.error("---- last %d lines of `docker logs %s` ----", n, container_name)
-    for line in blob.splitlines():
-        log.error("[%s] %s", container_name, line)
-    log.error("---- end of container logs ----")
+    try:
+        with open(target, "ab") as f:
+            f.write(f"\n---- post-mortem `docker logs --tail={n}` ----\n".encode())
+            f.write(blob if blob.endswith(b"\n") else blob + b"\n")
+            f.write(b"---- end post-mortem ----\n")
+    except OSError:
+        return
 
 
 # ── run flow ────────────────────────────────────────────────────────────────
@@ -361,7 +396,9 @@ def run(
     else:
         proc = None
 
-    log_streamer = _start_log_streamer(container_name) if persistent else None
+    streamer_proc, log_path = (
+        _start_log_streamer(container_name) if persistent else (None, None)
+    )
     try:
         _lifecycle.wait_until_healthy(
             health_url,
@@ -369,11 +406,13 @@ def run(
             and container_running(container_name),
         )
     except SystemExit:
-        # Give the streamer a beat to flush, then dump the tail explicitly in
-        # case the streamer attached late or the container is already gone.
+        # Give the streamer a beat to flush, then append a tail explicitly in
+        # case it attached late or the container is already gone.
         time.sleep(0.5)
-        _dump_recent_logs(container_name)
-        _stop_log_streamer(log_streamer)
+        _append_post_mortem(container_name, log_path)
+        _stop_log_streamer(streamer_proc)
+        if log_path is not None:
+            log.error("vLLM container failed — see %s", log_path)
         raise
 
     log.info("Ready  →  http://localhost:%d/v1  (docker: %s)", port, container_name)
@@ -392,7 +431,7 @@ def run(
             if rc != 0:
                 sys.exit(rc)
     finally:
-        _stop_log_streamer(log_streamer)
+        _stop_log_streamer(streamer_proc)
 
 
 # ── port → pid (used by the docker-aware stop helper for the pip fallback) ──


### PR DESCRIPTION
`docker run -d` left the container's stdout/stderr trapped in the docker daemon: when vLLM crashed mid-startup the wrapper exited with "vLLM exited before /health became reachable" while `--rm` removed the container, so the per-run log file held wrapper messages only and the actual error was lost.

Spawn `docker logs -f` as a child of the wrapper with inherited stdout/stderr right after `docker run -d` returns; the launcher prefix-forwards those lines into loguru just like the pip backend's output. On the wait-for-health failure path, also dump `docker logs --tail 200` through `log.error` as a fallback for the small race where the container is gone before the streamer attaches. Stop the streamer cleanly on the success path.

Add a troubleshooting entry covering the symptom, the curl health probe per service port, and how to read container logs post-mortem.