### PR TITLE
fix(xr-ai-vllm): _registry_for must require a slash, not just a colon

### DIFF
--- a/tests/test_vllm_docker.py
+++ b/tests/test_vllm_docker.py
@@ -30,6 +30,11 @@ class TestRegistryFor:
         # host:port/image has a colon in the first segment
         assert _registry_for("localhost:5000/myimage:latest") == "localhost:5000"
 
+    def test_tagged_unqualified_name_no_registry(self):
+        # A bare image with a tag must not be misread as a registry just
+        # because the tag's `:` looks like a host:port marker.
+        assert _registry_for("myimage:latest") is None
+
 
 class TestAlreadyLoggedIn:
     def test_no_docker_config(self, tmp_path, monkeypatch):

--- a/tests/test_vllm_docker.py
+++ b/tests/test_vllm_docker.py
@@ -35,6 +35,14 @@ class TestRegistryFor:
         # because the tag's `:` looks like a host:port marker.
         assert _registry_for("myimage:latest") is None
 
+    def test_namespace_no_registry(self):
+        # slash present but first segment has no dot or colon — Docker Hub library namespace
+        assert _registry_for("library/myimage") is None
+
+    def test_tagged_namespace_no_registry(self):
+        # same as above with an explicit tag — still not a registry reference
+        assert _registry_for("library/myimage:latest") is None
+
 
 class TestAlreadyLoggedIn:
     def test_no_docker_config(self, tmp_path, monkeypatch):

--- a/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
@@ -174,7 +174,15 @@ def stop_container(name: str, timeout_s: int = 20) -> bool:
 
 
 def _registry_for(image: str) -> str | None:
-    """Return the registry host for *image* if it is fully qualified, else None."""
+    """Return the registry host for *image* if it is fully qualified, else None.
+
+    A registry is only present when the reference contains a `/` AND the first
+    segment looks like a host (contains `.` for a hostname or `:` for a port).
+    Without the `/` check a bare tagged image like ``"myimage:latest"`` would
+    be misread as a registry because of the tag's colon.
+    """
+    if "/" not in image:
+        return None
     head = image.split("/", 1)[0]
     return head if "." in head or ":" in head else None
 


### PR DESCRIPTION
## Summary
- `_registry_for("myimage:latest")` used to return `"myimage:latest"` because the first segment-before-slash (the whole string, when no slash exists) contains `:` from the tag, which the registry heuristic mistakes for a `host:port` marker.
- Add the missing `"/" in image` precondition so bare tagged images correctly parse as having no registry.

Surfaced via review feedback on #113 — the bot's suggested replacement for a duplicate test (`"myimage:latest"` instead of `"myimage"`) immediately failed and revealed the bug. Kept that PR tests-only and split the behavioral change here.

## Manual verification
Ran every case through the patched `_registry_for`:

| Input | Old result | New result |
|---|---|---|
| `myimage` | `None` ✓ | `None` ✓ |
| `myimage:latest` | `"myimage:latest"` 🐛 | `None` ✓ |
| `library/myimage` | `None` ✓ | `None` ✓ |
| `library/myimage:latest` | `None` ✓ | `None` ✓ |
| `nvcr.io/nvidia/vllm:26.04-py3` | `"nvcr.io"` ✓ | `"nvcr.io"` ✓ |
| `localhost:5000/myimage:latest` | `"localhost:5000"` ✓ | `"localhost:5000"` ✓ |
| `docker.io/library/myimage` | `"docker.io"` ✓ | `"docker.io"` ✓ |

## Test plan
- [ ] Once #113 lands (which adds `xr-ai-vllm` to `tests/pyproject.toml` and the `_registry_for` test class), follow up by adding a regression case to `tests/test_vllm_docker.py::TestRegistryFor` for the `myimage:latest` input. Held back from this PR to keep it file-disjoint with #113 and avoid touching `tests/pyproject.toml` / `DEPENDENCIES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)