### PR TITLE
docs(xr-ai-models): adopt SDK + models.yaml convention in project docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,7 @@ mechanically:
 - [ ] `agent-samples/<name>/worker/<snake_name>_worker.py` — entry point + (optional) split helpers
 - [ ] `agent-samples/<name>/yaml/xr_media_hub.yaml` — hub config
 - [ ] `agent-samples/<name>/yaml/<command>.yaml` — one per process that needs config
+- [ ] `agent-samples/<name>/yaml/models.yaml` — logical model names + preset references (see `agent-sdk/xr-ai-models/README.md`)
 - [ ] `uv sync` in both `agent-samples/<name>/` and `agent-samples/<name>/worker/`
 - [ ] `README.md` updated — sample tour and quickstart
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,17 @@ starts everything.  Heavier demos (`xr-render-demo`) split model loading from
 the demo itself: start `model-servers` once, then run the demo as many times
 as you like without reloading weights.
 
+Every sample worker depends on `agent-sdk/xr-ai-models` — one SDK that
+abstracts the OpenAI-compatible HTTP wire format for LLM / VLM / STT / TTS
+behind four service protocols.  Each sample ships a `yaml/models.yaml` that
+names the logical models the worker needs (`llm`, `vlm`, `stt`, …) with
+preset references that pre-fill model-specific quirks (reasoning-field
+aliasing, `chat_template_kwargs`, served-model-name strings).  Workers call
+`make_llm(config, "llm")` / `make_vlm(config, "vlm")` / `make_stt(config,
+"stt")` / `make_tts(config, "tts")` — no hand-rolled httpx clients, no model
+quirks leaking out of the SDK.  Full quickstart and the built-in preset
+table: [`agent-sdk/xr-ai-models/README.md`](agent-sdk/xr-ai-models/README.md).
+
 ## Quickstart
 
 Every sample follows the same pattern: **start the server, then connect a

--- a/docs/adding-a-sample.md
+++ b/docs/adding-a-sample.md
@@ -40,6 +40,7 @@ agent-samples/<name>/
 ├── yaml/                           ← all YAML configs for this sample
 │   ├── xr_media_hub.yaml
 │   ├── <command>.yaml              ← one per launchable process
+│   ├── models.yaml                 ← logical model names + preset references
 │   └── …
 └── worker/
     ├── pyproject.toml              ← worker project
@@ -47,6 +48,14 @@ agent-samples/<name>/
     ├── agent.py                    ← <CamelName>Agent class
     └── …                           ← split helpers as needed (audio.py, services.py, …)
 ```
+
+`yaml/models.yaml` names the logical models the worker needs (`llm`,
+`vlm`, `stt`, `tts`, or any sample-specific name) with `kind:
+preset:<name>` + `base_url:` entries.  The worker passes its path to
+`load_models_config(...)` and constructs services via `make_llm` /
+`make_vlm` / `make_stt` / `make_tts` from `xr_ai_models`.  Schema, preset
+table, and the explicit (no-preset) spec are in
+[`agent-sdk/xr-ai-models/README.md`](../agent-sdk/xr-ai-models/README.md).
 
 When the worker is small (≲ 100 lines) keep it as a single file —
 `worker/<snake_name>_worker.py` containing everything. Only split once
@@ -99,11 +108,13 @@ version = "0.1.0"
 requires-python = ">=3.11,<3.13"
 dependencies = [
     "xr-ai-agent",
+    "xr-ai-models",
     # add task-specific deps here: numpy, torch, etc.
 ]
 
 [tool.uv.sources]
-xr-ai-agent = { path = "../../../agent-sdk", editable = true }
+xr-ai-agent  = { path = "../../../agent-sdk",              editable = true }
+xr-ai-models = { path = "../../../agent-sdk/xr-ai-models", editable = true }
 
 [project.scripts]
 <snake_name>_worker = "<snake_name>_worker:run"

--- a/docs/ai-services.md
+++ b/docs/ai-services.md
@@ -78,52 +78,53 @@ cp ../../agent-mcp-servers/video-mcp/video_mcp_server.yaml ./yaml/video_mcp_serv
 Edit the YAML as needed (model, port, device, etc.). The launcher auto-discovers
 `yaml/<command>.yaml` in the sample root and passes it as `--config`.
 
-## Calling the servers from a worker
+## Calling these from a worker
+
+Workers do not hand-roll `httpx` clients against these endpoints.  They
+depend on [`agent-sdk/xr-ai-models`](../agent-sdk/xr-ai-models/README.md),
+load a per-sample `yaml/models.yaml`, and construct service clients via
+`make_llm` / `make_vlm` / `make_stt` / `make_tts`.  The SDK encapsulates the
+OpenAI-compatible wire format and the per-model quirks (reasoning-field
+aliasing, `chat_template_kwargs`, served-model-name strings) so callers
+never branch on backend.
 
 ```python
-import httpx
+from xr_ai_models import load_models_config, make_llm, ChatMessage
 
-# STT — POST multipart/form-data
-async with httpx.AsyncClient() as client:
-    resp = await client.post(
-        "http://localhost:8103/v1/audio/transcriptions",
-        files={"file": ("audio.wav", wav_bytes, "audio/wav")},
-        data={"response_format": "json"},
+config = load_models_config("yaml/models.yaml")
+async with make_llm(config, "agent_llm") as llm:
+    resp = await llm.chat(
+        [ChatMessage(role="user", content="hello")],
+        max_tokens=128,
+        enable_thinking=True,
     )
-    transcript = resp.json()["text"]
-
-# TTS — POST JSON
-async with httpx.AsyncClient() as client:
-    resp = await client.post(
-        "http://localhost:8104/v1/audio/speech",
-        json={"input": "Hello from XR.", "response_format": "wav"},
-    )
-    wav_bytes = resp.content
-
-# VLM — POST JSON with base64 image
-async with httpx.AsyncClient() as client:
-    resp = await client.post(
-        "http://localhost:8100/v1/chat/completions",
-        json={"model": "vlm", "messages": [{"role": "user", "content": [
-            {"type": "image_url", "image_url": {"url": image_data_url}},
-            {"type": "text", "text": "What do you see?"},
-        ]}]},
-    )
-    answer = resp.json()["choices"][0]["message"]["content"]
-
-# LLM — POST JSON (pure-text chat completion)
-# Ports: 8106 llama_nemotron | 8107 nemotron3_nano.
-# The HTTP contract is identical across both; swap the port to swap
-# backends with no worker-side code changes.
-async with httpx.AsyncClient() as client:
-    resp = await client.post(
-        "http://localhost:8106/v1/chat/completions",
-        json={"model": "llm", "messages": [
-            {"role": "user", "content": "Say OK"},
-        ], "max_tokens": 16},
-    )
-    answer = resp.json()["choices"][0]["message"]["content"]
+    print(resp.content, resp.reasoning)
 ```
+
+A matching `models.yaml` for the four built-in service backends:
+
+```yaml
+agent_llm:
+  kind:     preset:nemotron3_nano
+  base_url: http://localhost:8107
+
+vlm:
+  kind:     preset:cosmos_vlm
+  base_url: http://localhost:8100
+
+stt:
+  kind:     preset:parakeet_stt
+  base_url: http://localhost:8103
+
+tts:
+  kind:     preset:piper_tts
+  base_url: http://localhost:8105
+```
+
+Swapping a backend is a `kind:` + `base_url:` edit in YAML; worker code does
+not change.  Full protocol surface, the preset table, and the explicit
+(no-preset) spec are in
+[`agent-sdk/xr-ai-models/README.md`](../agent-sdk/xr-ai-models/README.md).
 
 ## vLLM model persistence
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,27 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-05-14 — `xr-ai-models` seam fully adopted by all in-tree workers
+
+`vlm-mcp`, `simple-vlm-example`, `xr-render-demo`, and `xr-ai-pipecat` now
+depend on `agent-sdk/xr-ai-models` and construct their LLM / VLM / STT / TTS
+clients from a per-sample `yaml/models.yaml` via `make_llm` / `make_vlm` /
+`make_stt` / `make_tts`.  Per-model quirks (`chat_template_kwargs.enable_thinking`,
+`thinking_budget`, `reasoning` vs `reasoning_content` field naming,
+served-model-name strings) live in built-in presets — no caller branches on
+backend, and swapping a model is a `kind:` + `base_url:` YAML edit.
+
+The AGENTS.md hard rule "All HTTP calls to AI services go through
+`agent-sdk/xr-ai-models`" is now enforceable in review with no remaining
+hand-rolled `httpx` callers of `/v1/chat/completions`,
+`/v1/audio/transcriptions`, or `/v1/audio/speech` in any worker or MCP
+server.  Top-level docs (`README.md`, `docs/ai-services.md`,
+`docs/adding-a-sample.md`, `AGENTS.md`) surface the `models.yaml` convention
+in the new-sample checklist and the per-service call examples.
+
+See PR #135 (Unit 1, SDK) and Units 2–5 (consumer migrations) for the
+individual diffs.
+
 ### 2026-05-14 — Introduce `agent-sdk/xr-ai-models` SDK; collapse hand-rolled httpx clients behind four protocols
 
 Before this change, every consumer of an AI service rolled its own `httpx`

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,9 +9,9 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
-### 2026-05-14 — `xr-ai-models` seam fully adopted by all in-tree workers
+### 2026-05-14 — `xr-ai-models` seam adopted by migrated workers; one migration pending
 
-`vlm-mcp`, `simple-vlm-example`, `xr-render-demo`, and `xr-ai-pipecat` now
+`vlm-mcp` (#139), `xr-render-demo` (#140), and `xr-ai-pipecat` (#137) now
 depend on `agent-sdk/xr-ai-models` and construct their LLM / VLM / STT / TTS
 clients from a per-sample `yaml/models.yaml` via `make_llm` / `make_vlm` /
 `make_stt` / `make_tts`.  Per-model quirks (`chat_template_kwargs.enable_thinking`,
@@ -19,11 +19,13 @@ clients from a per-sample `yaml/models.yaml` via `make_llm` / `make_vlm` /
 served-model-name strings) live in built-in presets — no caller branches on
 backend, and swapping a model is a `kind:` + `base_url:` YAML edit.
 
-The AGENTS.md hard rule "All HTTP calls to AI services go through
-`agent-sdk/xr-ai-models`" is now enforceable in review with no remaining
-hand-rolled `httpx` callers of `/v1/chat/completions`,
-`/v1/audio/transcriptions`, or `/v1/audio/speech` in any worker or MCP
-server.  Top-level docs (`README.md`, `docs/ai-services.md`,
+The seam is consumed by `vlm-mcp` (#139), `xr-render-demo` (#140), and
+`xr-ai-pipecat` (#137); `simple-vlm-example`'s worker still uses inline
+`httpx` callers and migrates in #138.  The AGENTS.md hard rule
+"All HTTP calls to AI services go through `agent-sdk/xr-ai-models`"
+becomes universally enforceable on review once #138 lands.
+
+Top-level docs (`README.md`, `docs/ai-services.md`,
 `docs/adding-a-sample.md`, `AGENTS.md`) surface the `models.yaml` convention
 in the new-sample checklist and the per-service call examples.
 


### PR DESCRIPTION
## Summary

Unit 6 of the modular AI-models refactor — surfaces the new `xr-ai-models` SDK and the `models.yaml` per-sample convention into the project-level docs:

- Top-level `README.md` mentions the SDK + `models.yaml` pattern in the agent-samples section.
- `docs/ai-services.md` gains a "Calling these from a worker" section.
- `docs/adding-a-sample.md` adds `yaml/models.yaml` to the new-sample checklist.
- `AGENTS.md` "Adding a sample" checklist updated.
- `docs/changelog.md` closing entry confirming the AGENTS.md hard rule is enforceable.

Stacked on #135 — when #135 merges, GitHub auto-retargets this PR to `main`.

## Test plan
- [x] SPDX header check passes (no new files; existing headers preserved).
- [x] Relative links resolve.
- [x] Full non-GPU pytest suite still green (regression sanity).