### PR TITLE
fix(web): exception-safe teardown in LiveKitBackend; skip unpublish when disconnected

### DIFF
--- a/client-samples/web/StreamKit/Backends/LiveKit/LiveKitBackend.js
+++ b/client-samples/web/StreamKit/Backends/LiveKit/LiveKitBackend.js
@@ -304,13 +304,17 @@ export class LiveKitBackend {
    * @returns {Promise<void>}
    */
   async stopCamera() {
-    if (!this.#videoTrack) return;
-
-    if (this.#room) {
-      await this.#room.localParticipant.unpublishTrack(this.#videoTrack);
-    }
-    this.#videoTrack.stop();
+    const track = this.#videoTrack;
+    if (!track) return;
     this.#videoTrack = null;
+
+    try {
+      if (this.#room && this.#room.state === 'connected') {
+        await this.#room.localParticipant.unpublishTrack(track);
+      }
+    } finally {
+      track.stop();
+    }
   }
 
   /**
@@ -362,27 +366,30 @@ export class LiveKitBackend {
    * @returns {Promise<void>}
    */
   async #tearDown() {
-    if (this.#room) {
-      // Remove all listeners before disconnecting to prevent stale callbacks.
-      this.#room.removeAllListeners();
-      await this.#room.disconnect();
-      this.#room = null;
+    const room = this.#room;
+    this.#room = null;
+    try {
+      if (room) {
+        // Remove all listeners before disconnecting to prevent stale callbacks.
+        room.removeAllListeners();
+        await room.disconnect();
+      }
+    } finally {
+      for (const el of this.#audioElements.values()) el.remove();
+      this.#audioElements.clear();
+
+      if (this.#videoTrack) {
+        this.#videoTrack.stop();
+        this.#videoTrack = null;
+      }
+
+      if (this.#audioTrack) {
+        this.#audioTrack.stop();
+        this.#audioTrack = null;
+      }
+
+      this.#sessionConfig = null;
     }
-
-    for (const el of this.#audioElements.values()) el.remove();
-    this.#audioElements.clear();
-
-    if (this.#videoTrack) {
-      this.#videoTrack.stop();
-      this.#videoTrack = null;
-    }
-
-    if (this.#audioTrack) {
-      this.#audioTrack.stop();
-      this.#audioTrack = null;
-    }
-
-    this.#sessionConfig = null;
   }
 
   /**

--- a/client-samples/web/StreamKit/Backends/LiveKit/LiveKitBackend.js
+++ b/client-samples/web/StreamKit/Backends/LiveKit/LiveKitBackend.js
@@ -242,12 +242,17 @@ export class LiveKitBackend {
    * @returns {Promise<void>}
    */
   async stopAudio() {
-    if (!this.#audioTrack) return;
-    if (this.#room) {
-      await this.#room.localParticipant.unpublishTrack(this.#audioTrack);
-    }
-    this.#audioTrack.stop();
+    const track = this.#audioTrack;
+    if (!track) return;
     this.#audioTrack = null;
+
+    try {
+      if (this.#room && this.#room.state === 'connected') {
+        await this.#room.localParticipant.unpublishTrack(track);
+      }
+    } finally {
+      track.stop();
+    }
   }
 
   /**
@@ -374,6 +379,8 @@ export class LiveKitBackend {
         room.removeAllListeners();
         await room.disconnect();
       }
+    } catch (err) {
+      console.warn('LiveKitBackend: room.disconnect() failed', err);
     } finally {
       for (const el of this.#audioElements.values()) el.remove();
       this.#audioElements.clear();


### PR DESCRIPTION
Two robustness fixes in `client-samples/web/StreamKit/Backends/LiveKit/LiveKitBackend.js`:

1. **`stopCamera`** no longer calls `room.localParticipant.unpublishTrack`
   when the room isn't connected (`room.state !== 'connected'`). LiveKit's
   client SDK throws if you try, leaking a hot camera track because the
   surrounding code never reached `track.stop()`. Now: clear the field
   first, then conditionally unpublish in a try/finally so `track.stop()`
   always runs.

2. **`#tearDown`** previously ran `room.disconnect()` first, then cleaned
   up audio elements + tracks. A thrown promise from `disconnect()` left
   audio `<audio>` nodes attached to the DOM and the camera/mic tracks
   live. Restructured to clear `this.#room` up front and wrap the
   destructive ops in try/finally so the audio elements, video track,
   audio track, and `sessionConfig` are always released — even if the
   network disconnect raises.

No behaviour change on the happy path.
