### PR TITLE
chore(gitignore): ignore local Claude Code config under .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,6 +226,12 @@ cython_debug/
 .cursorignore
 .cursorindexingignore
 
+# Claude Code
+#  `.claude/` holds per-user local Claude Code configuration: custom subagents,
+#  agent memory, and session state. These are personal to each contributor and
+#  must not be committed. General agent guidelines live in AGENTS.md / CLAUDE.md.
+.claude/
+
 # Marimo
 marimo/_static/
 marimo/_lsp/


### PR DESCRIPTION
## Summary
- Ignore the `.claude/` directory in `.gitignore` so per-user Claude Code config (custom subagents, agent memory, session state) is never accidentally committed.
- General agent guidelines remain in the tracked `AGENTS.md` / `CLAUDE.md` — only the personal, per-contributor `.claude/` tree is excluded.

## Test plan
- [ ] `git check-ignore -v .claude/` resolves to the new rule
- [ ] `git status` on a fresh clone with a local `.claude/` shows no untracked entries
- [ ] `AGENTS.md` and `CLAUDE.md` remain tracked and unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)