### PR TITLE
feat(mcp-servers): XR_RUN_DIR-based defaults for transcripts + frame queries

### DIFF
--- a/agent-mcp-servers/transcript-mcp/transcript_mcp_server/__main__.py
+++ b/agent-mcp-servers/transcript-mcp/transcript_mcp_server/__main__.py
@@ -54,7 +54,9 @@ Config (transcript_mcp_server.yaml)
 from __future__ import annotations
 
 import argparse
+import asyncio
 import json
+import os
 import pathlib
 
 import uvicorn
@@ -304,19 +306,26 @@ def run() -> None:
 
     setup_logging("transcript-mcp")
 
-    transcripts_dir = cfg.get("transcripts_dir", "/tmp/xr_transcripts")
+    _run_dir = os.environ.get("XR_RUN_DIR")
+    _default_transcripts = (
+        str(pathlib.Path(_run_dir) / "transcripts") if _run_dir else "/tmp/xr_transcripts"
+    )
+    transcripts_dir = cfg.get("transcripts_dir") or _default_transcripts
     host            = cfg.get("host", "0.0.0.0")
     port            = int(cfg.get("port", 8200))
 
     store = TranscriptStore(transcripts_dir)
     app   = build_app(store)
 
-    if ns.ready_file:
-        ready_path = ns.ready_file
-        app.add_event_handler("startup", lambda: ready_path.touch())
+    async def _serve() -> None:
+        config = uvicorn.Config(app, host=host, port=port, log_level="warning")
+        server = uvicorn.Server(config)
+        logger.info("transcript-mcp-server  mcp=/mcp  port={}  dir={}", port, transcripts_dir)
+        if ns.ready_file:
+            ns.ready_file.touch()
+        await server.serve()
 
-    logger.info("transcript-mcp-server  mcp=/mcp  port={}  dir={}", port, transcripts_dir)
-    uvicorn.run(app, host=host, port=port, log_level="warning")
+    asyncio.run(_serve())
 
 
 if __name__ == "__main__":

--- a/agent-mcp-servers/video-mcp/video_mcp_server/__main__.py
+++ b/agent-mcp-servers/video-mcp/video_mcp_server/__main__.py
@@ -64,6 +64,7 @@ import argparse
 import asyncio
 import ctypes
 import json
+import os
 import pathlib
 import time
 
@@ -647,7 +648,9 @@ def build_app(
 
 async def _serve(cfg: dict, ready_file: pathlib.Path | None = None) -> None:
     recordings_dir_raw = cfg.get("recordings_dir", "")
-    out_dir            = pathlib.Path(cfg.get("out_dir", "/tmp/xr_video_queries"))
+    _run_dir = os.environ.get("XR_RUN_DIR")
+    _default_out = str(pathlib.Path(_run_dir) / "frames") if _run_dir else "/tmp/xr_video_queries"
+    out_dir    = pathlib.Path(cfg.get("out_dir") or _default_out)
     hub_pub            = cfg.get("hub_pub",  _DEFAULT_HUB_PUB)
     hub_push           = cfg.get("hub_push", _DEFAULT_HUB_PUSH)
     host               = cfg.get("host", "0.0.0.0")


### PR DESCRIPTION
Both `transcript-mcp` and `video-mcp` defaulted to fixed `/tmp/...` paths
for their on-disk state (`transcripts_dir`, `out_dir`). Multi-sample dev
on one box collides on those paths and orchestrators that already create
a per-run directory (`XR_RUN_DIR`) have no way to point the MCP servers
into it without overriding config files.

Both servers now consult `XR_RUN_DIR` first:

- `transcript-mcp`: defaults to `$XR_RUN_DIR/transcripts` when set,
  otherwise `/tmp/xr_transcripts`. Explicit `transcripts_dir:` in config
  still wins.
- `video-mcp`: defaults `out_dir` to `$XR_RUN_DIR/frames` when set,
  otherwise `/tmp/xr_video_queries`. Explicit `out_dir:` in config still
  wins. (`recordings_dir` is sample-specific, unchanged.)

`transcript-mcp`'s `run()` is also refactored from a sync
`uvicorn.run(...)` with a startup-event ready-file callback to an
explicit `asyncio.run(_serve())`, matching the pattern in `video-mcp`
and the other async MCP servers — the ready-file touch now happens
right before `server.serve()` rather than via a side-effect callback.

Behavior preserved when `XR_RUN_DIR` is unset.
