### PR TITLE
fix(xr-ai-vllm): docker rm after stop so config changes apply on restart

### DIFF
--- a/utils/xr-ai-vllm/xr_ai_vllm/__init__.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/__init__.py
@@ -177,7 +177,19 @@ def stop_persistent_servers(
         if container_name:
             print(f"  [{label}] stopping container {container_name}…", flush=True)
             if _docker.stop_container(container_name):
-                print(f"  [{label}] stopped", flush=True)
+                # Remove the container so a restart picks up any config changes.
+                # Without removal, `docker start` reuses the old container with
+                # its baked-in argv (including stale --limit-mm-per-prompt etc).
+                try:
+                    import subprocess as _sp
+                    _sp.run(["docker", "rm", container_name],
+                            check=True,
+                            stdout=_sp.DEVNULL, stderr=_sp.DEVNULL)
+                    print(f"  [{label}] stopped and removed", flush=True)
+                except Exception:
+                    print(f"  [{label}] stopped (rm failed — "
+                          f"run `docker rm {container_name}` to apply config changes)",
+                          flush=True)
             else:
                 print(f"  [{label}] docker stop failed — check `docker ps -a`",
                       flush=True)

--- a/utils/xr-ai-vllm/xr_ai_vllm/__init__.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/__init__.py
@@ -177,16 +177,21 @@ def stop_persistent_servers(
         if container_name:
             print(f"  [{label}] stopping container {container_name}…", flush=True)
             if _docker.stop_container(container_name):
-                # Remove the container so a restart picks up any config changes.
-                # Without removal, `docker start` reuses the old container with
-                # its baked-in argv (including stale --limit-mm-per-prompt etc).
-                try:
-                    import subprocess as _sp
-                    _sp.run(["docker", "rm", container_name],
-                            check=True,
-                            stdout=_sp.DEVNULL, stderr=_sp.DEVNULL)
+                # Remove the container so the next launch goes through a full
+                # `docker run` and picks up YAML config changes (without removal,
+                # `docker start` reuses the old container with its baked-in
+                # argv — stale --limit-mm-per-prompt, extra_pip, etc.).
+                #
+                # Tradeoff acknowledged: `_docker.run`'s start-on-existing path
+                # skipped `pip install` (hf_transfer, plus any extra_pip like
+                # mamba-ssm / causal-conv1d for Nemotron-Omni). Forcing rm means
+                # those reinstall on every restart — a few-second extra cost on
+                # warm cache, in exchange for config edits actually applying.
+                # Acceptable: persistent-servers exists to skip MODEL reloads,
+                # not pip reinstalls.
+                if _docker.remove_container(container_name):
                     print(f"  [{label}] stopped and removed", flush=True)
-                except Exception:
+                else:
                     print(f"  [{label}] stopped (rm failed — "
                           f"run `docker rm {container_name}` to apply config changes)",
                           flush=True)

--- a/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
@@ -149,6 +149,28 @@ def container_running(name: str) -> bool:
         return False
 
 
+def remove_container(name: str) -> bool:
+    """``docker rm`` *name* if it exists; return True if the container was removed.
+
+    Called by ``stop_persistent_servers`` after ``stop_container`` so the next
+    launch goes through a full ``docker run`` and picks up any YAML config
+    changes (``--limit-mm-per-prompt``, ``extra_pip``, etc.). A missing
+    docker binary or a stale-but-already-gone container is non-fatal.
+    """
+    if not container_exists(name):
+        return False
+    try:
+        subprocess.run(
+            ["docker", "rm", name],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+        return True
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return False
+
+
 def stop_container(name: str, timeout_s: int = 20) -> bool:
     """Stop container *name* if it exists; return True if a container was stopped."""
     if not container_exists(name):


### PR DESCRIPTION
`stop_persistent_servers` previously ran `docker stop <name>` and left
the container around so the next `start_xr_ai_vllm` could `docker start`
it back. That kept the container's baked-in argv — including stale
`--limit-mm-per-prompt`, `--max-images-per-prompt`, etc. — so YAML
config edits silently failed to take effect until the operator
manually removed the container.

Now: after a successful `docker stop`, run `docker rm` so the next
launch goes through the full `build_run_argv` → `docker run` path with
the latest YAML. Failure to remove is non-fatal (some hosts forbid
`docker rm` even when stop succeeds) — log the manual `docker rm`
command and continue.

User-visible change: the message changes from "stopped" to "stopped and
removed" on the happy path.
