### PR TITLE
fix(xr-media-hub): release held ring slots on participant leave (#143)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,40 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-05-20 — Hub releases held ring-buffer slots on participant leave (#143)
+
+`HubEndpoint` holds the latest SHM ring slot per `(participant_id,
+track_id)` so processors can fetch pixels on demand without an eager
+copy. The slot was only released when the *next* FRAME_SIGNAL for the
+same key arrived — so when a track ended (LiveKit `track_unsubscribed`
+or `participant_disconnected`), its last slot stayed held forever.
+After enough connect/publish/disconnect cycles the ring filled with
+abandoned slots and every subsequent frame from any participant was
+dropped at the connector with `Ring buffer full — dropped frame`.
+A new participant could publish video and the worker would log
+`tracks_seen=0` until the hub was restarted.
+
+**Fix.** The hub now releases every slot keyed by a participant when
+that participant's `PARTICIPANT_EVENT(joined=False)` arrives. The
+`notify_participant_left` path already fires on both `track_unsubscribed`
++ `participant_disconnected` (it is called from `_room_client._handle_left`),
+so no new message type is required. Reuses the established
+"release_slot without `view.data.release()`" pattern from the FRAME_SIGNAL
+branch — the connector's ring is still live at this point, so the
+memoryview does not need an explicit release.
+
+Also bumped `_DEFAULT_NUM_SLOTS` from 10 → 16 so a single ill-timed
+reconnect within the in-flight window between last frame and disconnect
+event can't still hit the ceiling. The slot is 12.4 MiB at the 4K NV12
+ceiling, so six extra slots adds ~75 MiB to the worst-case per-connector
+shm footprint — cheap insurance.
+
+**Out of scope.** Connector crash / OOM still leaks slots — `joined=False`
+is only emitted by the live `notify_participant_left` path, not by an
+unclean exit. A heartbeat or TTL scan would close that gap; deferred
+until there's evidence it matters in practice. The issue's reproduction
+is wholly covered by participant disconnect.
+
 ### 2026-05-18 — `nightly XR AI test` workflow on self-hosted `gpu` runner
 
 The `gpu`-marked pytest suite (`tests/test_gpu_*.py`,

--- a/server-runtime/xr_media_hub/ipc/_connector.py
+++ b/server-runtime/xr_media_hub/ipc/_connector.py
@@ -37,7 +37,7 @@ ReturnAudioCallback      = Callable[[AudioChunk],        Awaitable[None]]
 ReturnDataCallback       = Callable[[DataMessage],       Awaitable[None]]
 ReturnAudioFlushCallback = Callable[[ReturnAudioFlush],  Awaitable[None]]
 
-_DEFAULT_NUM_SLOTS       = 10
+_DEFAULT_NUM_SLOTS       = 16
 _DEFAULT_MAX_FRAME_BYTES = 12_441_600  # 4K NV12
 
 
@@ -81,7 +81,7 @@ class ConnectorEndpoint:
         sub_addr        : Hub's PUB address  — connector subscribes for return traffic.
         connector_id    : Unique ID for this connector. Defaults to a UUID.
         shm_name        : Shared-memory segment name. Defaults to xr_conn_<connector_id>.
-        num_slots       : Ring buffer slot count (default 10).
+        num_slots       : Ring buffer slot count (default 16).
         max_frame_bytes : Max bytes per slot (default 4K NV12 = 12 441 600).
         """
         self._connector_id = connector_id or uuid.uuid4().hex

--- a/server-runtime/xr_media_hub/ipc/_hub.py
+++ b/server-runtime/xr_media_hub/ipc/_hub.py
@@ -102,7 +102,9 @@ class HubEndpoint:
         self._participant_connector: dict[str, str] = {}
         # (participant_id, track_id) → (ring, SlotView) of the latest frame.
         # The slot is held open (not released) until the next frame for the same
-        # track arrives, so pixels can be copied on demand without eager allocation.
+        # track arrives, the participant disconnects, or the hub shuts down — so
+        # pixels can be copied on demand without eager allocation while still
+        # bounding ring occupancy across participant churn.
         self._latest_slots: dict[tuple[str, str], tuple[ShmRingBuffer, SlotView]] = {}
 
         self._frame_cbs:       list[FrameCallback]       = []
@@ -271,6 +273,13 @@ class HubEndpoint:
                 self._participant_connector[msg.participant_id] = msg.connector_id
             else:
                 self._participant_connector.pop(msg.participant_id, None)
+                # Release any slots held for this participant's tracks. Without
+                # this the ring fills up after enough connect/publish/disconnect
+                # cycles and every subsequent frame is dropped (issue #143).
+                stale = [k for k in self._latest_slots if k[0] == msg.participant_id]
+                for k in stale:
+                    ring, view = self._latest_slots.pop(k)
+                    ring.release_slot(view.signal.slot)
             for cb in self._participant_cbs:
                 await cb(msg)
             await self._pub.send_multipart([b"participant", encode(MsgType.PARTICIPANT_EVENT, msg)])

--- a/tests/test_participant_events.py
+++ b/tests/test_participant_events.py
@@ -12,9 +12,13 @@ import asyncio
 
 import pytest
 
-from xr_ai_agent import ParticipantEvent
+from xr_ai_agent import ParticipantEvent, PixelFormat
 
 pytestmark = pytest.mark.asyncio
+
+
+_W, _H = 4, 4  # tiny synthetic frames — content irrelevant for slot-accounting
+_FRAME = b"\x00" * (_W * _H * 3 // 2)  # I420: 1.5 bytes/pixel
 
 
 async def test_connected_participants_auto_maintained(hub, make_connector, make_processor, settle):
@@ -75,3 +79,47 @@ async def test_participant_event_seen_by_every_processor(hub, make_connector, ma
     assert [e.joined for e in events_a] == [True, False]
     assert [e.joined for e in events_b] == [True, False]
     assert all(e.participant_id == "alice" for e in events_a + events_b)
+
+
+async def test_participant_leave_releases_held_slots(hub, make_connector, settle):
+    """Regression for #143: ring slots held by ended tracks must be released
+    on participant disconnect, or the hub eventually drops 100% of frames
+    from fresh participants once the ring fills with abandoned slots."""
+    # make_connector uses num_slots=4; run more than that many connect/publish/
+    # leave cycles so the ring would saturate without the fix.
+    conn = make_connector()
+    await conn.register()
+    await settle()
+
+    cycles = 6  # > num_slots (4)
+    for i in range(cycles):
+        pid = f"churn_{i}"
+        await conn.notify_participant_joined(pid, pts_us=i)
+        await settle()
+        await conn.push_frame(
+            data=_FRAME, width=_W, height=_H, fmt=PixelFormat.I420,
+            pts_us=i, participant_id=pid, track_id=f"track_{i}",
+        )
+        await settle()
+        await conn.notify_participant_left(pid, pts_us=i)
+        await settle()
+
+    # Hub's _latest_slots map must be empty — every held slot was released
+    # when its participant left. Without the fix, this dict would carry
+    # one stale (pid, track_id) per cycle.
+    assert hub._latest_slots == {}
+
+    # And — the user-visible symptom — a brand-new participant can still
+    # publish frames. Pre-fix, push_frame on the connector raises
+    # RuntimeError("ShmRingBuffer: all slots occupied") after enough cycles.
+    await conn.notify_participant_joined("fresh", pts_us=99)
+    await settle()
+    for seq in range(3):
+        await conn.push_frame(
+            data=_FRAME, width=_W, height=_H, fmt=PixelFormat.I420,
+            pts_us=100 + seq, participant_id="fresh", track_id="cam",
+        )
+        await settle()
+
+    # The most recent frame for ("fresh", "cam") should be the one held.
+    assert ("fresh", "cam") in hub._latest_slots


### PR DESCRIPTION
## Summary

Fixes #143 — the hub-side ring-buffer slot leak that drops 100% of frames from new participants after enough tracks have ended.

`HubEndpoint` holds the latest SHM ring slot per `(participant_id, track_id)` so processors can fetch pixels on demand without an eager copy. The slot was only released when the *next* `FRAME_SIGNAL` for the same key arrived — when a track ended, its slot was never released. After ~`_DEFAULT_NUM_SLOTS` connect/publish/disconnect cycles, the connector's ring filled and every subsequent frame was dropped with `Ring buffer full — dropped frame`.

## Fix

- **`server-runtime/xr_media_hub/ipc/_hub.py`** — On `PARTICIPANT_EVENT(joined=False)`, release every slot keyed by that participant_id. `notify_participant_left` already fires on both LiveKit `track_unsubscribed` and `participant_disconnected` (called from `_room_client._handle_left`), so this single hook covers the issue's repro without adding a new message type. Reuses the established "release_slot without `view.data.release()`" pattern from the `FRAME_SIGNAL` branch — the connector's ring is still live, so no explicit memoryview release is needed.
- **`server-runtime/xr_media_hub/ipc/_connector.py`** — Bump `_DEFAULT_NUM_SLOTS` 10 → 16 as defence-in-depth against the brief window between last frame and disconnect event. Adds ~75 MiB to worst-case 4K-NV12 shm footprint per connector.
- **`tests/test_participant_events.py`** — New `test_participant_leave_releases_held_slots` runs 6 cycles of join → push_frame → leave against the standard `num_slots=4` connector fixture (>num_slots so the leak would saturate without the fix), then asserts `hub._latest_slots == {}` and that a fresh participant can publish frames after the churn.
- **`docs/changelog.md`** — Decision entry documenting the fix and the explicit out-of-scope item (connector crash/OOM still leaks; no `joined=False` is emitted on unclean exit).

## Out of scope

A connector that crashes (OOM, SIGKILL) never emits `notify_participant_left`, so its slots still leak. A heartbeat or TTL scan would close that gap but is deferred until there's evidence it matters in practice. The issue's reproduction is fully covered by participant disconnect.

No `MsgType.TRACK_END` (Option A's first variant) was added — the same-pid track-end-without-disconnect case isn't in the repro and adding a new message type for a hypothetical would be scope creep.

## Test plan

- [ ] `tests` workflow passes (CI runs `pytest` from `tests/` on `ubuntu-latest`; the new test is laptop-friendly IPC and doesn't need GPU/Docker/NVENC)
- [ ] Manual: reproduce the issue's steps against `agent-samples/simple-vlm-example` — connect/publish/disconnect 16+ times, then a fresh participant joins and asks a vision question; verify frames flow and the VLM answers (instead of `"camera unavailable, please try again"`)
- [ ] Confirm `hub.log` no longer shows runaway `Ring buffer full` counts attributed to a single fresh participant

Note: this PR was prepared in an environment without `uv` / Python 3.11+, so the new pytest case has not been executed locally. The patch is small (one branch in `_dispatch`, a constant, and a focused regression test); CI is the authoritative signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)