### PR TITLE
fix(xr-ai-vad): fix VAD end-of-speech detection and short-command registration

### DIFF
--- a/agent-samples/simple-vlm-example/worker/simple_vlm_example_worker.py
+++ b/agent-samples/simple-vlm-example/worker/simple_vlm_example_worker.py
@@ -29,7 +29,7 @@ Config (simple_vlm_example_worker.yaml — auto-passed by the launcher)
     camera_grace_s:            5.0   # keep camera on this long after a query (avoids restart on follow-ups)
     silero_threshold:           0.5   # Silero speech probability gate (0..1)
     silence_duration:           0.8   # seconds of silence that ends an utterance
-    min_speech:                 0.3   # minimum seconds of speech before STT fires
+    min_speech:                 0.1   # minimum seconds of speech before STT fires
 """
 from __future__ import annotations
 
@@ -85,7 +85,7 @@ async def main(
         camera_on_timeout_s   =float(cfg.get("camera_on_timeout_s",  10.0)),
         camera_grace_s        =float(cfg.get("camera_grace_s",         5.0)),
         silence_duration      =float(cfg.get("silence_duration",      0.8)),
-        min_speech            =float(cfg.get("min_speech",            0.3)),
+        min_speech            =float(cfg.get("min_speech",            0.1)),
         silero_threshold      =float(cfg.get("silero_threshold",      0.5)),
     )
 

--- a/agent-samples/simple-vlm-example/yaml/simple_vlm_example_worker.yaml
+++ b/agent-samples/simple-vlm-example/yaml/simple_vlm_example_worker.yaml
@@ -37,4 +37,4 @@ camera_grace_s:       5.0   # keep camera on this long after a query (avoids res
 # Tune if STT triggers too early or misses speech.
 silero_threshold:  0.5    # Silero speech-probability gate (0..1); lower = more sensitive
 silence_duration:  0.8    # seconds of silence that ends an utterance
-min_speech:        0.3    # minimum seconds of speech before STT is called
+min_speech:        0.1    # minimum seconds of speech before STT is called; 0.1s captures short commands like "stop"

--- a/tests/test_xr_ai_vad.py
+++ b/tests/test_xr_ai_vad.py
@@ -42,6 +42,9 @@ class _StubSilero:
         rms = float(np.sqrt(np.mean(arr.astype(np.float32) ** 2))) if arr.size else 0.0
         return 0.9 if rms >= self._threshold else 0.0
 
+    def reset_states(self) -> None:
+        pass
+
 
 def _install_stub(vad: VadDetector) -> None:
     """Replace the loaded silero model with a deterministic stub."""

--- a/utils/xr-ai-vad/xr_ai_vad/detector.py
+++ b/utils/xr-ai-vad/xr_ai_vad/detector.py
@@ -76,7 +76,6 @@ class VadDetector:
         self._speech_s:       float       = 0.0
         self._silent_s:       float       = 0.0
         self._speaking:       bool        = False
-        self._busy:           bool        = False   # on_utterance in flight
         # One-shot per utterance: ensures on_speech_start fires at most
         # once between finalizations.
         self._speech_start_fired: bool = False
@@ -100,6 +99,7 @@ class VadDetector:
         self._speech_start_fired = False
         self._pre_roll.clear()
         self._silero_buf = np.zeros(0, np.float32)
+        self._silero.reset_states()
 
     async def feed(self, pcm_int16: bytes, sample_rate: int) -> None:
         """Process one chunk of int16 LE PCM audio.
@@ -155,7 +155,6 @@ class VadDetector:
             self._speaking
             and self._speech_s >= self._min_speech
             and self._silent_s >= self._silence_duration
-            and not self._busy
         ):
             await self._finalize(sample_rate)
 
@@ -206,12 +205,13 @@ class VadDetector:
         self._silent_s           = 0.0
         self._speech_s           = 0.0
         self._speech_start_fired = False
-        self._busy               = True
+        # Reset Silero's RNN hidden state so the next utterance's silence
+        # detection isn't biased by this utterance's speech context.
+        self._silero_buf = np.zeros(0, np.float32)
+        self._silero.reset_states()
         dur_s = (len(audio_bytes) // 2) / max(sample_rate, 1)
         log.info("VAD: utterance finalized  dur=%.2fs", dur_s)
         try:
             await self._on_utterance(audio_bytes, sample_rate)
         except Exception:
             log.exception("on_utterance callback raised")
-        finally:
-            self._busy = False


### PR DESCRIPTION
## Summary

- **Remove \`_busy\` gate in \`VadDetector\`** — the flag blocked utterance finalization while STT was in-flight, causing speech + trailing silence to pile up in the buffer until STT returned, appearing as "VAD doesn't detect when I stop speaking." The per-participant \`vs.transcribing\` guard in the agent already handles overlapping STT.
- **Call \`silero.reset_states()\` after each finalization/reset** — Silero's RNN hidden state carries over between utterances and biases silence probability in the next one.
- **Lower \`min_speech\` 0.3 s → 0.1 s in simple-vlm-example** — short words like "stop" (~0.2 s) never crossed the 0.3 s threshold. The VAD kept the utterance buffered but never fired; repeating it caused accumulated \`speech_s\` to eventually cross, which is why multiple "stops" worked. At 0.1 s, a single "stop" registers on the first attempt.

## Test plan

- [ ] All existing VAD unit tests pass (6/6)
- [x] Single "stop" during active TTS response cancels the response
- [x] Longer utterances with natural pauses still transcribe correctly (silence_duration=0.8 s unchanged)
- [x] Second utterance spoken during STT is detected at the correct time, not accumulated until STT returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)