### PR TITLE
feat(client-sdk): add native C++ StreamKit client under client-sample…

### DIFF
--- a/client-samples/native/App/CMakeLists.txt
+++ b/client-samples/native/App/CMakeLists.txt
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_executable(streamkit_sample App/main.cpp)
+
+target_link_libraries(streamkit_sample PRIVATE streamkit)
+
+target_compile_features(streamkit_sample PRIVATE cxx_std_20)
+
+# Copy the binary next to the source tree so it's easy to run from the repo.
+set_target_properties(streamkit_sample PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)

--- a/client-samples/native/App/main.cpp
+++ b/client-samples/native/App/main.cpp
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * StreamKit native sample app.
+ *
+ * Demonstrates the full StreamSession lifecycle:
+ *   connect → start audio → start camera → send data → receive data → disconnect
+ *
+ * Usage:
+ *   streamkit_sample --host <ip> --token <jwt> [--port 7880] [--identity <name>]
+ *
+ * NOTE: The LiveKitBackend is currently a stub, so Connect() reports
+ * kConnected immediately without opening a real WebRTC session. Replace
+ * the stub with a real implementation to use this against a live server.
+ */
+
+#include <algorithm>
+#include <chrono>
+#include <cstring>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "streamkit/StreamSession.h"
+#include "streamkit/Config/BackendConfiguration.h"
+#include "streamkit/ConnectionState.h"
+#include "streamkit/StreamError.h"
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Argument parsing
+// ─────────────────────────────────────────────────────────────────────────────
+
+struct Args {
+    std::string host;
+    std::string token;
+    int         port     = 7880;
+    std::string identity = "native-client";
+};
+
+static std::string GetArg(const std::vector<std::string>& argv,
+                           const std::string& flag,
+                           const std::string& fallback = "") {
+    auto it = std::find(argv.begin(), argv.end(), flag);
+    if (it != argv.end() && std::next(it) != argv.end()) {
+        return *std::next(it);
+    }
+    return fallback;
+}
+
+static Args ParseArgs(int argc, char** argv) {
+    std::vector<std::string> args(argv, argv + argc);
+    Args result;
+    result.host     = GetArg(args, "--host");
+    result.token    = GetArg(args, "--token");
+    result.port     = std::stoi(GetArg(args, "--port", "7880"));
+    result.identity = GetArg(args, "--identity", "native-client");
+
+    if (result.host.empty() || result.token.empty()) {
+        std::cerr << "Usage: streamkit_sample --host <ip> --token <jwt>"
+                  << " [--port 7880] [--identity <name>]\n";
+        std::exit(1);
+    }
+    return result;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+static std::string StateToString(streamkit::ConnectionState state) {
+    switch (state) {
+        case streamkit::ConnectionState::kDisconnected:  return "disconnected";
+        case streamkit::ConnectionState::kConnecting:    return "connecting";
+        case streamkit::ConnectionState::kConnected:     return "connected";
+        case streamkit::ConnectionState::kReconnecting:  return "reconnecting";
+    }
+    return "unknown";
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// main
+// ─────────────────────────────────────────────────────────────────────────────
+
+int main(int argc, char** argv) {
+    const Args args = ParseArgs(argc, argv);
+
+    // ── Build BackendConfiguration ────────────────────────────────────────
+    streamkit::LiveKitConfig lk_config;
+    lk_config.host  = args.host;
+    lk_config.port  = args.port;
+    lk_config.token = args.token;
+
+    // ── Create StreamSession ──────────────────────────────────────────────
+    streamkit::StreamSession session{streamkit::BackendConfiguration{lk_config}};
+
+    // ── Wire event hooks ──────────────────────────────────────────────────
+    session.on_connection_state_changed = [](streamkit::ConnectionState state) {
+        std::cout << "[state] " << StateToString(state) << "\n";
+    };
+
+    session.on_data_received = [](std::string_view topic,
+                                  std::span<const std::byte> data) {
+        std::string payload(reinterpret_cast<const char*>(data.data()), data.size());
+        std::cout << "[data] topic='" << topic << "' payload='" << payload << "'\n";
+    };
+
+    session.on_agent_status = [](std::string_view status) {
+        std::cout << "[agent] status='" << status << "'\n";
+    };
+
+    // ── Connect ───────────────────────────────────────────────────────────
+    try {
+        std::cout << "Connecting to " << args.host << ":" << args.port
+                  << " as '" << args.identity << "'...\n";
+
+        session.Connect(streamkit::SessionConfig{args.identity});
+
+        std::cout << "Connected.\n";
+    } catch (const streamkit::StreamError& e) {
+        std::cerr << "[error] Connect failed: " << e.what() << "\n";
+        return 1;
+    }
+
+    // ── Start audio ───────────────────────────────────────────────────────
+    try {
+        session.StartAudio(streamkit::AudioConfig::Default());
+        std::cout << "Audio started.\n";
+    } catch (const streamkit::StreamError& e) {
+        // Audio failure never drops the connection — log and continue.
+        std::cerr << "[warn] StartAudio failed: " << e.what() << "\n";
+    }
+
+    // ── Start camera ──────────────────────────────────────────────────────
+    try {
+        session.StartCamera(streamkit::CameraConfig::Default());
+        std::cout << "Camera started.\n";
+    } catch (const streamkit::StreamError& e) {
+        std::cerr << "[warn] StartCamera failed: " << e.what() << "\n";
+    }
+
+    // ── Send a test message ───────────────────────────────────────────────
+    try {
+        const std::string msg = R"({"event":"hello","from":"native-client"})";
+        std::vector<std::byte> payload(msg.size());
+        std::transform(msg.begin(), msg.end(), payload.begin(),
+                       [](char c) { return static_cast<std::byte>(c); });
+
+        session.Send(payload, /*reliable=*/true, "xr.session.started");
+        std::cout << "Sent test message.\n";
+    } catch (const streamkit::StreamError& e) {
+        std::cerr << "[warn] Send failed: " << e.what() << "\n";
+    }
+
+    // ── Run for a few seconds then disconnect ─────────────────────────────
+    std::cout << "Running for 5 seconds...\n";
+    std::this_thread::sleep_for(std::chrono::seconds(5));
+
+    session.StopAudio();
+    session.StopCamera();
+    session.Disconnect();
+
+    std::cout << "Disconnected. Bye.\n";
+    return 0;
+}

--- a/client-samples/native/CMakeLists.txt
+++ b/client-samples/native/CMakeLists.txt
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.21)
+
+project(StreamKitNative
+    VERSION     0.1.0
+    DESCRIPTION "StreamKit — native C++ client for the xr-ai streaming platform"
+    LANGUAGES   CXX
+)
+
+# C++20 is required for std::span.
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Build options
+# ─────────────────────────────────────────────────────────────────────────────
+
+option(STREAMKIT_BUILD_SAMPLE
+    "Build the sample application in App/" ON)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Compiler defaults
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Warn loudly without being pedantic about platform headers.
+if(MSVC)
+    add_compile_options(/W4 /permissive-)
+else()
+    add_compile_options(-Wall -Wextra -Wpedantic -Wno-unused-parameter)
+endif()
+
+# ─────────────────────────────────────────────────────────────────────────────
+# StreamKit library
+# ─────────────────────────────────────────────────────────────────────────────
+
+add_subdirectory(StreamKit)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Sample application
+# ─────────────────────────────────────────────────────────────────────────────
+
+if(STREAMKIT_BUILD_SAMPLE)
+    include(App/CMakeLists.txt)
+endif()
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Quick-start
+# ─────────────────────────────────────────────────────────────────────────────
+#
+#   mkdir build && cd build
+#   cmake ..
+#   cmake --build . --parallel
+#   ./bin/streamkit_sample --host 192.168.1.100 --token <jwt>

--- a/client-samples/native/README.md
+++ b/client-samples/native/README.md
@@ -1,0 +1,286 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Wrapping the LiveKit C++ SDK into a StreamKit Client Library
+
+> **Audience:** Developers who have used LiveKit before and want to add a C++ StreamKit backend — e.g. for an embedded device, a native game engine plugin, or a CloudXR client.
+
+---
+
+## What StreamKit is (and isn't)
+
+StreamKit is a thin transport-agnostic wrapper that sits on top of LiveKit.
+It does **not** replace LiveKit — it constrains how you use it.
+
+The existing iOS, Android, and web clients all share the same shape:
+
+```
+Application code
+      │
+      ▼
+ StreamSession          ← single public entry-point, transport-agnostic
+      │  delegates to
+      ▼
+ StreamingBackend       ← interface/protocol — the seam between StreamKit and LiveKit
+      │  implemented by
+      ▼
+ LiveKitBackend         ← the only file that imports LiveKit directly
+      │
+      ▼
+ LiveKit SDK            ← Room, LocalParticipant, tracks, data channel
+```
+
+To add a C++ StreamKit library, you implement `StreamingBackend` against the LiveKit C++ SDK (or `livekit-ffi`), and all application code stays the same.
+
+---
+
+## What StreamKit adds on top of LiveKit
+
+### 1. A single entry-point with decoupled media
+
+Raw LiveKit lets you publish tracks as part of `room.connect()`. StreamKit splits the lifecycle into three independent phases:
+
+| Phase | StreamKit call | What it does |
+|---|---|---|
+| Transport | `connect(config)` | WebRTC peer connection + data channel only |
+| Audio | `startAudio(config)` / `stopAudio()` | Mic capture + publish; throws without dropping the connection |
+| Video | `startCamera(config)` / `stopCamera()` | Camera capture + publish; throws without dropping the connection |
+
+**Why this matters:** Audio/camera failures are isolated. A bad camera never kills the session.
+
+In C++, `connect()` calls `room->Connect(url, token)` and nothing else. `startAudio()` and `startCamera()` are separate calls made by the application after the room is connected.
+
+### 2. A typed `ConnectionState` enum
+
+LiveKit's connection state is an SDK-specific enum or string. StreamKit maps it to four values that are the same across every platform:
+
+```
+DISCONNECTED  →  CONNECTING  →  CONNECTED
+                                    │
+                              RECONNECTING
+```
+
+In `LiveKitBackend` (C++), subscribe to the room's connection-state delegate/callback and forward through the mapping:
+
+```cpp
+room->AddListener([this](livekit::ConnectionState state) {
+    if (state == livekit::ConnectionState::kConnected)
+        on_connection_state_changed_(ConnectionState::CONNECTED);
+    else if (state == livekit::ConnectionState::kReconnecting)
+        on_connection_state_changed_(ConnectionState::RECONNECTING);
+    // …
+});
+```
+
+### 3. Typed errors
+
+Instead of propagating LiveKit's internal error types, StreamKit defines a small set of errors that apply regardless of transport:
+
+| Error | When |
+|---|---|
+| `InvalidHost` | Empty or unparseable host string |
+| `NotConnected` | Method called before `connect()` succeeded |
+| `MissingToken` | Neither `token` nor `tokenURL` was provided |
+| `TokenFetchFailed` | HTTP request to token endpoint failed |
+| `CameraRequiresConnection` | `startCamera()` called while not connected |
+
+In C++, express these as an enum, `std::error_code`, or a `std::variant` — whichever fits your project's convention. The important thing is that callers never see LiveKit-specific error types.
+
+### 4. The agent status channel
+
+The xr-ai server publishes internal status messages (`"idle"`, `"processing"`, etc.) on a reserved data-channel topic: `_agent.status`. The payload is a JSON object `{"status": "…"}`.
+
+`LiveKitBackend` intercepts this topic in the `RoomEvent.DataReceived` handler and fires `onAgentStatus` instead of `onDataReceived`. Application code never sees `_agent.status` on the raw data callback.
+
+```cpp
+// In your C++ data-received handler:
+static constexpr std::string_view kAgentStatusTopic = "_agent.status";
+
+void OnDataReceived(std::span<const uint8_t> payload,
+                    std::string_view topic) {
+    if (topic == kAgentStatusTopic) {
+        // parse JSON, extract "status", call on_agent_status_
+        return;
+    }
+    on_data_received_(topic, payload);
+}
+```
+
+### 5. `AudioConfig` and `MicrophoneMode`
+
+Rather than exposing LiveKit's raw `AudioCaptureOptions`, StreamKit presents four presets:
+
+| Mode | What the backend does |
+|---|---|
+| `VOICE_PROCESSING` | Use hardware echo cancellation (AUVoiceIO on Apple, platform equivalent elsewhere). Disable WebRTC's own AEC/AGC/NS to avoid double-processing. |
+| `SOFTWARE_PROCESSING` | Enable WebRTC's software AEC, AGC, and noise suppression. |
+| `RAW` | No processing. Use when the server-side agent handles DSP. |
+| `DISABLED` | Don't capture or publish a microphone track at all. |
+
+In C++, map `MicrophoneMode` to the appropriate `AudioOptions` fields when calling `local_participant->SetMicrophoneEnabled()` or when creating a local audio track.
+
+### 6. Token acquisition
+
+`LiveKitConfig` carries either a pre-signed JWT (`token`) or a URL to fetch one from (`tokenURL`). The token endpoint contract is:
+
+```
+GET <tokenURL>?identity=<identity>
+→ 200 OK, body: "eyJ…"          (plain JWT string)
+→ 200 OK, body: {"token":"eyJ…"} (JSON envelope)
+```
+
+`LiveKitBackend` handles both response shapes. In C++ you can use `libcurl` or any HTTP client; the logic is straightforward:
+
+```cpp
+std::string FetchToken(const std::string& token_url,
+                       const std::string& identity) {
+    std::string url = token_url + "?identity=" + UrlEncode(identity);
+    std::string body = HttpGet(url);  // your HTTP client here
+
+    // Try JSON envelope first.
+    auto json = ParseJson(body);
+    if (json.contains("token")) return json["token"];
+
+    // Fall back to plain string.
+    return Trim(body);
+}
+```
+
+### 7. Frame injection (optional, for external video sources)
+
+The iOS backend has a `FrameInjectable` extension that lets you push raw video frames from any external camera (e.g. the Meta wearables SDK, a game engine texture, a hardware capture card) directly into a LiveKit `BufferCapturer`-backed track:
+
+```
+external camera callback
+        │
+        ▼
+session.injectVideoFrame(buffer)
+        │
+        ▼
+BufferCapturer.Capture(buffer)  ← first call also publishes the track
+```
+
+For C++, implement the equivalent using `livekit::LocalVideoTrack` with a custom `VideoSource`. Publish the track lazily on the first frame (the track must have at least one frame before LiveKit can complete the publish handshake and resolve stream dimensions).
+
+---
+
+## The `StreamingBackend` interface you need to implement
+
+Here is the interface in C++ terms. Every other platform has an identical surface area:
+
+```cpp
+// streamkit/streaming_backend.h
+
+#include <cstdint>
+#include <functional>
+#include <span>
+#include <string>
+#include <string_view>
+
+enum class ConnectionState { kDisconnected, kConnecting, kConnected, kReconnecting };
+
+struct SessionConfig {
+    std::string identity;
+};
+
+struct AudioConfig {
+    enum class MicrophoneMode { kVoiceProcessing, kSoftwareProcessing, kRaw, kDisabled };
+    MicrophoneMode mode = MicrophoneMode::kVoiceProcessing;
+};
+
+struct CameraConfig {
+    enum class Facing { kFront, kBack };
+    Facing facing = Facing::kFront;
+    std::string device_id;  // optional; overrides facing when set
+};
+
+class StreamingBackend {
+public:
+    virtual ~StreamingBackend() = default;
+
+    // ── Event hooks (set by StreamSession before calling Connect) ────────────
+    std::function<void(ConnectionState)>                       on_connection_state_changed;
+    std::function<void(std::string_view, std::span<const uint8_t>)> on_data_received;
+    std::function<void(std::string_view)>                      on_agent_status;
+
+    // ── Connection ───────────────────────────────────────────────────────────
+    virtual void Connect(const SessionConfig& config)    = 0;  // async
+    virtual void Disconnect()                            = 0;  // async
+
+    // ── Audio ────────────────────────────────────────────────────────────────
+    virtual void StartAudio(const AudioConfig& config)   = 0;  // throws NotConnected
+    virtual void StopAudio()                             = 0;
+
+    // ── Camera ───────────────────────────────────────────────────────────────
+    virtual void StartCamera(const CameraConfig& config) = 0;  // throws CameraRequiresConnection
+    virtual void StopCamera()                            = 0;
+
+    // ── Data channel ─────────────────────────────────────────────────────────
+    virtual void Send(std::span<const uint8_t> data,
+                      bool reliable = true,
+                      std::string_view topic = "") = 0;  // throws NotConnected
+};
+```
+
+`StreamSession` is a thin wrapper around this: it stores callbacks, wires them to the backend, and provides the same calls as public API. None of that logic changes when you swap to the C++ backend.
+
+---
+
+## Implementing `LiveKitBackend` in C++
+
+Walk through the same structure used in Swift and Kotlin:
+
+**Construction**: Accept a `LiveKitConfig` (host, port, secure, token/tokenURL).
+
+**`Connect()`**:
+1. Call `TearDown()` to clean up any previous session.
+2. Validate `config.host`; throw `InvalidHost` if empty.
+3. Acquire a JWT — either from `config.token` or by calling `FetchToken()`.
+4. Build the WebSocket URL (`ws://host:port` or `wss://`).
+5. Create a `livekit::Room`, register event listeners.
+6. Call `room->Connect(url, token)`.
+7. Fire `on_connection_state_changed(kConnecting)` before the call, `kConnected` after.
+
+**`StartAudio()`**:
+1. Guard: throw `NotConnected` if the room is not connected.
+2. Map `AudioConfig::MicrophoneMode` to the appropriate `AudioOptions`.
+3. Call `room->local_participant()->SetMicrophoneEnabled(true, options)`.
+
+**`StartCamera()`**:
+1. Guard: throw `CameraRequiresConnection` if not connected.
+2. Call `StopCamera()` first to tear down any existing track.
+3. Create a `LocalVideoTrack` with the appropriate device/facing constraint.
+4. Publish it via `room->local_participant()->PublishVideoTrack(track)`.
+
+**`Send()`**:
+1. Guard: throw `NotConnected` if not connected.
+2. Reject `topic == "_agent.status"` (reserved).
+3. Call `room->local_participant()->PublishData(data, reliable, topic)`.
+
+**Room event handler**:
+- `ConnectionStateChanged` → map and fire `on_connection_state_changed_`.
+- `DataReceived` → intercept `_agent.status` → parse JSON → fire `on_agent_status_`, else fire `on_data_received_`.
+- `TrackSubscribed` (audio) → attach the remote audio track to your platform's audio renderer.
+
+**`TearDown()`**:
+- Cancel any background tasks (simulator frame loop, pending publishes).
+- Disconnect and null out the room.
+- Fire `on_connection_state_changed(kDisconnected)`.
+
+---
+
+## What you get for free once the backend is done
+
+Once `LiveKitBackend` satisfies `StreamingBackend`, the rest of StreamKit — `StreamSession`, all configs, all error types, the agent-status channel — works without modification. You can also swap in a mock backend for unit tests without touching any LiveKit code.
+
+```cpp
+// Production
+auto session = StreamSession(std::make_unique<LiveKitBackend>(config));
+
+// Test
+auto session = StreamSession(std::make_unique<MockBackend>());
+```
+
+The mock backend just fires `on_connection_state_changed(kConnected)` from `Connect()` and records every `Send()` call — no WebRTC stack needed.

--- a/client-samples/native/StreamKit/CMakeLists.txt
+++ b/client-samples/native/StreamKit/CMakeLists.txt
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# ─────────────────────────────────────────────────────────────────────────────
+# StreamKit static library
+# ─────────────────────────────────────────────────────────────────────────────
+
+add_library(streamkit STATIC
+    src/StreamSession.cpp
+    src/Backends/LiveKit/LiveKitBackend.cpp
+)
+
+target_include_directories(streamkit
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+)
+
+target_compile_features(streamkit PUBLIC cxx_std_20)
+
+# ── LiveKit dependency ────────────────────────────────────────────────────────
+#
+# Replace the placeholder block below with a real livekit-ffi dependency once
+# you have chosen an integration path (see README).
+#
+# Path A — livekit-ffi pre-built:
+#   Set LIVEKIT_FFI_DIR to the directory containing livekit_ffi.h and the
+#   built library. Then uncomment:
+#
+#     find_library(LIVEKIT_FFI_LIB livekit_ffi
+#         PATHS "${LIVEKIT_FFI_DIR}/lib" REQUIRED)
+#     target_include_directories(streamkit PRIVATE "${LIVEKIT_FFI_DIR}/include")
+#     target_link_libraries(streamkit PRIVATE "${LIVEKIT_FFI_LIB}")
+#
+# Path B — livekit-ffi via FetchContent (builds Rust crate, requires Cargo):
+#
+#   include(FetchContent)
+#   FetchContent_Declare(
+#       livekit_ffi
+#       GIT_REPOSITORY https://github.com/livekit/rust-sdks.git
+#       GIT_TAG        main   # pin to a release tag in production
+#       SOURCE_SUBDIR  livekit-ffi
+#   )
+#   FetchContent_MakeAvailable(livekit_ffi)
+#   target_link_libraries(streamkit PRIVATE livekit_ffi)
+#
+# Until then, the LiveKitBackend compiles as a stub without any extra deps.
+
+message(STATUS
+    "[streamkit] LiveKit dependency not configured. "
+    "LiveKitBackend will compile as a stub. "
+    "See client-samples/native/StreamKit/CMakeLists.txt for integration instructions.")

--- a/client-samples/native/StreamKit/include/streamkit/Backends/LiveKit/LiveKitBackend.h
+++ b/client-samples/native/StreamKit/include/streamkit/Backends/LiveKit/LiveKitBackend.h
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/*
+ * StreamKit — LiveKitBackend
+ *
+ * Implements StreamingBackend using the LiveKit C++ SDK / livekit-ffi.
+ * This header is the only place in StreamKit that should include LiveKit
+ * headers directly — all other StreamKit code depends only on StreamingBackend.
+ *
+ * NOTE: The implementation in LiveKitBackend.cpp is currently a stub.
+ *       See that file and the README for instructions on wiring it up.
+ *
+ * Mirror of Swift `LiveKitBackend` and Kotlin `LiveKitBackend`.
+ */
+
+#include <atomic>
+#include <cstddef>
+#include <memory>
+#include <span>
+#include <string>
+#include <string_view>
+
+#include "streamkit/Backends/StreamingBackend.h"
+#include "streamkit/Config/BackendConfiguration.h"
+
+// Forward-declare the LiveKit room handle so that users of this header
+// don't need to include LiveKit headers. Replace with the actual type
+// once the LiveKit C++ SDK dependency is in place.
+//
+// e.g. #include <livekit/room.h>  →  livekit::Room
+struct LKRoom;  // TODO: replace with the real LiveKit room type
+
+namespace streamkit {
+
+/// StreamingBackend implementation using the LiveKit C++ SDK.
+///
+/// Do not construct this directly — use BackendConfiguration{LiveKitConfig{…}}
+/// passed to StreamSession, or call MakeBackend().
+///
+/// ## Status
+/// The public interface is complete and matches the Swift / Kotlin backends
+/// exactly. The method bodies in LiveKitBackend.cpp are stubs annotated with
+/// TODO comments that reference the exact LiveKit C++ / livekit-ffi API calls
+/// needed to complete each one.
+class LiveKitBackend final : public StreamingBackend {
+public:
+    explicit LiveKitBackend(const LiveKitConfig& config);
+    ~LiveKitBackend() override;
+
+    // Non-copyable, non-movable (holds live SDK state).
+    LiveKitBackend(const LiveKitBackend&)             = delete;
+    LiveKitBackend& operator=(const LiveKitBackend&)  = delete;
+    LiveKitBackend(LiveKitBackend&&)                  = delete;
+    LiveKitBackend& operator=(LiveKitBackend&&)       = delete;
+
+    // ── StreamingBackend ───────────────────────────────────────────────────
+
+    void Connect(const SessionConfig& config) override;
+    void Disconnect() override;
+
+    void StartAudio(const AudioConfig& config = AudioConfig::Default()) override;
+    void StopAudio() override;
+
+    void StartCamera(const CameraConfig& config = CameraConfig::Default()) override;
+    void StopCamera() override;
+
+    void Send(std::span<const std::byte> data,
+              bool reliable = true,
+              std::string_view topic = "") override;
+
+private:
+    // ── Private helpers ────────────────────────────────────────────────────
+
+    /// Disconnects the room, stops all tracks, fires kDisconnected.
+    void TearDown();
+
+    /// Fetches a LiveKit JWT from `config_.token_url`.
+    /// GET <url>?identity=<identity> → plain string or {"token":"eyJ…"}.
+    std::string FetchToken(const std::string& url, const std::string& identity);
+
+    /// Maps LiveKit connection-state events to StreamKit's ConnectionState
+    /// and fires on_connection_state_changed.
+    void HandleConnectionStateChange(/* livekit state */ int lk_state);
+
+    /// Routes incoming data-channel messages: intercepts "_agent.status",
+    /// fires on_data_received for everything else.
+    void HandleDataReceived(std::string_view topic,
+                            std::span<const std::byte> payload);
+
+    // ── State ──────────────────────────────────────────────────────────────
+
+    LiveKitConfig config_;
+    SessionConfig session_config_;
+
+    // TODO: Replace LKRoom* with the actual LiveKit room type once the SDK
+    // dependency is in place. Using a raw forward-declared pointer here so
+    // this header compiles without LiveKit headers.
+    LKRoom* room_ = nullptr;
+
+    std::atomic<bool> is_connected_{false};
+
+    // Reserved topic for internal agent-status messages. Must match the
+    // server-side constant in xr-ai-pipecat.
+    static constexpr std::string_view kAgentStatusTopic = "_agent.status";
+};
+
+} // namespace streamkit

--- a/client-samples/native/StreamKit/include/streamkit/Backends/StreamingBackend.h
+++ b/client-samples/native/StreamKit/include/streamkit/Backends/StreamingBackend.h
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/*
+ * StreamKit — StreamingBackend
+ *
+ * This is the single seam between StreamSession and any networking technology.
+ * The library ships with a LiveKit implementation; to use a different transport
+ * just subclass this and pass your instance to StreamSession.
+ *
+ * Mirror of Swift `StreamingBackend` protocol and Kotlin `StreamingBackend`
+ * interface.
+ */
+
+#include <cstddef>
+#include <functional>
+#include <span>
+#include <string_view>
+
+#include "streamkit/Config/AudioConfig.h"
+#include "streamkit/Config/CameraConfig.h"
+#include "streamkit/Config/SessionConfig.h"
+#include "streamkit/ConnectionState.h"
+
+namespace streamkit {
+
+/// The contract that every networking backend must satisfy.
+///
+/// StreamSession delegates all network operations to an object inheriting
+/// this class. The call-site never depends on a specific transport technology.
+///
+/// ## Lifecycle
+///
+/// ```
+/// Connect()             → WebRTC peer connection + data channel only
+/// StartAudio(config)    → mic capture + publish   (independent, throws on failure)
+/// StartCamera(config)   → cam capture + publish   (independent, throws on failure)
+/// Send(data, reliable)  → data channel message
+/// StopAudio()           → stop microphone
+/// StopCamera()          → stop camera
+/// Disconnect()          → tear down everything
+/// ```
+///
+/// Audio and camera failures never affect the connection itself.
+///
+/// ## Threading
+///
+/// Methods are called from whichever thread the application chooses.
+/// The implementation is responsible for any required synchronisation.
+/// Callbacks fire from whatever thread the backend's event loop runs on;
+/// use the mechanism appropriate for your platform (dispatch queue, strand,
+/// UI-thread post, etc.) to forward them to your application.
+///
+/// ## Implementing a custom backend
+///
+/// ```cpp
+/// class MyBackend : public streamkit::StreamingBackend {
+/// public:
+///     void Connect(const SessionConfig& config) override {
+///         on_connection_state_changed(ConnectionState::kConnected);
+///     }
+///     void Disconnect() override {}
+///     void StartAudio(const AudioConfig&) override {}
+///     void StopAudio() override {}
+///     void StartCamera(const CameraConfig&) override {}
+///     void StopCamera() override {}
+///     void Send(std::span<const std::byte>, bool, std::string_view) override {}
+/// };
+///
+/// auto session = StreamSession(std::make_unique<MyBackend>());
+/// ```
+class StreamingBackend {
+public:
+    virtual ~StreamingBackend() = default;
+
+    // ── Event hooks ────────────────────────────────────────────────────────
+    //
+    // StreamSession assigns these before calling Connect().
+    // Fire from any thread; StreamSession re-dispatches if needed.
+
+    /// Fired when the connection state changes.
+    std::function<void(ConnectionState)> on_connection_state_changed;
+
+    /// Fired when binary data arrives from the remote end.
+    /// `topic` identifies the logical channel; `data` is the raw payload.
+    std::function<void(std::string_view topic,
+                       std::span<const std::byte> data)> on_data_received;
+
+    /// Fired when an agent publishes a status update on the reserved
+    /// `_agent.status` topic. Common values: "idle", "processing".
+    /// These messages are NOT forwarded to on_data_received.
+    std::function<void(std::string_view status)> on_agent_status;
+
+    // ── Connection ─────────────────────────────────────────────────────────
+
+    /// Establish a WebRTC peer connection and data channel.
+    /// Does NOT start audio or camera capture.
+    /// Throws a StreamError subclass on failure.
+    virtual void Connect(const SessionConfig& config) = 0;
+
+    /// Cleanly disconnect and release all resources.
+    virtual void Disconnect() = 0;
+
+    // ── Audio ──────────────────────────────────────────────────────────────
+
+    /// Begin microphone capture and publish an audio track.
+    /// Throws NotConnectedError if called before Connect() succeeds.
+    /// A failure here does NOT affect the connection.
+    virtual void StartAudio(const AudioConfig& config = AudioConfig::Default()) = 0;
+
+    /// Stop microphone capture and unpublish the audio track.
+    virtual void StopAudio() = 0;
+
+    // ── Camera ─────────────────────────────────────────────────────────────
+
+    /// Begin camera capture and publish a video track.
+    /// Throws CameraRequiresConnectionError if called before Connect() succeeds.
+    /// A failure here does NOT affect the connection.
+    virtual void StartCamera(const CameraConfig& config = CameraConfig::Default()) = 0;
+
+    /// Stop camera capture and unpublish the video track.
+    virtual void StopCamera() = 0;
+
+    // ── Data channel ───────────────────────────────────────────────────────
+
+    /// Send binary data to remote participants.
+    ///
+    /// \param data     Payload. Keep individual messages ≤ 15 KB (LiveKit MTU).
+    /// \param reliable Ordered + guaranteed delivery when true (default).
+    /// \param topic    Optional logical channel label. The reserved topic
+    ///                 "_agent.status" is rejected with std::invalid_argument.
+    ///
+    /// Throws NotConnectedError if not connected.
+    virtual void Send(std::span<const std::byte> data,
+                      bool reliable = true,
+                      std::string_view topic = "") = 0;
+};
+
+} // namespace streamkit

--- a/client-samples/native/StreamKit/include/streamkit/Config/AudioConfig.h
+++ b/client-samples/native/StreamKit/include/streamkit/Config/AudioConfig.h
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+namespace streamkit {
+
+/// Configures microphone capture passed to StreamSession::StartAudio().
+///
+/// Mirror of Swift `AudioConfig` and Kotlin `AudioConfig`.
+struct AudioConfig {
+
+    /// Controls which audio processing pipeline is applied before the PCM
+    /// audio is handed to WebRTC.
+    enum class MicrophoneMode {
+        /// Platform hardware voice processing (e.g. platform AEC, AGC, NR).
+        /// Disable WebRTC's own DSP to avoid double-processing.
+        /// Best choice for voice calls on most platforms.
+        kVoiceProcessing,
+
+        /// WebRTC software DSP: echo cancellation, AGC, noise suppression.
+        /// Useful when hardware voice processing is unavailable.
+        kSoftwareProcessing,
+
+        /// Raw PCM — no processing. Choose this when the server-side agent
+        /// handles DSP, or for non-voice audio.
+        kRaw,
+
+        /// Microphone is not captured or published.
+        kDisabled,
+    };
+
+    MicrophoneMode mode = MicrophoneMode::kVoiceProcessing;
+
+    /// High-pass filter to cut sub-200 Hz rumble.
+    /// Only effective with kSoftwareProcessing.
+    bool highpass_filter = false;
+
+    /// Keyboard / typing noise suppression.
+    /// Only effective with kSoftwareProcessing.
+    bool typing_noise_detection = false;
+
+    // ── Presets ────────────────────────────────────────────────────────────
+
+    static AudioConfig Default()            { return {}; }
+    static AudioConfig SoftwareProcessing() { return {MicrophoneMode::kSoftwareProcessing}; }
+    static AudioConfig Raw()                { return {MicrophoneMode::kRaw}; }
+    static AudioConfig Disabled()           { return {MicrophoneMode::kDisabled}; }
+};
+
+} // namespace streamkit

--- a/client-samples/native/StreamKit/include/streamkit/Config/BackendConfiguration.h
+++ b/client-samples/native/StreamKit/include/streamkit/Config/BackendConfiguration.h
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/*
+ * StreamKit — BackendConfiguration
+ *
+ * Variant-based backend selection. Add a new alternative here when a new
+ * transport is integrated. To bypass entirely, construct StreamSession with
+ * a custom StreamingBackend directly.
+ *
+ * Mirror of Swift `BackendConfiguration`, Kotlin `BackendConfiguration`,
+ * and JS `BackendConfiguration`.
+ */
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <variant>
+
+namespace streamkit {
+
+class StreamingBackend;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// LiveKitConfig
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Connection parameters for the LiveKit backend.
+///
+/// Exactly one of `token` or `token_url` must be set before calling
+/// StreamSession::Connect().
+///
+/// Mirror of Swift `LiveKitConfig` and Kotlin `LiveKitConfig`.
+struct LiveKitConfig {
+    /// IP address or hostname of the LiveKit server (e.g. "192.168.1.100").
+    /// Do not include a scheme or port.
+    std::string host;
+
+    /// WebSocket port. Defaults to 7880 (LiveKit's default).
+    int port = 7880;
+
+    /// Use wss:// / https://. Set false for local / LAN connections.
+    bool secure = false;
+
+    /// A pre-signed LiveKit JWT. The token must encode the room name and
+    /// participant identity.
+    std::optional<std::string> token;
+
+    /// URL of a token-generation endpoint.
+    /// The SDK appends `?identity=<identity>` as a query parameter.
+    /// The endpoint must return either a plain JWT string or {"token":"eyJ…"}.
+    std::optional<std::string> token_url;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// BackendConfiguration
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Selects the networking backend used by StreamSession.
+///
+/// ```cpp
+/// // Built-in LiveKit backend
+/// auto session = StreamSession(BackendConfiguration{LiveKitConfig{
+///     .host      = "192.168.1.100",
+///     .token     = jwt,
+/// }});
+///
+/// // Custom backend
+/// auto session = StreamSession(std::make_unique<MyCustomBackend>());
+/// ```
+using BackendConfiguration = std::variant<LiveKitConfig>;
+
+/// Instantiates the concrete StreamingBackend for the given configuration.
+std::unique_ptr<StreamingBackend> MakeBackend(const BackendConfiguration& config);
+
+} // namespace streamkit

--- a/client-samples/native/StreamKit/include/streamkit/Config/CameraConfig.h
+++ b/client-samples/native/StreamKit/include/streamkit/Config/CameraConfig.h
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+namespace streamkit {
+
+/// Configures camera capture passed to StreamSession::StartCamera().
+///
+/// Resolution and frame-rate are intentionally not exposed: the LiveKit
+/// backend negotiates the best supported format with the hardware
+/// automatically (matching the iOS and Android behaviour).
+///
+/// Mirror of Swift `CameraConfig` and Kotlin `CameraConfig`.
+struct CameraConfig {
+
+    enum class Facing {
+        kFront,
+        kBack,
+    };
+
+    /// Which camera to use. Ignored when device_id is set.
+    Facing facing = Facing::kFront;
+
+    /// Pin to a specific device by its platform identifier.
+    /// When set, this takes precedence over `facing`.
+    std::optional<std::string> device_id;
+
+    // ── Presets ────────────────────────────────────────────────────────────
+
+    static CameraConfig Default() { return {}; }
+    static CameraConfig Rear()    { return {Facing::kBack, std::nullopt}; }
+};
+
+} // namespace streamkit

--- a/client-samples/native/StreamKit/include/streamkit/Config/SessionConfig.h
+++ b/client-samples/native/StreamKit/include/streamkit/Config/SessionConfig.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <random>
+#include <string>
+
+namespace streamkit {
+
+/// Configuration passed to StreamSession::Connect().
+///
+/// Only carries identity — network details live in BackendConfiguration /
+/// LiveKitConfig, and media settings are passed directly to StartAudio()
+/// and StartCamera().
+///
+/// Mirror of Swift `SessionConfig` and Kotlin `SessionConfig`.
+struct SessionConfig {
+    /// A unique label for this participant in the session.
+    std::string identity;
+
+    /// Returns a config with a random participant ID.
+    static SessionConfig Default() {
+        static std::mt19937 rng{std::random_device{}()};
+        static std::uniform_int_distribution<uint32_t> dist{100000, 999999};
+        return SessionConfig{"participant-" + std::to_string(dist(rng))};
+    }
+};
+
+} // namespace streamkit

--- a/client-samples/native/StreamKit/include/streamkit/ConnectionState.h
+++ b/client-samples/native/StreamKit/include/streamkit/ConnectionState.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+namespace streamkit {
+
+/// Connection lifecycle state reported by StreamSession.
+///
+/// Mirror of Swift `ConnectionState`, Kotlin `ConnectionState`,
+/// and the JS `ConnectionState` constants.
+enum class ConnectionState {
+    kDisconnected,
+    kConnecting,
+    kConnected,
+    kReconnecting,
+};
+
+} // namespace streamkit

--- a/client-samples/native/StreamKit/include/streamkit/FrameSink.h
+++ b/client-samples/native/StreamKit/include/streamkit/FrameSink.h
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/*
+ * StreamKit — FrameSink
+ *
+ * Optional mixin for backends that accept externally produced video frames —
+ * e.g. from a game engine render target, a hardware capture card, or an XR
+ * headset camera SDK.
+ *
+ * Mirror of Swift `FrameInjectable`.
+ *
+ * ## Workflow
+ *
+ *   // 1. Connect to the session.
+ *   session.Connect();
+ *
+ *   // 2. In your frame callback, inject each buffer:
+ *   if (auto* sink = dynamic_cast<FrameSink*>(session.GetBackend())) {
+ *       sink->InjectVideoFrame(pixels, width, height, format, timestamp_us);
+ *   }
+ *
+ * ## Frame publication
+ *
+ * The first InjectVideoFrame() call creates a BufferCapturer-backed LiveKit
+ * track and publishes it to the room. The track is published after the first
+ * frame (not before) because LiveKit requires at least one captured frame to
+ * resolve stream dimensions before the publish handshake can complete.
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+
+namespace streamkit {
+
+/// Pixel format of an injected video frame.
+enum class PixelFormat {
+    kI420,      ///< Planar YUV 4:2:0 — native WebRTC format, zero-copy path.
+    kNV12,      ///< Semi-planar YUV 4:2:0 — common on camera hardware.
+    kRGBA,      ///< Packed 8-bit RGBA.
+    kBGRA,      ///< Packed 8-bit BGRA.
+};
+
+/// Implemented by backends that accept raw video frames from external sources.
+///
+/// LiveKitBackend will implement this once the stub is filled in.
+class FrameSink {
+public:
+    virtual ~FrameSink() = default;
+
+    /// Push a single video frame into the published video track.
+    ///
+    /// \param data         Pointer to the first byte of pixel data.
+    /// \param width        Frame width in pixels.
+    /// \param height       Frame height in pixels.
+    /// \param stride       Row stride in bytes (may be > width * bytes_per_pixel).
+    /// \param format       Pixel layout of `data`.
+    /// \param timestamp_us Capture timestamp in microseconds (monotonic clock).
+    ///
+    /// A BufferCapturer-backed LocalVideoTrack is created and published on the
+    /// first call. Subsequent calls deliver frames to the already-published track.
+    ///
+    /// Throws NotConnectedError if not connected.
+    virtual void InjectVideoFrame(std::span<const std::byte> data,
+                                  int width,
+                                  int height,
+                                  int stride,
+                                  PixelFormat format,
+                                  int64_t timestamp_us) = 0;
+};
+
+} // namespace streamkit

--- a/client-samples/native/StreamKit/include/streamkit/StreamError.h
+++ b/client-samples/native/StreamKit/include/streamkit/StreamError.h
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+namespace streamkit {
+
+/// Base class for all StreamKit errors.
+///
+/// Mirror of Swift `StreamError` and Kotlin `StreamError`.
+class StreamError : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
+/// Thrown when a host string cannot be turned into a valid WebSocket URL.
+class InvalidHostError : public StreamError {
+public:
+    explicit InvalidHostError(const std::string& host)
+        : StreamError("'" + host + "' is not a valid hostname.") {}
+};
+
+/// Thrown when an operation that requires an active connection is called
+/// while disconnected.
+class NotConnectedError : public StreamError {
+public:
+    NotConnectedError() : StreamError("Not connected. Call Connect() first.") {}
+};
+
+/// Thrown when neither a token nor a tokenURL was provided to the LiveKit backend.
+class MissingTokenError : public StreamError {
+public:
+    MissingTokenError() : StreamError("Provide a token or token_url in LiveKitConfig.") {}
+};
+
+/// Thrown when the token-server request fails or returns an unparseable body.
+class TokenFetchFailedError : public StreamError {
+public:
+    explicit TokenFetchFailedError(const std::string& url)
+        : StreamError("Failed to fetch token from " + url + ".") {}
+};
+
+/// Thrown when StartCamera() is called while not connected.
+class CameraRequiresConnectionError : public StreamError {
+public:
+    CameraRequiresConnectionError()
+        : StreamError("Connect() before starting the camera.") {}
+};
+
+} // namespace streamkit

--- a/client-samples/native/StreamKit/include/streamkit/StreamSession.h
+++ b/client-samples/native/StreamKit/include/streamkit/StreamSession.h
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/*
+ * StreamKit — StreamSession
+ *
+ * The single public entry-point of the SDK.
+ *
+ * StreamSession is transport-agnostic: it delegates all network operations to
+ * a StreamingBackend. Application code never imports LiveKit directly.
+ *
+ * ## Lifecycle
+ *
+ *   // 1. Connect — WebRTC peer connection + data channel only.
+ *   session.Connect(SessionConfig{.identity = "workstation-1"});
+ *
+ *   // 2. Start media independently — each throws its own error,
+ *   //    never drops the connection.
+ *   session.StartAudio();
+ *   session.StartCamera();
+ *
+ *   // 3. Send / receive data.
+ *   session.on_data_received = [](auto topic, auto data) { ... };
+ *   session.Send(payload);
+ *
+ *   // 4. Stop media / disconnect.
+ *   session.StopAudio();
+ *   session.StopCamera();
+ *   session.Disconnect();
+ *
+ * Mirror of Swift `StreamSession`, Kotlin `StreamSession`, and JS `StreamSession`.
+ */
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <span>
+#include <string>
+#include <string_view>
+
+#include "streamkit/Backends/StreamingBackend.h"
+#include "streamkit/Config/AudioConfig.h"
+#include "streamkit/Config/BackendConfiguration.h"
+#include "streamkit/Config/CameraConfig.h"
+#include "streamkit/Config/SessionConfig.h"
+#include "streamkit/ConnectionState.h"
+
+namespace streamkit {
+
+class StreamSession {
+public:
+    // ── Construction ───────────────────────────────────────────────────────
+
+    /// Create a session backed by a built-in transport.
+    explicit StreamSession(const BackendConfiguration& config);
+
+    /// Create a session backed by a custom StreamingBackend implementation.
+    explicit StreamSession(std::unique_ptr<StreamingBackend> backend);
+
+    ~StreamSession() = default;
+
+    // Non-copyable; movable.
+    StreamSession(const StreamSession&)             = delete;
+    StreamSession& operator=(const StreamSession&)  = delete;
+    StreamSession(StreamSession&&)                  = default;
+    StreamSession& operator=(StreamSession&&)       = default;
+
+    // ── Event hooks (wire before calling Connect) ──────────────────────────
+
+    /// Fired when the connection lifecycle state changes.
+    std::function<void(ConnectionState)> on_connection_state_changed;
+
+    /// Fired when data is received from remote participants.
+    /// `topic` identifies the logical channel; `data` is the raw payload.
+    std::function<void(std::string_view topic,
+                       std::span<const std::byte> data)> on_data_received;
+
+    /// Fired when an agent publishes a status update.
+    /// Common values: "idle", "processing".
+    std::function<void(std::string_view status)> on_agent_status;
+
+    // ── State ──────────────────────────────────────────────────────────────
+
+    ConnectionState connection_state() const { return connection_state_; }
+
+    // ── Connection ─────────────────────────────────────────────────────────
+
+    /// Establishes a WebRTC peer connection and data channel.
+    /// Does NOT start audio or camera — call StartAudio() and StartCamera()
+    /// explicitly once connected.
+    void Connect(const SessionConfig& config = SessionConfig::Default());
+
+    /// Disconnects and releases all resources.
+    void Disconnect();
+
+    // ── Audio ──────────────────────────────────────────────────────────────
+
+    /// Starts microphone capture and publishes an audio track.
+    /// Throws NotConnectedError if not connected. Never drops the connection.
+    void StartAudio(const AudioConfig& config = AudioConfig::Default());
+
+    /// Stops microphone capture.
+    void StopAudio();
+
+    // ── Camera ─────────────────────────────────────────────────────────────
+
+    /// Starts camera capture and publishes a video track.
+    /// Throws CameraRequiresConnectionError if not connected.
+    /// Never drops the connection.
+    void StartCamera(const CameraConfig& config = CameraConfig::Default());
+
+    /// Stops camera capture.
+    void StopCamera();
+
+    // ── Data channel ───────────────────────────────────────────────────────
+
+    /// Sends binary data to remote participants.
+    ///
+    /// \param data     Payload. Keep individual messages ≤ 15 KB (LiveKit MTU).
+    /// \param reliable Ordered + guaranteed delivery when true (default).
+    /// \param topic    Optional logical channel label.
+    void Send(std::span<const std::byte> data,
+              bool reliable = true,
+              std::string_view topic = "");
+
+    // ── Advanced ──────────────────────────────────────────────────────────
+
+    /// Returns the underlying backend. Cast to FrameSink* to inject video
+    /// frames from an external camera source.
+    StreamingBackend* GetBackend() { return backend_.get(); }
+
+private:
+    void WireCallbacks();
+
+    std::unique_ptr<StreamingBackend> backend_;
+    ConnectionState connection_state_ = ConnectionState::kDisconnected;
+};
+
+} // namespace streamkit

--- a/client-samples/native/StreamKit/src/Backends/LiveKit/LiveKitBackend.cpp
+++ b/client-samples/native/StreamKit/src/Backends/LiveKit/LiveKitBackend.cpp
@@ -1,0 +1,392 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * StreamKit — LiveKitBackend (stub)
+ *
+ * This file is intentionally left unimplemented. Each method has TODO comments
+ * that describe exactly what needs to be called in the LiveKit C++ SDK / livekit-ffi.
+ *
+ * ## Dependency
+ *
+ * LiveKit provides two C/C++ integration paths:
+ *
+ *   1. livekit-ffi  — Rust-based, cross-platform, exposes a C ABI via a
+ *                     generated header (livekit_ffi.h). Suitable for most
+ *                     native targets.
+ *                     Repo: https://github.com/livekit/rust-sdks
+ *
+ *   2. WebRTC native — Build LiveKit's patched libwebrtc directly and use the
+ *                     room-level C++ API. Higher effort, more control.
+ *
+ * See the README for CMake integration instructions for both paths.
+ *
+ * ## How to complete this file
+ *
+ *   1. Add livekit-ffi (or your chosen SDK) via CMake FetchContent — see the
+ *      placeholder block in the root CMakeLists.txt.
+ *   2. Replace `#include "livekit_ffi_stub.h"` with the real SDK header.
+ *   3. Replace `LKRoom*` in LiveKitBackend.h with the real room type.
+ *   4. Fill in each TODO block below, following the pattern in the Swift and
+ *      Kotlin LiveKitBackend implementations for reference.
+ */
+
+#include "streamkit/Backends/LiveKit/LiveKitBackend.h"
+#include "streamkit/StreamError.h"
+
+#include <stdexcept>
+#include <string>
+
+// TODO: Replace with the real livekit-ffi or SDK header once the dependency
+//       is added to CMakeLists.txt.
+//
+// #include <livekit/livekit_ffi.h>
+
+namespace streamkit {
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Construction / destruction
+// ─────────────────────────────────────────────────────────────────────────────
+
+LiveKitBackend::LiveKitBackend(const LiveKitConfig& config)
+    : config_(config) {}
+
+LiveKitBackend::~LiveKitBackend() {
+    TearDown();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Connection
+// ─────────────────────────────────────────────────────────────────────────────
+
+void LiveKitBackend::Connect(const SessionConfig& session_config) {
+    session_config_ = session_config;
+    TearDown();  // clean up any previous session
+
+    // ── Validate host ─────────────────────────────────────────────────────
+    if (config_.host.empty()) {
+        throw InvalidHostError(config_.host);
+    }
+
+    // ── Build WebSocket URL ───────────────────────────────────────────────
+    const std::string scheme = config_.secure ? "wss" : "ws";
+    const std::string ws_url = scheme + "://" + config_.host + ":"
+                               + std::to_string(config_.port);
+
+    // ── Acquire JWT ───────────────────────────────────────────────────────
+    std::string token;
+    if (config_.token.has_value() && !config_.token->empty()) {
+        token = *config_.token;
+    } else if (config_.token_url.has_value() && !config_.token_url->empty()) {
+        token = FetchToken(*config_.token_url, session_config_.identity);
+    } else {
+        throw MissingTokenError{};
+    }
+
+    // ── Create Room and register event listeners ──────────────────────────
+    //
+    // TODO: Create the LiveKit room and register callbacks.
+    //
+    // Using livekit-ffi (C API):
+    //
+    //   LKRoomOptions opts = lk_room_options_default();
+    //   room_ = lk_room_create(&opts);
+    //
+    //   lk_room_set_callback(room_, LK_EVENT_CONNECTION_STATE_CHANGED,
+    //       [](LKConnectionState state, void* ctx) {
+    //           static_cast<LiveKitBackend*>(ctx)->HandleConnectionStateChange(state);
+    //       }, this);
+    //
+    //   lk_room_set_callback(room_, LK_EVENT_DATA_RECEIVED,
+    //       [](const uint8_t* data, size_t len, const char* topic, void* ctx) {
+    //           auto* self = static_cast<LiveKitBackend*>(ctx);
+    //           self->HandleDataReceived(topic,
+    //               std::span(reinterpret_cast<const std::byte*>(data), len));
+    //       }, this);
+
+    // ── Fire CONNECTING before the async handshake ────────────────────────
+    if (on_connection_state_changed) {
+        on_connection_state_changed(ConnectionState::kConnecting);
+    }
+
+    // ── Connect ───────────────────────────────────────────────────────────
+    //
+    // TODO: Call the SDK's connect method and block until connected or throw.
+    //
+    // Using livekit-ffi:
+    //
+    //   LKConnectOptions conn_opts = lk_connect_options_default();
+    //   conn_opts.timeout_ms = 5000;
+    //
+    //   LKError err = lk_room_connect(room_, ws_url.c_str(), token.c_str(), &conn_opts);
+    //   if (err.code != LK_OK) {
+    //       throw StreamError(err.message);
+    //   }
+    //
+    // For async SDKs, block with a promise/future or a condition variable:
+    //
+    //   std::promise<void> connected;
+    //   // ... wire connection callback to call connected.set_value() ...
+    //   connected.get_future().get();  // blocks until kConnected or throws
+
+    (void)ws_url;
+    (void)token;
+
+    is_connected_.store(true);
+
+    if (on_connection_state_changed) {
+        on_connection_state_changed(ConnectionState::kConnected);
+    }
+}
+
+void LiveKitBackend::Disconnect() {
+    TearDown();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Audio
+// ─────────────────────────────────────────────────────────────────────────────
+
+void LiveKitBackend::StartAudio(const AudioConfig& config) {
+    if (!is_connected_.load()) {
+        throw NotConnectedError{};
+    }
+
+    // ── Map MicrophoneMode to WebRTC AudioOptions ─────────────────────────
+    //
+    // TODO: Create a local audio track with the appropriate DSP settings and
+    //       publish it to the room.
+    //
+    // Using livekit-ffi:
+    //
+    //   LKAudioOptions audio_opts = lk_audio_options_default();
+    //
+    //   switch (config.mode) {
+    //     case AudioConfig::MicrophoneMode::kVoiceProcessing:
+    //       // Hardware AEC: disable WebRTC's own AEC/AGC/NS to avoid double-processing.
+    //       audio_opts.echo_cancellation  = false;
+    //       audio_opts.auto_gain_control  = false;
+    //       audio_opts.noise_suppression  = false;
+    //       break;
+    //     case AudioConfig::MicrophoneMode::kSoftwareProcessing:
+    //       audio_opts.echo_cancellation  = true;
+    //       audio_opts.auto_gain_control  = true;
+    //       audio_opts.noise_suppression  = true;
+    //       audio_opts.highpass_filter    = config.highpass_filter;
+    //       break;
+    //     case AudioConfig::MicrophoneMode::kRaw:
+    //     case AudioConfig::MicrophoneMode::kDisabled:
+    //       audio_opts.echo_cancellation  = false;
+    //       audio_opts.auto_gain_control  = false;
+    //       audio_opts.noise_suppression  = false;
+    //       break;
+    //   }
+    //
+    //   if (config.mode != AudioConfig::MicrophoneMode::kDisabled) {
+    //       LKError err = lk_local_participant_set_microphone_enabled(
+    //           lk_room_local_participant(room_), true, &audio_opts);
+    //       if (err.code != LK_OK) throw StreamError(err.message);
+    //   }
+
+    (void)config;
+}
+
+void LiveKitBackend::StopAudio() {
+    // TODO: Disable the microphone track.
+    //
+    // Using livekit-ffi:
+    //   lk_local_participant_set_microphone_enabled(
+    //       lk_room_local_participant(room_), false, nullptr);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Camera
+// ─────────────────────────────────────────────────────────────────────────────
+
+void LiveKitBackend::StartCamera(const CameraConfig& config) {
+    if (!is_connected_.load()) {
+        throw CameraRequiresConnectionError{};
+    }
+
+    StopCamera();  // unpublish any existing camera track first
+
+    // ── Create and publish a local video track ────────────────────────────
+    //
+    // TODO: Create a video track for the requested device and publish it.
+    //
+    // Using livekit-ffi:
+    //
+    //   LKVideoCaptureOptions cap_opts = lk_video_capture_options_default();
+    //   if (config.device_id.has_value()) {
+    //       cap_opts.device_id = config.device_id->c_str();
+    //   } else {
+    //       cap_opts.facing_mode = (config.facing == CameraConfig::Facing::kFront)
+    //                               ? LK_FACING_FRONT : LK_FACING_BACK;
+    //   }
+    //
+    //   LKLocalVideoTrack* track = lk_local_video_track_create_camera(&cap_opts);
+    //   LKError err = lk_local_participant_publish_video_track(
+    //       lk_room_local_participant(room_), track, nullptr);
+    //   if (err.code != LK_OK) throw StreamError(err.message);
+    //
+    // For frame injection from an external source (see FrameSink.h), create a
+    // BufferCapturer-backed track instead:
+    //
+    //   LKLocalVideoTrack* track = lk_local_video_track_create_buffer_capturer("camera");
+    //   // Store the track handle so InjectVideoFrame() can push frames into it.
+
+    (void)config;
+}
+
+void LiveKitBackend::StopCamera() {
+    // TODO: Unpublish and release the camera / buffer track.
+    //
+    // Using livekit-ffi:
+    //   if (camera_track_) {
+    //       lk_local_participant_unpublish_video_track(
+    //           lk_room_local_participant(room_), camera_track_);
+    //       lk_local_video_track_release(camera_track_);
+    //       camera_track_ = nullptr;
+    //   }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Data channel
+// ─────────────────────────────────────────────────────────────────────────────
+
+void LiveKitBackend::Send(std::span<const std::byte> data,
+                          bool reliable,
+                          std::string_view topic) {
+    if (!is_connected_.load()) {
+        throw NotConnectedError{};
+    }
+    if (topic == kAgentStatusTopic) {
+        throw std::invalid_argument(
+            "topic '" + std::string(topic) + "' is reserved for internal SDK use");
+    }
+
+    // TODO: Publish data via the LiveKit data channel.
+    //
+    // Using livekit-ffi:
+    //
+    //   LKDataPublishOptions opts{};
+    //   opts.reliable = reliable;
+    //   opts.topic    = topic.empty() ? nullptr : std::string(topic).c_str();
+    //
+    //   LKError err = lk_local_participant_publish_data(
+    //       lk_room_local_participant(room_),
+    //       reinterpret_cast<const uint8_t*>(data.data()),
+    //       data.size(),
+    //       &opts);
+    //   if (err.code != LK_OK) throw StreamError(err.message);
+
+    (void)data;
+    (void)reliable;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Event handlers
+// ─────────────────────────────────────────────────────────────────────────────
+
+void LiveKitBackend::HandleConnectionStateChange(int lk_state) {
+    // TODO: Map the SDK's connection-state type to ConnectionState and fire
+    //       on_connection_state_changed.
+    //
+    // Using livekit-ffi (LKConnectionState enum):
+    //
+    //   ConnectionState sk_state;
+    //   switch (static_cast<LKConnectionState>(lk_state)) {
+    //     case LK_CONNECTION_STATE_CONNECTED:    sk_state = ConnectionState::kConnected;    break;
+    //     case LK_CONNECTION_STATE_CONNECTING:   sk_state = ConnectionState::kConnecting;   break;
+    //     case LK_CONNECTION_STATE_RECONNECTING: sk_state = ConnectionState::kReconnecting; break;
+    //     default:                               sk_state = ConnectionState::kDisconnected; break;
+    //   }
+    //   is_connected_.store(sk_state == ConnectionState::kConnected);
+    //   if (on_connection_state_changed) on_connection_state_changed(sk_state);
+
+    (void)lk_state;
+}
+
+void LiveKitBackend::HandleDataReceived(std::string_view topic,
+                                        std::span<const std::byte> payload) {
+    // Intercept the reserved agent-status topic — never forward to on_data_received.
+    if (topic == kAgentStatusTopic) {
+        // TODO: Parse the JSON payload and extract the "status" string.
+        //
+        // The payload is: {"status": "idle"} or {"status": "processing"}
+        //
+        // Using nlohmann/json or a minimal parse:
+        //
+        //   auto json = nlohmann::json::parse(payload.begin(), payload.end(),
+        //                                     nullptr, /*exceptions=*/false);
+        //   if (!json.is_discarded() && json.contains("status")) {
+        //       std::string status = json["status"].get<std::string>();
+        //       if (!status.empty() && on_agent_status) on_agent_status(status);
+        //   }
+        return;
+    }
+
+    if (on_data_received) {
+        on_data_received(topic, payload);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Teardown
+// ─────────────────────────────────────────────────────────────────────────────
+
+void LiveKitBackend::TearDown() {
+    is_connected_.store(false);
+
+    // TODO: Disconnect the room and release the room handle.
+    //
+    // Using livekit-ffi:
+    //
+    //   if (room_) {
+    //       lk_room_disconnect(room_);
+    //       lk_room_release(room_);
+    //       room_ = nullptr;
+    //   }
+
+    if (on_connection_state_changed) {
+        on_connection_state_changed(ConnectionState::kDisconnected);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Token fetch
+// ─────────────────────────────────────────────────────────────────────────────
+
+std::string LiveKitBackend::FetchToken(const std::string& token_url,
+                                       const std::string& identity) {
+    // TODO: HTTP GET <token_url>?identity=<identity>, return the JWT string.
+    //
+    // The endpoint must return either:
+    //   - A plain JWT string in the response body, or
+    //   - A JSON object: { "token": "eyJ…" }
+    //
+    // Use libcurl, Poco::Net, cpp-httplib, or any other HTTP client available
+    // in your project. The Swift and Kotlin implementations both handle both
+    // response formats — the C++ version must too.
+    //
+    // Example with cpp-httplib:
+    //
+    //   httplib::Client cli(token_url);
+    //   auto res = cli.Get("/?identity=" + UrlEncode(identity));
+    //   if (!res || res->status != 200) throw TokenFetchFailedError(token_url);
+    //
+    //   // Try JSON first.
+    //   auto json = nlohmann::json::parse(res->body, nullptr, false);
+    //   if (!json.is_discarded() && json.contains("token"))
+    //       return json["token"].get<std::string>();
+    //
+    //   // Fall back to plain string.
+    //   auto trimmed = Trim(res->body);
+    //   if (!trimmed.empty()) return trimmed;
+    //
+    //   throw TokenFetchFailedError(token_url);
+
+    throw TokenFetchFailedError(token_url + " — FetchToken not yet implemented");
+}
+
+} // namespace streamkit

--- a/client-samples/native/StreamKit/src/StreamSession.cpp
+++ b/client-samples/native/StreamKit/src/StreamSession.cpp
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "streamkit/StreamSession.h"
+#include "streamkit/Backends/LiveKit/LiveKitBackend.h"
+#include "streamkit/Config/BackendConfiguration.h"
+
+#include <stdexcept>
+#include <utility>
+
+namespace streamkit {
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MakeBackend (BackendConfiguration.h factory)
+// ─────────────────────────────────────────────────────────────────────────────
+
+std::unique_ptr<StreamingBackend> MakeBackend(const BackendConfiguration& config) {
+    return std::visit([](auto&& cfg) -> std::unique_ptr<StreamingBackend> {
+        using T = std::decay_t<decltype(cfg)>;
+        if constexpr (std::is_same_v<T, LiveKitConfig>) {
+            return std::make_unique<LiveKitBackend>(cfg);
+        }
+    }, config);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// StreamSession
+// ─────────────────────────────────────────────────────────────────────────────
+
+StreamSession::StreamSession(const BackendConfiguration& config)
+    : backend_(MakeBackend(config)) {
+    WireCallbacks();
+}
+
+StreamSession::StreamSession(std::unique_ptr<StreamingBackend> backend)
+    : backend_(std::move(backend)) {
+    WireCallbacks();
+}
+
+// ── Connection ────────────────────────────────────────────────────────────────
+
+void StreamSession::Connect(const SessionConfig& config) {
+    backend_->Connect(config);
+}
+
+void StreamSession::Disconnect() {
+    backend_->Disconnect();
+    // The backend fires kDisconnected via on_connection_state_changed;
+    // agent_status is implicitly stale once disconnected.
+}
+
+// ── Audio ─────────────────────────────────────────────────────────────────────
+
+void StreamSession::StartAudio(const AudioConfig& config) {
+    backend_->StartAudio(config);
+}
+
+void StreamSession::StopAudio() {
+    backend_->StopAudio();
+}
+
+// ── Camera ────────────────────────────────────────────────────────────────────
+
+void StreamSession::StartCamera(const CameraConfig& config) {
+    backend_->StartCamera(config);
+}
+
+void StreamSession::StopCamera() {
+    backend_->StopCamera();
+}
+
+// ── Data channel ──────────────────────────────────────────────────────────────
+
+void StreamSession::Send(std::span<const std::byte> data,
+                         bool reliable,
+                         std::string_view topic) {
+    backend_->Send(data, reliable, topic);
+}
+
+// ── Private ───────────────────────────────────────────────────────────────────
+
+/// Subscribe to the backend's event hooks and forward them to this session's
+/// own public callbacks. Called once immediately after the backend is set.
+void StreamSession::WireCallbacks() {
+    backend_->on_connection_state_changed = [this](ConnectionState state) {
+        connection_state_ = state;
+        if (on_connection_state_changed) {
+            on_connection_state_changed(state);
+        }
+    };
+
+    backend_->on_data_received = [this](std::string_view topic,
+                                        std::span<const std::byte> data) {
+        if (on_data_received) {
+            on_data_received(topic, data);
+        }
+    };
+
+    backend_->on_agent_status = [this](std::string_view status) {
+        if (on_agent_status) {
+            on_agent_status(status);
+        }
+    };
+}
+
+} // namespace streamkit


### PR DESCRIPTION
…s/native

Adds a CMake project that mirrors the iOS/Android/web StreamKit structure for native C++ targets (embedded devices, game engines, CloudXR clients).

Fully implemented:
- StreamSession — transport-agnostic public entry-point, callback wiring
- StreamingBackend — pure-virtual base class (the seam between StreamKit and LiveKit)
- All config types: SessionConfig, AudioConfig (MicrophoneMode), CameraConfig, BackendConfiguration/LiveKitConfig
- ConnectionState enum, StreamError exception hierarchy
- FrameSink — interface for injecting external video frames (equiv. of iOS FrameInjectable)
- App/main.cpp — sample app showing the full connect→media→send→disconnect lifecycle

Stubbed (TODOs):
- LiveKitBackend.cpp — every method has inline comments referencing the exact livekit-ffi C API calls needed to complete the implementation
- StreamKit/CMakeLists.txt — placeholder comments for both pre-built and FetchContent livekit-ffi integration paths

Compiles clean (zero errors, zero warnings) with g++11 -std=c++20.