### PR TITLE
feat(tests): register gpu marker + add local-only dev script

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,4 +52,4 @@ jobs:
 
       - name: Run tests
         working-directory: tests
-        run: uv run pytest -v --tb=short --color=yes
+        run: uv run pytest -v --tb=short --color=yes -m "not gpu"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,21 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-05-12 — `gpu` pytest marker + local-only dev script for hardware-bound tests
+
+Some components (Docker-backed vLLM lifecycle, NVENC paths, anything that
+binds a real GPU) cannot be exercised on the GitHub `ubuntu-latest`
+runners. Rather than skip them at import time or hide them behind ad-hoc
+environment flags, we registered a single `gpu` pytest marker in
+`tests/pyproject.toml` (and defensively in `tests/conftest.py::pytest_configure`
+so branches that haven't picked up the pyproject change yet don't emit
+`PytestUnknownMarkWarning`). CI's pytest invocation in
+`.github/workflows/tests.yml` now passes `-m "not gpu"`, and developers
+run the hardware-bound suite via `tests/run_local_gpu_tests.sh`, which
+just calls `uv sync` then `pytest -m gpu` on the local box. Subsequent
+batches that add GPU / Docker / NVENC tests should decorate them with
+`@pytest.mark.gpu`; no further wiring is required.
+
 ### 2026-05-10 — TLS by default; canonicalize the same-origin wss:// proxy; drop the client-side `secure` toggle
 
 `web_server_tls` now defaults to **true**. The hub web server terminates

--- a/tests/README.md
+++ b/tests/README.md
@@ -35,7 +35,21 @@ uv run pytest -v
 
 The same command runs in GitHub Actions on every push and pull request
 via [`.github/workflows/tests.yml`](../.github/workflows/tests.yml),
-matrixed across Python 3.11 and 3.12 on `ubuntu-latest`.
+matrixed across Python 3.11 and 3.12 on `ubuntu-latest`. CI invokes
+pytest with `-m "not gpu"` so anything that needs real hardware is left
+to the developer box.
+
+## GPU / Docker / NVENC tests
+
+Tests that need a real GPU, Docker, or NVENC carry the `gpu` marker and
+are skipped in CI. Run them locally with:
+
+```bash
+bash tests/run_local_gpu_tests.sh        # or pass extra pytest args
+```
+
+Mark new tests with `@pytest.mark.gpu` whenever they need any of those
+resources.
 
 ## Test taxonomy
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,13 @@ from xr_ai_agent          import ProcessorEndpoint
 from xr_media_hub.ipc     import ConnectorEndpoint, HubEndpoint
 
 
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "gpu: requires local GPU / Docker / NVENC; skipped in CI",
+    )
+
+
 # ── address fixtures ────────────────────────────────────────────────────────
 
 

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -36,3 +36,6 @@ packages = ["xr_ai_tests"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths    = ["."]
+markers = [
+    "gpu: requires local GPU / Docker / NVENC; skipped in CI",
+]

--- a/tests/run_local_gpu_tests.sh
+++ b/tests/run_local_gpu_tests.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Run the gpu-marked tests against the local box. These tests need a real
+# GPU / Docker / NVENC and are filtered out of GitHub CI.
+
+set -euo pipefail
+cd "$(dirname "$0")"
+uv sync
+uv run pytest -v --tb=short --color=yes -m gpu "$@"


### PR DESCRIPTION
## Summary

Foundation for the GPU/local-only test suite — adds:
- `gpu` marker registered in `tests/pyproject.toml`
- `.github/workflows/tests.yml` filters with `-m "not gpu"` so CI stays green
- `tests/run_local_gpu_tests.sh` — `uv sync` + `pytest -m gpu` wrapper
- `tests/conftest.py` `pytest_configure` (defensive marker registration)
- `tests/README.md` documents the convention
- `docs/changelog.md` 2026-05-12 entry

This PR is the prerequisite for the rest of the gpu-test PR stack — merge first.

## Test plan

- [x] `pytest --collect-only -m gpu -q` → 0 tests collected (no gpu tests yet)
- [x] `pytest -m "not gpu" -q` → 166 passed (non-regression)
- [x] CI yml grep confirms `-m "not gpu"` filter present
- [x] SPDX check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)