### PR TITLE
chore(model-servers): set max_images_per_prompt: 4 on all GPU profiles

### DIFF
--- a/agent-samples/model-servers/yaml/96G_blackwell/vlm_server.yaml
+++ b/agent-samples/model-servers/yaml/96G_blackwell/vlm_server.yaml
@@ -16,6 +16,8 @@ gpu_memory_utilization: 0.20
 max_num_seqs: 4
 enforce_eager: true
 max_videos_per_prompt: 0
+# 4 fits within the default max_model_len=8192 (each Qwen2.5-VL image is
+# ~1.5k tokens). Raise both together if multi-image turns get larger.
 max_images_per_prompt: 4
 
 # vLLM runtime: pip (this wrapper's venv) or docker (NGC nvcr.io/nvidia/vllm).

--- a/agent-samples/model-servers/yaml/96G_blackwell/vlm_server.yaml
+++ b/agent-samples/model-servers/yaml/96G_blackwell/vlm_server.yaml
@@ -16,6 +16,7 @@ gpu_memory_utilization: 0.20
 max_num_seqs: 4
 enforce_eager: true
 max_videos_per_prompt: 0
+max_images_per_prompt: 4
 
 # vLLM runtime: pip (this wrapper's venv) or docker (NGC nvcr.io/nvidia/vllm).
 # See ai-services/vlm-server/vlm_server.yaml for the full toggle docs.

--- a/agent-samples/model-servers/yaml/dual_48G_ada/vlm_server.yaml
+++ b/agent-samples/model-servers/yaml/dual_48G_ada/vlm_server.yaml
@@ -28,6 +28,7 @@ model_cache: ../../../../models
 gpu_memory_utilization: 0.43
 enforce_eager: true
 max_videos_per_prompt: 0
+max_images_per_prompt: 4
 
 # vLLM runtime: pip (this wrapper's venv) or docker (NGC nvcr.io/nvidia/vllm).
 # See ai-services/vlm-server/vlm_server.yaml for the full toggle docs.

--- a/agent-samples/model-servers/yaml/dual_48G_ada/vlm_server.yaml
+++ b/agent-samples/model-servers/yaml/dual_48G_ada/vlm_server.yaml
@@ -28,6 +28,8 @@ model_cache: ../../../../models
 gpu_memory_utilization: 0.43
 enforce_eager: true
 max_videos_per_prompt: 0
+# 4 fits within the default max_model_len=8192 (each Qwen2.5-VL image is
+# ~1.5k tokens). Raise both together if multi-image turns get larger.
 max_images_per_prompt: 4
 
 # vLLM runtime: pip (this wrapper's venv) or docker (NGC nvcr.io/nvidia/vllm).

--- a/agent-samples/model-servers/yaml/spark/vlm_server.yaml
+++ b/agent-samples/model-servers/yaml/spark/vlm_server.yaml
@@ -16,6 +16,8 @@ gpu_memory_utilization: 0.20
 max_num_seqs: 4
 enforce_eager: true
 max_videos_per_prompt: 0
+# 4 fits within the default max_model_len=8192 (each Qwen2.5-VL image is
+# ~1.5k tokens). Raise both together if multi-image turns get larger.
 max_images_per_prompt: 4
 
 # vLLM runtime: pip (this wrapper's venv) or docker (NGC nvcr.io/nvidia/vllm).

--- a/agent-samples/model-servers/yaml/spark/vlm_server.yaml
+++ b/agent-samples/model-servers/yaml/spark/vlm_server.yaml
@@ -16,6 +16,7 @@ gpu_memory_utilization: 0.20
 max_num_seqs: 4
 enforce_eager: true
 max_videos_per_prompt: 0
+max_images_per_prompt: 4
 
 # vLLM runtime: pip (this wrapper's venv) or docker (NGC nvcr.io/nvidia/vllm).
 # See ai-services/vlm-server/vlm_server.yaml for the full toggle docs.

--- a/ai-services/vlm-server/vlm_server.yaml
+++ b/ai-services/vlm-server/vlm_server.yaml
@@ -25,8 +25,15 @@ max_model_len:          8192
 gpu_memory_utilization: 0.85
 enforce_eager:          false
 
-# Max images accepted per request. Increase if multi-image queries are needed.
-max_images_per_prompt:  1
+# Max images accepted per request.
+#
+# Budget note: each Qwen2.5-VL image consumes ~1.5k tokens of context at the
+# default preprocessor settings (smart_resize, max 1280×28 patches), so 4
+# images fit comfortably inside max_model_len=8192 alongside a typical
+# system+user prompt. If you raise this above ~5, also raise max_model_len
+# or tighten the image-preprocessor patch limit, otherwise long multi-image
+# turns will be truncated by vLLM at request time.
+max_images_per_prompt:  4
 
 # Max video items accepted per request. Default 0 (disabled).
 # Qwen2.5-VL-class models reserve activation memory at startup for the maximum


### PR DESCRIPTION
vLLM's `--limit-mm-per-prompt` defaults to 1 image per chat completion
request. Multi-image agent tools (e.g. comparing two frames in one VLM
call, image-grid scene reasoning) silently fail with the second image
ignored.

Bumped `max_images_per_prompt` to 4 in all three model-server GPU profiles
(`96G_blackwell`, `dual_48G_ada`, `spark`). 4 is the working ceiling at the
profile-default VRAM budgets without re-tuning `gpu_memory_utilization`.

Requires a model-server restart to take effect. With xr-ai-vllm's
`docker rm` on stop (separate change), `model_servers --stop` followed by
a fresh `model_servers` start is enough; no manual container cleanup
needed.
