### PR TITLE
docs(agent-sdk): document xr-ai-pipecat in AGENTS.md and DEPENDENCIES.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ historical decisions in `docs/changelog.md`.
 client-samples/     # Platform clients (Android, iOS/visionOS, Web)
 server-runtime/     # XR-Media-Hub core + LiveKit transport
 agent-sdk/          # xr-ai-agent: IPC client library (pyzmq + msgpack only)
+                    # xr-ai-pipecat: optional Pipecat transport bridge (heavier deps)
 utils/              # Shared infra: stdlib-only launcher + loguru logging bridge
 cloudxr-runtime/    # Shared CloudXR OpenXR runtime + WSS proxy (opt-in)
 ai-services/        # OpenAI-compatible inference servers (VLM, STT, TTS, LLM)
@@ -29,8 +30,10 @@ docs/               # Topic deep-dives + changelog
   `ProcessorEndpoint`; return traffic goes only to the originating client.
 - **Agents talk to the hub via IPC only.** LiveKit is an internal transport
   detail — never surface it to agents.
-- **`agent-sdk` (`xr-ai-agent`) depends only on `pyzmq` + `msgpack`.** No
-  LiveKit, FastAPI, or uvicorn.
+- **`agent-sdk/xr-ai-agent` depends only on `pyzmq` + `msgpack`.** No
+  LiveKit, FastAPI, or uvicorn. `agent-sdk/xr-ai-pipecat` is a separate
+  optional package with heavier deps (pipecat-ai, scipy, numpy, httpx,
+  fastmcp); it bridges `ProcessorEndpoint` to Pipecat pipelines.
 - **Workers never import from `server-runtime` or `xr_ai_launcher`.** Only
   `xr_ai_agent` + task-specific libs (numpy, torch, …).
 - **MCP servers are the agent's only interface to XR data and rendering.**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,9 @@ historical decisions in `docs/changelog.md`.
 ```
 client-samples/     # Platform clients (Android, iOS/visionOS, Web)
 server-runtime/     # XR-Media-Hub core + LiveKit transport
-agent-sdk/          # xr-ai-agent: IPC client library (pyzmq + msgpack only)
-                    # xr-ai-pipecat: optional Pipecat transport bridge (heavier deps)
+agent-sdk/          # Two packages:
+                    #   xr-ai-agent   — IPC client library (pyzmq + msgpack only)
+                    #   xr-ai-pipecat — optional Pipecat transport bridge (heavier deps)
 utils/              # Shared infra: stdlib-only launcher + loguru logging bridge
 cloudxr-runtime/    # Shared CloudXR OpenXR runtime + WSS proxy (opt-in)
 ai-services/        # OpenAI-compatible inference servers (VLM, STT, TTS, LLM)

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -43,6 +43,19 @@ xr-ai-agent  (agent-sdk/)
     └── pyzmq >=26.0
     └── msgpack >=1.0
 
+xr-ai-pipecat  (agent-sdk/xr-ai-pipecat/)
+    └── xr-ai-agent   [editable: ..]
+    └── xr-ai-logging [editable: ../../utils/xr-ai-logging]
+    └── pipecat-ai >=0.0.46
+    └── numpy >=1.24
+    └── scipy >=1.11
+    └── httpx >=0.27
+    └── fastmcp >=0.4
+    Optional Pipecat transport bridge: connects ProcessorEndpoint (ZMQ IPC)
+    to a Pipecat frame pipeline. Resamples hub float32 audio → 16 kHz int16
+    for STT; converts TTS int16 PCM back to float32 AudioChunks for return.
+    Not a dep of xr-ai-agent itself — import only in workers that use Pipecat.
+
 xr-ai-launcher  (utils/xr-ai-launcher/)
     └── (stdlib only — zero runtime deps)
 


### PR DESCRIPTION
## Summary

- Fixes a documentation gap: `xr-ai-pipecat` (`agent-sdk/xr-ai-pipecat/`) exists in the repo with heavy deps (pipecat-ai, scipy, numpy, httpx, fastmcp) but was invisible in both `AGENTS.md` and `DEPENDENCIES.md`.
- `AGENTS.md`'s hard rule *"`agent-sdk` depends only on `pyzmq` + `msgpack`"* was technically true for `xr-ai-agent` but misleading about the broader `agent-sdk/` directory.
- Scoped the rule to `agent-sdk/xr-ai-agent` explicitly; added a note that `xr-ai-pipecat` is a separate optional package in the same directory.
- Added `xr-ai-pipecat` entry to `DEPENDENCIES.md` with its full dep list, following the mandatory rule that any undocumented package must be reflected there.

**Files touched:** `AGENTS.md`, `DEPENDENCIES.md` only. No code changes.

## Test plan

- [x] Documentation-only change — no test suite to run
- [x] `AGENTS.md` and `DEPENDENCIES.md` updated in the same commit per project rules
- [x] File-disjoint from all other PRs in this batch (tests PRs touch `tests/` only)
- [x] No `pyproject.toml` changes in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)