### PR TITLE
fix(logging): demote lovr log to files, add banner at task completion

### DIFF
--- a/agent-mcp-servers/oxr-mcp/oxr_mcp_server/__main__.py
+++ b/agent-mcp-servers/oxr-mcp/oxr_mcp_server/__main__.py
@@ -358,7 +358,13 @@ async def _serve(cfg: Config, ready_file: Path | None = None) -> None:
     logger.info("oxr-mcp: ready to serve get_head_pose (session opens lazily on first request)")
     try:
         app = build_mcp(source).http_app(path="/mcp")
-        uv_cfg = uvicorn.Config(app, host=cfg.host, port=cfg.port, log_level="warning")
+        # log_config=None skips uvicorn's own dictConfig install so its
+        # uvicorn / uvicorn.error / uvicorn.access loggers fall back to root
+        # and get intercepted by the loguru bridge installed in setup_logging.
+        # log_level="warning" still applies (set independently via setLevel
+        # on each uvicorn logger), so only WARNING+ records reach loguru.
+        uv_cfg = uvicorn.Config(app, host=cfg.host, port=cfg.port,
+                                log_level="warning", log_config=None)
         server = uvicorn.Server(uv_cfg)
         logger.info("oxr-mcp  mcp=/mcp  port={}", cfg.port)
         if ready_file:

--- a/agent-mcp-servers/render-mcp/xr_app/main.lua
+++ b/agent-mcp-servers/render-mcp/xr_app/main.lua
@@ -9,11 +9,23 @@
 --   { op="scene.remove", value={ id } }
 --   { op="scene.scale",  value={ id, scale } }    -- high-frequency audio path
 
-print("[render-mcp-scene] main.lua: top of file")
+-- ── lovr.log override ────────────────────────────────────────────────────────
+-- Emit a tab-separated marker so render-mcp's Python side (the
+-- xr_ai_launcher._processes._forward forwarder) can route by authoritative
+-- LOVR severity. Levels follow https://lovr.org/docs/lovr.log: debug, info,
+-- warn, error. Anything calling lovr.log(...) below (or any LOVR engine
+-- message routed through this callback) flows through here.
+function lovr.log(message, level, tag)
+    if message:sub(-1) == "\n" then message = message:sub(1, -2) end
+    io.stdout:write(string.format("LOVR_LOG\t%s\t%s\t%s\n", level, tag or "", message))
+    io.stdout:flush()
+end
+
+lovr.log("main.lua: top of file", "info", "render-mcp-scene")
 
 local zmq = require("lib.zmq")
 local mp  = require("lib.msgpack")
-print("[render-mcp-scene] lib.zmq + lib.msgpack loaded")
+lovr.log("lib.zmq + lib.msgpack loaded", "info", "render-mcp-scene")
 
 -- ── Scene state ───────────────────────────────────────────────────────────────
 
@@ -35,7 +47,7 @@ local ok, err = pcall(function()
 end)
 if not ok then
     recv_err = tostring(err)
-    print("[render-mcp-scene] ZMQ error: " .. recv_err)
+    lovr.log("ZMQ error: " .. recv_err, "info", "render-mcp-scene")
 end
 
 -- ── Helpers ───────────────────────────────────────────────────────────────────
@@ -71,7 +83,7 @@ end
 local function handle_scene_add(v)
     local id = v.id
     if not id then
-        print("[render-mcp-scene] scene.add: missing id — dropping")
+        lovr.log("scene.add: missing id — dropping", "info", "render-mcp-scene")
         return
     end
     local ptype      = v.type or "sphere"
@@ -80,16 +92,18 @@ local function handle_scene_add(v)
     local size       = tonumber(v.size) or 0.1
     primitives[id]   = make_primitive(ptype, px, py, pz, cr, cg, cb, size)
     scale_warned[id] = nil   -- clear so the id can warn again if it goes missing
-    print(string.format(
-        "[render-mcp-scene] scene.add  id=%s type=%s pos=(%.2f,%.2f,%.2f) color=(%.2f,%.2f,%.2f) size=%.3fm  total=%d",
-        id, ptype, px, py, pz, cr, cg, cb, size, count_primitives()))
+    lovr.log(string.format(
+        "scene.add  id=%s type=%s pos=(%.2f,%.2f,%.2f) color=(%.2f,%.2f,%.2f) size=%.3fm  total=%d",
+        id, ptype, px, py, pz, cr, cg, cb, size, count_primitives()),
+        "info", "render-mcp-scene")
 end
 
 local function handle_scene_update(v)
     local id  = v.id
     local obj = id and primitives[id]
     if not obj then
-        print(string.format("[render-mcp-scene] scene.update: unknown id=%s", tostring(id)))
+        lovr.log(string.format("scene.update: unknown id=%s", tostring(id)),
+                 "info", "render-mcp-scene")
         return
     end
     local changed = {}
@@ -110,17 +124,20 @@ local function handle_scene_update(v)
             changed[#changed+1] = string.format("size=%.3fm", s)
         end
     end
-    print(string.format("[render-mcp-scene] scene.update id=%s  %s",
-                        id, #changed > 0 and table.concat(changed, "  ") or "(nothing changed)"))
+    lovr.log(string.format("scene.update id=%s  %s",
+                           id, #changed > 0 and table.concat(changed, "  ") or "(nothing changed)"),
+             "info", "render-mcp-scene")
 end
 
 local function handle_scene_remove(v)
     local id = v.id
     if id and primitives[id] then
         primitives[id] = nil
-        print(string.format("[render-mcp-scene] scene.remove id=%s  remaining=%d", id, count_primitives()))
+        lovr.log(string.format("scene.remove id=%s  remaining=%d", id, count_primitives()),
+                 "info", "render-mcp-scene")
     elseif id then
-        print(string.format("[render-mcp-scene] scene.remove: unknown id=%s", id))
+        lovr.log(string.format("scene.remove: unknown id=%s", id),
+                 "info", "render-mcp-scene")
     end
 end
 
@@ -133,7 +150,8 @@ local function handle_scene_scale(v)
     elseif id and not scale_warned[id] then
         -- Log exactly once per unknown id so it doesn't drown other output.
         scale_warned[id] = true
-        print(string.format("[render-mcp-scene] scene.scale: unknown id=%s (logged once)", tostring(id)))
+        lovr.log(string.format("scene.scale: unknown id=%s (logged once)", tostring(id)),
+                 "info", "render-mcp-scene")
     end
 end
 
@@ -142,17 +160,19 @@ end
 function lovr.load()
     lovr.graphics.setBackgroundColor(0, 0, 0, 0)
     lovr.headset.setClipDistance(256.0, 0.15)
-    print("[render-mcp-scene] lovr.load  socket=" .. socket_addr)
+    lovr.log("lovr.load  socket=" .. socket_addr, "info", "render-mcp-scene")
 
     local ok_a, active = pcall(lovr.headset.isActive)
     local ok_d, name   = pcall(lovr.headset.getDriver)
-    print(string.format("[render-mcp-scene] headset: active=%s driver=%s",
+    lovr.log(string.format("headset: active=%s driver=%s",
         ok_a and tostring(active) or "<err>",
-        ok_d and tostring(name)   or "<err>"))
+        ok_d and tostring(name)   or "<err>"),
+        "info", "render-mcp-scene")
 
     local ok_p, applied = pcall(lovr.headset.setPassthrough, "blend")
-    print(string.format("[render-mcp-scene] setPassthrough('blend') ok=%s applied=%s",
-        tostring(ok_p), tostring(applied)))
+    lovr.log(string.format("setPassthrough('blend') ok=%s applied=%s",
+        tostring(ok_p), tostring(applied)),
+        "info", "render-mcp-scene")
 end
 
 local function drain_commands()
@@ -163,11 +183,13 @@ local function drain_commands()
 
         local okd, decoded = pcall(mp.decode, raw)
         if not okd then
-            print("[render-mcp-scene] msgpack decode error: " .. tostring(decoded))
+            lovr.log("msgpack decode error: " .. tostring(decoded),
+                     "info", "render-mcp-scene")
             goto continue
         end
         if type(decoded) ~= "table" then
-            print("[render-mcp-scene] unexpected message type: " .. type(decoded))
+            lovr.log("unexpected message type: " .. type(decoded),
+                     "info", "render-mcp-scene")
             goto continue
         end
 
@@ -181,14 +203,15 @@ local function drain_commands()
         elseif op == "scene.remove" then ok_h, herr = pcall(handle_scene_remove, v)
         elseif op == "scene.scale"  then ok_h, herr = pcall(handle_scene_scale,  v)
         elseif op ~= nil then
-            print("[render-mcp-scene] unknown op=" .. tostring(op))
+            lovr.log("unknown op=" .. tostring(op), "info", "render-mcp-scene")
         else
-            print("[render-mcp-scene] message missing 'op' field")
+            lovr.log("message missing 'op' field", "info", "render-mcp-scene")
         end
 
         if ok_h == false then
-            print(string.format("[render-mcp-scene] handler error (op=%s): %s",
-                                tostring(op), tostring(herr)))
+            lovr.log(string.format("handler error (op=%s): %s",
+                                   tostring(op), tostring(herr)),
+                     "info", "render-mcp-scene")
         end
 
         ::continue::
@@ -219,14 +242,15 @@ function lovr.update(dt)
         heartbeat_t = 0.0
         local n = count_primitives()
         if n == 0 then
-            print("[render-mcp-scene] heartbeat: scene empty")
+            lovr.log("heartbeat: scene empty", "info", "render-mcp-scene")
         else
             for id, obj in pairs(primitives) do
-                print(string.format(
-                    "[render-mcp-scene] heartbeat: id=%s type=%s pos=(%.2f,%.2f,%.2f) size=%.3fm",
+                lovr.log(string.format(
+                    "heartbeat: id=%s type=%s pos=(%.2f,%.2f,%.2f) size=%.3fm",
                     id, obj.type,
                     obj.current_pos[1], obj.current_pos[2], obj.current_pos[3],
-                    obj.current_scale))
+                    obj.current_scale),
+                    "info", "render-mcp-scene")
             end
         end
     end

--- a/agent-samples/simple-vlm-example/worker/agent.py
+++ b/agent-samples/simple-vlm-example/worker/agent.py
@@ -43,11 +43,13 @@ from __future__ import annotations
 import asyncio
 import json
 import re
+import time
 
 import httpx
 from loguru import logger
 from xr_ai_agent import (AudioChunk, DataMessage, FrameSignal,
                           ParticipantEvent, ProcessorEndpoint)
+from xr_ai_logging import print_task_done_banner
 
 from audio import chunks_to_wav, now_us, rms, wav_to_chunks
 from pixels import encode_image, frame_to_pil
@@ -221,6 +223,8 @@ class SimpleVlmAgent:
             old_timer.cancel()
 
         self._camera_held.add(pid)
+        t0 = time.monotonic()
+        status = "done"
         try:
             # Acquire a fresh frame, requesting the camera if needed.
             sig = self._latest_signal(pid)
@@ -255,11 +259,23 @@ class SimpleVlmAgent:
 
             if full_response is not None:
                 await self._reply(pid, full_response, frame.pts_us)
+        except asyncio.CancelledError:
+            status = "interrupted"
+            raise
+        except Exception:
+            status = "error"
+            raise
         finally:
             self._camera_held.discard(pid)
             # After the query, keep camera on for a grace period so rapid
             # follow-up queries skip the startup delay.  Then send stopCamera.
             self._schedule_camera_off(pid)
+            print_task_done_banner(
+                "simple-vlm-example",
+                status=status,
+                detail=f"pid={pid!r}  query={query[:60]!r}",
+                duration_s=time.monotonic() - t0,
+            )
 
     async def _stream_and_speak(
         self, pid: str, image_url: str, query: str, fallback_pts_us: int,

--- a/agent-samples/xr-render-demo/main.py
+++ b/agent-samples/xr-render-demo/main.py
@@ -80,7 +80,8 @@ _PROCESSES: list[Process] = [
             config="yaml/video_mcp_server.yaml"),
     Process("render-mcp", "../../agent-mcp-servers/render-mcp",  "render_mcp"),
     Process("oxr-mcp",    "../../agent-mcp-servers/oxr-mcp",     "oxr_mcp_server",
-            config="yaml/oxr_mcp_server.yaml"),
+            config="yaml/oxr_mcp_server.yaml",
+            quiet_native_output=True),
     Process("worker",     "worker",                              "xr_render_demo_worker",
             config="yaml/xr_render_demo_worker.yaml"),
 ]

--- a/agent-samples/xr-render-demo/worker/processors.py
+++ b/agent-samples/xr-render-demo/worker/processors.py
@@ -52,6 +52,7 @@ except ImportError:
     _TORCH_AVAILABLE = False
 
 from xr_ai_agent import DataMessage
+from xr_ai_logging import print_task_done_banner
 from xr_ai_pipecat.audio import stream_sentences_to_audio
 from xr_ai_pipecat.services import SttClient, TtsClient
 from xr_ai_pipecat.transport import XRMediaHubTransport, SAMPLE_RATE
@@ -374,6 +375,8 @@ class RenderSceneProcessor(FrameProcessor):
                 text, pid, ref_us = self._pending
                 self._pending = None
 
+            t0 = time.monotonic()
+
             # Quick-ack: fast Minitron call that (a) speaks an immediate
             # acknowledgment and (b) classifies whether Nemotron needs
             # reasoning enabled.  Await it first so the think flag is ready
@@ -412,9 +415,11 @@ class RenderSceneProcessor(FrameProcessor):
                 name="agentic-loop",
             )
             response = None
+            outcome = "done"
             try:
                 response = await self._agentic_task
             except asyncio.CancelledError:
+                outcome = "interrupted"
                 logger.info("agentic loop interrupted by new utterance")
                 send_pid = pid or self._transport.target_participant
                 if send_pid:
@@ -425,6 +430,7 @@ class RenderSceneProcessor(FrameProcessor):
                             "flush_return_audio failed during cancellation",
                         )
             except Exception:
+                outcome = "error"
                 logger.exception("agentic loop failed")
                 response = "Something went wrong — please try again."
             finally:
@@ -434,6 +440,12 @@ class RenderSceneProcessor(FrameProcessor):
                     await still_task
                 except asyncio.CancelledError:
                     pass  # expected — we just cancelled it above
+                print_task_done_banner(
+                    "xr-render-demo",
+                    status=outcome,
+                    detail=f"pid={pid!r}  utterance={text[:60]!r}",
+                    duration_s=time.monotonic() - t0,
+                )
 
             send_pid = pid or self._transport.target_participant
 
@@ -708,8 +720,8 @@ class RenderSceneProcessor(FrameProcessor):
             ctx_parts.append("[Recent conversation]\n" + "\n".join(hist_lines))
 
         context = "\n".join(ctx_parts)
-        logger.info("pre-fetched context for turn")
-        _trace_log.info("CTX   {}", context.replace("\n", " | "))
+        logger.debug("pre-fetched context for turn")
+        _trace_log.debug("CTX   {}", context.replace("\n", " | "))
 
         try:
             system_content = self._prompt_path.read_text(encoding="utf-8").strip()
@@ -873,8 +885,8 @@ class RenderSceneProcessor(FrameProcessor):
                     # Data channel only — TTS is too spammy for per-tool updates.
                     await self._send(pid, progress, topic=_AGENT_PROGRESS_TOPIC)
 
-                logger.info("tool call  iter={}  tool={}  args={}", iteration, name, args)
-                _trace_log.info(
+                logger.debug("tool call  iter={}  tool={}  args={}", iteration, name, args)
+                _trace_log.debug(
                     "TOOL  [{}] {}({})", iteration, name,
                     ", ".join(f"{k}={v}" for k, v in args.items()),
                 )

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker.py
@@ -74,12 +74,14 @@ async def main(cfg: WorkerConfig, ready_file: pathlib.Path | None = None) -> Non
     # Curated session transcript — only records bound with extra={"trace": True}
     # via ``logger.bind(trace=True)`` reach this sink.  Tail this file (or
     # paste it) to see USER/CTX/TOOL/RES/RESP events without the full chatter.
+    # DEBUG so verbose CTX / TOOL records (demoted out of the terminal) still
+    # land here.
     logger.add(
         _TRACE_FILE,
         filter=lambda r: r["extra"].get("trace") is True,
         format="{time:HH:mm:ss}  {message}",
         mode="w",
-        level="INFO",
+        level="DEBUG",
     )
     logger.bind(trace=True).info("=== trace started ===")
 

--- a/utils/xr-ai-launcher/xr_ai_launcher/_processes.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/_processes.py
@@ -2,39 +2,137 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Generic subprocess context manager with prefixed log forwarding.
+Generic subprocess context manager with per-process log file routing.
 """
 from __future__ import annotations
 
 import asyncio
 import logging
-import sys
+import os
+import re
+import time
 from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import IO
 
 log = logging.getLogger(__name__)
 
 _STOP_TIMEOUT = 20.0  # seconds before SIGKILL (docker compose down can take ~10 s)
 
+# Lines emitted by a custom ``lovr.log`` callback (see render-mcp's main.lua)
+# carry an authoritative severity from LOVR's official level vocabulary
+# (debug | info | warn | error per https://lovr.org/docs/lovr.log).
+_LOVR_LOG_PREFIX = re.compile(r"^LOVR_LOG\t(?P<level>\w+)\t(?P<tag>[^\t]*)\t(?P<msg>.*)$")
 
-async def _forward(stream: asyncio.StreamReader, prefix: str) -> None:
+# Fallback for native C-level bytes that bypass lovr.log entirely (OpenXR
+# loader, Vulkan loader, AppImage extraction). LOVR-spec keywords plus a
+# couple of native conventions, matched case-insensitively. Underscore is a
+# word character in Python regex, so this won't false-match inside identifiers
+# like "no_validation_error_in_create_ref_space".
+_LOVR_TERMINAL_RE = re.compile(
+    r"\b(error|warn|warning|fatal|panic)\b",
+    re.IGNORECASE,
+)
+
+
+def _ts() -> str:
+    """``HH:MM:SS.mmm`` matching the loguru format in xr_ai_logging.setup_logging."""
+    now = time.time()
+    return time.strftime("%H:%M:%S", time.localtime(now)) + f".{int((now - int(now)) * 1000):03d}"
+
+
+def _open_log_file(name: str) -> IO[str] | None:
+    """Open ``<XR_AI_LOG_ROOT>/log_<ns>_<ts>/<name>.log`` for append.
+
+    Returns ``None`` when the per-run env vars are not stamped (i.e. the
+    parent never called :func:`xr_ai_logging.setup_logging`), so the caller
+    can fall back to ``print`` and not silently drop the subprocess output.
+    """
+    root = os.environ.get("XR_AI_LOG_ROOT")
+    ns   = os.environ.get("XR_AI_LOG_NAMESPACE")
+    ts   = os.environ.get("XR_AI_LOG_TIMESTAMP")
+    if not (root and ns and ts):
+        return None
+    log_dir = Path(root) / f"log_{ns}_{ts}"
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        return open(log_dir / f"{name}.log", "a", buffering=1, encoding="utf-8")
+    except OSError:
+        return None
+
+
+async def _forward(stream: asyncio.StreamReader, prefix: str, sink: IO[str] | None) -> None:
+    """Drain *stream* line-by-line.
+
+    Routing per line:
+
+    * ``LOVR_LOG`` markers are parsed for authoritative severity. Records at
+      ``warn`` or ``error`` are mirrored to the parent's stdout (visible in
+      terminal); everything is written to *sink* as ``[level tag] message``.
+    * Other lines are native C-level bytes (OpenXR loader, Vulkan, AppImage
+      extraction). Mirrored to the parent's stdout iff the line contains
+      ``error|warn|warning|fatal|panic`` (LOVR's level vocabulary plus common
+      C conventions, case-insensitive); always written verbatim to *sink*.
+    * When *sink* is ``None`` (env vars unset), fall back to today's
+      unconditional prefixed ``print`` so output isn't silently dropped.
+    """
     while True:
         line = await stream.readline()
         if not line:
             break
-        print(f"{prefix} {line.decode(errors='replace').rstrip()}", flush=True)
+        decoded = line.decode(errors='replace').rstrip()
+
+        if sink is None:
+            print(f"{prefix} {decoded}", flush=True)
+            continue
+
+        match = _LOVR_LOG_PREFIX.match(decoded)
+        if match:
+            level = match["level"]
+            tag   = match["tag"]
+            msg   = match["msg"]
+            file_line = f"[{level} {tag}] {msg}" if tag else f"[{level}] {msg}"
+            try:
+                sink.write(f"{_ts()} {file_line}\n")
+            except (OSError, ValueError):
+                # File closed mid-shutdown — fall back so we don't lose the line.
+                print(f"{prefix} {file_line}", flush=True)
+                continue
+            if level in ("warn", "error"):
+                print(f"{prefix} {file_line}", flush=True)
+        else:
+            try:
+                sink.write(f"{_ts()} {decoded}\n")
+            except (OSError, ValueError):
+                print(f"{prefix} {decoded}", flush=True)
+                continue
+            if _LOVR_TERMINAL_RE.search(decoded):
+                print(f"{prefix} {decoded}", flush=True)
 
 
 @asynccontextmanager
 async def ManagedProcess(name: str, cmd: list[str], cwd: Path | None = None,
                          env: dict[str, str] | None = None):
     """
-    Run *cmd* as a subprocess, forward stdout/stderr prefixed with [name],
-    and terminate it cleanly when the context exits.
+    Run *cmd* as a subprocess and terminate it cleanly when the context exits.
 
-    Sends SIGTERM on exit; escalates to SIGKILL after _STOP_TIMEOUT seconds.
-    *env*, if given, replaces the child's environment entirely; otherwise
-    the child inherits the parent's.
+    Output routing: when the parent has called
+    :func:`xr_ai_logging.setup_logging` (per-run env vars stamped), stdout
+    and stderr are appended line-by-line to ``<log_dir>/<name>.log`` with
+    ``HH:MM:SS.mmm`` timestamps. Lines emitted via a custom ``lovr.log``
+    callback (``LOVR_LOG\\t<level>\\t<tag>\\t<msg>``) are parsed for
+    authoritative severity; ``warn``/``error`` records are also mirrored to
+    the parent's stdout so they reach the terminal. Native bytes that don't
+    carry the marker fall back to a regex match on LOVR's level vocabulary
+    (case-insensitive ``error|warn|warning|fatal|panic``) before being
+    mirrored.
+
+    When the env vars are unset (standalone use), output is not lost: lines
+    fall back to prefixed ``[name] …`` prints on the parent's stdout.
+
+    Sends SIGTERM on exit; escalates to SIGKILL after ``_STOP_TIMEOUT``
+    seconds. *env*, if given, replaces the child's environment entirely;
+    otherwise the child inherits the parent's.
     """
     log.debug("[%s] starting: %s", name, " ".join(cmd))
     proc = await asyncio.create_subprocess_exec(
@@ -46,10 +144,14 @@ async def ManagedProcess(name: str, cmd: list[str], cwd: Path | None = None,
     )
     log.debug("[%s] pid=%d", name, proc.pid)
 
+    sink = _open_log_file(name)
+    if sink is not None:
+        log.info("[%s] output → %s", name, sink.name)
+
     prefix = f"[{name}]"
     pipe_tasks = [
-        asyncio.create_task(_forward(proc.stdout, prefix), name=f"{name}-stdout"),
-        asyncio.create_task(_forward(proc.stderr, prefix), name=f"{name}-stderr"),
+        asyncio.create_task(_forward(proc.stdout, prefix, sink), name=f"{name}-stdout"),
+        asyncio.create_task(_forward(proc.stderr, prefix, sink), name=f"{name}-stderr"),
     ]
 
     try:
@@ -67,4 +169,9 @@ async def ManagedProcess(name: str, cmd: list[str], cwd: Path | None = None,
         for t in pipe_tasks:
             t.cancel()
         await asyncio.gather(*pipe_tasks, return_exceptions=True)
+        if sink is not None:
+            try:
+                sink.close()
+            except OSError:
+                pass
         log.debug("[%s] stopped (returncode=%s)", name, proc.returncode)

--- a/utils/xr-ai-launcher/xr_ai_launcher/_stack.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/_stack.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import shutil
 import signal
 import subprocess
@@ -64,15 +65,22 @@ class Process:
     """
     Declares one process in the stack.
 
-    name        — label used in log output.
-    project     — path to the uv project (relative to the sample root, or absolute).
-    command     — entry-point script to run inside the project's venv.
-    config      — path to the YAML config (relative to the sample root, or absolute).
-                  Passed as ``--config <path>`` to the subprocess. Omit for processes
-                  that take no config.
-    gpu         — optional CUDA_VISIBLE_DEVICES value (e.g. ``"0"``, ``"0,1"``).
-    launch_mode — controls spawn + shutdown behaviour:
-    port        — optional service port, used to stop ``persist`` services.
+    name                 — label used in log output.
+    project              — path to the uv project (relative to the sample root, or absolute).
+    command              — entry-point script to run inside the project's venv.
+    config               — path to the YAML config (relative to the sample root, or absolute).
+                           Passed as ``--config <path>`` to the subprocess. Omit for
+                           processes that take no config.
+    gpu                  — optional CUDA_VISIBLE_DEVICES value (e.g. ``"0"``, ``"0,1"``).
+    launch_mode          — controls spawn + shutdown behaviour:
+    port                 — optional service port, used to stop ``persist`` services.
+    quiet_native_output  — when True, captured subprocess lines that don't look like
+                           Python loguru output (no ``HH:MM:SS.SSS`` prefix) are routed
+                           through stdlib ``logging`` at DEBUG instead of printed to
+                           stdout. Use for processes that emit native C/C++ chatter
+                           (e.g. OpenXR loader output) interleaved with their own Python
+                           loguru lines. Default ``False`` — every other Process keeps
+                           today's unconditional ``print`` behavior verbatim.
 
       ``"own"``     (default) — launcher spawns this process and kills it on shutdown.
       ``"persist"`` — launcher spawns this process but leaves it running on shutdown.
@@ -83,13 +91,14 @@ class Process:
                       process list documents the dependency; the launcher skips it
                       entirely and does not kill it on shutdown.
     """
-    name:        str
-    project:     str | Path
-    command:     str
-    config:      str | Path | None = None
-    gpu:         str | None = None
-    launch_mode: str = "own"
-    port:        int | None = None
+    name:                str
+    project:             str | Path
+    command:             str
+    config:              str | Path | None = None
+    gpu:                 str | None = None
+    launch_mode:         str = "own"
+    port:                int | None = None
+    quiet_native_output: bool = False
 
 
 @dataclass(frozen=True)
@@ -117,10 +126,29 @@ class Parallel:
 
 # ── subprocess helpers ─────────────────────────────────────────────────────────
 
-def _forward(stream, prefix: str) -> None:
-    """Drain *stream* line-by-line, printing each with *prefix*."""
+# Subprocess Python loguru lines start with the format set in
+# xr_ai_logging.setup_logging: "HH:mm:ss.SSS LEVEL    name message".
+# Used to distinguish loguru-formatted Python output (terminal-visible) from
+# untimed C-level native output (file-only) when ``quiet_native_output`` is set.
+_LOGURU_TIME_RE = re.compile(r"^\d{2}:\d{2}:\d{2}\.\d{3}\s")
+
+
+def _forward(stream, prefix: str, *, quiet_native: bool = False) -> None:
+    """Drain *stream* line-by-line, printing each with *prefix*.
+
+    When *quiet_native* is True, lines that don't carry a loguru-style
+    ``HH:MM:SS.SSS`` prefix are routed through stdlib ``logging`` at DEBUG
+    instead of printed. Those records reach the orchestrator's loguru file
+    sink (DEBUG) but not its stderr sink (INFO), keeping the terminal clean
+    of native C-level chatter while preserving full output in the log file.
+    """
     for raw in stream:
-        print(f"{prefix} {raw.decode(errors='replace').rstrip()}", flush=True)
+        line = raw.decode(errors='replace').rstrip()
+        formatted = f"{prefix} {line}"
+        if quiet_native and not _LOGURU_TIME_RE.match(line):
+            log.debug(formatted)
+        else:
+            print(formatted, flush=True)
 
 
 def _spawn(proc: Process, base: Path, ready_file: Path) -> subprocess.Popen:
@@ -147,7 +175,12 @@ def _spawn(proc: Process, base: Path, ready_file: Path) -> subprocess.Popen:
                          start_new_session=True)
     prefix = f"[{proc.name}]"
     for stream in (p.stdout, p.stderr):
-        threading.Thread(target=_forward, args=(stream, prefix), daemon=True).start()
+        threading.Thread(
+            target=_forward,
+            args=(stream, prefix),
+            kwargs={"quiet_native": proc.quiet_native_output},
+            daemon=True,
+        ).start()
     return p
 
 
@@ -279,6 +312,28 @@ def _shutdown(
                     )
 
 
+# ── readiness banner ───────────────────────────────────────────────────────────
+
+def _print_ready_banner(names: list[str]) -> None:
+    """Loud, single-message banner so the ready milestone is visible at a glance.
+
+    Style mirrors ``_print_log_dir_banner`` in xr_ai_logging — same width and
+    dim-grey bar — so the run begins and ends with matching brackets in the
+    user's terminal. ANSI is TTY-only; the file sink still has the loguru
+    record from ``log.info`` above.
+    """
+    bar = "─" * 78
+    is_tty = sys.stderr.isatty()
+    on  = "\x1b[1;32m" if is_tty else ""   # bright green, bold
+    dim = "\x1b[2m"    if is_tty else ""
+    off = "\x1b[0m"    if is_tty else ""
+    print(f"\n{dim}{bar}{off}",                  file=sys.stderr, flush=True)
+    print(f"  {on}All processes ready{off}",     file=sys.stderr, flush=True)
+    if names:
+        print(f"  {dim}{', '.join(names)}{off}", file=sys.stderr, flush=True)
+    print(f"{dim}{bar}{off}\n",                  file=sys.stderr, flush=True)
+
+
 # ── public API ─────────────────────────────────────────────────────────────────
 
 def run_stack(
@@ -362,6 +417,7 @@ def run_stack(
                     _wait_ready(item.name, ready_file, launched[item.name])
 
             log.info("All processes ready.")
+            _print_ready_banner(list(launched.keys()))
             if exit_after_ready:
                 return
             _monitor(launched)

--- a/utils/xr-ai-logging/xr_ai_logging/__init__.py
+++ b/utils/xr-ai-logging/xr_ai_logging/__init__.py
@@ -46,7 +46,7 @@ from pathlib import Path
 
 from loguru import logger
 
-__all__ = ["setup_logging"]
+__all__ = ["setup_logging", "print_task_done_banner"]
 
 _DEFAULT_LOG_ROOT = Path("/tmp")
 
@@ -194,3 +194,41 @@ def _print_log_dir_banner(log_dir: Path) -> None:
                                                                  file=sys.stderr, flush=True)
     print(f"  {dim}Tail all:      tail -F {log_dir}/*.log{off}", file=sys.stderr, flush=True)
     print(f"{dim}{bar}{off}\n",                                  file=sys.stderr, flush=True)
+
+
+_STATUS_COLORS: dict[str, str] = {
+    "done":        "\x1b[1;32m",   # bright green, bold
+    "interrupted": "\x1b[1;33m",   # bright yellow, bold
+    "error":       "\x1b[1;31m",   # bright red, bold
+}
+
+
+def print_task_done_banner(
+    label: str,
+    *,
+    status: str = "done",
+    detail: str | None = None,
+    duration_s: float | None = None,
+) -> None:
+    """One-shot banner on stderr marking the end of an agent task.
+
+    Mirrors :func:`_print_log_dir_banner` styling so begin/end milestones
+    bracket the run with matching dim-grey bars. ``status`` selects the
+    headline color (``done`` green, ``interrupted`` yellow, ``error`` red);
+    unknown statuses fall back to the ``done`` color.
+    """
+    bar = "─" * 78
+    is_tty = sys.stderr.isatty()
+    on  = _STATUS_COLORS.get(status, _STATUS_COLORS["done"]) if is_tty else ""
+    dim = "\x1b[2m" if is_tty else ""
+    off = "\x1b[0m" if is_tty else ""
+
+    head = f"{status} · {label}"
+    if duration_s is not None:
+        head += f"  ({duration_s:.2f}s)"
+
+    print(f"\n{dim}{bar}{off}",       file=sys.stderr, flush=True)
+    print(f"  {on}{head}{off}",       file=sys.stderr, flush=True)
+    if detail:
+        print(f"  {dim}{detail}{off}", file=sys.stderr, flush=True)
+    print(f"{dim}{bar}{off}\n",       file=sys.stderr, flush=True)


### PR DESCRIPTION

* utils/xr-ai-launcher/xr_ai_launcher/_stack.py: print a one-shot "All processes ready" banner from run_stack once every process has signaled ready, mirroring xr_ai_logging._print_log_dir_banner so the run begins and ends with matching brackets in the user's terminal. Add Process.quiet_native_output: bool = False; when set, _forward routes captured lines that don't carry a loguru HH:MM:SS.SSS prefix through stdlib log.debug instead of printing.

* utils/xr-ai-launcher/xr_ai_launcher/_processes.py: ManagedProcess routes captured subprocess stdout/stderr to <log_dir>/<name>.log when the orchestrator has stamped per-run env vars (XR_AI_LOG_*); falls back to today's prefixed prints for standalone use. Parses LOVR_LOG\\t<level>\\t<tag>\\t<msg> markers (emitted by the custom lovr.log callback in render-mcp's main.lua) for authoritative severity routing — warn/error mirror to the terminal, everything else is file-only. Native bytes that bypass lovr.log fall back to a case-insensitive \\b(error|warn|warning|fatal|panic)\\b regex so genuine C-level failures still surface in the terminal.

* utils/xr-ai-logging/xr_ai_logging/__init__.py: add print_task_done_banner(label, *, status, detail, duration_s) — a stdlib-only stderr banner with green/yellow/red status colors (done/interrupted/error), exported in __all__.

* agent-samples/simple-vlm-example/worker/agent.py: wrap _handle_query in try/except CancelledError/except Exception/finally with outcome tracking; emit print_task_done_banner per task end.

* agent-samples/xr-render-demo/worker/processors.py: same banner wiring in RenderSceneProcessor._drain. Demote per-turn CTX dump ("pre-fetched context for turn" + _trace_log "CTX") and per-tool "tool call" + _trace_log "TOOL" records from logger.info to .debug.

* agent-samples/xr-render-demo/worker/xr_render_demo_worker.py: lower the dedicated trace-file sink from level=INFO to level=DEBUG so the now-DEBUG CTX/TOOL records still reach /tmp/xr-agent-trace.log; USER/ACK/RESP records stay at INFO and remain visible in the terminal.

* agent-mcp-servers/render-mcp/xr_app/main.lua: install a custom lovr.log callback that emits a tab-separated LOVR_LOG marker on stdout for the launcher to parse. Migrate all 20 bare print() call sites to lovr.log(message, "info", "render-mcp-scene") so every Lua-emitted line carries an authoritative LOVR level via the override.

* agent-samples/xr-render-demo/main.py: enable quiet_native_output=True on the oxr-mcp Process so the OpenXR loader's C-level chatter (no Python timestamps, bypasses loguru) routes to orchestrator.log at DEBUG instead of polluting the terminal; oxr-mcp's own Python loguru lines (timestamped) keep flowing through.

* agent-mcp-servers/oxr-mcp/oxr_mcp_server/__main__.py: pass log_config=None to uvicorn.Config so its uvicorn / uvicorn.error / uvicorn.access loggers fall back to root and get intercepted by the loguru bridge installed in setup_logging. log_level= "warning" still applies (via setLevel on the three uvicorn loggers), so only WARNING+ uvicorn records reach loguru and the terminal — but they reach it as proper loguru-formatted lines
  (timestamped) instead of uvicorn's "ERROR:    message" raw stderr
  format.