### PR TITLE
refactor(xr-ai-pipecat): rewire SttClient/TtsClient on xr-ai-models SDK

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -46,6 +46,7 @@ xr-ai-agent  (agent-sdk/)
 xr-ai-pipecat  (agent-sdk/xr-ai-pipecat/)
     └── xr-ai-agent   [editable: ..]
     └── xr-ai-logging [editable: ../../utils/xr-ai-logging]
+    └── xr-ai-models  [editable: ../xr-ai-models]
     └── pipecat-ai >=0.0.46
     └── numpy >=1.24
     └── scipy >=1.11
@@ -54,6 +55,9 @@ xr-ai-pipecat  (agent-sdk/xr-ai-pipecat/)
     Optional Pipecat transport bridge: connects ProcessorEndpoint (ZMQ IPC)
     to a Pipecat frame pipeline. Resamples hub float32 audio → 16 kHz int16
     for STT; converts TTS int16 PCM back to float32 AudioChunks for return.
+    SttClient / TtsClient are thin wrappers around xr-ai-models'
+    OpenAICompatSTT / OpenAICompatTTS — PCM→WAV conversion is handled by
+    the SDK. httpx is retained for http_probe() readiness checks.
     Not a dep of xr-ai-agent itself — import only in workers that use Pipecat.
 
 xr-ai-models  (agent-sdk/xr-ai-models/)
@@ -150,6 +154,7 @@ oxr-mcp-server  (agent-mcp-servers/oxr-mcp/)
 xr-ai-tests  (tests/)
     └── xr-ai-agent             [editable: ../agent-sdk]
     └── xr-ai-models            [editable: ../agent-sdk/xr-ai-models]
+    └── xr-ai-pipecat           [editable: ../agent-sdk/xr-ai-pipecat]
     └── xr-media-hub            [editable: ../server-runtime]    (pulls in livekit, livekit-api for the wss /rtc proxy + room-client tests)
     └── xr-ai-launcher          [editable: ../utils/xr-ai-launcher]
     └── xr-ai-logging           [editable: ../utils/xr-ai-logging]

--- a/agent-sdk/xr-ai-models/xr_ai_models/openai_compat.py
+++ b/agent-sdk/xr-ai-models/xr_ai_models/openai_compat.py
@@ -505,7 +505,7 @@ class OpenAICompatSTT:
         channels: int = 1,
         timeout: float | None = None,
     ) -> str:
-        wav_bytes = _pcm_to_wav(audio, sample_rate, channels) if sample_rate else audio
+        wav_bytes = _pcm_to_wav(audio, sample_rate, channels) if sample_rate is not None else audio
         kwargs: dict[str, Any] = {
             "files":   {"file": ("audio.wav", wav_bytes, "audio/wav")},
             "data":    {"response_format": "json"},

--- a/agent-sdk/xr-ai-pipecat/pyproject.toml
+++ b/agent-sdk/xr-ai-pipecat/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.11,<3.13"
 dependencies = [
     "xr-ai-agent",
     "xr-ai-logging",
+    "xr-ai-models",
     "pipecat-ai>=0.0.46",
     "numpy>=1.24",
     "scipy>=1.11",
@@ -22,6 +23,7 @@ dependencies = [
 [tool.uv.sources]
 xr-ai-agent   = { path = "..", editable = true }
 xr-ai-logging = { path = "../../utils/xr-ai-logging", editable = true }
+xr-ai-models  = { path = "../xr-ai-models", editable = true }
 
 [tool.hatch.build.targets.wheel]
 packages = ["xr_ai_pipecat"]

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/services.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/services.py
@@ -7,77 +7,68 @@ Thin async clients for stt-server and tts-server, plus generic readiness probes.
 from __future__ import annotations
 
 import asyncio
-import io
-import wave
-from typing import Awaitable, Callable
+from typing import Any, Awaitable, Callable
 
 import httpx
 from fastmcp import Client as McpClient
 from loguru import logger
 
+from xr_ai_models.openai_compat import OpenAICompatSTT, OpenAICompatTTS
+
 
 # ── STT ───────────────────────────────────────────────────────────────────────
 
 class SttClient:
-    """OpenAI-compatible /v1/audio/transcriptions client."""
+    """OpenAI-compatible /v1/audio/transcriptions client.
+
+    Thin wrapper around :class:`xr_ai_models.OpenAICompatSTT` that preserves
+    the ``(base_url, timeout)`` constructor signature used by existing callers.
+    """
 
     def __init__(self, base_url: str, timeout: float = 30.0) -> None:
-        base = base_url.rstrip("/")
-        self.health_url     = base + "/health"
-        self.transcribe_url = base + "/v1/audio/transcriptions"
-        self._client        = httpx.AsyncClient(timeout=timeout)
+        self._stt = OpenAICompatSTT(base_url, timeout=timeout)
 
     async def transcribe(
         self, audio_data: bytes, sample_rate: int, channels: int = 1,
     ) -> str:
-        wav_bytes = _pcm_to_wav(audio_data, sample_rate, channels)
-        resp = await self._client.post(
-            self.transcribe_url,
-            files={"file": ("audio.wav", wav_bytes, "audio/wav")},
-            data={"response_format": "json"},
+        # sample_rate triggers PCM→WAV conversion inside the SDK client.
+        return await self._stt.transcribe(
+            audio_data, sample_rate=sample_rate, channels=channels,
         )
-        if resp.is_error:
-            logger.error("stt {}: {}", resp.status_code, resp.text[:300])
-        resp.raise_for_status()
-        return resp.json().get("text", "")
 
     async def close(self) -> None:
-        await self._client.aclose()
+        await self._stt.close()
 
+    async def __aenter__(self) -> "SttClient":
+        return self
 
-def _pcm_to_wav(pcm_data: bytes, sample_rate: int, channels: int) -> bytes:
-    buf = io.BytesIO()
-    with wave.open(buf, "wb") as wf:
-        wf.setnchannels(channels)
-        wf.setsampwidth(2)
-        wf.setframerate(sample_rate)
-        wf.writeframes(pcm_data)
-    return buf.getvalue()
+    async def __aexit__(self, *exc: Any) -> None:
+        await self.close()
 
 
 # ── TTS ───────────────────────────────────────────────────────────────────────
 
 class TtsClient:
-    """OpenAI-compatible /v1/audio/speech client."""
+    """OpenAI-compatible /v1/audio/speech client.
+
+    Thin wrapper around :class:`xr_ai_models.OpenAICompatTTS` that preserves
+    the ``(base_url, timeout)`` constructor signature used by existing callers.
+    """
 
     def __init__(self, base_url: str, timeout: float = 30.0) -> None:
-        base = base_url.rstrip("/")
-        self.health_url     = base + "/health"
-        self.synthesize_url = base + "/v1/audio/speech"
-        self._client        = httpx.AsyncClient(timeout=timeout)
+        self._tts = OpenAICompatTTS(base_url, timeout=timeout)
 
     async def synthesize(self, text: str) -> bytes:
-        resp = await self._client.post(
-            self.synthesize_url,
-            json={"input": text, "response_format": "wav"},
-        )
-        if resp.is_error:
-            logger.error("tts {}: {}", resp.status_code, resp.text[:300])
-        resp.raise_for_status()
-        return resp.content
+        return await self._tts.synthesize(text)
 
     async def close(self) -> None:
-        await self._client.aclose()
+        await self._tts.close()
+
+    async def __aenter__(self) -> "TtsClient":
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        await self.close()
 
 
 # ── readiness probes ──────────────────────────────────────────────────────────

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/services.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/services.py
@@ -25,8 +25,18 @@ class SttClient:
     the ``(base_url, timeout)`` constructor signature used by existing callers.
     """
 
-    def __init__(self, base_url: str, timeout: float = 30.0) -> None:
-        self._stt = OpenAICompatSTT(base_url, timeout=timeout)
+    def __init__(
+        self,
+        base_url: str,
+        timeout: float = 30.0,
+        *,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._stt = OpenAICompatSTT(base_url, timeout=timeout, client=client)
+
+    @property
+    def health_url(self) -> str:
+        return self._stt.health_url
 
     async def transcribe(
         self, audio_data: bytes, sample_rate: int, channels: int = 1,
@@ -55,8 +65,18 @@ class TtsClient:
     the ``(base_url, timeout)`` constructor signature used by existing callers.
     """
 
-    def __init__(self, base_url: str, timeout: float = 30.0) -> None:
-        self._tts = OpenAICompatTTS(base_url, timeout=timeout)
+    def __init__(
+        self,
+        base_url: str,
+        timeout: float = 30.0,
+        *,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._tts = OpenAICompatTTS(base_url, timeout=timeout, client=client)
+
+    @property
+    def health_url(self) -> str:
+        return self._tts.health_url
 
     async def synthesize(self, text: str) -> bytes:
         return await self._tts.synthesize(text)

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     # Pulled in via editable installs of the workspace packages.
     "xr-ai-agent",
     "xr-ai-models",
+    "xr-ai-pipecat",
     "xr-media-hub",
     "xr-ai-launcher",
     "xr-ai-logging",
@@ -36,6 +37,7 @@ dependencies = [
 [tool.uv.sources]
 xr-ai-agent           = { path = "../agent-sdk",                        editable = true }
 xr-ai-models          = { path = "../agent-sdk/xr-ai-models",           editable = true }
+xr-ai-pipecat         = { path = "../agent-sdk/xr-ai-pipecat",          editable = true }
 xr-media-hub          = { path = "../server-runtime",                   editable = true }
 xr-ai-launcher        = { path = "../utils/xr-ai-launcher",             editable = true }
 xr-ai-logging         = { path = "../utils/xr-ai-logging",              editable = true }

--- a/tests/test_pipecat_services_wire.py
+++ b/tests/test_pipecat_services_wire.py
@@ -14,7 +14,6 @@ import json
 import wave
 
 from _stub_openai import StubOpenAI
-from xr_ai_models.openai_compat import OpenAICompatSTT, OpenAICompatTTS
 from xr_ai_pipecat.services import SttClient, TtsClient
 
 
@@ -38,17 +37,11 @@ def _parse_wav_header(data: bytes) -> dict:
 
 
 def _wire_stt_client(stub: StubOpenAI) -> SttClient:
-    """Return a SttClient whose underlying SDK client uses the stub transport."""
-    client = SttClient.__new__(SttClient)
-    client._stt = OpenAICompatSTT("http://stub", client=stub.client())
-    return client
+    return SttClient("http://stub", client=stub.client())
 
 
 def _wire_tts_client(stub: StubOpenAI) -> TtsClient:
-    """Return a TtsClient whose underlying SDK client uses the stub transport."""
-    client = TtsClient.__new__(TtsClient)
-    client._tts = OpenAICompatTTS("http://stub", client=stub.client())
-    return client
+    return TtsClient("http://stub", client=stub.client())
 
 
 # ── SttClient wire tests ──────────────────────────────────────────────────────

--- a/tests/test_pipecat_services_wire.py
+++ b/tests/test_pipecat_services_wire.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Wire-trace tests for xr_ai_pipecat.SttClient and TtsClient.
+
+Verifies that the pipecat wrappers produce exactly the same HTTP wire format as
+the pre-migration hand-rolled httpx clients did — multipart form POST for STT
+and JSON POST for TTS — by injecting an httpx.MockTransport stub.
+"""
+from __future__ import annotations
+
+import io
+import json
+import wave
+
+from _stub_openai import StubOpenAI
+from xr_ai_models.openai_compat import OpenAICompatSTT, OpenAICompatTTS
+from xr_ai_pipecat.services import SttClient, TtsClient
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _make_pcm(n_frames: int = 160) -> bytes:
+    """16-bit silence at 16 kHz — smallest valid PCM block."""
+    return b"\x00\x00" * n_frames
+
+
+def _parse_wav_header(data: bytes) -> dict:
+    """Return sample_rate, channels, and sample_width from a WAV header."""
+    buf = io.BytesIO(data)
+    with wave.open(buf, "rb") as wf:
+        return {
+            "channels":     wf.getnchannels(),
+            "sample_width": wf.getsampwidth(),
+            "sample_rate":  wf.getframerate(),
+            "n_frames":     wf.getnframes(),
+        }
+
+
+def _wire_stt_client(stub: StubOpenAI) -> SttClient:
+    """Return a SttClient whose underlying SDK client uses the stub transport."""
+    client = SttClient.__new__(SttClient)
+    client._stt = OpenAICompatSTT("http://stub", client=stub.client())
+    return client
+
+
+def _wire_tts_client(stub: StubOpenAI) -> TtsClient:
+    """Return a TtsClient whose underlying SDK client uses the stub transport."""
+    client = TtsClient.__new__(TtsClient)
+    client._tts = OpenAICompatTTS("http://stub", client=stub.client())
+    return client
+
+
+# ── SttClient wire tests ──────────────────────────────────────────────────────
+
+async def test_stt_transcribe_posts_to_audio_transcriptions() -> None:
+    stub = StubOpenAI()
+    stt = _wire_stt_client(stub)
+    pcm = _make_pcm()
+    result = await stt.transcribe(pcm, sample_rate=16000)
+    assert result == "stub-transcription"
+    assert stub.last_request().url.path == "/v1/audio/transcriptions"
+
+
+async def test_stt_transcribe_sends_wav_wrapped_audio() -> None:
+    """PCM bytes must be wrapped in a WAV container before posting."""
+    stub = StubOpenAI()
+    stt = _wire_stt_client(stub)
+    pcm = _make_pcm(320)
+    await stt.transcribe(pcm, sample_rate=16000, channels=1)
+
+    req = stub.last_request()
+    # The request is multipart — find the WAV file part in the body.
+    content_type = req.headers["content-type"]
+    assert "multipart/form-data" in content_type
+
+    body = req.read()
+    # The WAV magic bytes RIFF must appear somewhere in the multipart body.
+    assert b"RIFF" in body
+    assert b"WAVE" in body
+
+
+async def test_stt_transcribe_wav_header_matches_pcm_params() -> None:
+    """WAV header sample_rate and channels must reflect the values passed in."""
+    stub = StubOpenAI()
+    stt = _wire_stt_client(stub)
+    n_frames = 480
+    pcm = _make_pcm(n_frames)
+    await stt.transcribe(pcm, sample_rate=16000, channels=1)
+
+    body = stub.last_request().read()
+    # Isolate WAV bytes from the multipart boundary — same extraction as the
+    # SDK-level STT tests: split on the first CRLF to drop any trailing boundary.
+    riff_offset = body.index(b"RIFF")
+    wav_bytes = body[riff_offset:].split(b"\r\n", 1)[0]
+    hdr = _parse_wav_header(wav_bytes)
+    assert hdr["sample_rate"]  == 16000
+    assert hdr["channels"]     == 1
+    assert hdr["sample_width"] == 2        # 16-bit PCM
+    assert hdr["n_frames"]     == n_frames
+
+
+async def test_stt_transcribe_multipart_includes_response_format_json() -> None:
+    """form-data must include response_format=json (server needs it)."""
+    stub = StubOpenAI()
+    stt = _wire_stt_client(stub)
+    await stt.transcribe(_make_pcm(), sample_rate=16000)
+
+    body = stub.last_request().read()
+    assert b"response_format" in body
+    assert b"json" in body
+
+
+async def test_stt_transcribe_returns_text_field() -> None:
+    stub = StubOpenAI()
+    stub.set_transcribe_text("hello world")
+    stt = _wire_stt_client(stub)
+    result = await stt.transcribe(_make_pcm(), sample_rate=8000)
+    assert result == "hello world"
+
+
+async def test_stt_constructor_signature_preserved() -> None:
+    """SttClient(base_url, timeout) must work without keyword-only args."""
+    client = SttClient("http://localhost:8103", 45.0)
+    assert client._stt is not None
+    await client.close()
+
+
+# ── TtsClient wire tests ──────────────────────────────────────────────────────
+
+async def test_tts_synthesize_posts_to_audio_speech() -> None:
+    stub = StubOpenAI()
+    tts = _wire_tts_client(stub)
+    await tts.synthesize("hello")
+    assert stub.last_request().url.path == "/v1/audio/speech"
+
+
+async def test_tts_synthesize_sends_json_body_with_input_and_response_format() -> None:
+    """Wire body must be {input: text, response_format: wav}."""
+    stub = StubOpenAI()
+    tts = _wire_tts_client(stub)
+    await tts.synthesize("speak this")
+
+    body = json.loads(stub.bodies[-1].decode())
+    assert body["input"]           == "speak this"
+    assert body["response_format"] == "wav"
+
+
+async def test_tts_synthesize_returns_raw_bytes() -> None:
+    stub = StubOpenAI()
+    stub.set_speech_bytes(b"RIFF\x00\x00\x00\x00WAVEdata")
+    tts = _wire_tts_client(stub)
+    result = await tts.synthesize("test")
+    assert result == b"RIFF\x00\x00\x00\x00WAVEdata"
+
+
+async def test_tts_constructor_signature_preserved() -> None:
+    """TtsClient(base_url, timeout) must work without keyword-only args."""
+    client = TtsClient("http://localhost:8105", 45.0)
+    assert client._tts is not None
+    await client.close()
+
+
+# ── context manager protocol ──────────────────────────────────────────────────
+
+async def test_stt_async_context_manager() -> None:
+    stub = StubOpenAI()
+    async with _wire_stt_client(stub) as stt:
+        result = await stt.transcribe(_make_pcm(), sample_rate=16000)
+    assert result == "stub-transcription"
+
+
+async def test_tts_async_context_manager() -> None:
+    stub = StubOpenAI()
+    async with _wire_tts_client(stub) as tts:
+        result = await tts.synthesize("hi")
+    assert result == stub._speech_bytes


### PR DESCRIPTION
## Summary

Unit 5 of the modular AI-models refactor — rewires pipecat's
`SttClient` and `TtsClient` to be thin wrappers around the SDK's
`OpenAICompatSTT` / `OpenAICompatTTS`.

- Public constructor signatures `(base_url, timeout=30.0)` preserved.
- Public methods `transcribe(audio, sample_rate, channels)` / `synthesize(text)` preserved.
- PCM→WAV conversion now lives inside the SDK — pipecat's local `_pcm_to_wav` is gone.
- `http_probe`, `mcp_probe`, `wait_for_services` are unchanged (unrelated to model HTTP).
- `DEPENDENCIES.md` updated in the same commit per the docs rule.
- New `tests/test_pipecat_services_wire.py` drives both clients against `_stub_openai` and asserts the wire shape (multipart for STT, JSON for TTS) matches the pre-migration goldens — 12 tests, all pass.

Stacked on #135 — Unit 5 of the modular AI-models refactor. When #135 merges, GitHub auto-retargets this PR to ``main``.

## Test plan
- [x] 12 new wire-trace tests pass.
- [x] Full non-GPU suite (\`uv run pytest -m \"not gpu\"\`) regression-clean (58 passed in the pipecat+models slice; full suite green).
- [x] SPDX header check: \`OK: 306 file(s) carry a valid SPDX header\`.
- [ ] GPU smoke skipped (no GPU available in sandbox).