### PR TITLE
feat(web): camera preview + agent response display in the web sample

### DIFF
--- a/client-samples/web/App/app.js
+++ b/client-samples/web/App/app.js
@@ -33,7 +33,23 @@ import {
 // Model state  (mirrors AppModel.swift field-for-field)
 // ─────────────────────────────────────────────────────────────────────────────
 
-const model = { ...createBaseModel() };
+const model = {
+  ...createBaseModel(),
+  /** @type {string|null} Most recent agent.response message text. */
+  agentResponse: null,
+};
+
+// Local camera preview stream (separate from the LiveKit publish stream).
+let _previewStream = null;
+
+function releasePreviewStream() {
+  if (!_previewStream) return;
+  _previewStream.getTracks().forEach(t => t.stop());
+  _previewStream = null;
+  const videoEl = $('camera-preview');
+  videoEl.srcObject = null;
+  videoEl.style.transform = '';
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Error toast
@@ -57,18 +73,91 @@ function showError(message) {
 // Render + bound actions
 // ─────────────────────────────────────────────────────────────────────────────
 
-function render()           { renderBase(model); }
+function render() {
+  renderBase(model);
+
+  // Camera preview elements.
+  const video       = $('camera-preview');
+  const placeholder = $('preview-placeholder');
+  const liveBadge   = $('preview-live-badge');
+  if (model.isCameraActive) {
+    video.classList.add('active');
+    placeholder.style.display = 'none';
+    liveBadge.classList.add('active');
+  } else {
+    video.classList.remove('active');
+    placeholder.style.display = '';
+    liveBadge.classList.remove('active');
+  }
+
+  // Agent response.
+  const responseEl = $('agent-response-text');
+  if (model.agentResponse) {
+    responseEl.textContent = model.agentResponse;
+    responseEl.classList.remove('empty');
+  } else {
+    responseEl.textContent = 'Waiting for agent…';
+    responseEl.classList.add('empty');
+  }
+}
 
 function enumerateCameras() { return _enumerateCameras(model, render); }
-function stopCamera()       { return _stopCamera(model, render, showError); }
-function startCamera()      { return _startCamera(model, { render, showError, enumerateCameras }); }
+
+async function stopCamera() {
+  try {
+    await _stopCamera(model, render, showError);
+  } finally {
+    releasePreviewStream();
+  }
+}
+
+async function startCamera() {
+  await _startCamera(model, { render, showError, enumerateCameras });
+  if (model.isCameraActive) {
+    try {
+      releasePreviewStream();
+      const constraints = model.selectedCameraId
+        ? { video: { deviceId: { exact: model.selectedCameraId } } }
+        : { video: true };
+      _previewStream = await navigator.mediaDevices.getUserMedia(constraints);
+      const videoEl = $('camera-preview');
+      videoEl.srcObject = _previewStream;
+
+      // Mirror the preview only for front-facing cameras — back cameras should
+      // show the same orientation the server receives (no transform).
+      const track = _previewStream.getVideoTracks()[0];
+      const facingMode = track?.getSettings?.()?.facingMode ?? '';
+      videoEl.style.transform = facingMode === 'user' ? 'scaleX(-1)' : '';
+    } catch { /* preview failure is non-fatal */ }
+  }
+  render();
+}
+
 function startAudio()       { return _startAudio(model, render, showError); }
 function stopAudio()        { return _stopAudio(model, render, showError); }
-function disconnect()       { return _disconnect(model, render); }
+async function disconnect() {
+  releasePreviewStream();
+  try {
+    await _disconnect(model, render);
+  } finally {
+    releasePreviewStream();
+    render();
+  }
+}
 function sendPing()         { return _sendPing(model, startCamera); }
 function sendCustom(text)   { return _sendCustom(model, text, showError); }
 function connect()          {
-  return _connect(model, { render, showError, enumerateCameras, stopCamera });
+  return _connect(model, {
+    render, showError, enumerateCameras, stopCamera,
+    onDataReceived(topic, data) {
+      if (topic === 'agent.response') {
+        model.agentResponse = new TextDecoder().decode(data);
+        render();
+        return true; // suppress from the received messages list
+      }
+      return false;
+    },
+  });
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -76,4 +165,9 @@ function connect()          {
 // ─────────────────────────────────────────────────────────────────────────────
 
 wireBaseEvents(model, { connect, disconnect, startAudio, stopAudio, startCamera, stopCamera, sendPing, sendCustom });
+window.addEventListener('pagehide', () => {
+  releasePreviewStream();
+  const pendingDisconnect = model.session?.disconnect();
+  if (pendingDisconnect) pendingDisconnect.catch(() => {});
+});
 render();

--- a/client-samples/web/App/app.js
+++ b/client-samples/web/App/app.js
@@ -116,23 +116,26 @@ async function startCamera() {
   if (model.isCameraActive) {
     try {
       releasePreviewStream();
-      // Match LiveKit's default selection (facingMode: 'user') when no specific
-      // deviceId is chosen, so the preview and the published track land on the
-      // same physical camera. The cleaner fix — cloning the LiveKit publish
-      // track instead of opening a second getUserMedia — requires StreamKit
-      // accessors and lands in PR #153.
+      // No facingMode default — let the browser pick the same camera LiveKit
+      // picks (both calls use `{video: true}` when no deviceId is selected,
+      // so they converge on the system default). When the user has explicitly
+      // chosen a camera in the dropdown, both pin to that deviceId.
       const constraints = model.selectedCameraId
         ? { video: { deviceId: { exact: model.selectedCameraId } } }
-        : { video: { facingMode: 'user' } };
+        : { video: true };
       _previewStream = await navigator.mediaDevices.getUserMedia(constraints);
       const videoEl = $('camera-preview');
       videoEl.srcObject = _previewStream;
 
-      // Mirror by default (desktop/laptop webcams report no facingMode but are
-      // selfie cameras). Only the explicit back-camera case skips the flip.
+      // Default: do NOT mirror — XR / glasses / mobile-back-camera capture
+      // should preserve real-world orientation (left = left, right = right).
+      // Only flip when the camera is explicitly user-facing (front mobile cam,
+      // `facingMode === 'user'`). Desktop selfie webcams typically report no
+      // facingMode and stay unmirrored; users who want the FaceTime-style
+      // mirror UX on a desktop webcam can add a manual toggle later.
       const track = _previewStream.getVideoTracks()[0];
       const facingMode = track?.getSettings?.()?.facingMode ?? '';
-      videoEl.style.transform = facingMode === 'environment' ? '' : 'scaleX(-1)';
+      videoEl.style.transform = facingMode === 'user' ? 'scaleX(-1)' : '';
     } catch { /* preview failure is non-fatal */ }
   }
   render();

--- a/client-samples/web/App/app.js
+++ b/client-samples/web/App/app.js
@@ -116,18 +116,23 @@ async function startCamera() {
   if (model.isCameraActive) {
     try {
       releasePreviewStream();
+      // Match LiveKit's default selection (facingMode: 'user') when no specific
+      // deviceId is chosen, so the preview and the published track land on the
+      // same physical camera. The cleaner fix — cloning the LiveKit publish
+      // track instead of opening a second getUserMedia — requires StreamKit
+      // accessors and lands in PR #153.
       const constraints = model.selectedCameraId
         ? { video: { deviceId: { exact: model.selectedCameraId } } }
-        : { video: true };
+        : { video: { facingMode: 'user' } };
       _previewStream = await navigator.mediaDevices.getUserMedia(constraints);
       const videoEl = $('camera-preview');
       videoEl.srcObject = _previewStream;
 
-      // Mirror the preview only for front-facing cameras — back cameras should
-      // show the same orientation the server receives (no transform).
+      // Mirror by default (desktop/laptop webcams report no facingMode but are
+      // selfie cameras). Only the explicit back-camera case skips the flip.
       const track = _previewStream.getVideoTracks()[0];
       const facingMode = track?.getSettings?.()?.facingMode ?? '';
-      videoEl.style.transform = facingMode === 'user' ? 'scaleX(-1)' : '';
+      videoEl.style.transform = facingMode === 'environment' ? '' : 'scaleX(-1)';
     } catch { /* preview failure is non-fatal */ }
   }
   render();

--- a/client-samples/web/App/core.js
+++ b/client-samples/web/App/core.js
@@ -263,22 +263,24 @@ export function renderBase(model) {
     selectRow.style.display = 'none';
   }
 
-  // ── Agent status ───────────────────────────────────────────────────────────
+  // ── Agent status (optional — some clients replace this with their own UI) ──
   const agentDot   = $('agent-status-dot');
   const agentLabel = $('agent-status-label');
 
-  if (!isConnected) {
-    agentDot.className     = 'state-dot disconnected';
-    agentLabel.textContent = '—';
-  } else if (model.agentStatus === 'processing') {
-    agentDot.className     = 'state-dot connecting';
-    agentLabel.textContent = 'Processing…';
-  } else if (model.agentStatus === 'idle') {
-    agentDot.className     = 'state-dot connected';
-    agentLabel.textContent = 'Idle';
-  } else {
-    agentDot.className     = 'state-dot disconnected';
-    agentLabel.textContent = 'Unknown';
+  if (agentDot && agentLabel) {
+    if (!isConnected) {
+      agentDot.className     = 'state-dot disconnected';
+      agentLabel.textContent = '—';
+    } else if (model.agentStatus === 'processing') {
+      agentDot.className     = 'state-dot connecting';
+      agentLabel.textContent = 'Processing…';
+    } else if (model.agentStatus === 'idle') {
+      agentDot.className     = 'state-dot connected';
+      agentLabel.textContent = 'Idle';
+    } else {
+      agentDot.className     = 'state-dot disconnected';
+      agentLabel.textContent = 'Unknown';
+    }
   }
 
   // ── Data channel ───────────────────────────────────────────────────────────
@@ -350,12 +352,14 @@ export async function connect(model, {
   }
 
   newSession.onConnectionStateChanged = (state) => {
+    const wasCameraActive = model.isCameraActive;
     model.connectionState = state;
     if (state === ConnectionState.CONNECTED) {
       // Enumerate cameras on connect so the selector is populated before the
       // user starts the camera for the first time.
       _ec?.();
     } else if (state === ConnectionState.DISCONNECTED) {
+      if (wasCameraActive) _sc?.();
       model.isAudioActive  = false;
       model.isCameraActive = false;
       model.agentStatus    = null;

--- a/client-samples/web/index.html
+++ b/client-samples/web/index.html
@@ -417,7 +417,7 @@
     <section class="section">
       <h2 class="section-header">Agent</h2>
       <div class="agent-response-card">
-        <p id="agent-response-text" class="empty">Waiting for agent…</p>
+        <p id="agent-response-text" class="empty" role="status" aria-live="polite" aria-atomic="true">Waiting for agent…</p>
       </div>
     </section>
 

--- a/client-samples/web/index.html
+++ b/client-samples/web/index.html
@@ -309,6 +309,88 @@
       opacity: 1;
     }
 
+    /* ── Camera preview ──────────────────────────────────────────────── */
+    .preview-card {
+      background: #000;
+      border-radius: var(--radius);
+      overflow: hidden;
+      aspect-ratio: 16 / 9;
+      margin-bottom: 32px;
+      box-shadow: 0 1px 0 var(--separator);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      position: relative;
+    }
+
+    #camera-preview {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: none;
+      /* Mirroring applied dynamically in app.js based on facingMode */
+    }
+
+    #camera-preview.active { display: block; }
+
+    .preview-placeholder {
+      color: rgba(255, 255, 255, 0.3);
+      font-size: 14px;
+      pointer-events: none;
+    }
+
+    .preview-live-badge {
+      display: none;
+      position: absolute;
+      top: 10px;
+      left: 12px;
+      background: rgba(0, 0, 0, 0.55);
+      backdrop-filter: blur(6px);
+      -webkit-backdrop-filter: blur(6px);
+      border-radius: 6px;
+      padding: 3px 8px;
+      gap: 5px;
+      align-items: center;
+      font-size: 12px;
+      font-weight: 600;
+      color: #fff;
+    }
+
+    .preview-live-badge.active { display: flex; }
+
+    .preview-live-dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--red);
+      animation: pulse 1.2s ease-in-out infinite;
+    }
+
+    /* ── Agent response display ───────────────────────────────────────── */
+    .agent-response-card {
+      background: var(--card);
+      border-radius: var(--radius);
+      overflow: hidden;
+      box-shadow: 0 1px 0 var(--separator);
+      margin-bottom: 32px;
+      min-height: 72px;
+      display: flex;
+      align-items: center;
+      padding: 16px;
+    }
+
+    #agent-response-text {
+      font-size: 17px;
+      line-height: 1.5;
+      color: var(--label);
+    }
+
+    #agent-response-text.empty {
+      color: var(--secondary);
+      font-style: italic;
+      font-size: 15px;
+    }
+
     /* ── Responsive max-width ─────────────────────────────────────────── */
     .page-content {
       max-width: 540px;
@@ -320,6 +402,24 @@
 <body>
   <div class="page-content">
     <h1 class="page-title">NVIDIA XR-AI Sample</h1>
+
+    <!-- ── Camera preview ────────────────────────────────────────────────── -->
+    <div class="preview-card">
+      <span class="preview-placeholder" id="preview-placeholder">Camera off</span>
+      <video id="camera-preview" autoplay playsinline muted></video>
+      <div class="preview-live-badge" id="preview-live-badge">
+        <span class="preview-live-dot"></span>
+        <span>LIVE</span>
+      </div>
+    </div>
+
+    <!-- ── Agent response ─────────────────────────────────────────────────── -->
+    <section class="section">
+      <h2 class="section-header">Agent</h2>
+      <div class="agent-response-card">
+        <p id="agent-response-text" class="empty">Waiting for agent…</p>
+      </div>
+    </section>
 
     <!-- ── Connection section ─────────────────────────────────────────── -->
     <section class="section">
@@ -461,20 +561,6 @@
           <span id="camera-status" class="status-text status-idle">Not connected</span>
         </div>
 
-      </div>
-    </section>
-
-    <!-- ── Agent section ────────────────────────────────────────────────── -->
-    <section class="section">
-      <h2 class="section-header">Agent</h2>
-      <div class="card">
-        <div class="labeled-row">
-          <span class="row-label">Status</span>
-          <div class="state-badge">
-            <span id="agent-status-dot" class="state-dot disconnected"></span>
-            <span id="agent-status-label">—</span>
-          </div>
-        </div>
       </div>
     </section>
 


### PR DESCRIPTION
Two user-facing additions to the web sample's main page, useful for
debugging any voice+vision agent (today's `simple-vlm-example`,
tomorrow's `glasses-agent-nat`):

1. **Live camera preview card** — 16:9 black panel at the top of the
   page that mirrors the user's selected camera while the LiveKit
   track is publishing. Uses its own `navigator.mediaDevices.getUserMedia`
   stream so the preview keeps working even if the publish track
   restarts. Front-cameras (`facingMode: "user"`) are mirrored
   horizontally to match user expectation; back-cameras keep the
   sensor orientation the server sees. A "LIVE" badge floats over
   the top-left while active.

2. **Agent response card** — text panel below the preview that
   displays whatever was last sent on the `agent.response` data-channel
   topic. Wired via a new `onDataReceived(topic, data) -> boolean`
   hook in `App/core.js`'s `connect()` flow; returning `true`
   suppresses the message from the generic received-messages list.

Cleanup paths: `releasePreviewStream()` stops the local tracks on
camera stop, disconnect, or page unload (`pagehide`).

Removed the old small "Agent status dot" card from `index.html` since
the response panel covers the same intent more usefully. `core.js`
now guards the agent-status DOM lookup with `if (agentDot && agentLabel)`
so clients that don't render the status card (this one, and others) no
longer crash on render.

Also: `core.js::ConnectionState.DISCONNECTED` handler now invokes
`_sc?.()` (stop-camera callback) when the camera was active at
disconnect time — without this, the local camera track stays live
across reconnects.
