### PR TITLE
test(transcript-mcp): add CI-viable subprocess test for transcript-mcp-server

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -133,17 +133,20 @@ oxr-mcp-server  (agent-mcp-servers/oxr-mcp/)
     cloudxr-runtime must start before oxr-mcp (serial launch order).
 
 xr-ai-tests  (tests/)
-    └── xr-ai-agent     [editable: ../agent-sdk]
-    └── xr-media-hub    [editable: ../server-runtime]
-    └── xr-ai-launcher  [editable: ../utils/xr-ai-launcher]
-    └── xr-ai-logging   [editable: ../utils/xr-ai-logging]
-    └── xr-ai-vllm      [editable: ../utils/xr-ai-vllm]
+    └── xr-ai-agent             [editable: ../agent-sdk]
+    └── xr-media-hub            [editable: ../server-runtime]
+    └── xr-ai-launcher          [editable: ../utils/xr-ai-launcher]
+    └── xr-ai-logging           [editable: ../utils/xr-ai-logging]
+    └── xr-ai-vllm              [editable: ../utils/xr-ai-vllm]
+    └── transcript-mcp-server   [editable: ../agent-mcp-servers/transcript-mcp]
     └── pytest >=8.0
     └── pytest-asyncio >=0.23
     └── numpy >=1.24
     Multi-client / multi-agent integration tests over the IPC layer.
     Driven via ZMQ `ipc://` only — no Docker / LiveKit / NVENC required.
-    Also covers unit tests for the leaf util packages (launcher, logging, vllm).
+    Also covers unit tests for the leaf util packages (launcher, logging, vllm)
+    and a CI-viable subprocess test for transcript-mcp-server (fastmcp pulled
+    in transitively).
 
 vlm-server  (ai-services/vlm-server/)
     └── vllm >=0.12.0

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -17,6 +17,10 @@ dependencies = [
     "xr-ai-launcher",
     "xr-ai-logging",
     "xr-ai-vllm",
+    # Pulled in editably so the CI-viable transcript-mcp test can spawn it
+    # as a subprocess and exercise it via fastmcp.Client (fastmcp transitively
+    # included from this dep).
+    "transcript-mcp-server",
     # Test runner.
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
@@ -24,11 +28,12 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-xr-ai-agent    = { path = "../agent-sdk",               editable = true }
-xr-media-hub   = { path = "../server-runtime",          editable = true }
-xr-ai-launcher = { path = "../utils/xr-ai-launcher",   editable = true }
-xr-ai-logging  = { path = "../utils/xr-ai-logging",    editable = true }
-xr-ai-vllm     = { path = "../utils/xr-ai-vllm",       editable = true }
+xr-ai-agent           = { path = "../agent-sdk",                            editable = true }
+xr-media-hub          = { path = "../server-runtime",                       editable = true }
+xr-ai-launcher        = { path = "../utils/xr-ai-launcher",                editable = true }
+xr-ai-logging         = { path = "../utils/xr-ai-logging",                 editable = true }
+xr-ai-vllm            = { path = "../utils/xr-ai-vllm",                    editable = true }
+transcript-mcp-server = { path = "../agent-mcp-servers/transcript-mcp",     editable = true }
 
 [tool.hatch.build.targets.wheel]
 packages = ["xr_ai_tests"]

--- a/tests/test_transcript_mcp.py
+++ b/tests/test_transcript_mcp.py
@@ -60,6 +60,7 @@ async def _wait_ready(url: str, proc: subprocess.Popen, timeout: float) -> None:
             async with McpClient(url) as mcp:
                 await mcp.list_tools()
                 return
+        # Connect refused / handshake error while the server is still booting — retry.
         except Exception:
             await asyncio.sleep(0.1)
     raise TimeoutError(f"transcript_mcp_server at {url} not ready within {timeout}s")

--- a/tests/test_transcript_mcp.py
+++ b/tests/test_transcript_mcp.py
@@ -1,0 +1,181 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CI-viable integration test for the transcript-mcp server.
+
+Spawns ``python -m transcript_mcp_server`` as a subprocess against a
+temporary transcripts directory, polls readiness via ``McpClient.list_tools``
+(same pattern as production ``mcp_probe``), then drives the four public
+FastMCP tools end-to-end over StreamableHTTP and verifies the on-disk
+JSONL artefacts. No GPU, Docker, or model weights.
+
+Note: the ``--ready-file`` codepath in ``__main__.py`` calls
+``app.add_event_handler`` which Starlette 1.0 removed, so this test polls
+the MCP surface for readiness instead. That bug is out of scope here.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+import yaml
+from fastmcp import Client as McpClient
+
+pytestmark = pytest.mark.asyncio
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _free_port() -> int:
+    """Pick a free TCP port; binding to 0 lets the kernel pick atomically."""
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _tool_payload(result):
+    """Extract structured output from a FastMCP CallToolResult."""
+    if hasattr(result, "data") and result.data is not None:
+        return result.data
+    return getattr(result, "structured_content", None)
+
+
+async def _wait_ready(url: str, proc: subprocess.Popen, timeout: float) -> None:
+    """Poll list_tools() until the server answers or the subprocess dies."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(
+                f"transcript_mcp_server exited early (rc={proc.returncode})"
+            )
+        try:
+            async with McpClient(url) as mcp:
+                await mcp.list_tools()
+                return
+        except Exception:
+            await asyncio.sleep(0.1)
+    raise TimeoutError(f"transcript_mcp_server at {url} not ready within {timeout}s")
+
+
+# ── test ─────────────────────────────────────────────────────────────────────
+
+async def test_transcript_mcp_end_to_end():
+    with tempfile.TemporaryDirectory() as td:
+        tmp           = Path(td)
+        transcripts   = tmp / "transcripts"
+        config_path   = tmp / "transcript_mcp_server.yaml"
+        port          = _free_port()
+        url           = f"http://127.0.0.1:{port}/mcp"
+
+        config_path.write_text(yaml.safe_dump({
+            "transcripts_dir": str(transcripts),
+            "host":            "127.0.0.1",
+            "port":            port,
+        }))
+
+        # Redirect loguru's on-disk sink under the tmpdir so the test
+        # doesn't write into the developer's $HOME log root.
+        env = {**os.environ, "XR_AI_LOG_ROOT": str(tmp / "logs")}
+
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "transcript_mcp_server",
+             "--config", str(config_path)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            env=env,
+        )
+
+        try:
+            await _wait_ready(url, proc, timeout=15.0)
+
+            async with McpClient(url) as mcp:
+                tools = {t.name for t in await mcp.list_tools()}
+                assert tools == {
+                    "query_transcripts", "add_transcript",
+                    "list_sources",      "get_transcript_stats",
+                }
+
+                # Two utterances from one source plus one from another;
+                # the empty-text guard must produce an error dict.
+                add_alice_1 = _tool_payload(await mcp.call_tool(
+                    "add_transcript",
+                    {"source_id": "alice@home", "timestamp_us": 1_000_000, "text": "hello"},
+                ))
+                add_alice_2 = _tool_payload(await mcp.call_tool(
+                    "add_transcript",
+                    {"source_id": "alice@home", "timestamp_us": 2_000_000, "text": "world"},
+                ))
+                add_bob = _tool_payload(await mcp.call_tool(
+                    "add_transcript",
+                    {"source_id": "agent-vlm", "timestamp_us": 3_000_000, "text": "frame seen"},
+                ))
+                add_empty = _tool_payload(await mcp.call_tool(
+                    "add_transcript",
+                    {"source_id": "alice@home", "timestamp_us": 4_000_000, "text": "   "},
+                ))
+                assert add_alice_1 == {"ok": True}
+                assert add_alice_2 == {"ok": True}
+                assert add_bob     == {"ok": True}
+                assert "error" in add_empty
+
+                sources = _tool_payload(await mcp.call_tool("list_sources", {}))
+                assert set(sources) == {"alice@home", "agent-vlm"}
+
+                # Inclusive window covering both alice utterances.
+                q = _tool_payload(await mcp.call_tool(
+                    "query_transcripts",
+                    {"source_id": "alice@home", "start_us": 0, "end_us": 5_000_000},
+                ))
+                assert [r["text"] for r in q] == ["hello", "world"]
+                assert [r["timestamp_us"] for r in q] == [1_000_000, 2_000_000]
+
+                # Half-open window — only the later utterance lands inside.
+                q_late = _tool_payload(await mcp.call_tool(
+                    "query_transcripts",
+                    {"source_id": "alice@home", "start_us": 1_500_000, "end_us": 5_000_000},
+                ))
+                assert [r["text"] for r in q_late] == ["world"]
+
+                stats = _tool_payload(await mcp.call_tool(
+                    "get_transcript_stats", {"source_id": "alice@home"},
+                ))
+                assert stats["source_id"]   == "alice@home"
+                assert stats["count"]       == 2
+                assert stats["total_chars"] == len("hello") + len("world")
+                assert stats["earliest_us"] == 1_000_000
+                assert stats["latest_us"]   == 2_000_000
+
+                missing_stats = _tool_payload(await mcp.call_tool(
+                    "get_transcript_stats", {"source_id": "never-seen"},
+                ))
+                assert "error" in missing_stats
+
+            # On-disk artefacts — _safe_name turns '@' into '_', so the
+            # alice file is sanitized while agent-vlm passes through.
+            alice_jsonl = transcripts / "alice_home.jsonl"
+            bob_jsonl   = transcripts / "agent-vlm.jsonl"
+            assert alice_jsonl.exists()
+            assert bob_jsonl.exists()
+            alice_lines = [json.loads(ln) for ln in alice_jsonl.read_text().splitlines() if ln]
+            assert alice_lines == [
+                {"timestamp_us": 1_000_000, "text": "hello"},
+                {"timestamp_us": 2_000_000, "text": "world"},
+            ]
+            # Sidecar preserves the raw source_id with the unsanitized '@'.
+            assert (transcripts / "alice_home.identity").read_text() == "alice@home"
+
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=10.0)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=5.0)


### PR DESCRIPTION
## Summary

**CI-viable** subprocess test for `agent-mcp-servers/transcript-mcp` — pure JSONL file I/O, no GPU/Docker/weights, runs on `ubuntu-latest`.

**New test** (`tests/test_transcript_mcp.py`, **no marker — CI**):
- Spawns `python -m transcript_mcp_server` against a `TemporaryDirectory`
- Polls readiness via `fastmcp.Client.list_tools()` (same pattern as `mcp_probe`)
- Exercises all four MCP tools: `add_transcript`, `query_transcripts`, `list_sources`, `get_transcript_stats`
- Tests the empty-text guard, half-open time window, missing-source error path
- Asserts on-disk `*.jsonl` / `*.identity` sidecar artefacts
- `XR_AI_LOG_ROOT` redirected into the tmpdir so loguru doesn't write into `$HOME`

`transcript-mcp-server` added as editable workspace source in `tests/pyproject.toml`; `DEPENDENCIES.md` updated in the same commit.

## Out-of-scope bug surfaced

The transcript server's `--ready-file` path calls `app.add_event_handler` which Starlette 1.0 removed — the server would crash before serving when `--ready-file` is passed. The test polls the MCP surface for readiness instead; flagged in the docstring for a focused follow-up fix.

## Test plan

- [x] `pytest tests/test_transcript_mcp.py -v` → 1 passed
- [x] `pytest -m "not gpu" -q` → 167 passed (166 + this one)
- [x] No GPU/Docker/weights required — runs in CI matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)