### PR TITLE
test(mcp): add vlm-mcp + render-mcp coverage; fix port collision and lifecycle leaks

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -138,12 +138,15 @@ xr-ai-tests  (tests/)
     └── xr-ai-launcher  [editable: ../utils/xr-ai-launcher]
     └── xr-ai-logging   [editable: ../utils/xr-ai-logging]
     └── xr-ai-vllm      [editable: ../utils/xr-ai-vllm]
+    └── vlm-mcp-server  [editable: ../agent-mcp-servers/vlm-mcp]
+    └── render-mcp      [editable: ../agent-mcp-servers/render-mcp]
     └── pytest >=8.0
     └── pytest-asyncio >=0.23
     └── numpy >=1.24
     Multi-client / multi-agent integration tests over the IPC layer.
     Driven via ZMQ `ipc://` only — no Docker / LiveKit / NVENC required.
-    Also covers unit tests for the leaf util packages (launcher, logging, vllm).
+    Also covers unit tests for the leaf util packages (launcher, logging, vllm)
+    and the vlm-mcp / render-mcp adapter surfaces (mocked upstreams).
 
 vlm-server  (ai-services/vlm-server/)
     └── vllm >=0.12.0

--- a/agent-mcp-servers/render-mcp/render_mcp/__main__.py
+++ b/agent-mcp-servers/render-mcp/render_mcp/__main__.py
@@ -27,6 +27,7 @@ import asyncio
 import contextlib
 import glob
 import os
+import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -96,14 +97,38 @@ def _build_config(yaml_path: Path, raw: dict) -> Config:
     if env_file_raw:
         env_file = _resolve(yaml_dir, env_file_raw)
 
+    scene_socket = raw.get("scene_socket", "ipc:///tmp/xr_render_scene")
+    _validate_scene_socket(scene_socket)
+
     return Config(
         lovr_bin         = lovr_bin,
         xr_app_dir       = xr_app_dir,
-        scene_socket     = raw.get("scene_socket", "ipc:///tmp/xr_render_scene"),
+        scene_socket     = scene_socket,
         cloudxr_env_file = env_file,
         host             = raw.get("host", "0.0.0.0"),
         port             = int(raw.get("port", 8220)),
     )
+
+
+# ZMQ transport prefixes we accept for the LOVR-facing PUSH socket. The ipc
+# branch requires a non-empty path under the leading slash so we reject
+# `ipc:///` — that's the exact typo that produces a cryptic bind() error
+# deep inside pyzmq.
+_SCENE_SOCKET_RE = re.compile(
+    r"^(?:ipc://(?:/[^/].*|[^/].*)|tcp://[^/]+:\d+|inproc://.+)$"
+)
+
+
+def _validate_scene_socket(value: str) -> None:
+    """Fail fast on malformed scene_socket URLs (e.g. 'ipc:///' with no path).
+
+    Catches the common typos before pyzmq's bind() raises an opaque error.
+    """
+    if not isinstance(value, str) or not _SCENE_SOCKET_RE.match(value):
+        sys.exit(
+            f"render-mcp: invalid scene_socket {value!r}.\n"
+            "  Expected ipc://<path>, tcp://<host>:<port>, or inproc://<name>."
+        )
 
 
 def _find_bundled_libzmq() -> Path | None:
@@ -151,6 +176,7 @@ class SceneDispatcher:
         self._spawn_lock: asyncio.Lock = asyncio.Lock()
         self._render_drops: int = 0
         self._spawn_error: str | None = None
+        self._watch_task: asyncio.Task | None = None
 
         # Scene state: { id → { type, position, color, scale } }
         self._objects: dict[str, dict] = {}
@@ -202,7 +228,7 @@ class SceneDispatcher:
                 )
                 self._lovr_started = False
 
-            asyncio.create_task(_watch(), name="lovr-watch")
+            self._watch_task = asyncio.create_task(_watch(), name="lovr-watch")
 
             self._lovr_started = True
             logger.info("render-mcp: LOVR spawned (xr.start handled)")
@@ -301,6 +327,8 @@ class SceneDispatcher:
             return {"ok": False, "reason": "backpressure"}
 
     def close(self) -> None:
+        if self._watch_task is not None and not self._watch_task.done():
+            self._watch_task.cancel()
         with contextlib.suppress(Exception):
             self._push.close(linger=0)
 

--- a/agent-mcp-servers/vlm-mcp/vlm_mcp_server.yaml
+++ b/agent-mcp-servers/vlm-mcp/vlm_mcp_server.yaml
@@ -15,7 +15,7 @@
 # treats as an error.
 
 host:                  0.0.0.0
-port:                  8220
+port:                  8240
 
 # URL of the vlm-server (ai-services/vlm-server/). The MCP tool forwards the
 # loaded image + the LLM's question to this service over HTTP.

--- a/agent-mcp-servers/vlm-mcp/vlm_mcp_server/__main__.py
+++ b/agent-mcp-servers/vlm-mcp/vlm_mcp_server/__main__.py
@@ -4,7 +4,7 @@
 """
 VLM MCP server.
 
-Pure FastMCP — one tool at /mcp on port 8220. There are no REST endpoints,
+Pure FastMCP — one tool at /mcp on port 8240. There are no REST endpoints,
 no hub IPC subscription, and no `xr-ai-agent` runtime dependency.
 
 The single tool ``ask_image(question, image_path)`` reads a local PNG path,
@@ -31,7 +31,7 @@ Tool (FastMCP, mounted at /mcp)
 Config (vlm_mcp_server.yaml)
 ────────────────────────────
     host:                 0.0.0.0
-    port:                 8220
+    port:                 8240
     vlm_server:           http://localhost:8100
     vlm_request_timeout_s: 60.0
 """
@@ -214,7 +214,7 @@ def build_mcp(vlm: VlmClient) -> FastMCP:
 
 async def _serve(cfg: dict, ready_file: pathlib.Path | None = None) -> None:
     host                  = cfg.get("host", "0.0.0.0")
-    port                  = int(cfg.get("port", 8220))
+    port                  = int(cfg.get("port", 8240))
     vlm_server            = cfg.get("vlm_server", "http://localhost:8100")
     vlm_request_timeout_s = float(cfg.get("vlm_request_timeout_s", 60.0))
     enable_thinking       = bool(cfg.get("enable_thinking", False))

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
     "xr-ai-launcher",
     "xr-ai-logging",
     "xr-ai-vllm",
+    "vlm-mcp-server",
+    "render-mcp",
     # Test runner.
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
@@ -24,11 +26,13 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-xr-ai-agent    = { path = "../agent-sdk",               editable = true }
-xr-media-hub   = { path = "../server-runtime",          editable = true }
-xr-ai-launcher = { path = "../utils/xr-ai-launcher",   editable = true }
-xr-ai-logging  = { path = "../utils/xr-ai-logging",    editable = true }
-xr-ai-vllm     = { path = "../utils/xr-ai-vllm",       editable = true }
+xr-ai-agent     = { path = "../agent-sdk",                       editable = true }
+xr-media-hub    = { path = "../server-runtime",                  editable = true }
+xr-ai-launcher  = { path = "../utils/xr-ai-launcher",            editable = true }
+xr-ai-logging   = { path = "../utils/xr-ai-logging",             editable = true }
+xr-ai-vllm      = { path = "../utils/xr-ai-vllm",                editable = true }
+vlm-mcp-server  = { path = "../agent-mcp-servers/vlm-mcp",       editable = true }
+render-mcp      = { path = "../agent-mcp-servers/render-mcp",    editable = true }
 
 [tool.hatch.build.targets.wheel]
 packages = ["xr_ai_tests"]

--- a/tests/test_local_render_mcp.py
+++ b/tests/test_local_render_mcp.py
@@ -1,0 +1,372 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Local-only tests for render-mcp's ZMQ scene-socket wire format and lifecycle.
+
+LOVR (the OpenXR rendering app) is stubbed — the goal is to verify render-mcp's
+ZMQ PUSH wire format, the in-memory scene state, the FastMCP tool surface,
+config validation, and the lifecycle bookkeeping that keeps the LOVR watch
+task from leaking. No real OpenXR / Vulkan is exercised.
+
+Marked ``gpu`` because the suite is local-development-only: it spins up
+ephemeral ipc:// sockets in /tmp and is not part of the CI matrix.
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import uuid
+from pathlib import Path
+
+import msgpack
+import pytest
+import zmq
+import zmq.asyncio
+
+from render_mcp.__main__ import (
+    Config,
+    SceneDispatcher,
+    _build_config,
+    _validate_scene_socket,
+    build_mcp,
+)
+
+pytestmark = pytest.mark.gpu
+
+# Per-class asyncio marker so the synchronous helper tests below don't trip
+# pytest-asyncio's "marked but not async" warning. asyncio_mode = "auto" also
+# auto-detects but the explicit marker is what the rest of the suite uses.
+_asyncio = pytest.mark.asyncio
+
+
+# ── ZMQ fixtures ─────────────────────────────────────────────────────────────
+
+
+def _unique_ipc(tmp_path: Path) -> str:
+    """Return a per-test ipc:// socket path under tmp_path."""
+    return f"ipc://{tmp_path}/scene_{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture
+async def dispatcher(tmp_path: Path):
+    """Yield (SceneDispatcher, pull_socket) sharing a fresh ipc:// path.
+
+    The dispatcher binds PUSH; the test acts as LOVR via a PULL on the same
+    address. ``_lovr_started`` is flipped True so ``forward()`` actually
+    sends — the test is exercising the wire format, not the spawn gate.
+    """
+    sock_path = _unique_ipc(tmp_path)
+    cfg = Config(
+        lovr_bin         = Path("/nonexistent"),  # never spawned in these tests
+        xr_app_dir       = tmp_path,
+        scene_socket     = sock_path,
+        cloudxr_env_file = None,
+        host             = "127.0.0.1",
+        port             = 0,
+    )
+    stack = contextlib.AsyncExitStack()
+    await stack.__aenter__()
+    disp = SceneDispatcher(cfg, stack)
+    disp._lovr_started = True  # bypass spawn-gating
+
+    ctx  = zmq.asyncio.Context.instance()
+    pull = ctx.socket(zmq.PULL)
+    pull.setsockopt(zmq.LINGER, 0)
+    pull.connect(sock_path)
+    # ZMQ PUSH/PULL over ipc:// connects asynchronously; give the kernel a tick
+    # before the first send so messages aren't queued before the peer attaches.
+    await asyncio.sleep(0.05)
+
+    try:
+        yield disp, pull
+    finally:
+        pull.close(linger=0)
+        disp.close()
+        await stack.__aexit__(None, None, None)
+
+
+async def _recv_op(pull: zmq.asyncio.Socket, timeout: float = 1.0) -> dict:
+    raw = await asyncio.wait_for(pull.recv(), timeout=timeout)
+    return msgpack.unpackb(raw, raw=False)
+
+
+# ── scene_socket validation (tech debt #13) ──────────────────────────────────
+
+
+class TestSceneSocketValidation:
+    def test_accepts_ipc(self):
+        _validate_scene_socket("ipc:///tmp/foo")
+
+    def test_accepts_tcp(self):
+        _validate_scene_socket("tcp://127.0.0.1:5555")
+
+    def test_accepts_inproc(self):
+        _validate_scene_socket("inproc://name")
+
+    def test_rejects_empty_ipc_path(self):
+        with pytest.raises(SystemExit):
+            _validate_scene_socket("ipc:///")
+
+    def test_rejects_bare_ipc(self):
+        with pytest.raises(SystemExit):
+            _validate_scene_socket("ipc://")
+
+    def test_rejects_tcp_without_port(self):
+        with pytest.raises(SystemExit):
+            _validate_scene_socket("tcp://127.0.0.1")
+
+    def test_rejects_garbage(self):
+        with pytest.raises(SystemExit):
+            _validate_scene_socket("not-a-socket")
+
+    def test_rejects_non_string(self):
+        with pytest.raises(SystemExit):
+            _validate_scene_socket(None)  # type: ignore[arg-type]
+
+
+class TestBuildConfigRejectsBadSceneSocket:
+    """_build_config propagates the validation failure end-to-end."""
+
+    def test_malformed_scene_socket_fails_fast(self, tmp_path: Path, monkeypatch):
+        # Synthesize a valid lovr_bin so we get past the earlier checks.
+        lovr_bin = tmp_path / "lovr"
+        lovr_bin.write_text("#!/bin/sh\nexit 0\n")
+        lovr_bin.chmod(0o755)
+        xr_app_dir = tmp_path / "xr_app"
+        xr_app_dir.mkdir()
+
+        yaml_path = tmp_path / "render_mcp.yaml"
+        yaml_path.write_text("")  # _build_config takes raw dict directly
+
+        raw = {
+            "lovr_bin":     str(lovr_bin),
+            "xr_app_dir":   str(xr_app_dir),
+            "scene_socket": "ipc:///",   # malformed
+        }
+        with pytest.raises(SystemExit):
+            _build_config(yaml_path, raw)
+
+
+# ── scene state bookkeeping ──────────────────────────────────────────────────
+
+
+class TestSceneState:
+    """Pure-state methods don't touch ZMQ — they're synchronous and cheap."""
+
+    def _disp(self, tmp_path: Path) -> SceneDispatcher:
+        cfg = Config(
+            lovr_bin=Path("/nonexistent"), xr_app_dir=tmp_path,
+            scene_socket=_unique_ipc(tmp_path),
+            cloudxr_env_file=None, host="127.0.0.1", port=0,
+        )
+        return SceneDispatcher(cfg, contextlib.AsyncExitStack())
+
+    def test_add_assigns_unique_ids(self, tmp_path: Path):
+        disp = self._disp(tmp_path)
+        try:
+            a = disp.add("sphere", {"x": 0, "y": 0, "z": 0}, {"r": 1, "g": 0, "b": 0}, 0.1)
+            b = disp.add("sphere", {"x": 1, "y": 0, "z": 0}, {"r": 0, "g": 1, "b": 0}, 0.2)
+            c = disp.add("box",    {"x": 0, "y": 1, "z": 0}, {"r": 0, "g": 0, "b": 1}, 0.3)
+            assert a == "sphere-0"
+            assert b == "sphere-1"
+            assert c == "box-0"
+        finally:
+            disp.close()
+
+    def test_update_merges_position_partially(self, tmp_path: Path):
+        disp = self._disp(tmp_path)
+        try:
+            oid = disp.add("sphere", {"x": 0, "y": 1, "z": 2}, {"r": 1, "g": 1, "b": 1}, 0.1)
+            disp.update(oid, {"position": {"y": 5.0}})
+            obj = disp.get_object(oid)
+            assert obj["position"] == {"x": 0, "y": 5.0, "z": 2}
+        finally:
+            disp.close()
+
+    def test_remove_returns_false_on_unknown_id(self, tmp_path: Path):
+        disp = self._disp(tmp_path)
+        try:
+            assert disp.remove("does-not-exist") is False
+        finally:
+            disp.close()
+
+    def test_snapshots_reflect_lifecycle(self, tmp_path: Path):
+        disp = self._disp(tmp_path)
+        try:
+            assert disp.health_snapshot() == {
+                "status": "ok", "lovr_started": False,
+                "spawn_error": None, "render_drops": 0,
+            }
+            disp.add("sphere", {"x": 0, "y": 0, "z": 0}, {"r": 1, "g": 1, "b": 1}, 0.1)
+            snap = disp.scene_snapshot()
+            assert len(snap["objects"]) == 1 and snap["objects"][0]["id"] == "sphere-0"
+        finally:
+            disp.close()
+
+
+# ── ZMQ forward wire format ──────────────────────────────────────────────────
+
+
+@_asyncio
+class TestForwardWireFormat:
+    async def test_forward_emits_msgpack_op_value_frame(self, dispatcher):
+        disp, pull = dispatcher
+        result = await disp.forward("scene.add", {"id": "sphere-0", "type": "sphere"})
+        assert result == {"ok": True}
+        msg = await _recv_op(pull)
+        assert msg == {"op": "scene.add", "value": {"id": "sphere-0", "type": "sphere"}}
+
+    async def test_forward_drops_when_lovr_not_started(self, tmp_path: Path):
+        cfg = Config(
+            lovr_bin=Path("/nonexistent"), xr_app_dir=tmp_path,
+            scene_socket=_unique_ipc(tmp_path),
+            cloudxr_env_file=None, host="127.0.0.1", port=0,
+        )
+        disp = SceneDispatcher(cfg, contextlib.AsyncExitStack())
+        try:
+            assert disp._lovr_started is False
+            result = await disp.forward("scene.add", {"id": "x"})
+            assert result == {"ok": False, "reason": "not_started"}
+            assert disp.health_snapshot()["render_drops"] == 1
+        finally:
+            disp.close()
+
+
+# ── FastMCP tool surface end-to-end through the dispatcher ───────────────────
+
+
+@_asyncio
+class TestMcpToolsThroughDispatcher:
+    async def test_add_primitive_pushes_scene_add_op(self, dispatcher):
+        disp, pull = dispatcher
+        mcp = build_mcp(disp)
+        result = await mcp.call_tool("add_primitive", {
+            "prim_type": "sphere",
+            "x": 0.0, "y": 1.5, "z": -2.0,
+            "r": 1.0, "g": 0.0, "b": 0.0,
+            "size": 0.25,
+        })
+        body = result.structured_content
+        assert body["id"] == "sphere-0" and body["ok"] is True
+
+        msg = await _recv_op(pull)
+        assert msg["op"] == "scene.add"
+        v = msg["value"]
+        assert v["id"] == "sphere-0"
+        assert v["type"] == "sphere"
+        assert v["position"] == [0.0, 1.5, -2.0]
+        assert v["color"]    == [1.0, 0.0, 0.0]
+        assert v["size"]     == 0.25
+
+    async def test_remove_primitive_pushes_scene_remove_op(self, dispatcher):
+        disp, pull = dispatcher
+        mcp = build_mcp(disp)
+        await mcp.call_tool("add_primitive", {"prim_type": "box"})
+        _ = await _recv_op(pull)  # drain add
+
+        result = await mcp.call_tool("remove_primitive", {"obj_id": "box-0"})
+        assert result.structured_content == {"ok": True}
+        msg = await _recv_op(pull)
+        assert msg == {"op": "scene.remove", "value": {"id": "box-0"}}
+
+    async def test_remove_unknown_id_does_not_push(self, dispatcher):
+        disp, pull = dispatcher
+        mcp = build_mcp(disp)
+        result = await mcp.call_tool("remove_primitive", {"obj_id": "ghost"})
+        assert result.structured_content == {"ok": False, "reason": "not_found"}
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(pull.recv(), timeout=0.2)
+
+    async def test_update_primitive_partial_position_update(self, dispatcher):
+        disp, pull = dispatcher
+        mcp = build_mcp(disp)
+        await mcp.call_tool("add_primitive", {"prim_type": "sphere", "y": 1.0})
+        _ = await _recv_op(pull)
+
+        await mcp.call_tool("update_primitive", {"obj_id": "sphere-0", "y": 2.5})
+        msg = await _recv_op(pull)
+        assert msg["op"] == "scene.update"
+        # Position is rewritten with the merged state — y bumped, x/z preserved.
+        assert msg["value"]["id"] == "sphere-0"
+        assert msg["value"]["position"][1] == 2.5
+
+    async def test_get_health_and_scene_state(self, dispatcher):
+        disp, pull = dispatcher
+        mcp = build_mcp(disp)
+        await mcp.call_tool("add_primitive", {"prim_type": "sphere"})
+        _ = await _recv_op(pull)
+
+        scene = await mcp.call_tool("get_scene_state", {})
+        ids = [o["id"] for o in scene.structured_content["objects"]]
+        assert ids == ["sphere-0"]
+
+        health = await mcp.call_tool("get_health", {})
+        assert health.structured_content["lovr_started"] is True
+        assert health.structured_content["render_drops"] == 0
+
+
+# ── Tech debt #2: watch-task cleanup ─────────────────────────────────────────
+
+
+class _FakeLovrProc:
+    """Stand-in for ManagedProcess that never exits until cancelled."""
+    def __init__(self) -> None:
+        self._done = asyncio.Event()
+
+    async def wait(self) -> int:
+        await self._done.wait()
+        return 0
+
+
+class _FakeManagedProcessCtx:
+    def __init__(self) -> None:
+        self.proc = _FakeLovrProc()
+
+    async def __aenter__(self) -> _FakeLovrProc:
+        return self.proc
+
+    async def __aexit__(self, *exc) -> None:
+        return None
+
+
+@_asyncio
+async def test_close_cancels_lovr_watch_task(tmp_path: Path, monkeypatch):
+    """Without the fix, _watch() leaks on shutdown. With the fix, close() cancels it."""
+    sock_path = _unique_ipc(tmp_path)
+    lovr_bin  = tmp_path / "lovr.sh"
+    lovr_bin.write_text("#!/bin/sh\nsleep 999\n")
+    lovr_bin.chmod(0o755)
+    xr_app_dir = tmp_path / "xr_app"
+    xr_app_dir.mkdir()
+
+    cfg = Config(
+        lovr_bin         = lovr_bin,
+        xr_app_dir       = xr_app_dir,
+        scene_socket     = sock_path,
+        cloudxr_env_file = None,
+        host             = "127.0.0.1",
+        port             = 0,
+    )
+
+    # Swap ManagedProcess out before SceneDispatcher.start_lovr_once runs.
+    import render_mcp.__main__ as render_main
+    monkeypatch.setattr(render_main, "ManagedProcess",
+                        lambda *a, **kw: _FakeManagedProcessCtx())
+
+    stack = contextlib.AsyncExitStack()
+    await stack.__aenter__()
+    try:
+        disp = SceneDispatcher(cfg, stack)
+        result = await disp.start_lovr_once()
+        assert result == {"status": "started"}
+        assert disp._watch_task is not None
+        assert not disp._watch_task.done()
+
+        # close() must cancel the watch task so it can't leak past teardown.
+        disp.close()
+        # Let the cancellation propagate.
+        with contextlib.suppress(asyncio.CancelledError):
+            await disp._watch_task
+        assert disp._watch_task.done()
+    finally:
+        await stack.__aexit__(None, None, None)

--- a/tests/test_local_render_mcp.py
+++ b/tests/test_local_render_mcp.py
@@ -23,6 +23,7 @@ import pytest
 import zmq
 import zmq.asyncio
 
+import render_mcp.__main__ as render_main
 from render_mcp.__main__ import (
     Config,
     SceneDispatcher,
@@ -186,7 +187,9 @@ class TestSceneState:
     def test_remove_returns_false_on_unknown_id(self, tmp_path: Path):
         disp = self._disp(tmp_path)
         try:
-            assert disp.remove("does-not-exist") is False
+            # Call outside the assert — `python -O` strips assert bodies.
+            removed = disp.remove("does-not-exist")
+            assert removed is False
         finally:
             disp.close()
 
@@ -349,7 +352,6 @@ async def test_close_cancels_lovr_watch_task(tmp_path: Path, monkeypatch):
     )
 
     # Swap ManagedProcess out before SceneDispatcher.start_lovr_once runs.
-    import render_mcp.__main__ as render_main
     monkeypatch.setattr(render_main, "ManagedProcess",
                         lambda *a, **kw: _FakeManagedProcessCtx())
 

--- a/tests/test_vlm_mcp.py
+++ b/tests/test_vlm_mcp.py
@@ -1,0 +1,201 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for vlm-mcp's FastMCP wrapper around vlm-server.
+
+vlm-mcp is a pure HTTP wrapper — no GPU, no hub IPC. These tests stand up an
+in-process aiohttp mock for the upstream vlm-server `/v1/chat/completions`
+endpoint, wire vlm-mcp's ``VlmClient`` at it, and exercise the ``ask_image``
+MCP tool against a synthetic PNG.
+
+Both the wire-shape contract (data URL encoding, prompt forwarding, model
+field, ``enable_thinking`` knob) and the response-relay path are covered.
+"""
+from __future__ import annotations
+
+import base64
+import socket
+import struct
+import zlib
+from pathlib import Path
+
+import pytest
+from aiohttp import web
+
+from vlm_mcp_server.__main__ import VlmClient, _load_jpeg_data_url, build_mcp
+
+pytestmark = pytest.mark.asyncio
+
+
+def _pick_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _tiny_png_bytes(size: int = 8) -> bytes:
+    """Return a minimal valid grayscale PNG (no external deps)."""
+    def _chunk(tag: bytes, data: bytes) -> bytes:
+        crc = zlib.crc32(tag + data) & 0xFFFFFFFF
+        return struct.pack(">I", len(data)) + tag + data + struct.pack(">I", crc)
+
+    sig  = b"\x89PNG\r\n\x1a\n"
+    ihdr = struct.pack(">IIBBBBB", size, size, 8, 0, 0, 0, 0)
+    raw  = b"".join(b"\x00" + bytes([(i * 8) & 0xFF] * size) for i in range(size))
+    idat = zlib.compress(raw, 9)
+    return sig + _chunk(b"IHDR", ihdr) + _chunk(b"IDAT", idat) + _chunk(b"IEND", b"")
+
+
+class _MockVlmServer:
+    """Tiny aiohttp app standing in for vlm-server's chat-completions route."""
+
+    def __init__(self, answer: str = "a cat sitting on a mat") -> None:
+        self.answer = answer
+        self.requests: list[dict] = []
+        self.runner: web.AppRunner | None = None
+        self.port: int = 0
+
+    async def _handle(self, request: web.Request) -> web.Response:
+        body = await request.json()
+        self.requests.append(body)
+        return web.json_response({
+            "choices": [{"message": {"content": self.answer}}],
+        })
+
+    async def start(self) -> str:
+        app = web.Application()
+        app.router.add_post("/v1/chat/completions", self._handle)
+        self.runner = web.AppRunner(app)
+        await self.runner.setup()
+        self.port = _pick_free_port()
+        site = web.TCPSite(self.runner, "127.0.0.1", self.port)
+        await site.start()
+        return f"http://127.0.0.1:{self.port}"
+
+    async def stop(self) -> None:
+        if self.runner is not None:
+            await self.runner.cleanup()
+
+
+@pytest.fixture
+async def mock_vlm():
+    server = _MockVlmServer()
+    base_url = await server.start()
+    try:
+        yield server, base_url
+    finally:
+        await server.stop()
+
+
+@pytest.fixture
+def png_path(tmp_path: Path) -> Path:
+    p = tmp_path / "frame.png"
+    p.write_bytes(_tiny_png_bytes())
+    return p
+
+
+async def test_load_jpeg_data_url_emits_data_url(png_path: Path):
+    url = _load_jpeg_data_url(str(png_path))
+    assert url.startswith("data:image/jpeg;base64,")
+    # The payload must round-trip through base64 cleanly.
+    head, _, payload = url.partition(",")
+    assert head == "data:image/jpeg;base64"
+    raw = base64.b64decode(payload)
+    # JPEG SOI / EOI markers — proves PIL re-encoded as JPEG, not just relayed PNG.
+    assert raw[:2] == b"\xff\xd8"
+    assert raw[-2:] == b"\xff\xd9"
+
+
+async def test_ask_image_relays_response_and_request_shape(mock_vlm, png_path: Path):
+    server, base_url = mock_vlm
+    vlm = VlmClient(base_url, timeout=5.0, enable_thinking=False)
+    try:
+        mcp = build_mcp(vlm)
+        result = await mcp.call_tool(
+            "ask_image",
+            {"question": "what is in this image?", "image_path": str(png_path)},
+        )
+    finally:
+        await vlm.close()
+
+    # FastMCP returns the str directly under structured_content['result'].
+    text = result.structured_content["result"]
+    assert text == "a cat sitting on a mat"
+
+    assert len(server.requests) == 1
+    payload = server.requests[0]
+    assert payload["model"] == "vlm"
+    # enable_thinking=False must surface as chat_template_kwargs to suppress <think>.
+    assert payload["chat_template_kwargs"] == {"enable_thinking": False}
+
+    msgs = payload["messages"]
+    assert len(msgs) == 1 and msgs[0]["role"] == "user"
+    parts = msgs[0]["content"]
+    image_part = next(p for p in parts if p["type"] == "image_url")
+    text_part  = next(p for p in parts if p["type"] == "text")
+    assert text_part["text"] == "what is in this image?"
+    assert image_part["image_url"]["url"].startswith("data:image/jpeg;base64,")
+
+
+async def test_ask_image_enable_thinking_omits_template_kwarg(mock_vlm, png_path: Path):
+    """When enable_thinking=True, the chat_template_kwargs key must NOT appear."""
+    server, base_url = mock_vlm
+    vlm = VlmClient(base_url, timeout=5.0, enable_thinking=True)
+    try:
+        mcp = build_mcp(vlm)
+        await mcp.call_tool(
+            "ask_image",
+            {"question": "describe", "image_path": str(png_path)},
+        )
+    finally:
+        await vlm.close()
+    assert "chat_template_kwargs" not in server.requests[0]
+
+
+async def test_ask_image_strips_think_block(mock_vlm, png_path: Path):
+    server, base_url = mock_vlm
+    server.answer = "<think>let me look</think>\n  the answer is yes  "
+    vlm = VlmClient(base_url, timeout=5.0)
+    try:
+        mcp = build_mcp(vlm)
+        result = await mcp.call_tool(
+            "ask_image",
+            {"question": "q?", "image_path": str(png_path)},
+        )
+    finally:
+        await vlm.close()
+    assert result.structured_content["result"] == "the answer is yes"
+
+
+async def test_ask_image_missing_path_returns_error_string():
+    """Missing image_path is a user error — must not raise, returns guidance."""
+    vlm = VlmClient("http://127.0.0.1:1", timeout=1.0)
+    try:
+        mcp = build_mcp(vlm)
+        # Empty string → guidance error.
+        empty = await mcp.call_tool("ask_image", {"question": "q", "image_path": ""})
+        assert empty.structured_content["result"].startswith("ask_image: image_path is empty")
+        # Non-existent file → file-not-found error.
+        missing = await mcp.call_tool(
+            "ask_image",
+            {"question": "q", "image_path": "/nonexistent/path/should/not/exist.png"},
+        )
+        assert "file not found" in missing.structured_content["result"]
+    finally:
+        await vlm.close()
+
+
+async def test_ask_image_http_error_returns_error_string(png_path: Path):
+    """When vlm-server is unreachable, the tool returns an error string —
+    it must never raise into the agent's tool-call loop."""
+    # Point the client at a closed port.
+    vlm = VlmClient(f"http://127.0.0.1:{_pick_free_port()}", timeout=1.0)
+    try:
+        mcp = build_mcp(vlm)
+        result = await mcp.call_tool(
+            "ask_image",
+            {"question": "q", "image_path": str(png_path)},
+        )
+    finally:
+        await vlm.close()
+    assert result.structured_content["result"].startswith("ask_image: vlm-server request failed")


### PR DESCRIPTION
## Summary

Coverage for `vlm-mcp` (CI-viable, mocked upstream) and `render-mcp` (local-only, LOVR-stubbed) plus three tech-debt fixes.

**New tests:**
- `tests/test_vlm_mcp.py` (**no marker — CI**, 6 tests): mocks vlm-server via in-process aiohttp; covers `ask_image` wire shape, response relay, `<think>` stripping, error-string paths.
- `tests/test_local_render_mcp.py` (`@pytest.mark.gpu`, 21 tests): LOVR-stubbed; covers `_validate_scene_socket`, scene state, ZMQ PUSH wire format with msgpack, FastMCP tool surface, and watch-task cleanup.

**Fixes folded in:**
- **Port collision (#1):** render-mcp default was 8220, vlm-mcp default was *also* 8220 — both servers would fight for the same port if started together. Aligned vlm-mcp to 8240 (per `docs/xr-render-demo.md`'s canonical assignment) instead of moving render-mcp off its documented 8220.
- **LOVR watch-task leak (#2):** `SceneDispatcher._watch_task` is now stored and cancelled in `close()`. Previously the watch task leaked if render-mcp shut down during spawn.
- **scene_socket validation (#13):** added `_validate_scene_socket()` with regex check inside `_build_config()` — malformed sockets (`ipc:///` no path, `tcp://` no port, etc.) fail fast with a clear error instead of dying at PUSH-bind time.

## Test plan

- [x] `pytest test_vlm_mcp.py -v` → 6 passed (CI-runnable)
- [x] `pytest -m gpu test_local_render_mcp.py -v` → 21 passed (LOVR-stubbed)
- [x] `pytest -m "not gpu" -q` → 172 passed (166 + 6 vlm-mcp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)