### PR TITLE
feat(xr-ai-models): unified LLM/VLM/STT/TTS SDK with OpenAI-compat clients

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,9 @@ historical decisions in `docs/changelog.md`.
 ```
 client-samples/     # Platform clients (Android, iOS/visionOS, Web)
 server-runtime/     # XR-Media-Hub core + LiveKit transport
-agent-sdk/          # Two packages:
+agent-sdk/          # Three packages:
                     #   xr-ai-agent   — IPC client library (pyzmq + msgpack only)
+                    #   xr-ai-models  — LLM/VLM/STT/TTS service protocols + OpenAI-compat clients
                     #   xr-ai-pipecat — optional Pipecat transport bridge (heavier deps)
 utils/              # Shared infra: stdlib-only launcher + loguru logging bridge
 cloudxr-runtime/    # Shared CloudXR OpenXR runtime + WSS proxy (opt-in)
@@ -35,8 +36,16 @@ docs/               # Topic deep-dives + changelog
   LiveKit, FastAPI, or uvicorn. `agent-sdk/xr-ai-pipecat` is a separate
   optional package with heavier deps (pipecat-ai, scipy, numpy, httpx,
   fastmcp); it bridges `ProcessorEndpoint` to Pipecat pipelines.
+- **All HTTP calls to AI services go through `agent-sdk/xr-ai-models`.**
+  Workers and MCP servers depend on its four protocols
+  (`LLMService`, `VLMService`, `STTService`, `TTSService`) and construct
+  clients from a per-sample `yaml/models.yaml` via `make_llm` /
+  `make_vlm` / `make_stt` / `make_tts`.  Hand-rolled `httpx` clients
+  against `/v1/chat/completions`, `/v1/audio/transcriptions`, or
+  `/v1/audio/speech` are forbidden — model quirks belong in this one
+  package's presets, not in callers.
 - **Workers never import from `server-runtime` or `xr_ai_launcher`.** Only
-  `xr_ai_agent` + task-specific libs (numpy, torch, …).
+  `xr_ai_agent` + `xr_ai_models` + task-specific libs (numpy, torch, …).
 - **MCP servers are the agent's only interface to XR data and rendering.**
 - **No API keys or tokens in source files** — use env vars or
   `xr_media_hub.yaml`. See `docs/credentials.md`.
@@ -114,8 +123,9 @@ Hard rules (also in `DEPENDENCIES.md`):
 
 - `utils/xr-ai-launcher/` has zero runtime dependencies — stdlib only. Keep it that way.
 - `utils/xr-ai-logging/` depends only on `loguru>=0.7`. Used by every process via `setup_logging()`.
-- `agent-sdk/` (`xr-ai-agent`) depends only on `pyzmq` + `msgpack`.
-- Agent workers import only from `xr_ai_agent` (and task-specific libs).
+- `agent-sdk/xr-ai-agent` depends only on `pyzmq` + `msgpack`.
+- `agent-sdk/xr-ai-models` depends only on `xr-ai-logging` + `httpx` + `pyyaml`. No vendor SDKs.
+- Agent workers import only from `xr_ai_agent` + `xr_ai_models` (and task-specific libs).
 - Agent workers must never import from `xr_media_hub` or `xr_ai_launcher`.
 - Don't add abstractions until needed by two concrete use-cases.
 

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -56,6 +56,21 @@ xr-ai-pipecat  (agent-sdk/xr-ai-pipecat/)
     for STT; converts TTS int16 PCM back to float32 AudioChunks for return.
     Not a dep of xr-ai-agent itself — import only in workers that use Pipecat.
 
+xr-ai-models  (agent-sdk/xr-ai-models/)
+    └── xr-ai-logging [editable: ../../utils/xr-ai-logging]
+    └── httpx >=0.27
+    └── pyyaml >=6.0
+    Unified service protocols (LLMService, VLMService, STTService, TTSService)
+    and OpenAI-compatible HTTP clients that cover every in-tree model backend
+    (vLLM-served VLM/LLMs, NeMo Parakeet STT, Piper/Magpie TTS).  Per-model
+    quirks live behind one seam: reasoning-field aliasing (nano_v3 →
+    `reasoning`, nemotron_v3 → `reasoning_content`), `chat_template_kwargs`
+    plumbing for `enable_thinking` / `thinking_budget`, and built-in presets
+    for the seven in-tree services.  Future backends (LiteLLM, vendor SDKs)
+    plug in as new `kind`s in `factory.py::make_*` without touching the
+    protocols or callers.  Workers depend on this instead of rolling their
+    own httpx wrappers.
+
 xr-ai-launcher  (utils/xr-ai-launcher/)
     └── (stdlib only — zero runtime deps)
 
@@ -134,6 +149,7 @@ oxr-mcp-server  (agent-mcp-servers/oxr-mcp/)
 
 xr-ai-tests  (tests/)
     └── xr-ai-agent             [editable: ../agent-sdk]
+    └── xr-ai-models            [editable: ../agent-sdk/xr-ai-models]
     └── xr-media-hub            [editable: ../server-runtime]    (pulls in livekit, livekit-api for the wss /rtc proxy + room-client tests)
     └── xr-ai-launcher          [editable: ../utils/xr-ai-launcher]
     └── xr-ai-logging           [editable: ../utils/xr-ai-logging]
@@ -376,6 +392,8 @@ updated in the same commit**.
 | Any `pyproject.toml` dependency | `DEPENDENCIES.md` (this file) |
 | Any new sample added | `DEPENDENCIES.md`, `AGENTS.md`, `README.md` |
 | Any new shared component added (peer of `server-runtime/`) | `AGENTS.md` Architecture section, `DEPENDENCIES.md` |
+| `xr-ai-models` protocols (`LLMService`, `VLMService`, …) or `models.yaml` schema | `AGENTS.md` "HTTP calls go through `xr-ai-models`" rule, `agent-sdk/xr-ai-models/README.md`, every sample's `yaml/models.yaml` |
+| `xr-ai-models` preset added (new in-tree service or backend variant) | `agent-sdk/xr-ai-models/xr_ai_models/presets/__init__.py` registry, `agent-sdk/xr-ai-models/README.md` preset table |
 
 ---
 
@@ -386,7 +404,11 @@ updated in the same commit**.
 - `utils/xr-ai-vllm/` — zero runtime dependencies. Stdlib only. Adding deps
   here would defeat docker mode (whose point is to keep heavy vllm-side deps
   out of the wrapper's venv).
-- `agent-sdk/` — only `pyzmq` + `msgpack`. No server-side packages.
-- Agent workers — `xr-ai-agent` + task-specific libs (numpy, torch, etc.).
-  Must never import from `xr-media-hub` or `xr-ai-launcher`.
+- `agent-sdk/` (`xr-ai-agent`) — only `pyzmq` + `msgpack`. No server-side packages.
+- `agent-sdk/xr-ai-models/` — `xr-ai-logging` + `httpx` + `pyyaml` only. No
+  vendor SDKs (no `openai`, no `anthropic`, no `litellm`). All in-tree
+  backends speak OpenAI-compatible HTTP; vendor adapters arrive as new
+  `kind`s in Phase B if/when needed.
+- Agent workers — `xr-ai-agent` + `xr-ai-models` + task-specific libs (numpy,
+  torch, etc.). Must never import from `xr-media-hub` or `xr-ai-launcher`.
 - New external deps require a note here explaining why they were added.

--- a/agent-sdk/xr-ai-models/README.md
+++ b/agent-sdk/xr-ai-models/README.md
@@ -62,7 +62,7 @@ Built-in presets — see `xr_ai_models/presets/`:
 
 | Preset | Service it targets | Notes |
 |---|---|---|
-| `cosmos_vlm`     | vlm-server               | `enable_thinking=false` by default |
+| `cosmos_vlm`     | vlm-server               | image + video; `enable_thinking=false` by default. Video requires vlm-server's `max_videos_per_prompt >= 1` |
 | `llama_nemotron` | llama-nemotron-llm-server | OpenAI tool calling via llama3_json (server-side) |
 | `nemotron3_nano` | nemotron3-nano-llm-server | reasoning field: `reasoning` |
 | `nemotron_omni`  | nemotron-omni-llm-server  | reasoning field: `reasoning_content`, vision + video |
@@ -101,6 +101,9 @@ class LLMService(Protocol):
 class VLMService(Protocol):
     capabilities: Capabilities
     async def ask_image(self, image, question, *, system_prompt="",
+                        max_tokens=None, temperature=None,
+                        timeout=None) -> ChatResponse: ...
+    async def ask_video(self, video, question, *, system_prompt="",
                         max_tokens=None, temperature=None,
                         timeout=None) -> ChatResponse: ...
 

--- a/agent-sdk/xr-ai-models/README.md
+++ b/agent-sdk/xr-ai-models/README.md
@@ -1,0 +1,131 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# xr-ai-models
+
+Unified service protocols and OpenAI-compatible HTTP clients for the xr-ai
+model layer.  Worker code depends on the four protocols
+(`LLMService`, `VLMService`, `STTService`, `TTSService`) and constructs
+concrete clients from a `models.yaml` config — no hand-rolled httpx calls
+in callers, no model quirks leaking out of this package.
+
+## Why
+
+Before this package, every consumer (vlm-mcp, simple-vlm-example worker,
+xr-render-demo worker, xr-ai-pipecat) rolled its own httpx wrappers and
+hard-coded model quirks (`chat_template_kwargs`, served-model-name strings,
+the `reasoning` vs `reasoning_content` field difference between
+nano_v3 and nemotron_v3 parsers).  Swapping an LLM meant editing N files.
+
+After: one `models.yaml` per sample names the logical models the worker
+needs; `make_llm(config, "agent_llm")` returns something that satisfies
+`LLMService` regardless of which backend or quirks are involved.
+
+## Quickstart
+
+```python
+from xr_ai_models import load_models_config, make_llm, ChatMessage
+
+config = load_models_config("yaml/models.yaml")
+async with make_llm(config, "agent_llm") as llm:
+    resp = await llm.chat(
+        [ChatMessage(role="user", content="hello")],
+        max_tokens=128,
+        enable_thinking=True,
+    )
+    print(resp.content, resp.reasoning)
+```
+
+`models.yaml`:
+
+```yaml
+agent_llm:
+  kind:     preset:nemotron3_nano
+  base_url: http://localhost:8107
+
+vlm:
+  kind:     preset:cosmos_vlm
+  base_url: http://localhost:8100
+
+stt:
+  kind:     preset:parakeet_stt
+  base_url: http://localhost:8103
+
+tts:
+  kind:     preset:piper_tts
+  base_url: http://localhost:8105
+```
+
+Built-in presets — see `xr_ai_models/presets/`:
+
+| Preset | Service it targets | Notes |
+|---|---|---|
+| `cosmos_vlm`     | vlm-server               | `enable_thinking=false` by default |
+| `llama_nemotron` | llama-nemotron-llm-server | OpenAI tool calling via llama3_json (server-side) |
+| `nemotron3_nano` | nemotron3-nano-llm-server | reasoning field: `reasoning` |
+| `nemotron_omni`  | nemotron-omni-llm-server  | reasoning field: `reasoning_content`, vision + video |
+| `parakeet_stt`   | stt-server               | |
+| `piper_tts`      | tts/piper                | |
+| `magpie_tts`     | tts/magpie               | |
+
+## Explicit (no-preset) spec
+
+```yaml
+agent_llm:
+  kind:       openai_compat
+  category:   llm
+  base_url:   http://localhost:8107
+  model_name: llm
+  capabilities: { tool_calls: true, reasoning: true }
+  reasoning_field: reasoning
+  default_extras:
+    chat_template_kwargs: { enable_thinking: false }
+  timeout: 60.0
+```
+
+`category:` is required when not using a preset.
+
+## Protocols
+
+```python
+class LLMService(Protocol):
+    capabilities: Capabilities
+    async def chat(self, messages, *, tools=None, max_tokens=None,
+                   temperature=None, enable_thinking=False,
+                   thinking_budget=None, timeout=None) -> ChatResponse: ...
+    def stream(self, messages, *, ...) -> AsyncIterator[str]: ...
+    async def close(self) -> None: ...
+
+class VLMService(Protocol):
+    capabilities: Capabilities
+    async def ask_image(self, image, question, *, system_prompt="",
+                        max_tokens=None, temperature=None,
+                        timeout=None) -> ChatResponse: ...
+
+class STTService(Protocol):
+    async def transcribe(self, audio: bytes, *, sample_rate=None,
+                         channels=1, timeout=None) -> str: ...
+
+class TTSService(Protocol):
+    async def synthesize(self, text: str, *, response_format="wav",
+                         timeout=None) -> bytes: ...
+```
+
+`ChatResponse.reasoning` is the canonical reasoning field — the
+`reasoning_field` knob normalizes `reasoning_content` (nemotron_v3 parser)
+into the same surface.
+
+## Phase B preview
+
+Cloud / remote endpoints are a `base_url` change — any spec can point at a
+non-localhost OpenAI-compatible URL and pass `api_key_env:
+OPENAI_API_KEY` for `Authorization: Bearer …`.  Future non-OpenAI-compat
+backends (LiteLLM, vendor SDKs) plug in as new `kind`s in
+`factory.py::make_*`; the protocols and callers do not change.
+
+## Tests
+
+`tests/test_models_*.py` exercise the wire format against a
+`tests/_stub_openai.StubOpenAI` httpx MockTransport — no GPU required.

--- a/agent-sdk/xr-ai-models/pyproject.toml
+++ b/agent-sdk/xr-ai-models/pyproject.toml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "xr-ai-models"
+version = "0.1.0"
+requires-python = ">=3.11,<3.13"
+dependencies = [
+    "xr-ai-logging",
+    "httpx>=0.27",
+    "pyyaml>=6.0",
+]
+
+[tool.uv.sources]
+xr-ai-logging = { path = "../../utils/xr-ai-logging", editable = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["xr_ai_models"]

--- a/agent-sdk/xr-ai-models/xr_ai_models/__init__.py
+++ b/agent-sdk/xr-ai-models/xr_ai_models/__init__.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""xr-ai-models — unified LLM / VLM / STT / TTS service protocols and clients.
+
+Worker code talks to the four ``*Service`` protocols.  The concrete
+``OpenAICompat*`` clients cover every in-tree backend (vLLM, in-process
+NeMo/Piper) and any external OpenAI-compatible endpoint.  Additional backend
+kinds (LiteLLM, vendor SDKs) slot in as new ``kind``s in ``factory.py``
+without changing the protocols or callers.
+"""
+from .protocols import (
+    Capabilities,
+    ChatMessage,
+    ChatResponse,
+    ContentPart,
+    ImageInput,
+    ImagePart,
+    LLMService,
+    STTService,
+    TextPart,
+    ToolCall,
+    ToolDef,
+    TTSService,
+    VLMService,
+)
+from .openai_compat import (
+    OpenAICompatLLM,
+    OpenAICompatSTT,
+    OpenAICompatTTS,
+    OpenAICompatVLM,
+)
+from .config import (
+    LLMSpec,
+    ModelsConfig,
+    STTSpec,
+    TTSSpec,
+    VLMSpec,
+    load_models_config,
+)
+from .factory import make_llm, make_stt, make_tts, make_vlm
+
+__all__ = [
+    "Capabilities",
+    "ChatMessage",
+    "ChatResponse",
+    "ContentPart",
+    "ImageInput",
+    "ImagePart",
+    "LLMService",
+    "STTService",
+    "TextPart",
+    "ToolCall",
+    "ToolDef",
+    "TTSService",
+    "VLMService",
+    "OpenAICompatLLM",
+    "OpenAICompatSTT",
+    "OpenAICompatTTS",
+    "OpenAICompatVLM",
+    "LLMSpec",
+    "ModelsConfig",
+    "STTSpec",
+    "TTSSpec",
+    "VLMSpec",
+    "load_models_config",
+    "make_llm",
+    "make_stt",
+    "make_tts",
+    "make_vlm",
+]

--- a/agent-sdk/xr-ai-models/xr_ai_models/__init__.py
+++ b/agent-sdk/xr-ai-models/xr_ai_models/__init__.py
@@ -22,6 +22,8 @@ from .protocols import (
     ToolCall,
     ToolDef,
     TTSService,
+    VideoInput,
+    VideoPart,
     VLMService,
 )
 from .openai_compat import (
@@ -53,6 +55,8 @@ __all__ = [
     "ToolCall",
     "ToolDef",
     "TTSService",
+    "VideoInput",
+    "VideoPart",
     "VLMService",
     "OpenAICompatLLM",
     "OpenAICompatSTT",

--- a/agent-sdk/xr-ai-models/xr_ai_models/_utils.py
+++ b/agent-sdk/xr-ai-models/xr_ai_models/_utils.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Internal helpers shared between config and openai_compat."""
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+
+def merge_dicts(
+    base: dict[str, Any],
+    overlay: dict[str, Any],
+    *,
+    skip_keys: Iterable[str] = (),
+) -> dict[str, Any]:
+    """Shallow top-level merge with one-level nested dict merging.
+
+    Neither input is mutated.  Nested dicts (e.g. ``chat_template_kwargs``)
+    are merged by key; non-dict values from ``overlay`` replace ``base``.
+    """
+    skip = set(skip_keys)
+    out = dict(base)
+    for k, v in overlay.items():
+        if k in skip:
+            continue
+        if isinstance(v, dict) and isinstance(out.get(k), dict):
+            out[k] = {**out[k], **v}
+        else:
+            out[k] = v
+    return out

--- a/agent-sdk/xr-ai-models/xr_ai_models/config.py
+++ b/agent-sdk/xr-ai-models/xr_ai_models/config.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""``models.yaml`` schema, typed specs, and the loader.
+
+One ``models.yaml`` lives next to each sample (``yaml/models.yaml``) and maps
+logical names (``llm``, ``agent_llm``, ``vlm``, ``stt``, ``tts``, …) to a spec
+that either inlines all knobs or references a built-in preset
+(``kind: preset:<name>``).  Presets fill in everything except ``base_url``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal, TypeVar
+
+import yaml
+
+from . import presets as _presets
+from ._utils import merge_dicts
+
+
+Category = Literal["llm", "vlm", "stt", "tts"]
+ModelKind = Literal["openai_compat"]
+
+KIND_OPENAI_COMPAT: ModelKind = "openai_compat"
+
+
+@dataclass(frozen=True)
+class LLMSpec:
+    kind: ModelKind = KIND_OPENAI_COMPAT
+    base_url: str = ""
+    model_name: str = ""
+    api_key_env: str | None = None
+    reasoning_field: str | None = None
+    capabilities: dict[str, Any] = field(default_factory=dict)
+    default_extras: dict[str, Any] = field(default_factory=dict)
+    timeout: float = 60.0
+
+
+@dataclass(frozen=True)
+class VLMSpec:
+    kind: ModelKind = KIND_OPENAI_COMPAT
+    base_url: str = ""
+    model_name: str = ""
+    api_key_env: str | None = None
+    capabilities: dict[str, Any] = field(default_factory=dict)
+    default_extras: dict[str, Any] = field(default_factory=dict)
+    timeout: float = 60.0
+
+
+@dataclass(frozen=True)
+class STTSpec:
+    kind: ModelKind = KIND_OPENAI_COMPAT
+    base_url: str = ""
+    api_key_env: str | None = None
+    timeout: float = 30.0
+
+
+@dataclass(frozen=True)
+class TTSSpec:
+    kind: ModelKind = KIND_OPENAI_COMPAT
+    base_url: str = ""
+    api_key_env: str | None = None
+    timeout: float = 30.0
+
+
+Spec = LLMSpec | VLMSpec | STTSpec | TTSSpec
+T = TypeVar("T", LLMSpec, VLMSpec, STTSpec, TTSSpec)
+
+
+@dataclass(frozen=True)
+class ModelsConfig:
+    """Logical-name → spec map for one sample/process.
+
+    Use :func:`load_models_config` to build from YAML.  ``entries`` is keyed
+    by logical name; the typed accessors (:py:meth:`llm`, :py:meth:`vlm`,
+    :py:meth:`stt`, :py:meth:`tts`) cast and validate at lookup time.
+    """
+    entries: dict[str, Spec]
+
+    def llm(self, name: str) -> LLMSpec:
+        return _typed(self.entries, name, LLMSpec)
+
+    def vlm(self, name: str) -> VLMSpec:
+        return _typed(self.entries, name, VLMSpec)
+
+    def stt(self, name: str) -> STTSpec:
+        return _typed(self.entries, name, STTSpec)
+
+    def tts(self, name: str) -> TTSSpec:
+        return _typed(self.entries, name, TTSSpec)
+
+
+def _typed(entries: dict[str, Spec], name: str, cls: type[T]) -> T:
+    try:
+        spec = entries[name]
+    except KeyError as exc:
+        raise KeyError(f"no spec named {name!r} in models config") from exc
+    if not isinstance(spec, cls):
+        raise TypeError(
+            f"spec {name!r} is {type(spec).__name__}, expected {cls.__name__}"
+        )
+    return spec
+
+
+def load_models_config(path: Path | str) -> ModelsConfig:
+    """Load a ``models.yaml`` and resolve any ``kind: preset:<name>`` refs."""
+    raw = yaml.safe_load(Path(path).read_text()) or {}
+    if not isinstance(raw, dict):
+        raise ValueError(f"{path}: top-level must be a mapping")
+    entries: dict[str, Spec] = {}
+    for name, body in raw.items():
+        if not isinstance(body, dict):
+            raise ValueError(f"{path}: entry {name!r} must be a mapping")
+        entries[name] = _build_spec(name, body)
+    return ModelsConfig(entries=entries)
+
+
+def _build_spec(name: str, body: dict[str, Any]) -> Spec:
+    resolved, preset_category = _resolve_preset(body)
+    explicit_category = resolved.get("category")
+    if preset_category is not None and explicit_category is not None \
+            and explicit_category != preset_category:
+        raise ValueError(
+            f"{name!r}: category mismatch — preset gave {preset_category!r}"
+            f" but entry overrides to {explicit_category!r}"
+        )
+    category = preset_category or explicit_category
+    if category not in {"llm", "vlm", "stt", "tts"}:
+        raise ValueError(
+            f"{name!r}: missing or unknown category (got {category!r});"
+            " presets set it implicitly — set ``category:`` if not using one"
+        )
+    return _construct(category, resolved)
+
+
+def _resolve_preset(body: dict[str, Any]) -> tuple[dict[str, Any], Category | None]:
+    kind = body.get("kind", KIND_OPENAI_COMPAT)
+    if not isinstance(kind, str) or not kind.startswith("preset:"):
+        return dict(body), None
+    preset_name = kind.split(":", 1)[1]
+    preset = _presets.get_preset(preset_name)
+    merged = merge_dicts(preset, body, skip_keys=("kind",))
+    merged["kind"] = preset.get("kind", KIND_OPENAI_COMPAT)
+    return merged, preset["category"]
+
+
+def _construct(category: Category, body: dict[str, Any]) -> Spec:
+    common: dict[str, Any] = {
+        "kind":     body.get("kind", KIND_OPENAI_COMPAT),
+        "base_url": _require_str(body, "base_url"),
+    }
+    if "api_key_env" in body:
+        common["api_key_env"] = body["api_key_env"]
+    if category in ("llm", "vlm"):
+        return _construct_chat(category, body, common)
+    if category == "stt":
+        return STTSpec(**common, timeout=float(body.get("timeout", 30.0)))
+    if category == "tts":
+        return TTSSpec(**common, timeout=float(body.get("timeout", 30.0)))
+    raise AssertionError(category)
+
+
+def _construct_chat(category: Category, body: dict[str, Any], common: dict[str, Any]) -> Spec:
+    chat_common = {
+        **common,
+        "model_name":     _require_str(body, "model_name"),
+        "capabilities":   dict(body.get("capabilities") or {}),
+        "default_extras": dict(body.get("default_extras") or {}),
+        "timeout":        float(body.get("timeout", 60.0)),
+    }
+    if category == "llm":
+        return LLMSpec(reasoning_field=body.get("reasoning_field"), **chat_common)
+    return VLMSpec(**chat_common)
+
+
+def _require_str(body: dict[str, Any], key: str) -> str:
+    val = body.get(key)
+    if not isinstance(val, str) or not val:
+        raise ValueError(f"missing required string field {key!r}")
+    return val

--- a/agent-sdk/xr-ai-models/xr_ai_models/factory.py
+++ b/agent-sdk/xr-ai-models/xr_ai_models/factory.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""``make_*`` constructors that dispatch a :class:`Spec` to a concrete client."""
+from __future__ import annotations
+
+from .config import KIND_OPENAI_COMPAT, ModelsConfig
+from .openai_compat import (
+    OpenAICompatLLM,
+    OpenAICompatSTT,
+    OpenAICompatTTS,
+    OpenAICompatVLM,
+)
+from .protocols import Capabilities, LLMService, STTService, TTSService, VLMService
+
+
+def make_llm(config: ModelsConfig, name: str) -> LLMService:
+    spec = config.llm(name)
+    if spec.kind == KIND_OPENAI_COMPAT:
+        return OpenAICompatLLM(
+            base_url=spec.base_url,
+            model_name=spec.model_name,
+            capabilities=Capabilities(**spec.capabilities),
+            reasoning_field=spec.reasoning_field,
+            default_extras=spec.default_extras,
+            api_key_env=spec.api_key_env,
+            timeout=spec.timeout,
+        )
+    raise ValueError(f"unsupported LLM kind: {spec.kind!r}")
+
+
+def make_vlm(config: ModelsConfig, name: str) -> VLMService:
+    spec = config.vlm(name)
+    if spec.kind == KIND_OPENAI_COMPAT:
+        return OpenAICompatVLM(
+            base_url=spec.base_url,
+            model_name=spec.model_name,
+            capabilities=Capabilities(**spec.capabilities),
+            default_extras=spec.default_extras,
+            api_key_env=spec.api_key_env,
+            timeout=spec.timeout,
+        )
+    raise ValueError(f"unsupported VLM kind: {spec.kind!r}")
+
+
+def make_stt(config: ModelsConfig, name: str) -> STTService:
+    spec = config.stt(name)
+    if spec.kind == KIND_OPENAI_COMPAT:
+        return OpenAICompatSTT(
+            base_url=spec.base_url,
+            api_key_env=spec.api_key_env,
+            timeout=spec.timeout,
+        )
+    raise ValueError(f"unsupported STT kind: {spec.kind!r}")
+
+
+def make_tts(config: ModelsConfig, name: str) -> TTSService:
+    spec = config.tts(name)
+    if spec.kind == KIND_OPENAI_COMPAT:
+        return OpenAICompatTTS(
+            base_url=spec.base_url,
+            api_key_env=spec.api_key_env,
+            timeout=spec.timeout,
+        )
+    raise ValueError(f"unsupported TTS kind: {spec.kind!r}")

--- a/agent-sdk/xr-ai-models/xr_ai_models/openai_compat.py
+++ b/agent-sdk/xr-ai-models/xr_ai_models/openai_compat.py
@@ -32,6 +32,8 @@ from .protocols import (
     TextPart,
     ToolCall,
     ToolDef,
+    VideoInput,
+    VideoPart,
 )
 
 
@@ -63,6 +65,8 @@ def _part_to_openai(part: ContentPart) -> dict[str, Any]:
         return {"type": "text", "text": part.text}
     if isinstance(part, ImagePart):
         return {"type": "image_url", "image_url": {"url": part.url}}
+    if isinstance(part, VideoPart):
+        return {"type": "video_url", "video_url": {"url": part.url}}
     raise TypeError(f"unsupported content part: {type(part).__name__}")
 
 
@@ -138,6 +142,39 @@ def _normalize_image(image: ImageInput) -> str:
         b = bytes(image)
         return _to_data_url(b, _sniff_mime(b))
     raise TypeError(f"unsupported image input: {type(image).__name__}")
+
+
+_VIDEO_SUFFIXES = {
+    ".mp4":  "video/mp4",
+    ".m4v":  "video/mp4",
+    ".webm": "video/webm",
+    ".mov":  "video/quicktime",
+    ".mkv":  "video/x-matroska",
+}
+
+
+def _sniff_video_mime(data: bytes) -> str:
+    # ISO BMFF (mp4/mov/m4v): bytes 4..8 == "ftyp"; webm: EBML magic 1A 45 DF A3.
+    if len(data) >= 12 and data[4:8] == b"ftyp":
+        return "video/mp4"
+    if data[:4] == b"\x1a\x45\xdf\xa3":
+        return "video/webm"
+    return "application/octet-stream"
+
+
+def _video_mime_from_suffix(p: Path) -> str:
+    return _VIDEO_SUFFIXES.get(p.suffix.lower(), "application/octet-stream")
+
+
+def _normalize_video(video: VideoInput) -> str:
+    if isinstance(video, str):
+        return video
+    if isinstance(video, Path):
+        return _to_data_url(video.read_bytes(), _video_mime_from_suffix(video))
+    if isinstance(video, (bytes, bytearray, memoryview)):
+        b = bytes(video)
+        return _to_data_url(b, _sniff_video_mime(b))
+    raise TypeError(f"unsupported video input: {type(video).__name__}")
 
 
 def _pcm_to_wav(pcm: bytes, sample_rate: int, channels: int) -> bytes:
@@ -368,6 +405,42 @@ class OpenAICompatVLM:
     ) -> ChatResponse:
         return await self._llm.chat(
             self._build_messages(image, question, system_prompt),
+            max_tokens=max_tokens, temperature=temperature, timeout=timeout,
+        )
+
+    def _build_video_messages(
+        self, video: VideoInput, question: str, system_prompt: str
+    ) -> list[ChatMessage]:
+        url = _normalize_video(video)
+        msgs: list[ChatMessage] = []
+        if system_prompt:
+            msgs.append(ChatMessage(role="system", content=system_prompt))
+        msgs.append(
+            ChatMessage(
+                role="user",
+                content=[VideoPart(url=url), TextPart(text=question)],
+            )
+        )
+        return msgs
+
+    async def ask_video(
+        self,
+        video: VideoInput,
+        question: str,
+        *,
+        system_prompt: str = "",
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        timeout: float | None = None,
+    ) -> ChatResponse:
+        if not self.capabilities.video:
+            raise ValueError(
+                "this VLM was constructed with capabilities.video=False; "
+                "flip the preset / spec to declare video support before "
+                "calling ask_video"
+            )
+        return await self._llm.chat(
+            self._build_video_messages(video, question, system_prompt),
             max_tokens=max_tokens, temperature=temperature, timeout=timeout,
         )
 

--- a/agent-sdk/xr-ai-models/xr_ai_models/openai_compat.py
+++ b/agent-sdk/xr-ai-models/xr_ai_models/openai_compat.py
@@ -1,0 +1,525 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenAI-compatible HTTP clients for the four service protocols.
+
+Per-model quirks (reasoning field name, mandatory ``chat_template_kwargs``)
+are absorbed by ``reasoning_field`` and ``default_extras`` on the
+constructor; per-call quirks (``enable_thinking``, ``thinking_budget``)
+fold into ``chat_template_kwargs`` on the wire.
+"""
+from __future__ import annotations
+
+import base64
+import io
+import json
+import os
+import wave
+from pathlib import Path
+from typing import Any, AsyncIterator, Sequence
+
+import httpx
+from loguru import logger
+
+from ._utils import merge_dicts
+from .protocols import (
+    Capabilities,
+    ChatMessage,
+    ChatResponse,
+    ContentPart,
+    ImageInput,
+    ImagePart,
+    TextPart,
+    ToolCall,
+    ToolDef,
+)
+
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+
+def _msg_to_openai(msg: ChatMessage) -> dict[str, Any]:
+    out: dict[str, Any] = {"role": msg.role}
+    if isinstance(msg.content, str):
+        out["content"] = msg.content
+    else:
+        out["content"] = [_part_to_openai(p) for p in msg.content]
+    if msg.tool_calls:
+        out["tool_calls"] = [
+            {
+                "id": tc.id,
+                "type": "function",
+                "function": {"name": tc.name, "arguments": tc.arguments},
+            }
+            for tc in msg.tool_calls
+        ]
+    if msg.tool_call_id is not None:
+        out["tool_call_id"] = msg.tool_call_id
+    return out
+
+
+def _part_to_openai(part: ContentPart) -> dict[str, Any]:
+    if isinstance(part, TextPart):
+        return {"type": "text", "text": part.text}
+    if isinstance(part, ImagePart):
+        return {"type": "image_url", "image_url": {"url": part.url}}
+    raise TypeError(f"unsupported content part: {type(part).__name__}")
+
+
+def _parse_chat_response(data: dict[str, Any], reasoning_field: str | None) -> ChatResponse:
+    choice = data["choices"][0]
+    msg = choice.get("message", {})
+    content = msg.get("content") or ""
+
+    if reasoning_field:
+        reasoning = msg.get(reasoning_field)
+    else:
+        reasoning = msg.get("reasoning") or msg.get("reasoning_content")
+
+    raw_tool_calls = msg.get("tool_calls")
+    tool_calls: list[ToolCall] | None = None
+    if raw_tool_calls:
+        tool_calls = [
+            ToolCall(
+                id=tc["id"],
+                name=tc["function"]["name"],
+                arguments=tc["function"]["arguments"],
+            )
+            for tc in raw_tool_calls
+        ]
+
+    return ChatResponse(
+        content=content,
+        reasoning=reasoning,
+        tool_calls=tool_calls,
+        finish_reason=choice.get("finish_reason"),
+        raw=data,
+    )
+
+
+_IMAGE_MAGIC: tuple[tuple[bytes, str], ...] = (
+    (b"\x89PNG\r\n\x1a\n", "image/png"),
+    (b"\xff\xd8\xff",       "image/jpeg"),
+    (b"GIF87a",             "image/gif"),
+    (b"GIF89a",             "image/gif"),
+)
+
+
+def _sniff_mime(data: bytes) -> str:
+    for magic, mime in _IMAGE_MAGIC:
+        if data.startswith(magic):
+            return mime
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "image/webp"
+    return "application/octet-stream"
+
+
+def _mime_from_suffix(p: Path) -> str:
+    return {
+        ".png":  "image/png",
+        ".jpg":  "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".gif":  "image/gif",
+        ".webp": "image/webp",
+    }.get(p.suffix.lower(), "application/octet-stream")
+
+
+def _to_data_url(data: bytes, mime: str) -> str:
+    b64 = base64.b64encode(data).decode("ascii")
+    return f"data:{mime};base64,{b64}"
+
+
+def _normalize_image(image: ImageInput) -> str:
+    if isinstance(image, str):
+        return image
+    if isinstance(image, Path):
+        return _to_data_url(image.read_bytes(), _mime_from_suffix(image))
+    if isinstance(image, (bytes, bytearray, memoryview)):
+        b = bytes(image)
+        return _to_data_url(b, _sniff_mime(b))
+    raise TypeError(f"unsupported image input: {type(image).__name__}")
+
+
+def _pcm_to_wav(pcm: bytes, sample_rate: int, channels: int) -> bytes:
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(channels)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm)
+    return buf.getvalue()
+
+
+# ── LLM ────────────────────────────────────────────────────────────────────
+
+
+class OpenAICompatLLM:
+    """OpenAI-compatible /v1/chat/completions client.
+
+    Used directly for plain LLMs (Llama-Nemotron, Nemotron3-Nano,
+    Nemotron-Omni) and indirectly via :class:`OpenAICompatVLM` for VLMs.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        model_name: str,
+        *,
+        capabilities: Capabilities | None = None,
+        reasoning_field: str | None = None,
+        default_extras: dict[str, Any] | None = None,
+        api_key_env: str | None = None,
+        timeout: float = 60.0,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        base = base_url.rstrip("/")
+        self._chat_url   = base + "/v1/chat/completions"
+        self.health_url  = base + "/health"
+        self._model      = model_name
+        self.capabilities = capabilities or Capabilities()
+        self._reasoning_field = reasoning_field
+        self._default_extras  = default_extras or {}
+        self._api_key = os.environ.get(api_key_env) if api_key_env else None
+        self._client  = client or httpx.AsyncClient(timeout=timeout, trust_env=False)
+        self._owns_client = client is None
+
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self._api_key}"} if self._api_key else {}
+
+    def _build_payload(
+        self,
+        messages: Sequence[ChatMessage],
+        *,
+        tools: Sequence[ToolDef] | None,
+        max_tokens: int | None,
+        temperature: float | None,
+        enable_thinking: bool,
+        thinking_budget: int | None,
+        stream: bool,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "model": self._model,
+            "messages": [_msg_to_openai(m) for m in messages],
+        }
+        if stream:
+            payload["stream"] = True
+        if tools:
+            payload["tools"] = [t.to_openai() for t in tools]
+        if max_tokens is not None:
+            payload["max_tokens"] = max_tokens
+        if temperature is not None:
+            payload["temperature"] = temperature
+
+        per_call: dict[str, Any] = {}
+        if enable_thinking or thinking_budget is not None:
+            tpl: dict[str, Any] = {}
+            if enable_thinking:
+                tpl["enable_thinking"] = True
+            if thinking_budget is not None:
+                tpl["thinking_budget"] = thinking_budget
+            per_call["chat_template_kwargs"] = tpl
+        for k, v in merge_dicts(self._default_extras, per_call).items():
+            payload[k] = v
+        return payload
+
+    async def chat(
+        self,
+        messages: Sequence[ChatMessage],
+        *,
+        tools: Sequence[ToolDef] | None = None,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        enable_thinking: bool = False,
+        thinking_budget: int | None = None,
+        timeout: float | None = None,
+    ) -> ChatResponse:
+        payload = self._build_payload(
+            messages,
+            tools=tools, max_tokens=max_tokens, temperature=temperature,
+            enable_thinking=enable_thinking, thinking_budget=thinking_budget,
+            stream=False,
+        )
+        kwargs: dict[str, Any] = {"json": payload, "headers": self._headers()}
+        if timeout is not None:
+            kwargs["timeout"] = timeout
+        resp = await self._client.post(self._chat_url, **kwargs)
+        if resp.is_error:
+            logger.error("llm {} {}: {}", self._model, resp.status_code, resp.text[:300])
+        resp.raise_for_status()
+        return _parse_chat_response(resp.json(), self._reasoning_field)
+
+    async def stream(
+        self,
+        messages: Sequence[ChatMessage],
+        *,
+        tools: Sequence[ToolDef] | None = None,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        enable_thinking: bool = False,
+        thinking_budget: int | None = None,
+        timeout: float | None = None,
+    ) -> AsyncIterator[str]:
+        payload = self._build_payload(
+            messages,
+            tools=tools, max_tokens=max_tokens, temperature=temperature,
+            enable_thinking=enable_thinking, thinking_budget=thinking_budget,
+            stream=True,
+        )
+        kwargs: dict[str, Any] = {"json": payload, "headers": self._headers()}
+        if timeout is not None:
+            kwargs["timeout"] = timeout
+        async with self._client.stream("POST", self._chat_url, **kwargs) as resp:
+            if resp.is_error:
+                body = await resp.aread()
+                logger.error("llm {} {}: {}", self._model, resp.status_code, body[:300])
+                resp.raise_for_status()
+            async for line in resp.aiter_lines():
+                if not line.startswith("data: "):
+                    continue
+                data = line[6:]
+                if data == "[DONE]":
+                    return
+                try:
+                    chunk = json.loads(data)
+                    delta = chunk["choices"][0]["delta"]
+                except (json.JSONDecodeError, KeyError, IndexError):
+                    continue
+                content = delta.get("content")
+                if content:
+                    yield content
+
+    async def health(self) -> bool:
+        try:
+            resp = await self._client.get(self.health_url, timeout=3.0)
+            return resp.is_success
+        except httpx.HTTPError:
+            return False
+
+    async def close(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def __aenter__(self) -> "OpenAICompatLLM":
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        await self.close()
+
+
+# ── VLM ────────────────────────────────────────────────────────────────────
+
+
+class OpenAICompatVLM:
+    """Vision LLM client — image-bearing chat completions, fronted as ``ask_image``."""
+
+    def __init__(
+        self,
+        base_url: str,
+        model_name: str,
+        *,
+        capabilities: Capabilities | None = None,
+        default_extras: dict[str, Any] | None = None,
+        api_key_env: str | None = None,
+        timeout: float = 60.0,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._llm = OpenAICompatLLM(
+            base_url,
+            model_name,
+            capabilities=capabilities or Capabilities(vision=True),
+            default_extras=default_extras,
+            api_key_env=api_key_env,
+            timeout=timeout,
+            client=client,
+        )
+
+    @property
+    def capabilities(self) -> Capabilities:
+        return self._llm.capabilities
+
+    @property
+    def health_url(self) -> str:
+        return self._llm.health_url
+
+    def _build_messages(
+        self, image: ImageInput, question: str, system_prompt: str
+    ) -> list[ChatMessage]:
+        url = _normalize_image(image)
+        msgs: list[ChatMessage] = []
+        if system_prompt:
+            msgs.append(ChatMessage(role="system", content=system_prompt))
+        msgs.append(
+            ChatMessage(
+                role="user",
+                content=[ImagePart(url=url), TextPart(text=question)],
+            )
+        )
+        return msgs
+
+    async def ask_image(
+        self,
+        image: ImageInput,
+        question: str,
+        *,
+        system_prompt: str = "",
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        timeout: float | None = None,
+    ) -> ChatResponse:
+        return await self._llm.chat(
+            self._build_messages(image, question, system_prompt),
+            max_tokens=max_tokens, temperature=temperature, timeout=timeout,
+        )
+
+    async def stream(
+        self,
+        image: ImageInput,
+        question: str,
+        *,
+        system_prompt: str = "",
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        timeout: float | None = None,
+    ) -> AsyncIterator[str]:
+        async for chunk in self._llm.stream(
+            self._build_messages(image, question, system_prompt),
+            max_tokens=max_tokens, temperature=temperature, timeout=timeout,
+        ):
+            yield chunk
+
+    async def health(self) -> bool:
+        return await self._llm.health()
+
+    async def close(self) -> None:
+        await self._llm.close()
+
+    async def __aenter__(self) -> "OpenAICompatVLM":
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        await self.close()
+
+
+# ── STT ────────────────────────────────────────────────────────────────────
+
+
+class OpenAICompatSTT:
+    """STT client — multipart POST to /v1/audio/transcriptions."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        api_key_env: str | None = None,
+        timeout: float = 30.0,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        base = base_url.rstrip("/")
+        self._url       = base + "/v1/audio/transcriptions"
+        self.health_url = base + "/health"
+        self._api_key   = os.environ.get(api_key_env) if api_key_env else None
+        self._client    = client or httpx.AsyncClient(timeout=timeout, trust_env=False)
+        self._owns_client = client is None
+
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self._api_key}"} if self._api_key else {}
+
+    async def transcribe(
+        self,
+        audio: bytes,
+        *,
+        sample_rate: int | None = None,
+        channels: int = 1,
+        timeout: float | None = None,
+    ) -> str:
+        wav_bytes = _pcm_to_wav(audio, sample_rate, channels) if sample_rate else audio
+        kwargs: dict[str, Any] = {
+            "files":   {"file": ("audio.wav", wav_bytes, "audio/wav")},
+            "data":    {"response_format": "json"},
+            "headers": self._headers(),
+        }
+        if timeout is not None:
+            kwargs["timeout"] = timeout
+        resp = await self._client.post(self._url, **kwargs)
+        if resp.is_error:
+            logger.error("stt {}: {}", resp.status_code, resp.text[:300])
+        resp.raise_for_status()
+        return resp.json().get("text", "")
+
+    async def health(self) -> bool:
+        try:
+            resp = await self._client.get(self.health_url, timeout=3.0)
+            return resp.is_success
+        except httpx.HTTPError:
+            return False
+
+    async def close(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def __aenter__(self) -> "OpenAICompatSTT":
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        await self.close()
+
+
+# ── TTS ────────────────────────────────────────────────────────────────────
+
+
+class OpenAICompatTTS:
+    """TTS client — JSON POST to /v1/audio/speech, returns raw audio bytes."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        api_key_env: str | None = None,
+        timeout: float = 30.0,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        base = base_url.rstrip("/")
+        self._url       = base + "/v1/audio/speech"
+        self.health_url = base + "/health"
+        self._api_key   = os.environ.get(api_key_env) if api_key_env else None
+        self._client    = client or httpx.AsyncClient(timeout=timeout, trust_env=False)
+        self._owns_client = client is None
+
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self._api_key}"} if self._api_key else {}
+
+    async def synthesize(
+        self,
+        text: str,
+        *,
+        response_format: str = "wav",
+        timeout: float | None = None,
+    ) -> bytes:
+        kwargs: dict[str, Any] = {
+            "json":    {"input": text, "response_format": response_format},
+            "headers": self._headers(),
+        }
+        if timeout is not None:
+            kwargs["timeout"] = timeout
+        resp = await self._client.post(self._url, **kwargs)
+        if resp.is_error:
+            logger.error("tts {}: {}", resp.status_code, resp.text[:300])
+        resp.raise_for_status()
+        return resp.content
+
+    async def health(self) -> bool:
+        try:
+            resp = await self._client.get(self.health_url, timeout=3.0)
+            return resp.is_success
+        except httpx.HTTPError:
+            return False
+
+    async def close(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def __aenter__(self) -> "OpenAICompatTTS":
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        await self.close()

--- a/agent-sdk/xr-ai-models/xr_ai_models/presets/__init__.py
+++ b/agent-sdk/xr-ai-models/xr_ai_models/presets/__init__.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Built-in presets for in-tree AI services.
+
+Each preset is a dict with the same keys a ``models.yaml`` entry would carry
+(except ``base_url``, which is the caller's responsibility).  A YAML entry
+that says ``kind: preset:<name>`` merges its keys on top of the preset's;
+explicit keys win.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from .cosmos_vlm      import COSMOS_VLM
+from .llama_nemotron  import LLAMA_NEMOTRON
+from .magpie_tts      import MAGPIE_TTS
+from .nemotron3_nano  import NEMOTRON3_NANO
+from .nemotron_omni   import NEMOTRON_OMNI
+from .parakeet_stt    import PARAKEET_STT
+from .piper_tts       import PIPER_TTS
+
+
+_PRESETS: dict[str, dict[str, Any]] = {
+    "cosmos_vlm":     COSMOS_VLM,
+    "llama_nemotron": LLAMA_NEMOTRON,
+    "magpie_tts":     MAGPIE_TTS,
+    "nemotron3_nano": NEMOTRON3_NANO,
+    "nemotron_omni":  NEMOTRON_OMNI,
+    "parakeet_stt":   PARAKEET_STT,
+    "piper_tts":      PIPER_TTS,
+}
+
+
+def get_preset(name: str) -> dict[str, Any]:
+    try:
+        return deepcopy(_PRESETS[name])
+    except KeyError as exc:
+        raise KeyError(
+            f"unknown preset {name!r}; known: {sorted(_PRESETS)}"
+        ) from exc
+
+
+def available_presets() -> list[str]:
+    return sorted(_PRESETS)
+
+
+__all__ = ["get_preset", "available_presets"]

--- a/agent-sdk/xr-ai-models/xr_ai_models/presets/cosmos_vlm.py
+++ b/agent-sdk/xr-ai-models/xr_ai_models/presets/cosmos_vlm.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Preset for ``ai-services/vlm-server`` (Cosmos-Reason1-7B via vLLM)."""
+
+COSMOS_VLM = {
+    "category":   "vlm",
+    "kind":       "openai_compat",
+    "model_name": "vlm",
+    "capabilities": {
+        "streaming": True,
+        "vision":    True,
+    },
+    "default_extras": {
+        # Cosmos-Reason emits <think>…</think> blobs by default; turn that off
+        # so VLM content is the plain answer the worker can show / speak.
+        "chat_template_kwargs": {"enable_thinking": False},
+    },
+}

--- a/agent-sdk/xr-ai-models/xr_ai_models/presets/cosmos_vlm.py
+++ b/agent-sdk/xr-ai-models/xr_ai_models/presets/cosmos_vlm.py
@@ -1,7 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Preset for ``ai-services/vlm-server`` (Cosmos-Reason1-7B via vLLM)."""
+"""Preset for ``ai-services/vlm-server`` (Cosmos-Reason1-7B via vLLM).
+
+Cosmos-Reason1-7B is a Qwen2.5-VL-7B fine-tune that accepts image *and* video
+content blocks.  Video is opt-in at the server: vlm-server's
+``max_videos_per_prompt`` defaults to 0, since vLLM reserves tens of GiB of
+activation memory at startup once it is set non-zero.  Callers that send
+``video_url`` content must set it to >= 1 in the server YAML.
+"""
 
 COSMOS_VLM = {
     "category":   "vlm",
@@ -10,6 +17,7 @@ COSMOS_VLM = {
     "capabilities": {
         "streaming": True,
         "vision":    True,
+        "video":     True,
     },
     "default_extras": {
         # Cosmos-Reason emits <think>…</think> blobs by default; turn that off

--- a/agent-sdk/xr-ai-models/xr_ai_models/presets/llama_nemotron.py
+++ b/agent-sdk/xr-ai-models/xr_ai_models/presets/llama_nemotron.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Preset for ``ai-services/llm/llama_nemotron`` (Llama-3.1-Nemotron-Nano-8B via vLLM)."""
+
+LLAMA_NEMOTRON = {
+    "category":   "llm",
+    "kind":       "openai_compat",
+    "model_name": "llm",
+    "capabilities": {
+        "streaming":  True,
+        "tool_calls": True,
+    },
+}

--- a/agent-sdk/xr-ai-models/xr_ai_models/presets/magpie_tts.py
+++ b/agent-sdk/xr-ai-models/xr_ai_models/presets/magpie_tts.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Preset for ``ai-services/tts/magpie`` (Magpie multilingual via NeMo)."""
+
+MAGPIE_TTS = {
+    "category": "tts",
+    "kind":     "openai_compat",
+    "timeout":  60.0,
+}

--- a/agent-sdk/xr-ai-models/xr_ai_models/presets/nemotron3_nano.py
+++ b/agent-sdk/xr-ai-models/xr_ai_models/presets/nemotron3_nano.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Preset for ``ai-services/llm/nemotron3_nano`` (Nemotron-3-Nano-30B via vLLM).
+
+vLLM's ``--reasoning-parser nano_v3`` writes reasoning into the
+``reasoning`` response field.
+"""
+
+NEMOTRON3_NANO = {
+    "category":        "llm",
+    "kind":            "openai_compat",
+    "model_name":      "llm",
+    "reasoning_field": "reasoning",
+    "capabilities": {
+        "streaming":  True,
+        "tool_calls": True,
+        "reasoning":  True,
+    },
+}

--- a/agent-sdk/xr-ai-models/xr_ai_models/presets/nemotron_omni.py
+++ b/agent-sdk/xr-ai-models/xr_ai_models/presets/nemotron_omni.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Preset for ``ai-services/llm/nemotron_omni`` (Nemotron-3-Nano-Omni-30B via vLLM).
+
+Multimodal text + video.  vLLM's ``--reasoning-parser nemotron_v3`` writes
+reasoning into the ``reasoning_content`` response field.
+"""
+
+NEMOTRON_OMNI = {
+    "category":        "llm",
+    "kind":            "openai_compat",
+    "model_name":      "llm",
+    "reasoning_field": "reasoning_content",
+    "capabilities": {
+        "streaming":  True,
+        "tool_calls": True,
+        "vision":     True,
+        "video":      True,
+        "reasoning":  True,
+    },
+}

--- a/agent-sdk/xr-ai-models/xr_ai_models/presets/parakeet_stt.py
+++ b/agent-sdk/xr-ai-models/xr_ai_models/presets/parakeet_stt.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Preset for ``ai-services/stt-server`` (Parakeet-TDT-0.6B via NeMo)."""
+
+PARAKEET_STT = {
+    "category": "stt",
+    "kind":     "openai_compat",
+    "timeout":  30.0,
+}

--- a/agent-sdk/xr-ai-models/xr_ai_models/presets/piper_tts.py
+++ b/agent-sdk/xr-ai-models/xr_ai_models/presets/piper_tts.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Preset for ``ai-services/tts/piper`` (Piper ONNX voices)."""
+
+PIPER_TTS = {
+    "category": "tts",
+    "kind":     "openai_compat",
+    "timeout":  30.0,
+}

--- a/agent-sdk/xr-ai-models/xr_ai_models/protocols.py
+++ b/agent-sdk/xr-ai-models/xr_ai_models/protocols.py
@@ -19,6 +19,9 @@ from typing import Any, AsyncIterator, Literal, Protocol, Sequence, runtime_chec
 ImageInput = bytes | Path | str
 """bytes, filesystem path, ``data:`` URL, or ``http(s)://`` URL."""
 
+VideoInput = bytes | Path | str
+"""bytes, filesystem path, ``data:`` URL, or ``http(s)://`` URL."""
+
 
 @dataclass(frozen=True)
 class TextPart:
@@ -32,7 +35,13 @@ class ImagePart:
     type: Literal["image_url"] = "image_url"
 
 
-ContentPart = TextPart | ImagePart
+@dataclass(frozen=True)
+class VideoPart:
+    url: str
+    type: Literal["video_url"] = "video_url"
+
+
+ContentPart = TextPart | ImagePart | VideoPart
 
 
 @dataclass(frozen=True)
@@ -124,6 +133,17 @@ class VLMService(Protocol):
     async def ask_image(
         self,
         image: ImageInput,
+        question: str,
+        *,
+        system_prompt: str = "",
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        timeout: float | None = None,
+    ) -> ChatResponse: pass
+
+    async def ask_video(
+        self,
+        video: VideoInput,
         question: str,
         *,
         system_prompt: str = "",

--- a/agent-sdk/xr-ai-models/xr_ai_models/protocols.py
+++ b/agent-sdk/xr-ai-models/xr_ai_models/protocols.py
@@ -100,7 +100,7 @@ class LLMService(Protocol):
         enable_thinking: bool = False,
         thinking_budget: int | None = None,
         timeout: float | None = None,
-    ) -> ChatResponse: ...
+    ) -> ChatResponse: pass
 
     def stream(
         self,
@@ -112,9 +112,9 @@ class LLMService(Protocol):
         enable_thinking: bool = False,
         thinking_budget: int | None = None,
         timeout: float | None = None,
-    ) -> AsyncIterator[str]: ...
+    ) -> AsyncIterator[str]: pass
 
-    async def close(self) -> None: ...
+    async def close(self) -> None: pass
 
 
 @runtime_checkable
@@ -130,7 +130,7 @@ class VLMService(Protocol):
         max_tokens: int | None = None,
         temperature: float | None = None,
         timeout: float | None = None,
-    ) -> ChatResponse: ...
+    ) -> ChatResponse: pass
 
     def stream(
         self,
@@ -141,9 +141,9 @@ class VLMService(Protocol):
         max_tokens: int | None = None,
         temperature: float | None = None,
         timeout: float | None = None,
-    ) -> AsyncIterator[str]: ...
+    ) -> AsyncIterator[str]: pass
 
-    async def close(self) -> None: ...
+    async def close(self) -> None: pass
 
 
 @runtime_checkable
@@ -155,9 +155,9 @@ class STTService(Protocol):
         sample_rate: int | None = None,
         channels: int = 1,
         timeout: float | None = None,
-    ) -> str: ...
+    ) -> str: pass
 
-    async def close(self) -> None: ...
+    async def close(self) -> None: pass
 
 
 @runtime_checkable
@@ -168,6 +168,6 @@ class TTSService(Protocol):
         *,
         response_format: str = "wav",
         timeout: float | None = None,
-    ) -> bytes: ...
+    ) -> bytes: pass
 
-    async def close(self) -> None: ...
+    async def close(self) -> None: pass

--- a/agent-sdk/xr-ai-models/xr_ai_models/protocols.py
+++ b/agent-sdk/xr-ai-models/xr_ai_models/protocols.py
@@ -11,7 +11,7 @@ name.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, AsyncIterator, Literal, Protocol, Sequence, runtime_checkable
 

--- a/agent-sdk/xr-ai-models/xr_ai_models/protocols.py
+++ b/agent-sdk/xr-ai-models/xr_ai_models/protocols.py
@@ -1,0 +1,173 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Service protocols, message types, and capability flags.
+
+Worker code depends on the four ``*Service`` protocols and treats every
+concrete client as a structural match.  Reasoning-token field naming differs
+across servers (``reasoning`` for nano_v3, ``reasoning_content`` for
+nemotron_v3); ``ChatResponse.reasoning`` is the canonical post-normalization
+name.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, AsyncIterator, Literal, Protocol, Sequence, runtime_checkable
+
+
+ImageInput = bytes | Path | str
+"""bytes, filesystem path, ``data:`` URL, or ``http(s)://`` URL."""
+
+
+@dataclass(frozen=True)
+class TextPart:
+    text: str
+    type: Literal["text"] = "text"
+
+
+@dataclass(frozen=True)
+class ImagePart:
+    url: str
+    type: Literal["image_url"] = "image_url"
+
+
+ContentPart = TextPart | ImagePart
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    id: str
+    name: str
+    arguments: str
+    """JSON-encoded arguments string, per the OpenAI tool-call contract."""
+
+
+@dataclass(frozen=True)
+class ToolDef:
+    name: str
+    description: str
+    parameters: dict[str, Any]
+
+    def to_openai(self) -> dict[str, Any]:
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": self.parameters,
+            },
+        }
+
+
+@dataclass(frozen=True)
+class ChatMessage:
+    role: Literal["system", "user", "assistant", "tool"]
+    content: str | list[ContentPart]
+    tool_calls: list[ToolCall] | None = None
+    tool_call_id: str | None = None
+
+
+@dataclass(frozen=True)
+class ChatResponse:
+    content: str
+    reasoning: str | None
+    tool_calls: list[ToolCall] | None
+    finish_reason: str | None
+    raw: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class Capabilities:
+    streaming: bool = True
+    tool_calls: bool = False
+    vision: bool = False
+    video: bool = False
+    reasoning: bool = False
+
+
+@runtime_checkable
+class LLMService(Protocol):
+    capabilities: Capabilities
+
+    async def chat(
+        self,
+        messages: Sequence[ChatMessage],
+        *,
+        tools: Sequence[ToolDef] | None = None,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        enable_thinking: bool = False,
+        thinking_budget: int | None = None,
+        timeout: float | None = None,
+    ) -> ChatResponse: ...
+
+    def stream(
+        self,
+        messages: Sequence[ChatMessage],
+        *,
+        tools: Sequence[ToolDef] | None = None,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        enable_thinking: bool = False,
+        thinking_budget: int | None = None,
+        timeout: float | None = None,
+    ) -> AsyncIterator[str]: ...
+
+    async def close(self) -> None: ...
+
+
+@runtime_checkable
+class VLMService(Protocol):
+    capabilities: Capabilities
+
+    async def ask_image(
+        self,
+        image: ImageInput,
+        question: str,
+        *,
+        system_prompt: str = "",
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        timeout: float | None = None,
+    ) -> ChatResponse: ...
+
+    def stream(
+        self,
+        image: ImageInput,
+        question: str,
+        *,
+        system_prompt: str = "",
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        timeout: float | None = None,
+    ) -> AsyncIterator[str]: ...
+
+    async def close(self) -> None: ...
+
+
+@runtime_checkable
+class STTService(Protocol):
+    async def transcribe(
+        self,
+        audio: bytes,
+        *,
+        sample_rate: int | None = None,
+        channels: int = 1,
+        timeout: float | None = None,
+    ) -> str: ...
+
+    async def close(self) -> None: ...
+
+
+@runtime_checkable
+class TTSService(Protocol):
+    async def synthesize(
+        self,
+        text: str,
+        *,
+        response_format: str = "wav",
+        timeout: float | None = None,
+    ) -> bytes: ...
+
+    async def close(self) -> None: ...

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -54,6 +54,17 @@ This is Unit 1 of a multi-PR refactor.  Subsequent units migrate
 vlm-mcp, simple-vlm-example, xr-render-demo, and xr-ai-pipecat to depend
 on `xr-ai-models` instead of rolling their own clients.
 
+`VLMService` also exposes `ask_video(video, question)`, mirroring
+`ask_image`.  The wire format is a `{"type": "video_url", "video_url":
+{...}}` content part — what vLLM's Qwen2.5-VL serving expects when
+`--limit-mm-per-prompt {"video": >=1}` is set.  `cosmos_vlm` declares
+`capabilities: { vision, video }` because Cosmos-Reason1-7B is a
+Qwen2.5-VL fine-tune primarily designed for video reasoning; video is
+opt-in at the server because vLLM reserves tens of GiB of activation
+memory for it at startup.  Callers that haven't enabled video on their
+spec get a `ValueError` from `ask_video` rather than a silent server
+500.
+
 ### 2026-05-14 — CodeQL Advanced Setup (committed workflow) instead of Default Setup
 
 `Analyze (python)` and `Analyze (javascript-typescript)` are required status

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,13 +9,51 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
-### 2026-05-12 — `FrameSink::InjectVideoFrame` gains a zero-copy overload
+### 2026-05-14 — Introduce `agent-sdk/xr-ai-models` SDK; collapse hand-rolled httpx clients behind four protocols
 
-The span-only `InjectVideoFrame(std::span<const std::byte>, …)` forced backends to allocate + memcpy the entire pixel buffer on every frame before they could construct an owning `livekit::VideoFrame`. On an embedded 32-bit ARMv7-A target (720p I420 @ 30 fps) this dominated per-frame cost at ~63 ms — the camera HAL collapsed to ~6 fps. Hardware-validated A/B against a new `InjectVideoFrame(std::vector<std::uint8_t>&&, …)` overload that moves the buffer directly into the SDK: total per-frame cost drops from ~70 ms to ~5 ms (14× speedup), matching the in-house baseline publisher.
+Before this change, every consumer of an AI service rolled its own `httpx`
+wrapper around `/v1/chat/completions` / `/v1/audio/transcriptions` /
+`/v1/audio/speech` — `VlmClient` existed in three places (vlm-mcp,
+simple-vlm-example/worker/services.py, xr-render-demo/worker/processors.py
+where four inline `httpx.post(.../v1/chat/completions)` sites duplicated the
+OpenAI request shape); `SttClient` / `TtsClient` lived in both
+xr-ai-pipecat and simple-vlm-example.  Per-model quirks
+(`chat_template_kwargs.enable_thinking`, `thinking_budget=1024` in the
+agentic loop, the `reasoning` vs `reasoning_content` field-name difference
+between vLLM's `nano_v3` and `nemotron_v3` reasoning parsers) leaked into
+every caller.  Swapping a model meant editing N files.
 
-**Design**: the overload is strictly additive. Default impl forwards to the span overload, so any backend that only overrides one path keeps working. Callers with read-only / shared buffers continue to use the span overload; owning callers get the fast path.
+The new `agent-sdk/xr-ai-models/` package introduces four service
+protocols — `LLMService`, `VLMService`, `STTService`, `TTSService` — and
+one `OpenAICompat*` implementation per protocol that covers every in-tree
+backend (vLLM-served VLM/LLMs, NeMo Parakeet STT, Piper/Magpie TTS) and
+any future OpenAI-compatible endpoint.  Worker code constructs services
+from a per-sample `yaml/models.yaml` via `make_llm` / `make_vlm` /
+`make_stt` / `make_tts`; built-in presets (`cosmos_vlm`,
+`llama_nemotron`, `nemotron3_nano`, `nemotron_omni`, `parakeet_stt`,
+`piper_tts`, `magpie_tts`) pre-fill the model-specific quirks so a sample
+entry only needs `kind: preset:<name>` + `base_url:`.
 
-The fix benefits every native C++ consumer (CloudXR, native game-engine plugins, embedded camera SDKs), not just embedded — the embedded case is just where the cost crosses from "wasteful" to "unusable". See finding #12 in [issue #134](https://github.com/NVIDIA/xr-ai/issues/134) for the diagnostic methodology, on-device numbers, and the cross-platform impact estimate.
+`ChatResponse.reasoning` is the canonical reasoning surface; the
+`reasoning_field` knob normalizes `reasoning_content` (nemotron_v3) into
+that one name so callers do not branch.  `enable_thinking` and
+`thinking_budget` are typed kwargs on `chat()` that flatten into
+`chat_template_kwargs` on the wire — callers never construct that dict.
+
+**Why not LiteLLM or any-llm-sdk.** Both are excellent for cross-vendor
+fan-out but solve a problem we do not have yet — every in-tree backend
+already speaks OpenAI-compatible HTTP, and both libraries pass our most
+painful quirk (the reasoning-field name) straight through; we would still
+write the normalization layer on top.  They would also pull `openai`,
+`pydantic`, `tiktoken`, and friends into every worker venv.  The
+`factory.py::make_*` `kind` dispatch is the seam where a `LiteLLMBackend`
+slots in as a new `kind` later if/when Phase B brings true cross-vendor
+needs — protocols and callers do not change.
+
+This is Unit 1 of a multi-PR refactor.  Subsequent units migrate
+vlm-mcp, simple-vlm-example, xr-render-demo, and xr-ai-pipecat to depend
+on `xr-ai-models` instead of rolling their own clients.
+
 ### 2026-05-14 — CodeQL Advanced Setup (committed workflow) instead of Default Setup
 
 `Analyze (python)` and `Analyze (javascript-typescript)` are required status
@@ -29,6 +67,14 @@ and all visible checks green (first hit by PR #131). We've committed
 required contexts unconditionally. Default Setup must stay disabled in
 `Settings → Code security → Code scanning` — Advanced Setup and Default Setup
 cannot coexist.
+
+### 2026-05-12 — `FrameSink::InjectVideoFrame` gains a zero-copy overload
+
+The span-only `InjectVideoFrame(std::span<const std::byte>, …)` forced backends to allocate + memcpy the entire pixel buffer on every frame before they could construct an owning `livekit::VideoFrame`. On an embedded 32-bit ARMv7-A target (720p I420 @ 30 fps) this dominated per-frame cost at ~63 ms — the camera HAL collapsed to ~6 fps. Hardware-validated A/B against a new `InjectVideoFrame(std::vector<std::uint8_t>&&, …)` overload that moves the buffer directly into the SDK: total per-frame cost drops from ~70 ms to ~5 ms (14× speedup), matching the in-house baseline publisher.
+
+**Design**: the overload is strictly additive. Default impl forwards to the span overload, so any backend that only overrides one path keeps working. Callers with read-only / shared buffers continue to use the span overload; owning callers get the fast path.
+
+The fix benefits every native C++ consumer (CloudXR, native game-engine plugins, embedded camera SDKs), not just embedded — the embedded case is just where the cost crosses from "wasteful" to "unusable". See finding #12 in [issue #134](https://github.com/NVIDIA/xr-ai/issues/134) for the diagnostic methodology, on-device numbers, and the cross-platform impact estimate.
 
 ### 2026-05-12 — `gpu` pytest marker + local-only dev script for hardware-bound tests
 

--- a/tests/_stub_openai.py
+++ b/tests/_stub_openai.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Stub OpenAI-compatible HTTP server backed by ``httpx.MockTransport``.
+
+Used by ``test_models_openai_compat.py`` to verify wire format without a
+real server: the stub records every inbound request and lets the test set
+canned responses for ``/v1/chat/completions`` (streaming and not),
+``/v1/audio/transcriptions``, ``/v1/audio/speech``, and ``/health``.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+
+
+_DEFAULT_CHAT = {
+    "choices": [{
+        "message":      {"role": "assistant", "content": "ok"},
+        "finish_reason": "stop",
+    }],
+}
+
+
+class StubOpenAI:
+    def __init__(self) -> None:
+        self.requests: list[httpx.Request] = []
+        self.bodies:   list[bytes] = []
+        self._chat_status:    int = 200
+        self._chat_response:  dict[str, Any] = dict(_DEFAULT_CHAT)
+        self._stream_tokens:  list[str] = []
+        self._transcribe_text: str = "stub-transcription"
+        self._speech_bytes:    bytes = b"RIFF\x00\x00\x00\x00WAVEstub"
+        self._health_status:  int = 200
+
+    # ── configuration setters ──────────────────────────────────────────────
+
+    def set_chat_message(
+        self,
+        *,
+        content: str = "",
+        reasoning: str | None = None,
+        reasoning_field: str = "reasoning",
+        tool_calls: list[dict[str, Any]] | None = None,
+        finish_reason: str | None = "stop",
+    ) -> None:
+        msg: dict[str, Any] = {"role": "assistant", "content": content}
+        if reasoning is not None:
+            msg[reasoning_field] = reasoning
+        if tool_calls is not None:
+            msg["tool_calls"] = tool_calls
+        self._chat_response = {
+            "choices": [{"message": msg, "finish_reason": finish_reason}],
+        }
+
+    def set_chat_status(self, status: int) -> None:
+        self._chat_status = status
+
+    def set_stream_tokens(self, tokens: list[str]) -> None:
+        self._stream_tokens = tokens
+
+    def set_transcribe_text(self, text: str) -> None:
+        self._transcribe_text = text
+
+    def set_speech_bytes(self, data: bytes) -> None:
+        self._speech_bytes = data
+
+    def set_health_status(self, status: int) -> None:
+        self._health_status = status
+
+    # ── transport / client ─────────────────────────────────────────────────
+
+    @property
+    def transport(self) -> httpx.MockTransport:
+        return httpx.MockTransport(self._handle)
+
+    def client(self, *, timeout: float = 5.0) -> httpx.AsyncClient:
+        return httpx.AsyncClient(transport=self.transport, timeout=timeout)
+
+    # ── request inspection ─────────────────────────────────────────────────
+
+    def last_json(self) -> dict[str, Any]:
+        return json.loads(self.bodies[-1].decode())
+
+    def last_request(self) -> httpx.Request:
+        return self.requests[-1]
+
+    # ── handler ────────────────────────────────────────────────────────────
+
+    def _handle(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        self.bodies.append(request.content)
+        path = request.url.path
+
+        if path == "/health":
+            return httpx.Response(self._health_status, text="ok")
+
+        if path == "/v1/chat/completions":
+            body = json.loads(request.content) if request.content else {}
+            if body.get("stream"):
+                sse_chunks = [
+                    "data: " + json.dumps({
+                        "choices": [{"delta": {"content": tok}}],
+                    }) + "\n\n"
+                    for tok in self._stream_tokens
+                ]
+                sse_chunks.append("data: [DONE]\n\n")
+                return httpx.Response(
+                    200,
+                    content="".join(sse_chunks).encode(),
+                    headers={"Content-Type": "text/event-stream"},
+                )
+            return httpx.Response(self._chat_status, json=self._chat_response)
+
+        if path == "/v1/audio/transcriptions":
+            return httpx.Response(200, json={"text": self._transcribe_text})
+
+        if path == "/v1/audio/speech":
+            return httpx.Response(
+                200,
+                content=self._speech_bytes,
+                headers={"Content-Type": "audio/wav"},
+            )
+
+        return httpx.Response(404, text=f"unknown path: {path}")

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -13,6 +13,7 @@ requires-python = ">=3.11,<3.13"
 dependencies = [
     # Pulled in via editable installs of the workspace packages.
     "xr-ai-agent",
+    "xr-ai-models",
     "xr-media-hub",
     "xr-ai-launcher",
     "xr-ai-logging",
@@ -34,6 +35,7 @@ dependencies = [
 
 [tool.uv.sources]
 xr-ai-agent           = { path = "../agent-sdk",                        editable = true }
+xr-ai-models          = { path = "../agent-sdk/xr-ai-models",           editable = true }
 xr-media-hub          = { path = "../server-runtime",                   editable = true }
 xr-ai-launcher        = { path = "../utils/xr-ai-launcher",             editable = true }
 xr-ai-logging         = { path = "../utils/xr-ai-logging",              editable = true }

--- a/tests/test_models_config.py
+++ b/tests/test_models_config.py
@@ -120,6 +120,8 @@ vlm:
     assert spec.default_extras == {
         "chat_template_kwargs": {"enable_thinking": False},
     }
+    assert spec.capabilities.get("vision") is True
+    assert spec.capabilities.get("video")  is True
 
 
 def test_stt_and_tts_presets(tmp_path) -> None:

--- a/tests/test_models_config.py
+++ b/tests/test_models_config.py
@@ -1,0 +1,206 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""``load_models_config`` + preset resolution coverage."""
+from __future__ import annotations
+
+import pytest
+
+from xr_ai_models import (
+    LLMSpec,
+    STTSpec,
+    TTSSpec,
+    VLMSpec,
+    load_models_config,
+    make_llm,
+    make_stt,
+    make_tts,
+    make_vlm,
+)
+from xr_ai_models.presets import available_presets, get_preset
+
+
+# ── preset registry ───────────────────────────────────────────────────────
+
+
+def test_seven_presets_registered() -> None:
+    assert set(available_presets()) == {
+        "cosmos_vlm",
+        "llama_nemotron",
+        "magpie_tts",
+        "nemotron3_nano",
+        "nemotron_omni",
+        "parakeet_stt",
+        "piper_tts",
+    }
+
+
+def test_get_preset_returns_deep_copy() -> None:
+    p1 = get_preset("nemotron3_nano")
+    p1["capabilities"]["tool_calls"] = False
+    p2 = get_preset("nemotron3_nano")
+    assert p2["capabilities"]["tool_calls"] is True
+
+
+def test_unknown_preset_raises() -> None:
+    with pytest.raises(KeyError, match="unknown preset"):
+        get_preset("nope")
+
+
+# ── YAML loader ───────────────────────────────────────────────────────────
+
+
+def _write(tmp_path, text: str):
+    p = tmp_path / "models.yaml"
+    p.write_text(text)
+    return p
+
+
+def test_preset_reference_fills_in_defaults(tmp_path) -> None:
+    cfg = load_models_config(_write(tmp_path, """
+agent_llm:
+  kind: preset:nemotron3_nano
+  base_url: http://localhost:8107
+"""))
+    spec = cfg.llm("agent_llm")
+    assert isinstance(spec, LLMSpec)
+    assert spec.base_url        == "http://localhost:8107"
+    assert spec.model_name      == "llm"
+    assert spec.reasoning_field == "reasoning"
+    assert spec.capabilities["reasoning"] is True
+
+
+def test_inline_spec_requires_category(tmp_path) -> None:
+    with pytest.raises(ValueError, match="category"):
+        load_models_config(_write(tmp_path, """
+agent_llm:
+  kind:       openai_compat
+  base_url:   http://localhost:8107
+  model_name: llm
+"""))
+
+
+def test_inline_spec_with_explicit_category(tmp_path) -> None:
+    cfg = load_models_config(_write(tmp_path, """
+agent_llm:
+  kind:       openai_compat
+  category:   llm
+  base_url:   http://localhost:8107
+  model_name: llm
+  capabilities: { tool_calls: true }
+"""))
+    spec = cfg.llm("agent_llm")
+    assert spec.model_name == "llm"
+    assert spec.capabilities == {"tool_calls": True}
+
+
+def test_entry_overrides_preset(tmp_path) -> None:
+    cfg = load_models_config(_write(tmp_path, """
+agent_llm:
+  kind:       preset:nemotron3_nano
+  base_url:   http://localhost:9999
+  timeout:    120
+  reasoning_field: reasoning_content
+"""))
+    spec = cfg.llm("agent_llm")
+    assert spec.base_url        == "http://localhost:9999"
+    assert spec.timeout         == 120.0
+    assert spec.reasoning_field == "reasoning_content"
+
+
+def test_vlm_preset(tmp_path) -> None:
+    cfg = load_models_config(_write(tmp_path, """
+vlm:
+  kind:     preset:cosmos_vlm
+  base_url: http://localhost:8100
+"""))
+    spec = cfg.vlm("vlm")
+    assert isinstance(spec, VLMSpec)
+    assert spec.model_name == "vlm"
+    assert spec.default_extras == {
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+
+
+def test_stt_and_tts_presets(tmp_path) -> None:
+    cfg = load_models_config(_write(tmp_path, """
+stt:
+  kind:     preset:parakeet_stt
+  base_url: http://localhost:8103
+tts:
+  kind:     preset:piper_tts
+  base_url: http://localhost:8105
+"""))
+    assert isinstance(cfg.stt("stt"), STTSpec)
+    assert isinstance(cfg.tts("tts"), TTSSpec)
+    assert cfg.stt("stt").base_url == "http://localhost:8103"
+    assert cfg.tts("tts").base_url == "http://localhost:8105"
+
+
+def test_wrong_category_accessor_raises(tmp_path) -> None:
+    cfg = load_models_config(_write(tmp_path, """
+vlm:
+  kind:     preset:cosmos_vlm
+  base_url: http://localhost:8100
+"""))
+    with pytest.raises(TypeError, match="expected LLMSpec"):
+        cfg.llm("vlm")
+
+
+def test_missing_base_url_raises(tmp_path) -> None:
+    with pytest.raises(ValueError, match="base_url"):
+        load_models_config(_write(tmp_path, """
+agent_llm:
+  kind: preset:nemotron3_nano
+"""))
+
+
+def test_unknown_name_raises(tmp_path) -> None:
+    cfg = load_models_config(_write(tmp_path, """
+agent_llm:
+  kind:     preset:nemotron3_nano
+  base_url: http://localhost:8107
+"""))
+    with pytest.raises(KeyError, match="no spec named"):
+        cfg.llm("nope")
+
+
+# ── factory dispatch ──────────────────────────────────────────────────────
+
+
+async def test_make_llm_constructs_client(tmp_path) -> None:
+    cfg = load_models_config(_write(tmp_path, """
+agent_llm:
+  kind:     preset:nemotron3_nano
+  base_url: http://localhost:8107
+"""))
+    llm = make_llm(cfg, "agent_llm")
+    try:
+        assert llm.capabilities.reasoning is True
+    finally:
+        await llm.close()
+
+
+async def test_make_vlm_make_stt_make_tts(tmp_path) -> None:
+    cfg = load_models_config(_write(tmp_path, """
+vlm:
+  kind:     preset:cosmos_vlm
+  base_url: http://localhost:8100
+stt:
+  kind:     preset:parakeet_stt
+  base_url: http://localhost:8103
+tts:
+  kind:     preset:piper_tts
+  base_url: http://localhost:8105
+"""))
+    vlm = make_vlm(cfg, "vlm")
+    stt = make_stt(cfg, "stt")
+    tts = make_tts(cfg, "tts")
+    try:
+        assert vlm.capabilities.vision is True
+        assert stt.health_url == "http://localhost:8103/health"
+        assert tts.health_url == "http://localhost:8105/health"
+    finally:
+        await vlm.close()
+        await stt.close()
+        await tts.close()

--- a/tests/test_models_openai_compat.py
+++ b/tests/test_models_openai_compat.py
@@ -361,7 +361,6 @@ async def test_stt_transcribe_pcm_converts_to_wav() -> None:
     sent = stub.last_request().content
     start = sent.find(b"RIFF")
     assert start >= 0
-    end = sent.find(b"\r\n", start + 4) or len(sent)
     extracted = sent[start:].split(b"\r\n", 1)[0]
     with wave.open(io.BytesIO(extracted), "rb") as wf:
         assert wf.getframerate() == 16000

--- a/tests/test_models_openai_compat.py
+++ b/tests/test_models_openai_compat.py
@@ -11,21 +11,16 @@ from __future__ import annotations
 import base64
 import io
 import wave
-from pathlib import Path
-
 import pytest
 
 from _stub_openai import StubOpenAI
 
 from xr_ai_models import (
-    Capabilities,
     ChatMessage,
-    ImagePart,
     OpenAICompatLLM,
     OpenAICompatSTT,
     OpenAICompatTTS,
     OpenAICompatVLM,
-    TextPart,
     ToolDef,
 )
 

--- a/tests/test_models_openai_compat.py
+++ b/tests/test_models_openai_compat.py
@@ -16,6 +16,7 @@ import pytest
 from _stub_openai import StubOpenAI
 
 from xr_ai_models import (
+    Capabilities,
     ChatMessage,
     OpenAICompatLLM,
     OpenAICompatSTT,
@@ -327,6 +328,77 @@ async def test_vlm_default_extras_propagate() -> None:
         await vlm.ask_image(_PNG_HEADER, "?")
     body = stub.last_json()
     assert body["chat_template_kwargs"] == {"enable_thinking": False}
+
+
+# ── VLM: video ────────────────────────────────────────────────────────────
+
+
+# ISO BMFF header: 4 bytes box size, "ftyp" magic, "isom" major brand,
+# minor version, then "isom"/"mp42" compat brands. Smallest plausible mp4 prefix.
+_MP4_HEADER = (
+    b"\x00\x00\x00\x20ftypisom\x00\x00\x02\x00"
+    b"isomiso2avc1mp41" + b"\x00" * 8
+)
+_WEBM_HEADER = b"\x1a\x45\xdf\xa3" + b"\x00" * 24
+
+
+async def test_vlm_ask_video_with_bytes_sniffs_mp4_and_builds_data_url() -> None:
+    stub = StubOpenAI()
+    stub.set_chat_message(content="a person walks left")
+    async with OpenAICompatVLM(
+        "http://stub", "vlm",
+        capabilities=Capabilities(vision=True, video=True),
+        client=stub.client(),
+    ) as vlm:
+        resp = await vlm.ask_video(_MP4_HEADER, "what happens?")
+    assert resp.content == "a person walks left"
+
+    body  = stub.last_json()
+    parts = body["messages"][0]["content"]
+    assert parts[0]["type"] == "video_url"
+    url = parts[0]["video_url"]["url"]
+    assert url.startswith("data:video/mp4;base64,")
+    assert base64.b64decode(url.split(",", 1)[1]) == _MP4_HEADER
+    assert parts[1] == {"type": "text", "text": "what happens?"}
+
+
+async def test_vlm_ask_video_with_path_uses_suffix_mime(tmp_path) -> None:
+    p = tmp_path / "clip.webm"
+    p.write_bytes(_WEBM_HEADER)
+    stub = StubOpenAI()
+    async with OpenAICompatVLM(
+        "http://stub", "vlm",
+        capabilities=Capabilities(vision=True, video=True),
+        client=stub.client(),
+    ) as vlm:
+        await vlm.ask_video(p, "?")
+    body = stub.last_json()
+    url = body["messages"][0]["content"][0]["video_url"]["url"]
+    assert url.startswith("data:video/webm;base64,")
+
+
+async def test_vlm_ask_video_with_string_passes_through_url() -> None:
+    stub = StubOpenAI()
+    async with OpenAICompatVLM(
+        "http://stub", "vlm",
+        capabilities=Capabilities(vision=True, video=True),
+        client=stub.client(),
+    ) as vlm:
+        await vlm.ask_video("https://example.com/clip.mp4", "?")
+    body = stub.last_json()
+    assert body["messages"][0]["content"][0]["video_url"]["url"] == \
+        "https://example.com/clip.mp4"
+
+
+async def test_vlm_ask_video_raises_when_capability_off() -> None:
+    stub = StubOpenAI()
+    async with OpenAICompatVLM(
+        "http://stub", "vlm",
+        capabilities=Capabilities(vision=True),
+        client=stub.client(),
+    ) as vlm:
+        with pytest.raises(ValueError, match="video"):
+            await vlm.ask_video(_MP4_HEADER, "?")
 
 
 # ── STT ───────────────────────────────────────────────────────────────────

--- a/tests/test_models_openai_compat.py
+++ b/tests/test_models_openai_compat.py
@@ -1,0 +1,412 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Wire-format and behavior coverage for the OpenAICompat* clients.
+
+Uses :class:`_stub_openai.StubOpenAI` (an ``httpx.MockTransport``) so no
+real HTTP listener is needed.
+"""
+from __future__ import annotations
+
+import base64
+import io
+import wave
+from pathlib import Path
+
+import pytest
+
+from _stub_openai import StubOpenAI
+
+from xr_ai_models import (
+    Capabilities,
+    ChatMessage,
+    ImagePart,
+    OpenAICompatLLM,
+    OpenAICompatSTT,
+    OpenAICompatTTS,
+    OpenAICompatVLM,
+    TextPart,
+    ToolDef,
+)
+
+
+# ── LLM: chat ─────────────────────────────────────────────────────────────
+
+
+async def test_llm_chat_builds_minimal_payload() -> None:
+    stub = StubOpenAI()
+    stub.set_chat_message(content="hi there")
+    async with OpenAICompatLLM(
+        "http://stub", "llm", client=stub.client(),
+    ) as llm:
+        resp = await llm.chat([ChatMessage(role="user", content="hello")])
+
+    assert resp.content == "hi there"
+    assert resp.reasoning is None
+    assert resp.tool_calls is None
+    assert resp.finish_reason == "stop"
+
+    body = stub.last_json()
+    assert body["model"]    == "llm"
+    assert body["messages"] == [{"role": "user", "content": "hello"}]
+    assert "stream" not in body
+
+
+async def test_llm_chat_passes_through_max_tokens_temperature() -> None:
+    stub = StubOpenAI()
+    async with OpenAICompatLLM(
+        "http://stub", "llm", client=stub.client(),
+    ) as llm:
+        await llm.chat(
+            [ChatMessage(role="user", content="hello")],
+            max_tokens=40, temperature=0.7,
+        )
+    body = stub.last_json()
+    assert body["max_tokens"]  == 40
+    assert body["temperature"] == 0.7
+
+
+async def test_llm_chat_folds_thinking_kwargs_into_chat_template_kwargs() -> None:
+    stub = StubOpenAI()
+    async with OpenAICompatLLM(
+        "http://stub", "llm", client=stub.client(),
+    ) as llm:
+        await llm.chat(
+            [ChatMessage(role="user", content="x")],
+            enable_thinking=True, thinking_budget=1024,
+        )
+    body = stub.last_json()
+    assert body["chat_template_kwargs"] == {
+        "enable_thinking": True,
+        "thinking_budget": 1024,
+    }
+
+
+async def test_llm_chat_default_extras_merged_with_per_call() -> None:
+    stub = StubOpenAI()
+    async with OpenAICompatLLM(
+        "http://stub", "llm",
+        default_extras={"chat_template_kwargs": {"enable_thinking": False}},
+        client=stub.client(),
+    ) as llm:
+        await llm.chat(
+            [ChatMessage(role="user", content="x")],
+            thinking_budget=256,
+        )
+    body = stub.last_json()
+    assert body["chat_template_kwargs"] == {
+        "enable_thinking": False,
+        "thinking_budget": 256,
+    }
+
+
+async def test_llm_chat_reasoning_field_aliasing() -> None:
+    stub = StubOpenAI()
+    stub.set_chat_message(
+        content="answer",
+        reasoning="thinking…",
+        reasoning_field="reasoning_content",
+    )
+    async with OpenAICompatLLM(
+        "http://stub", "llm",
+        reasoning_field="reasoning_content",
+        client=stub.client(),
+    ) as llm:
+        resp = await llm.chat([ChatMessage(role="user", content="x")])
+    assert resp.reasoning == "thinking…"
+
+
+async def test_llm_chat_reasoning_default_checks_both_field_names() -> None:
+    stub = StubOpenAI()
+    stub.set_chat_message(
+        content="answer", reasoning="r1", reasoning_field="reasoning_content",
+    )
+    async with OpenAICompatLLM(
+        "http://stub", "llm", client=stub.client(),
+    ) as llm:
+        r1 = await llm.chat([ChatMessage(role="user", content="x")])
+    assert r1.reasoning == "r1"
+
+    stub.set_chat_message(
+        content="a2", reasoning="r2", reasoning_field="reasoning",
+    )
+    async with OpenAICompatLLM(
+        "http://stub", "llm", client=stub.client(),
+    ) as llm:
+        r2 = await llm.chat([ChatMessage(role="user", content="x")])
+    assert r2.reasoning == "r2"
+
+
+async def test_llm_chat_tool_definitions_serialized_to_openai_shape() -> None:
+    stub = StubOpenAI()
+    tool = ToolDef(
+        name="get_weather",
+        description="Get current weather.",
+        parameters={
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    )
+    async with OpenAICompatLLM(
+        "http://stub", "llm", client=stub.client(),
+    ) as llm:
+        await llm.chat([ChatMessage(role="user", content="x")], tools=[tool])
+    body = stub.last_json()
+    assert body["tools"] == [{
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get current weather.",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        },
+    }]
+
+
+async def test_llm_chat_tool_calls_parsed_from_response() -> None:
+    stub = StubOpenAI()
+    stub.set_chat_message(
+        content="",
+        tool_calls=[{
+            "id":   "call_abc",
+            "type": "function",
+            "function": {
+                "name":      "get_weather",
+                "arguments": '{"city":"Paris"}',
+            },
+        }],
+        finish_reason="tool_calls",
+    )
+    async with OpenAICompatLLM(
+        "http://stub", "llm", client=stub.client(),
+    ) as llm:
+        resp = await llm.chat([ChatMessage(role="user", content="weather?")])
+    assert resp.tool_calls is not None
+    assert len(resp.tool_calls) == 1
+    tc = resp.tool_calls[0]
+    assert tc.id        == "call_abc"
+    assert tc.name      == "get_weather"
+    assert tc.arguments == '{"city":"Paris"}'
+    assert resp.finish_reason == "tool_calls"
+
+
+async def test_llm_chat_sends_bearer_when_api_key_env_set(monkeypatch) -> None:
+    monkeypatch.setenv("STUB_API_KEY", "sk-test-123")
+    stub = StubOpenAI()
+    async with OpenAICompatLLM(
+        "http://stub", "llm",
+        api_key_env="STUB_API_KEY",
+        client=stub.client(),
+    ) as llm:
+        await llm.chat([ChatMessage(role="user", content="x")])
+    assert stub.last_request().headers["Authorization"] == "Bearer sk-test-123"
+
+
+async def test_llm_chat_no_auth_header_without_api_key_env() -> None:
+    stub = StubOpenAI()
+    async with OpenAICompatLLM(
+        "http://stub", "llm", client=stub.client(),
+    ) as llm:
+        await llm.chat([ChatMessage(role="user", content="x")])
+    assert "Authorization" not in stub.last_request().headers
+
+
+async def test_llm_chat_raises_on_http_error() -> None:
+    import httpx
+    stub = StubOpenAI()
+    stub.set_chat_status(500)
+    async with OpenAICompatLLM(
+        "http://stub", "llm", client=stub.client(),
+    ) as llm:
+        with pytest.raises(httpx.HTTPStatusError):
+            await llm.chat([ChatMessage(role="user", content="x")])
+
+
+# ── LLM: stream ───────────────────────────────────────────────────────────
+
+
+async def test_llm_stream_yields_content_tokens_and_stops_at_done() -> None:
+    stub = StubOpenAI()
+    stub.set_stream_tokens(["Hel", "lo", " world"])
+    chunks: list[str] = []
+    async with OpenAICompatLLM(
+        "http://stub", "llm", client=stub.client(),
+    ) as llm:
+        async for tok in llm.stream([ChatMessage(role="user", content="x")]):
+            chunks.append(tok)
+    assert chunks == ["Hel", "lo", " world"]
+    body = stub.last_json()
+    assert body["stream"] is True
+
+
+# ── LLM: health ───────────────────────────────────────────────────────────
+
+
+async def test_llm_health_true_on_200() -> None:
+    stub = StubOpenAI()
+    async with OpenAICompatLLM(
+        "http://stub", "llm", client=stub.client(),
+    ) as llm:
+        assert (await llm.health()) is True
+
+
+async def test_llm_health_false_on_503() -> None:
+    stub = StubOpenAI()
+    stub.set_health_status(503)
+    async with OpenAICompatLLM(
+        "http://stub", "llm", client=stub.client(),
+    ) as llm:
+        assert (await llm.health()) is False
+
+
+# ── VLM ───────────────────────────────────────────────────────────────────
+
+
+_PNG_HEADER = b"\x89PNG\r\n\x1a\n" + b"\x00" * 24
+
+
+async def test_vlm_ask_image_with_bytes_builds_data_url() -> None:
+    stub = StubOpenAI()
+    stub.set_chat_message(content="it's a cat")
+    async with OpenAICompatVLM(
+        "http://stub", "vlm", client=stub.client(),
+    ) as vlm:
+        resp = await vlm.ask_image(_PNG_HEADER, "what is this?")
+    assert resp.content == "it's a cat"
+
+    body = stub.last_json()
+    parts = body["messages"][0]["content"]
+    assert parts[0]["type"] == "image_url"
+    url = parts[0]["image_url"]["url"]
+    assert url.startswith("data:image/png;base64,")
+    assert base64.b64decode(url.split(",", 1)[1]) == _PNG_HEADER
+    assert parts[1] == {"type": "text", "text": "what is this?"}
+
+
+async def test_vlm_ask_image_with_path_reads_file(tmp_path) -> None:
+    p = tmp_path / "img.png"
+    p.write_bytes(_PNG_HEADER)
+    stub = StubOpenAI()
+    async with OpenAICompatVLM(
+        "http://stub", "vlm", client=stub.client(),
+    ) as vlm:
+        await vlm.ask_image(p, "?")
+    body = stub.last_json()
+    url = body["messages"][0]["content"][0]["image_url"]["url"]
+    assert url.startswith("data:image/png;base64,")
+
+
+async def test_vlm_ask_image_with_string_passes_through_url() -> None:
+    stub = StubOpenAI()
+    async with OpenAICompatVLM(
+        "http://stub", "vlm", client=stub.client(),
+    ) as vlm:
+        await vlm.ask_image("https://example.com/img.png", "?")
+    body = stub.last_json()
+    assert body["messages"][0]["content"][0]["image_url"]["url"] == \
+        "https://example.com/img.png"
+
+
+async def test_vlm_ask_image_includes_system_prompt_when_set() -> None:
+    stub = StubOpenAI()
+    async with OpenAICompatVLM(
+        "http://stub", "vlm", client=stub.client(),
+    ) as vlm:
+        await vlm.ask_image(_PNG_HEADER, "?", system_prompt="be terse")
+    body = stub.last_json()
+    assert body["messages"][0] == {"role": "system", "content": "be terse"}
+    assert body["messages"][1]["role"] == "user"
+
+
+async def test_vlm_default_extras_propagate() -> None:
+    stub = StubOpenAI()
+    async with OpenAICompatVLM(
+        "http://stub", "vlm",
+        default_extras={"chat_template_kwargs": {"enable_thinking": False}},
+        client=stub.client(),
+    ) as vlm:
+        await vlm.ask_image(_PNG_HEADER, "?")
+    body = stub.last_json()
+    assert body["chat_template_kwargs"] == {"enable_thinking": False}
+
+
+# ── STT ───────────────────────────────────────────────────────────────────
+
+
+async def test_stt_transcribe_wav_bytes_passthrough() -> None:
+    stub = StubOpenAI()
+    stub.set_transcribe_text("hello world")
+    wav_bytes = b"RIFF\x00\x00\x00\x00WAVEdata"
+    async with OpenAICompatSTT(
+        "http://stub", client=stub.client(),
+    ) as stt:
+        text = await stt.transcribe(wav_bytes)
+    assert text == "hello world"
+    req = stub.last_request()
+    assert req.url.path == "/v1/audio/transcriptions"
+    assert wav_bytes in req.content
+
+
+async def test_stt_transcribe_pcm_converts_to_wav() -> None:
+    stub = StubOpenAI()
+    pcm = b"\x00\x01" * 480
+    async with OpenAICompatSTT(
+        "http://stub", client=stub.client(),
+    ) as stt:
+        await stt.transcribe(pcm, sample_rate=16000, channels=1)
+    sent = stub.last_request().content
+    start = sent.find(b"RIFF")
+    assert start >= 0
+    end = sent.find(b"\r\n", start + 4) or len(sent)
+    extracted = sent[start:].split(b"\r\n", 1)[0]
+    with wave.open(io.BytesIO(extracted), "rb") as wf:
+        assert wf.getframerate() == 16000
+        assert wf.getnchannels() == 1
+
+
+# ── TTS ───────────────────────────────────────────────────────────────────
+
+
+async def test_tts_synthesize_returns_audio_bytes() -> None:
+    stub = StubOpenAI()
+    stub.set_speech_bytes(b"\x01\x02\x03")
+    async with OpenAICompatTTS(
+        "http://stub", client=stub.client(),
+    ) as tts:
+        data = await tts.synthesize("hello")
+    assert data == b"\x01\x02\x03"
+    body = stub.last_json()
+    assert body == {"input": "hello", "response_format": "wav"}
+
+
+async def test_tts_response_format_override() -> None:
+    stub = StubOpenAI()
+    async with OpenAICompatTTS(
+        "http://stub", client=stub.client(),
+    ) as tts:
+        await tts.synthesize("hi", response_format="pcm")
+    body = stub.last_json()
+    assert body["response_format"] == "pcm"
+
+
+# ── lifecycle ─────────────────────────────────────────────────────────────
+
+
+async def test_external_client_not_closed_by_close() -> None:
+    stub = StubOpenAI()
+    client = stub.client()
+    llm = OpenAICompatLLM("http://stub", "llm", client=client)
+    await llm.close()
+    assert client.is_closed is False
+    await client.aclose()
+
+
+async def test_owned_client_closed_by_close() -> None:
+    llm = OpenAICompatLLM("http://stub", "llm")
+    inner = llm._client
+    await llm.close()
+    assert inner.is_closed is True

--- a/tests/test_models_protocols.py
+++ b/tests/test_models_protocols.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Structural-typing checks for the four xr-ai-models protocols."""
+from __future__ import annotations
+
+from xr_ai_models import (
+    Capabilities,
+    LLMService,
+    OpenAICompatLLM,
+    OpenAICompatSTT,
+    OpenAICompatTTS,
+    OpenAICompatVLM,
+    STTService,
+    TTSService,
+    VLMService,
+)
+
+
+def test_openai_compat_llm_satisfies_llm_service() -> None:
+    llm = OpenAICompatLLM("http://stub", "llm")
+    assert isinstance(llm, LLMService)
+
+
+def test_openai_compat_vlm_satisfies_vlm_service() -> None:
+    vlm = OpenAICompatVLM("http://stub", "vlm")
+    assert isinstance(vlm, VLMService)
+
+
+def test_openai_compat_stt_satisfies_stt_service() -> None:
+    stt = OpenAICompatSTT("http://stub")
+    assert isinstance(stt, STTService)
+
+
+def test_openai_compat_tts_satisfies_tts_service() -> None:
+    tts = OpenAICompatTTS("http://stub")
+    assert isinstance(tts, TTSService)
+
+
+def test_capabilities_defaults_to_text_streaming_only() -> None:
+    cap = Capabilities()
+    assert cap.streaming is True
+    assert cap.tool_calls is False
+    assert cap.vision is False
+    assert cap.video is False
+    assert cap.reasoning is False
+
+
+def test_llm_capabilities_propagate_from_constructor() -> None:
+    llm = OpenAICompatLLM(
+        "http://stub", "llm",
+        capabilities=Capabilities(tool_calls=True, reasoning=True),
+    )
+    assert llm.capabilities.tool_calls is True
+    assert llm.capabilities.reasoning is True
+
+
+def test_vlm_defaults_to_vision_capability() -> None:
+    vlm = OpenAICompatVLM("http://stub", "vlm")
+    assert vlm.capabilities.vision is True


### PR DESCRIPTION
## Summary

Unit 1 of the modular AI-models refactor — introduces `agent-sdk/xr-ai-models/`, a new SDK that absorbs every hand-rolled `httpx` wrapper around `/v1/chat/completions`, `/v1/audio/transcriptions`, and `/v1/audio/speech` behind four service protocols (`LLMService`, `VLMService`, `STTService`, `TTSService`) with `OpenAICompat*` implementations covering all seven in-tree backends.

- Per-model quirks (reasoning-field aliasing for `nano_v3` vs `nemotron_v3`; `chat_template_kwargs` plumbing for `enable_thinking` / `thinking_budget`) live behind the SDK seam — callers do not branch on them.
- Built-in presets for `cosmos_vlm`, `llama_nemotron`, `nemotron3_nano`, `nemotron_omni`, `parakeet_stt`, `piper_tts`, `magpie_tts` — a sample's `yaml/models.yaml` entry becomes `kind: preset:<name>` + `base_url:`.
- `AGENTS.md` gains the new hard rule "All HTTP calls to AI services go through `agent-sdk/xr-ai-models`" and `DEPENDENCIES.md` / `docs/changelog.md` are updated in the same commit per the docs rule.
- No callers change in this PR — subsequent units migrate `vlm-mcp`, `simple-vlm-example`, `xr-render-demo`, and `xr-ai-pipecat` to depend on this SDK.

## Test plan

- [x] 46 new unit tests under `tests/test_models_*.py` against an `httpx.MockTransport` stub
- [x] Full non-GPU test suite (220 tests) regression-clean on Python 3.12
- [x] SPDX header check passes (305 files)
- [x] `uv lock` resolves cleanly for the new package
- [ ] Reviewer: `cd tests && uv sync && uv run pytest -m "not gpu" -k models`

🤖 Generated with [Claude Code](https://claude.com/claude-code)