### PR TITLE
ci(codeql): switch to Advanced Setup so required checks always report

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: CodeQL
+
+# Advanced Setup (committed workflow) instead of GitHub's Default Setup:
+# Default Setup only runs when a PR's diff touches a configured language, but
+# `Analyze (python)` and `Analyze (javascript-typescript)` are required status
+# checks on `main` — so PRs that change only non-configured languages (e.g.
+# C++/CMake) silently skip analysis and the required contexts never report,
+# leaving the PR permanently BLOCKED. Advanced Setup always runs the matrix
+# and posts both contexts.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '0 6 * * 1'
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python, javascript-typescript]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,20 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-05-14 — CodeQL Advanced Setup (committed workflow) instead of Default Setup
+
+`Analyze (python)` and `Analyze (javascript-typescript)` are required status
+checks on `main`. With GitHub's Default Setup (the implicit
+`dynamic/github-code-scanning/codeql` workflow), CodeQL only runs when a PR's
+diff touches a configured language — so a PR whose diff is entirely C++/CMake
+or docs silently skipped analysis and the required contexts never reported,
+leaving the PR permanently `mergeStateStatus=BLOCKED` even with an approval
+and all visible checks green (first hit by PR #131). We've committed
+`.github/workflows/codeql.yml` so the matrix runs on every PR and posts both
+required contexts unconditionally. Default Setup must stay disabled in
+`Settings → Code security → Code scanning` — Advanced Setup and Default Setup
+cannot coexist.
+
 ### 2026-05-12 — `gpu` pytest marker + local-only dev script for hardware-bound tests
 
 Some components (Docker-backed vLLM lifecycle, NVENC paths, anything that


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/codeql.yml` so CodeQL runs as Advanced Setup (committed workflow) instead of GitHub's Default Setup.
- Default Setup only runs CodeQL when a PR's diff touches a configured language. Because `Analyze (python)` and `Analyze (javascript-typescript)` are required status checks on `main`, PRs whose diff is entirely outside those languages (e.g. C++/CMake-only, like #131) silently skip analysis and the required contexts never report — leaving the PR permanently `mergeStateStatus=BLOCKED` even with an approval and all other checks green.
- Advanced Setup runs the matrix on every PR (and on push to `main` + weekly), so both required contexts always report.

## Action required before merge

**Disable Default Setup in `Settings -> Code security -> Code scanning -> CodeQL`** (switch from "Default" to "Advanced", or turn it off). The two cannot coexist — Advanced Setup runs will fail with a config error until Default Setup is off.

After this merges, PR #131 (and any future C++/docs-only PR) can land. If anything stalls, re-run the CodeQL workflow on the stuck PR — the contexts will then be posted.

## Test plan

- [ ] Disable CodeQL Default Setup in repo settings.
- [ ] CI on this PR shows `Analyze (python)` and `Analyze (javascript-typescript)` running from `.github/workflows/codeql.yml` (not from `dynamic/github-code-scanning/codeql`).
- [ ] After merge, push an empty/no-op commit to #131's branch and confirm both `Analyze (...)` contexts post and the PR moves to `mergeStateStatus=CLEAN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)