### PR TITLE
test(stt-server): GPU smoke + clarify eager-load comment + accept HF cache

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -143,7 +143,9 @@ xr-ai-tests  (tests/)
     └── numpy >=1.24
     Multi-client / multi-agent integration tests over the IPC layer.
     Driven via ZMQ `ipc://` only — no Docker / LiveKit / NVENC required.
-    Also covers unit tests for the leaf util packages (launcher, logging, vllm).
+    Also covers unit tests for the leaf util packages (launcher, logging, vllm)
+    and `gpu`-marked smoke tests (e.g. `test_gpu_stt_server.py`) that spawn
+    real ai-services via `uv run` and need cached model weights.
 
 vlm-server  (ai-services/vlm-server/)
     └── vllm >=0.12.0

--- a/ai-services/stt-server/stt_server/__main__.py
+++ b/ai-services/stt-server/stt_server/__main__.py
@@ -219,7 +219,10 @@ async def _run(cfg: dict, yaml_dir: Path, ready_file: Path | None = None) -> Non
 
     app, backend = _build_app(cfg, model_cache)
 
-    # Warm up at startup so first request is instant.
+    # Load weights before serving so a bad model name / OOM crashes the
+    # process at startup instead of surfacing as HTTP 500 on the first
+    # client request. Doing this before uvicorn.Config() means the port
+    # never opens if the model can't be loaded.
     loop = asyncio.get_running_loop()
     await loop.run_in_executor(None, backend._ensure_loaded)
 

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -36,3 +36,6 @@ packages = ["xr_ai_tests"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths    = ["."]
+markers      = [
+    "gpu: requires local GPU / Docker / NVENC; skipped in CI",
+]

--- a/tests/test_gpu_stt_server.py
+++ b/tests/test_gpu_stt_server.py
@@ -36,7 +36,9 @@ pytestmark = [pytest.mark.asyncio, pytest.mark.gpu]
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _STT_DIR   = _REPO_ROOT / "ai-services" / "stt-server"
 _REPO_CACHE = _REPO_ROOT / "ai-services" / "models"
-_HF_CACHE   = Path("~/.cache/huggingface").expanduser()
+# Honor HF_HOME so callers with a non-default cache (e.g. a shared NAS or
+# a CI bind-mount) don't trigger a cold redownload.
+_HF_CACHE   = Path(os.environ.get("HF_HOME", "~/.cache/huggingface")).expanduser()
 _CANDIDATE_CACHES = (_REPO_CACHE, _HF_CACHE)
 _MODEL     = "nvidia/parakeet-tdt-0.6b-v3"
 
@@ -47,6 +49,9 @@ _SHUTDOWN_TIMEOUT_S  = 20.0
 
 
 def _pick_free_port() -> int:
+    # TOCTOU: another process can grab this port between bind() and the
+    # server's own bind(). Acceptable for a single-host dev test; would
+    # need a port-0 + parse-stdout pattern for hard determinism.
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
         return s.getsockname()[1]
@@ -140,6 +145,12 @@ def _terminate(proc: subprocess.Popen) -> None:
     except subprocess.TimeoutExpired:
         proc.kill()
         proc.wait(timeout=5)
+    # Drain stdout/stderr so the subprocess isn't blocked on a full pipe.
+    if proc.stdout is not None:
+        try:
+            proc.stdout.read()
+        except (ValueError, OSError):
+            pass  # pipe already closed by the kernel during teardown
 
 
 @pytest.fixture

--- a/tests/test_gpu_stt_server.py
+++ b/tests/test_gpu_stt_server.py
@@ -116,6 +116,7 @@ def _health_ok(port: int) -> bool:
             f"http://127.0.0.1:{port}/health", timeout=2,
         ) as r:
             return r.status == 200
+    # Connection refused / DNS / timeout during the poll loop — caller retries.
     except Exception:
         return False
 

--- a/tests/test_gpu_stt_server.py
+++ b/tests/test_gpu_stt_server.py
@@ -1,0 +1,216 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""GPU smoke test for ai-services/stt-server.
+
+Boots the real NeMo ASR server (parakeet-tdt-0.6b-v3) as a subprocess via
+``uv run``, POSTs a short sine-wave WAV to ``/v1/audio/transcriptions``, and
+asserts the response is well-formed JSON with a ``text`` field. The transcript
+content is intentionally unchecked — a brief sine wave produces no semantic
+output and the goal here is wiring (model loads, port serves, endpoint
+returns 200), not recognition quality.
+"""
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import math
+import os
+import shutil
+import signal
+import socket
+import struct
+import subprocess
+import urllib.error
+import urllib.request
+import uuid
+import wave
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.gpu]
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_STT_DIR   = _REPO_ROOT / "ai-services" / "stt-server"
+_CACHE_DIR = _REPO_ROOT / "ai-services" / "models"
+_MODEL     = "nvidia/parakeet-tdt-0.6b-v3"
+
+_STARTUP_TIMEOUT_S   = 600.0   # cold model load can easily take minutes.
+_SHUTDOWN_TIMEOUT_S  = 20.0
+
+
+def _pick_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _make_sine_wav(seconds: float = 1.0, sample_rate: int = 16_000,
+                   freq_hz: float = 440.0, amplitude: float = 0.2) -> bytes:
+    """Return raw bytes of a mono 16-bit PCM WAV file (stdlib only)."""
+    n_samples = int(seconds * sample_rate)
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        peak = int(amplitude * 32767)
+        frames = bytearray()
+        for n in range(n_samples):
+            v = int(peak * math.sin(2 * math.pi * freq_hz * n / sample_rate))
+            frames += struct.pack("<h", v)
+        wf.writeframes(bytes(frames))
+    return buf.getvalue()
+
+
+def _weights_cached() -> bool:
+    """True iff a NeMo or HF weight file is present under ai-services/models.
+
+    The server resolves ``model_cache: ../models`` (relative to its YAML) and
+    sets ``NEMO_CACHE_DIR`` / ``HF_HOME`` underneath it. A pristine repo
+    has no weights, so without this check the test would block for minutes
+    pulling ~1 GB before failing.
+    """
+    for root in (_CACHE_DIR / "nemo", _CACHE_DIR / "huggingface"):
+        if not root.is_dir():
+            continue
+        for pattern in ("*.nemo", "*.safetensors"):
+            if next(root.rglob(pattern), None) is not None:
+                return True
+    return False
+
+
+def _build_multipart(field_name: str, filename: str, payload: bytes,
+                     extra_fields: dict[str, str]) -> tuple[bytes, str]:
+    """Hand-rolled multipart/form-data — saves pulling in requests/httpx."""
+    boundary = f"----xrai-stt-{uuid.uuid4().hex}"
+    crlf     = b"\r\n"
+    body     = bytearray()
+    for key, val in extra_fields.items():
+        body += f"--{boundary}".encode() + crlf
+        body += f'Content-Disposition: form-data; name="{key}"'.encode() + crlf + crlf
+        body += val.encode() + crlf
+    body += f"--{boundary}".encode() + crlf
+    body += (
+        f'Content-Disposition: form-data; name="{field_name}"; '
+        f'filename="{filename}"'
+    ).encode() + crlf
+    body += b"Content-Type: audio/wav" + crlf + crlf
+    body += payload + crlf
+    body += f"--{boundary}--".encode() + crlf
+    return bytes(body), f"multipart/form-data; boundary={boundary}"
+
+
+def _health_ok(port: int) -> bool:
+    try:
+        with urllib.request.urlopen(
+            f"http://127.0.0.1:{port}/health", timeout=2,
+        ) as r:
+            return r.status == 200
+    except Exception:
+        return False
+
+
+async def _wait_for_health(port: int, deadline_s: float) -> None:
+    loop  = asyncio.get_running_loop()
+    until = loop.time() + deadline_s
+    while loop.time() < until:
+        if await loop.run_in_executor(None, _health_ok, port):
+            return
+        await asyncio.sleep(1.0)
+    raise TimeoutError(f"stt server did not become healthy on :{port}")
+
+
+def _terminate(proc: subprocess.Popen) -> None:
+    if proc.poll() is not None:
+        return
+    proc.send_signal(signal.SIGTERM)
+    try:
+        proc.wait(timeout=_SHUTDOWN_TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5)
+
+
+@pytest.fixture
+def stt_yaml(tmp_path: Path) -> tuple[Path, int]:
+    """Write a temp YAML pointing at the shared model cache on a free port."""
+    port = _pick_free_port()
+    cfg  = (
+        "model: nvidia/parakeet-tdt-0.6b-v3\n"
+        "device: auto\n"
+        f"port: {port}\n"
+        'host: "127.0.0.1"\n'
+        f"model_cache: {_CACHE_DIR}\n"
+    )
+    path = tmp_path / "stt_server.yaml"
+    path.write_text(cfg)
+    return path, port
+
+
+async def test_stt_server_transcribes_sine_wav(stt_yaml: tuple[Path, int]) -> None:
+    if shutil.which("uv") is None:
+        pytest.skip("uv not on PATH")
+    if not _STT_DIR.exists():
+        pytest.skip(f"stt-server source tree missing: {_STT_DIR}")
+    if not _weights_cached():
+        pytest.skip(
+            f"NeMo/HF weights for {_MODEL} not cached under {_CACHE_DIR}; "
+            "run the stt server once outside the test to populate it.",
+        )
+
+    cfg_path, port = stt_yaml
+
+    proc = subprocess.Popen(
+        ["uv", "run", "--directory", str(_STT_DIR),
+         "stt_server", "--config", str(cfg_path)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        env={**os.environ, "PYTHONUNBUFFERED": "1"},
+    )
+
+    try:
+        try:
+            await _wait_for_health(port, _STARTUP_TIMEOUT_S)
+        except TimeoutError:
+            # Drain whatever the subprocess printed so the failure is debuggable.
+            _terminate(proc)
+            tail = proc.stdout.read().decode(errors="replace") if proc.stdout else ""
+            pytest.fail(
+                f"stt server failed to start on :{port}\n"
+                f"--- subprocess output ---\n{tail[-4000:]}",
+            )
+
+        wav_bytes = _make_sine_wav()
+        body, content_type = _build_multipart(
+            "file", "sine.wav", wav_bytes,
+            extra_fields={"model": _MODEL, "response_format": "json"},
+        )
+
+        loop = asyncio.get_running_loop()
+
+        def _post() -> tuple[int, bytes]:
+            req = urllib.request.Request(
+                f"http://127.0.0.1:{port}/v1/audio/transcriptions",
+                data=body,
+                method="POST",
+                headers={"Content-Type": content_type},
+            )
+            try:
+                with urllib.request.urlopen(req, timeout=120) as r:
+                    return r.status, r.read()
+            except urllib.error.HTTPError as e:
+                return e.code, e.read()
+
+        status, payload = await loop.run_in_executor(None, _post)
+
+        assert status == 200, f"unexpected status {status}: {payload[:500]!r}"
+        obj = json.loads(payload.decode())
+        assert "text" in obj, f"missing 'text' key in response: {obj}"
+        assert isinstance(obj["text"], str), f"'text' is not a string: {obj}"
+
+    finally:
+        _terminate(proc)

--- a/tests/test_gpu_stt_server.py
+++ b/tests/test_gpu_stt_server.py
@@ -35,10 +35,14 @@ pytestmark = [pytest.mark.asyncio, pytest.mark.gpu]
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _STT_DIR   = _REPO_ROOT / "ai-services" / "stt-server"
-_CACHE_DIR = _REPO_ROOT / "ai-services" / "models"
+_REPO_CACHE = _REPO_ROOT / "ai-services" / "models"
+_HF_CACHE   = Path("~/.cache/huggingface").expanduser()
+_CANDIDATE_CACHES = (_REPO_CACHE, _HF_CACHE)
 _MODEL     = "nvidia/parakeet-tdt-0.6b-v3"
 
-_STARTUP_TIMEOUT_S   = 600.0   # cold model load can easily take minutes.
+# Generous cold-start budget — first run may download the ~600 MB
+# parakeet bundle from HF before model load.
+_STARTUP_TIMEOUT_S   = 900.0
 _SHUTDOWN_TIMEOUT_S  = 20.0
 
 
@@ -66,21 +70,23 @@ def _make_sine_wav(seconds: float = 1.0, sample_rate: int = 16_000,
     return buf.getvalue()
 
 
-def _weights_cached() -> bool:
-    """True iff a NeMo or HF weight file is present under ai-services/models.
+def _resolve_cached_cache_root() -> Path | None:
+    """Return the first cache root containing parakeet weights, or None.
 
-    The server resolves ``model_cache: ../models`` (relative to its YAML) and
-    sets ``NEMO_CACHE_DIR`` / ``HF_HOME`` underneath it. A pristine repo
-    has no weights, so without this check the test would block for minutes
-    pulling ~1 GB before failing.
+    Checks both the repo-local model cache (``ai-services/models``, the
+    canonical location wired into the stt-server YAML) and the standard
+    Hugging Face cache (``~/.cache/huggingface``) so weights downloaded by
+    any other tool are reused without a redundant fetch.
     """
-    for root in (_CACHE_DIR / "nemo", _CACHE_DIR / "huggingface"):
-        if not root.is_dir():
-            continue
-        for pattern in ("*.nemo", "*.safetensors"):
-            if next(root.rglob(pattern), None) is not None:
-                return True
-    return False
+    for root in _CANDIDATE_CACHES:
+        for sub in ("nemo", "huggingface", "hub"):
+            base = root / sub
+            if not base.is_dir():
+                continue
+            for pattern in ("*.nemo", "*.safetensors"):
+                if next(base.rglob(pattern), None) is not None:
+                    return root
+    return None
 
 
 def _build_multipart(field_name: str, filename: str, payload: bytes,
@@ -137,14 +143,15 @@ def _terminate(proc: subprocess.Popen) -> None:
 
 @pytest.fixture
 def stt_yaml(tmp_path: Path) -> tuple[Path, int]:
-    """Write a temp YAML pointing at the shared model cache on a free port."""
+    """Write a temp YAML pointing at whichever cache root holds the weights."""
     port = _pick_free_port()
+    cache_root = _resolve_cached_cache_root() or _REPO_CACHE
     cfg  = (
         "model: nvidia/parakeet-tdt-0.6b-v3\n"
         "device: auto\n"
         f"port: {port}\n"
         'host: "127.0.0.1"\n'
-        f"model_cache: {_CACHE_DIR}\n"
+        f"model_cache: {cache_root}\n"
     )
     path = tmp_path / "stt_server.yaml"
     path.write_text(cfg)
@@ -156,11 +163,9 @@ async def test_stt_server_transcribes_sine_wav(stt_yaml: tuple[Path, int]) -> No
         pytest.skip("uv not on PATH")
     if not _STT_DIR.exists():
         pytest.skip(f"stt-server source tree missing: {_STT_DIR}")
-    if not _weights_cached():
-        pytest.skip(
-            f"NeMo/HF weights for {_MODEL} not cached under {_CACHE_DIR}; "
-            "run the stt server once outside the test to populate it.",
-        )
+
+    # The server downloads parakeet weights on first run into the resolved
+    # cache root (see stt_yaml fixture); subsequent runs reuse them.
 
     cfg_path, port = stt_yaml
 


### PR DESCRIPTION
## Summary

GPU smoke test for `ai-services/stt-server` (NeMo Parakeet ASR) plus a comment/invariant hardening fix.

**New test** (`tests/test_gpu_stt_server.py`, `@pytest.mark.gpu`): spawns `stt_server` subprocess, synthesizes a 1 s 16 kHz sine wav via stdlib, POSTs to `/v1/audio/transcriptions`, asserts a `text` field returned. Self-sufficient on a fresh box — `_resolve_cached_cache_root()` checks both repo-local `ai-services/models` and `~/.cache/huggingface/hub` for weights, points the server's `model_cache` at whichever has them (or repo-local if neither, in which case NeMo downloads on first run). Cold-start budget 900 s.

**Fix folded in:**
- `ai-services/stt-server/stt_server/__main__.py` — the eager model-load at startup was already in place (await `_ensure_loaded()` before `uvicorn.Config`); reworked the inline comment to state the invariant ("port never opens if weights can't load") instead of describing the warm-up. No behavior change.

## Test plan

- [x] `pytest -m gpu test_gpu_stt_server.py -v` passes on L40S (~57 s warm cache)
- [x] `pytest -m "not gpu" -q` → no regressions
- [x] Skip path tested: with `uv` absent, test cleanly skips with message

🤖 Generated with [Claude Code](https://claude.com/claude-code)