### PR TITLE
test(video-mcp): add GPU end-to-end test for NVDEC decode path

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -133,17 +133,24 @@ oxr-mcp-server  (agent-mcp-servers/oxr-mcp/)
     cloudxr-runtime must start before oxr-mcp (serial launch order).
 
 xr-ai-tests  (tests/)
-    └── xr-ai-agent     [editable: ../agent-sdk]
-    └── xr-media-hub    [editable: ../server-runtime]
-    └── xr-ai-launcher  [editable: ../utils/xr-ai-launcher]
-    └── xr-ai-logging   [editable: ../utils/xr-ai-logging]
-    └── xr-ai-vllm      [editable: ../utils/xr-ai-vllm]
+    └── xr-ai-agent       [editable: ../agent-sdk]
+    └── xr-media-hub      [editable: ../server-runtime]
+    └── xr-ai-launcher    [editable: ../utils/xr-ai-launcher]
+    └── xr-ai-logging     [editable: ../utils/xr-ai-logging]
+    └── xr-ai-vllm        [editable: ../utils/xr-ai-vllm]
+    └── video-mcp-server  [editable: ../agent-mcp-servers/video-mcp]
     └── pytest >=8.0
     └── pytest-asyncio >=0.23
     └── numpy >=1.24
+    └── fastmcp >=0.4   (only used by tests marked `gpu`)
+    └── Pillow >=10.0   (only used by tests marked `gpu`)
+    └── pyyaml >=6.0    (only used by tests marked `gpu`)
     Multi-client / multi-agent integration tests over the IPC layer.
     Driven via ZMQ `ipc://` only — no Docker / LiveKit / NVENC required.
     Also covers unit tests for the leaf util packages (launcher, logging, vllm).
+    Tests marked `gpu` additionally exercise NVENC / NVDEC via PyNvVideoCodec
+    (transitively pulled in by `video-mcp-server`); they're skipped cleanly
+    when the import or hardware is unavailable.
 
 vlm-server  (ai-services/vlm-server/)
     └── vllm >=0.12.0

--- a/agent-mcp-servers/video-mcp/video_mcp_server/__main__.py
+++ b/agent-mcp-servers/video-mcp/video_mcp_server/__main__.py
@@ -685,10 +685,15 @@ async def _serve(cfg: dict, ready_file: pathlib.Path | None = None) -> None:
     finally:
         ep.stop()
         ep_task.cancel()
+        # ep.run() may raise on shutdown (socket closed mid-poll); we've
+        # already stopped the endpoint so that's benign — swallow it but
+        # surface anything unexpected to the log for postmortem.
         try:
             await ep_task
-        except (asyncio.CancelledError, Exception):
+        except asyncio.CancelledError:
             pass
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("video-mcp: ep_task exited with {!r} during shutdown", exc)
         ep.close()
 
 

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -17,18 +17,24 @@ dependencies = [
     "xr-ai-launcher",
     "xr-ai-logging",
     "xr-ai-vllm",
+    "video-mcp-server",
     # Test runner.
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "numpy>=1.24",
+    # GPU/MCP test deps — only exercised by tests marked `gpu`.
+    "fastmcp>=0.4",
+    "Pillow>=10.0",
+    "pyyaml>=6.0",
 ]
 
 [tool.uv.sources]
-xr-ai-agent    = { path = "../agent-sdk",               editable = true }
-xr-media-hub   = { path = "../server-runtime",          editable = true }
-xr-ai-launcher = { path = "../utils/xr-ai-launcher",   editable = true }
-xr-ai-logging  = { path = "../utils/xr-ai-logging",    editable = true }
-xr-ai-vllm     = { path = "../utils/xr-ai-vllm",       editable = true }
+xr-ai-agent      = { path = "../agent-sdk",                       editable = true }
+xr-media-hub     = { path = "../server-runtime",                  editable = true }
+xr-ai-launcher   = { path = "../utils/xr-ai-launcher",            editable = true }
+xr-ai-logging    = { path = "../utils/xr-ai-logging",             editable = true }
+xr-ai-vllm       = { path = "../utils/xr-ai-vllm",                editable = true }
+video-mcp-server = { path = "../agent-mcp-servers/video-mcp",     editable = true }
 
 [tool.hatch.build.targets.wheel]
 packages = ["xr_ai_tests"]
@@ -36,3 +42,6 @@ packages = ["xr_ai_tests"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths    = ["."]
+markers      = [
+    "gpu: requires NVENC / NVDEC capable GPU hardware",
+]

--- a/tests/test_gpu_video_mcp.py
+++ b/tests/test_gpu_video_mcp.py
@@ -19,7 +19,6 @@ import pathlib
 import socket
 import subprocess
 import sys
-import tempfile
 import time
 import uuid
 

--- a/tests/test_gpu_video_mcp.py
+++ b/tests/test_gpu_video_mcp.py
@@ -27,7 +27,13 @@ import numpy as np
 import pytest
 import yaml
 
-nvc = pytest.importorskip("PyNvVideoCodec")
+# PyNvVideoCodec loads libnvidia-encode.so.1 at import time and raises
+# RuntimeError when NVENC drivers are absent (e.g. on CI runners).
+try:
+    import PyNvVideoCodec as nvc
+except (ImportError, RuntimeError, OSError) as exc:
+    pytest.skip(f"PyNvVideoCodec unavailable: {exc}", allow_module_level=True)
+
 PIL_Image = pytest.importorskip("PIL.Image")
 pytest.importorskip("fastmcp")
 

--- a/tests/test_gpu_video_mcp.py
+++ b/tests/test_gpu_video_mcp.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end GPU test for the video-mcp server.
+
+Synthesises a short NVENC-encoded H.264 chunk on disk in the on-disk layout
+the hub recorder writes (chunk + JSON sidecar + ``.identity`` sidecar),
+boots ``video_mcp_server`` against that directory in a subprocess, and
+asks it to retrieve a frame via the ``get_frame_from_time`` MCP tool —
+exercising the NVDEC decode + Pillow PNG re-encode path end-to-end.
+
+Skipped cleanly when PyNvVideoCodec or NVENC/NVDEC hardware is missing.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import pathlib
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+
+import numpy as np
+import pytest
+import yaml
+
+nvc = pytest.importorskip("PyNvVideoCodec")
+PIL_Image = pytest.importorskip("PIL.Image")
+pytest.importorskip("fastmcp")
+
+from fastmcp import Client as McpClient  # noqa: E402
+
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.gpu]
+
+
+# ── chunk synthesis ─────────────────────────────────────────────────────────
+
+
+_WIDTH, _HEIGHT, _FRAMES, _FPS, _BITRATE = 320, 240, 10, 30, 1_500_000
+
+
+def _synthetic_nv12(idx: int) -> np.ndarray:
+    """Return one ``(H*3//2, W)`` uint8 NV12 frame with a diagonal stripe
+    that drifts per call so the encoder sees real spatial and temporal
+    entropy — without it H.264 collapses each frame to a tiny keyframe."""
+    yy, xx   = np.indices((_HEIGHT, _WIDTH))
+    y_plane  = ((xx + yy + idx * 8 + idx * 20 + 16) % 240).astype(np.uint8)
+    uv_plane = np.full((_HEIGHT // 2, _WIDTH), 128, dtype=np.uint8)
+    return np.concatenate([y_plane, uv_plane], axis=0)
+
+
+def _encode_chunk(out_dir: pathlib.Path, pid: str, start_us: int) -> dict:
+    """Encode ``_FRAMES`` synthetic NV12 frames into ``<start_us>.264`` plus
+    matching JSON sidecar inside ``out_dir/<pid>/``. Returns the sidecar dict.
+
+    Mirrors ``server-runtime/xr_media_hub/video/_recorder.py``: same encoder
+    options, same NV12 layout, same ``.identity`` + ``<start_us>.json``
+    layout the video-mcp ``ChunkStore`` reads back.
+    """
+    pid_dir = out_dir / pid
+    pid_dir.mkdir(parents=True, exist_ok=True)
+    (pid_dir / ".identity").write_text(pid, encoding="utf-8")
+
+    encoder = nvc.CreateEncoder(
+        _WIDTH, _HEIGHT, "NV12",
+        True,  # usecpuinputbuffer
+        gpu_id=0, codec="h264",
+        preset="P4", tuning_info="high_quality",
+        rc="vbr", fps=_FPS,
+        bitrate=_BITRATE, maxbitrate=_BITRATE,
+        bf=0, repeat_sps_pps=1,
+    )
+
+    buf = bytearray()
+    for i in range(_FRAMES):
+        chunk = encoder.Encode(_synthetic_nv12(i))
+        if chunk:
+            buf.extend(chunk)
+    flushed = encoder.EndEncode()
+    if flushed:
+        buf.extend(flushed)
+
+    h264_path = pid_dir / f"{start_us}.264"
+    h264_path.write_bytes(bytes(buf))
+
+    # end_us must be strictly > start_us so the ratio math in
+    # get_frame_from_time picks a non-zero frame index.
+    end_us = start_us + int(_FRAMES * 1_000_000 / _FPS)
+    meta = {
+        "start_us":   start_us,
+        "end_us":     end_us,
+        "num_frames": _FRAMES,
+        "width":      _WIDTH,
+        "height":     _HEIGHT,
+        "size_bytes": len(buf),
+    }
+    (pid_dir / f"{start_us}.json").write_text(json.dumps(meta))
+    return meta
+
+
+# ── server lifecycle ────────────────────────────────────────────────────────
+
+
+def _free_port() -> int:
+    """Bind/release pattern: kernel won't immediately reuse the port, so by
+    the time the server starts a few hundred ms later it's still ours."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+async def _wait_ready(ready_file: pathlib.Path, proc: subprocess.Popen, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if ready_file.exists():
+            return
+        if proc.poll() is not None:
+            raise RuntimeError(
+                f"video_mcp_server exited early with code {proc.returncode} "
+                f"before touching the ready-file"
+            )
+        await asyncio.sleep(0.1)
+    raise TimeoutError(f"video_mcp_server did not become ready within {timeout}s")
+
+
+# ── test ────────────────────────────────────────────────────────────────────
+
+
+async def test_get_frame_from_time_returns_valid_png(tmp_path: pathlib.Path) -> None:
+    pid       = f"gpu_test_{uuid.uuid4().hex[:8]}"
+    rec_dir   = tmp_path / "recordings"
+    out_dir   = tmp_path / "queries"
+    rec_dir.mkdir()
+    out_dir.mkdir()
+
+    start_us = int(time.time() * 1_000_000)
+    try:
+        meta = _encode_chunk(rec_dir, pid, start_us)
+    except Exception as exc:  # noqa: BLE001
+        # No NVENC hardware (or driver mismatch) — skip cleanly per the
+        # task brief; we only care about the path when the GPU is present.
+        pytest.skip(f"NVENC unavailable: {exc!r}")
+
+    port      = _free_port()
+    cfg_path  = tmp_path / "video_mcp_server.yaml"
+    ready     = tmp_path / "video_mcp.ready"
+    cfg_path.write_text(yaml.safe_dump({
+        "recordings_dir": str(rec_dir),
+        "out_dir":        str(out_dir),
+        # Unique per-test IPC sockets so the server's ProcessorEndpoint
+        # binds without colliding with a real hub on the dev box.
+        "hub_pub":        f"ipc://{tmp_path}/hub_pub",
+        "hub_push":       f"ipc://{tmp_path}/hub_push",
+        "host":           "127.0.0.1",
+        "port":           port,
+        "gpu_id":         0,
+    }))
+
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "video_mcp_server",
+         "--config", str(cfg_path), "--ready-file", str(ready)],
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+    )
+    try:
+        await _wait_ready(ready, proc, timeout=30.0)
+
+        url = f"http://127.0.0.1:{port}/mcp"
+        # Anchor inside the chunk window with second_ago=0 — forces the
+        # NVDEC path (live IPC is bypassed when reference_time_us > 0).
+        anchor_us = (meta["start_us"] + meta["end_us"]) // 2
+        async with McpClient(url) as client:
+            res = await client.call_tool(
+                "get_frame_from_time",
+                {"participant_id": pid, "second_ago": 0,
+                 "reference_time_us": anchor_us},
+            )
+
+        # fastmcp Client returns a CallToolResult whose ``.data`` holds the
+        # tool's JSON return when present; older shapes expose the same
+        # payload under ``structured_content``.
+        payload = getattr(res, "data", None) or getattr(res, "structured_content", None)
+        assert isinstance(payload, dict), f"unexpected tool result: {res!r}"
+        assert "error" not in payload, f"tool error: {payload.get('error')}"
+
+        png_path = pathlib.Path(payload["path"])
+        assert png_path.exists(), f"PNG not written: {png_path}"
+
+        with PIL_Image.open(png_path) as img:
+            img.load()
+            assert img.format == "PNG"
+            assert img.size == (_WIDTH, _HEIGHT), (
+                f"PNG dims {img.size} != encoded {(_WIDTH, _HEIGHT)}"
+            )
+
+        assert payload["width"]  == _WIDTH
+        assert payload["height"] == _HEIGHT
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)


### PR DESCRIPTION
## Summary

GPU end-to-end test for `agent-mcp-servers/video-mcp`'s NVDEC decode path.

**New test** (`tests/test_gpu_video_mcp.py`, `@pytest.mark.gpu`):
- Encodes 10 synthetic NV12 frames via `pynvvideocodec.CreateEncoder(...)` (same options as `_recorder.py`) into a `tempfile.TemporaryDirectory`, draining via `EndEncode()` and writing the matching `.json` sidecar + `.identity` file that video-mcp expects.
- Spawns `python -m video_mcp_server` with a per-test YAML pointing at the recordings dir and a free port.
- Calls `get_frame_from_time(participant_id, second_ago=0, reference_time_us=<inside chunk window>)` via `fastmcp.Client` to force the NVDEC decode path.
- Asserts the returned PNG opens in PIL and matches encoded dimensions.

Skips cleanly if `pynvvideocodec` / PIL / fastmcp imports fail or NVENC hardware is unreachable.

`video-mcp-server`, `fastmcp`, `Pillow`, `pyyaml` added as workspace deps in `tests/pyproject.toml`; `DEPENDENCIES.md` updated in the same commit.

**Minor cleanup folded in:**
- `agent-mcp-servers/video-mcp/video_mcp_server/__main__.py`: replaced an `except (CancelledError, Exception): pass` swallow in shutdown with a `logger.debug(...)` + one-sentence comment explaining the benign-post-stop rationale.

## Test plan

- [x] `pytest -m gpu test_gpu_video_mcp.py -v` → passed on L40S
- [x] `pytest -m "not gpu" -q` → no regressions
- [x] Skip path: import-missing skip works (verified via `pytest.importorskip`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)