### PR TITLE
fix: resolve Sonar findings in native samples

### DIFF
--- a/agent-samples/xr-render-demo/eval/eval_watch.sh
+++ b/agent-samples/xr-render-demo/eval/eval_watch.sh
@@ -20,6 +20,7 @@ EVAL="$HERE/eval.py"
 WORKER="$HERE/../worker"
 SELF="$(readlink -f "$0")"
 DEBOUNCE_SECS=10
+TIME_FMT='+%H:%M:%S'
 
 last_hash=""
 pending=0
@@ -55,7 +56,8 @@ echo $$ > "$LOCK"
 # editors / language servers / git tools re-save the file without changing
 # bytes (focus changes, refresh-on-blur, etc.).
 file_hash() {
-    sha1sum "$PROMPT" 2>/dev/null | awk '{print $1}'
+    sha1sum "$PROMPT" 2>/dev/null | awk '{print $1}' || true
+    return 0
 }
 
 kill_running() {
@@ -66,17 +68,18 @@ kill_running() {
         kill -TERM -- "-$running_pid" 2>/dev/null || true
         sleep 0.3
         kill -KILL -- "-$running_pid" 2>/dev/null || true
-        echo "  ── aborted at $(date '+%H:%M:%S') ──" >> "$LOG"
+        echo "  ── aborted at $(date "$TIME_FMT") ──" >> "$LOG"
     fi
     wait "$running_pid" 2>/dev/null || true
     running_pid=""
+    return 0
 }
 
 trigger() {
     {
         echo
         echo "═══════════════════════════════════════════════════════════════"
-        echo "  $(date '+%H:%M:%S')  prompt=$PROMPT"
+        echo "  $(date "$TIME_FMT")  prompt=$PROMPT"
         echo "═══════════════════════════════════════════════════════════════"
     } >> "$LOG"
     # Reuse the worker's already-resolved venv so we don't go through
@@ -86,16 +89,18 @@ trigger() {
     setsid uv run --project "$WORKER" python "$EVAL" \
         --verbose --prompt "$PROMPT" >> "$LOG" 2>&1 &
     running_pid=$!
+    return 0
 }
 
 cleanup() {
     kill_running
     rm -f "$LOCK"
+    return 0
 }
 trap cleanup EXIT INT TERM HUP
 
 echo "watching $PROMPT — log $LOG  debounce ${DEBOUNCE_SECS}s  (stop: kill $$)"
-echo "started $(date '+%H:%M:%S') (PID $$)" >> "$LOG"
+echo "started $(date "$TIME_FMT") (PID $$)" >> "$LOG"
 
 # Baseline run on startup so the user sees a score immediately.
 last_hash=$(file_hash)
@@ -113,7 +118,7 @@ while true; do
     fi
     now=$(date +%s)
     if [[ "$hash" != "$last_hash" ]]; then
-        echo "  ── change detected at $(date '+%H:%M:%S') (sha ${last_hash:0:8} → ${hash:0:8}) ──" >> "$LOG"
+        echo "  ── change detected at $(date "$TIME_FMT") (sha ${last_hash:0:8} → ${hash:0:8}) ──" >> "$LOG"
         last_hash="$hash"
         pending=1
         pending_since=$now

--- a/client-samples/native/App/main.cpp
+++ b/client-samples/native/App/main.cpp
@@ -22,8 +22,9 @@
 
 #include <algorithm>
 #include <chrono>
-#include <cstring>
+#include <cstddef>
 #include <iostream>
+#include <span>
 #include <stdexcept>
 #include <string>
 #include <thread>
@@ -48,8 +49,8 @@ struct Args {
 static std::string GetArg(const std::vector<std::string>& argv,
                            const std::string& flag,
                            const std::string& fallback = "") {
-    auto it = std::find(argv.begin(), argv.end(), flag);
-    if (it != argv.end() && std::next(it) != argv.end()) {
+    if (auto it = std::ranges::find(argv, flag);
+        it != argv.end() && std::next(it) != argv.end()) {
         return *std::next(it);
     }
     return fallback;
@@ -76,13 +77,22 @@ static Args ParseArgs(int argc, char** argv) {
 // ─────────────────────────────────────────────────────────────────────────────
 
 static std::string StateToString(streamkit::ConnectionState state) {
+    using enum streamkit::ConnectionState;
     switch (state) {
-        case streamkit::ConnectionState::kDisconnected:  return "disconnected";
-        case streamkit::ConnectionState::kConnecting:    return "connecting";
-        case streamkit::ConnectionState::kConnected:     return "connected";
-        case streamkit::ConnectionState::kReconnecting:  return "reconnecting";
+        case kDisconnected:  return "disconnected";
+        case kConnecting:    return "connecting";
+        case kConnected:     return "connected";
+        case kReconnecting:  return "reconnecting";
     }
     return "unknown";
+}
+
+static std::string BytesToString(std::span<const std::byte> data) {
+    std::string payload(data.size(), '\0');
+    std::ranges::transform(data, payload.begin(), [](std::byte byte) {
+        return static_cast<char>(std::to_integer<unsigned char>(byte));
+    });
+    return payload;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -108,7 +118,7 @@ int main(int argc, char** argv) {
 
     session.on_data_received = [](std::string_view topic,
                                   std::span<const std::byte> data) {
-        std::string payload(reinterpret_cast<const char*>(data.data()), data.size());
+        const std::string payload = BytesToString(data);
         std::cout << "[data] topic='" << topic << "' payload='" << payload << "'\n";
     };
 
@@ -149,10 +159,7 @@ int main(int argc, char** argv) {
     // ── Send a test message ───────────────────────────────────────────────
     try {
         const std::string msg = R"({"event":"hello","from":"native-client"})";
-        std::vector<std::byte> payload(msg.size());
-        std::transform(msg.begin(), msg.end(), payload.begin(),
-                       [](char c) { return static_cast<std::byte>(c); });
-
+        const auto payload = std::as_bytes(std::span<const char>(msg.data(), msg.size()));
         session.Send(payload, /*reliable=*/true, "xr.session.started");
         std::cout << "Sent test message.\n";
     } catch (const streamkit::StreamError& e) {

--- a/client-samples/native/App/main.cpp
+++ b/client-samples/native/App/main.cpp
@@ -15,9 +15,8 @@
  * Without it, the backend compiles in stub mode and `Connect()` reports
  * `kConnected` immediately for header-only verification.
  *
- * This sample assumes an inline JWT; `LiveKitConfig::token_url` is not
- * wired (the default backend's `FetchToken` throws). Subclass
- * `LiveKitBackend` and override `FetchToken` to drive your own HTTP client.
+ * This sample assumes an inline JWT in `LiveKitConfig::token`;
+ * `token_url` is not wired (the backend's `FetchToken` always throws).
  */
 
 #include <algorithm>

--- a/client-samples/native/StreamKit/Tests/StreamKitTests/AgentStatusTests.cpp
+++ b/client-samples/native/StreamKit/Tests/StreamKitTests/AgentStatusTests.cpp
@@ -6,58 +6,59 @@
 #include "Backends/LiveKit/AgentStatusParser.h"
 
 #include <cstddef>
-#include <cstring>
 #include <span>
 #include <string>
+#include <string_view>
 
 namespace {
 
-std::span<const std::byte> bytes_of(const char* s) {
-    return std::span<const std::byte>(
-        reinterpret_cast<const std::byte*>(s), std::strlen(s));
+std::span<const std::byte> bytes_of(std::string_view s) {
+    return std::as_bytes(std::span<const char>(s.data(), s.size()));
 }
 
 }  // namespace
 
 int main() {
     using streamkit::internal::ExtractAgentStatus;
+    using streamkit::test::Expect;
+    using streamkit::test::ExpectEq;
 
     // Canonical payload shipped by xr-ai-pipecat's set_status:
     {
         auto r = ExtractAgentStatus(bytes_of(R"({"status": "idle"})"));
-        SK_EXPECT(r.has_value());
-        SK_EXPECT_EQ(*r, std::string("idle"));
+        Expect(r.has_value());
+        ExpectEq(*r, std::string("idle"));
     }
     {
         auto r = ExtractAgentStatus(bytes_of(R"({"status":"processing"})"));
-        SK_EXPECT(r.has_value());
-        SK_EXPECT_EQ(*r, std::string("processing"));
+        Expect(r.has_value());
+        ExpectEq(*r, std::string("processing"));
     }
 
     // Missing key → nullopt
     {
         auto r = ExtractAgentStatus(bytes_of(R"({"other": "x"})"));
-        SK_EXPECT(!r.has_value());
+        Expect(!r.has_value());
     }
 
     // Truncated payload — no closing quote.
     {
         auto r = ExtractAgentStatus(bytes_of(R"({"status": "idle)"));
-        SK_EXPECT(!r.has_value());
+        Expect(!r.has_value());
     }
 
     // Empty value is a valid match; HandleDataReceived skips empty status
     // separately so the parser itself just reports what it saw.
     {
         auto r = ExtractAgentStatus(bytes_of(R"({"status": ""})"));
-        SK_EXPECT(r.has_value());
-        SK_EXPECT_EQ(*r, std::string(""));
+        Expect(r.has_value());
+        ExpectEq(*r, std::string(""));
     }
 
     // Empty payload
     {
         auto r = ExtractAgentStatus(bytes_of(""));
-        SK_EXPECT(!r.has_value());
+        Expect(!r.has_value());
     }
 
     return 0;

--- a/client-samples/native/StreamKit/Tests/StreamKitTests/AudioSinkTests.cpp
+++ b/client-samples/native/StreamKit/Tests/StreamKitTests/AudioSinkTests.cpp
@@ -55,18 +55,20 @@ struct RecordingAudioSink : streamkit::AudioSink {
 }  // namespace
 
 int main() {
+    using streamkit::test::ExpectEq;
+
     // 1. Direct dispatch via the concrete subclass.
     {
         RecordingAudioSink sink;
         std::vector<std::int16_t> pcm(480, std::int16_t{1234});  // 10 ms @ 48 kHz mono
         sink.InjectAudioFrame(pcm, 48000, 1, 480, 5000);
-        SK_EXPECT_EQ(sink.calls, 1);
-        SK_EXPECT_EQ(sink.last_sample_rate, 48000);
-        SK_EXPECT_EQ(sink.last_channels, 1);
-        SK_EXPECT_EQ(sink.last_samples_per_channel, 480);
-        SK_EXPECT_EQ(sink.last_ts, int64_t{5000});
-        SK_EXPECT_EQ(sink.last_sample_count, std::size_t{480});
-        SK_EXPECT_EQ(sink.last_first_sample, std::int16_t{1234});
+        ExpectEq(sink.calls, 1);
+        ExpectEq(sink.last_sample_rate, 48000);
+        ExpectEq(sink.last_channels, 1);
+        ExpectEq(sink.last_samples_per_channel, 480);
+        ExpectEq(sink.last_ts, int64_t{5000});
+        ExpectEq(sink.last_sample_count, std::size_t{480});
+        ExpectEq(sink.last_first_sample, std::int16_t{1234});
     }
 
     // 2. Dispatch through an AudioSink& reference — the path
@@ -76,11 +78,11 @@ int main() {
         streamkit::AudioSink& base = sink;
         std::vector<std::int16_t> pcm(960, std::int16_t{-7});  // 10 ms @ 48 kHz stereo
         base.InjectAudioFrame(pcm, 48000, 2, 480, 99);
-        SK_EXPECT_EQ(sink.calls, 1);
-        SK_EXPECT_EQ(sink.last_channels, 2);
-        SK_EXPECT_EQ(sink.last_samples_per_channel, 480);
-        SK_EXPECT_EQ(sink.last_sample_count, std::size_t{960});
-        SK_EXPECT_EQ(sink.last_first_sample, std::int16_t{-7});
+        ExpectEq(sink.calls, 1);
+        ExpectEq(sink.last_channels, 2);
+        ExpectEq(sink.last_samples_per_channel, 480);
+        ExpectEq(sink.last_sample_count, std::size_t{960});
+        ExpectEq(sink.last_first_sample, std::int16_t{-7});
     }
 
     return 0;

--- a/client-samples/native/StreamKit/Tests/StreamKitTests/FrameSinkTests.cpp
+++ b/client-samples/native/StreamKit/Tests/StreamKitTests/FrameSinkTests.cpp
@@ -25,6 +25,8 @@
 namespace {
 
 struct SpanOnlySink : streamkit::FrameSink {
+    using streamkit::FrameSink::InjectVideoFrame;
+
     int span_calls = 0;
     std::size_t last_span_size = 0;
     int last_width = 0;
@@ -62,7 +64,8 @@ struct BothOverloadsSink : streamkit::FrameSink {
                           streamkit::PixelFormat /*format*/,
                           int64_t /*timestamp_us*/) override {
         ++move_calls;
-        last_move_capacity = data.capacity();
+        auto owned = std::move(data);
+        last_move_capacity = owned.capacity();
     }
 };
 
@@ -70,6 +73,8 @@ struct BothOverloadsSink : streamkit::FrameSink {
 
 int main() {
     using streamkit::PixelFormat;
+    using streamkit::test::Expect;
+    using streamkit::test::ExpectEq;
 
     // 1. Span-only subclass — the move overload should fall through the
     //    default impl to the span overload. The call goes through a
@@ -82,12 +87,12 @@ int main() {
         std::vector<std::uint8_t> buffer(1024, std::uint8_t{0xAB});
         base.InjectVideoFrame(std::move(buffer), 32, 16,
                               PixelFormat::kI420, 12345);
-        SK_EXPECT_EQ(sink.span_calls, 1);
-        SK_EXPECT_EQ(sink.last_span_size, std::size_t{1024});
-        SK_EXPECT_EQ(sink.last_width, 32);
-        SK_EXPECT_EQ(sink.last_height, 16);
-        SK_EXPECT(sink.last_format == PixelFormat::kI420);
-        SK_EXPECT_EQ(sink.last_ts, int64_t{12345});
+        ExpectEq(sink.span_calls, 1);
+        ExpectEq(sink.last_span_size, std::size_t{1024});
+        ExpectEq(sink.last_width, 32);
+        ExpectEq(sink.last_height, 16);
+        Expect(sink.last_format == PixelFormat::kI420);
+        ExpectEq(sink.last_ts, int64_t{12345});
     }
 
     // 2. Backend that overrides both — the move overload is called directly,
@@ -97,9 +102,9 @@ int main() {
         std::vector<std::uint8_t> buffer(2048);
         sink.InjectVideoFrame(std::move(buffer), 64, 32,
                               PixelFormat::kNV12, 999);
-        SK_EXPECT_EQ(sink.move_calls, 1);
-        SK_EXPECT_EQ(sink.span_calls, 0);
-        SK_EXPECT(sink.last_move_capacity >= std::size_t{2048});
+        ExpectEq(sink.move_calls, 1);
+        ExpectEq(sink.span_calls, 0);
+        Expect(sink.last_move_capacity >= std::size_t{2048});
     }
 
     // 3. Span overload on a both-overloads backend still routes through span
@@ -110,8 +115,8 @@ int main() {
         std::span<const std::byte> view(
             reinterpret_cast<const std::byte*>(buffer.data()), buffer.size());
         sink.InjectVideoFrame(view, 16, 8, PixelFormat::kRGBA, 1);
-        SK_EXPECT_EQ(sink.span_calls, 1);
-        SK_EXPECT_EQ(sink.move_calls, 0);
+        ExpectEq(sink.span_calls, 1);
+        ExpectEq(sink.move_calls, 0);
     }
 
     return 0;

--- a/client-samples/native/StreamKit/Tests/StreamKitTests/LiveKitBackendTests.cpp
+++ b/client-samples/native/StreamKit/Tests/StreamKitTests/LiveKitBackendTests.cpp
@@ -24,6 +24,8 @@
 
 int main() {
     using streamkit::ConnectionState;
+    using streamkit::test::Expect;
+    using streamkit::test::ExpectEq;
 
     streamkit::LiveKitConfig lk;
     lk.host  = "localhost";
@@ -33,38 +35,38 @@ int main() {
         streamkit::BackendConfiguration{lk}};
 
     std::vector<ConnectionState> states;
-    session.on_connection_state_changed = [&](ConnectionState s) {
+    session.on_connection_state_changed = [&states](ConnectionState s) {
         states.push_back(s);
     };
 
     // ── First Connect — must NOT emit a spurious initial kDisconnected
     //    from TearDown(), and must emit exactly one kConnected. ────────────
     session.Connect();
-    SK_EXPECT_EQ(states.size(), std::size_t{2});
-    SK_EXPECT(states[0] == ConnectionState::kConnecting);
-    SK_EXPECT(states[1] == ConnectionState::kConnected);
+    ExpectEq(states.size(), std::size_t{2});
+    Expect(states[0] == ConnectionState::kConnecting);
+    Expect(states[1] == ConnectionState::kConnected);
 
     // ── Disconnect — exactly one kDisconnected. ──────────────────────────
     session.Disconnect();
-    SK_EXPECT_EQ(states.size(), std::size_t{3});
-    SK_EXPECT(states[2] == ConnectionState::kDisconnected);
+    ExpectEq(states.size(), std::size_t{3});
+    Expect(states[2] == ConnectionState::kDisconnected);
 
     // ── Reconnect — still no spurious leading kDisconnected. The
     //    TearDown() at the top of Connect sees last_fired_state_ ==
     //    kDisconnected and skips. ────────────────────────────────────────
     session.Connect();
-    SK_EXPECT_EQ(states.size(), std::size_t{5});
-    SK_EXPECT(states[3] == ConnectionState::kConnecting);
-    SK_EXPECT(states[4] == ConnectionState::kConnected);
+    ExpectEq(states.size(), std::size_t{5});
+    Expect(states[3] == ConnectionState::kConnecting);
+    Expect(states[4] == ConnectionState::kConnected);
 
     // ── Idempotent disconnect — second Disconnect after the first is a
     //    no-op for the callback. ──────────────────────────────────────────
     session.Disconnect();
-    SK_EXPECT_EQ(states.size(), std::size_t{6});
-    SK_EXPECT(states[5] == ConnectionState::kDisconnected);
+    ExpectEq(states.size(), std::size_t{6});
+    Expect(states[5] == ConnectionState::kDisconnected);
 
     session.Disconnect();
-    SK_EXPECT_EQ(states.size(), std::size_t{6});  // unchanged
+    ExpectEq(states.size(), std::size_t{6});  // unchanged
 
     // ── Buffer-size validation in the move overload — packed contract.
     //    Reconnect, arm the camera, then push a deliberately-wrong-size
@@ -74,7 +76,7 @@ int main() {
     session.Connect();
     session.StartCamera();
     auto* sink = dynamic_cast<streamkit::FrameSink*>(session.GetBackend());
-    SK_EXPECT(sink != nullptr);
+    Expect(sink != nullptr);
 
     // 16×16 I420 packed = 16*16 + 2 * (8*8) = 384 bytes.
     // Pass 100 bytes to force the mismatch.
@@ -86,7 +88,7 @@ int main() {
     } catch (const std::invalid_argument&) {
         threw_invalid = true;
     }
-    SK_EXPECT(threw_invalid);
+    Expect(threw_invalid);
 
     // Correct size goes through (stub-mode no-op past the validation).
     std::vector<std::uint8_t> packed(384);

--- a/client-samples/native/StreamKit/Tests/StreamKitTests/MappingTests.cpp
+++ b/client-samples/native/StreamKit/Tests/StreamKitTests/MappingTests.cpp
@@ -7,11 +7,13 @@
 
 int main() {
     using streamkit::ConnectionState;
+    using streamkit::test::Expect;
+    using streamkit::test::ExpectEq;
 
-    SK_EXPECT_EQ(ConnectionState::kConnected, ConnectionState::kConnected);
-    SK_EXPECT(ConnectionState::kDisconnected != ConnectionState::kConnected);
-    SK_EXPECT(ConnectionState::kConnecting   != ConnectionState::kConnected);
-    SK_EXPECT(ConnectionState::kReconnecting != ConnectionState::kConnected);
+    ExpectEq(ConnectionState::kConnected, ConnectionState::kConnected);
+    Expect(ConnectionState::kDisconnected != ConnectionState::kConnected);
+    Expect(ConnectionState::kConnecting   != ConnectionState::kConnected);
+    Expect(ConnectionState::kReconnecting != ConnectionState::kConnected);
 
     return 0;
 }

--- a/client-samples/native/StreamKit/Tests/StreamKitTests/StreamSessionTests.cpp
+++ b/client-samples/native/StreamKit/Tests/StreamKitTests/StreamSessionTests.cpp
@@ -14,14 +14,23 @@
 #include "streamkit/ConnectionState.h"
 #include "streamkit/StreamSession.h"
 
+#include <algorithm>
 #include <cstddef>
-#include <cstring>
 #include <memory>
+#include <span>
 #include <string>
 #include <string_view>
 #include <vector>
 
 namespace {
+
+std::string BytesToString(std::span<const std::byte> data) {
+    std::string payload(data.size(), '\0');
+    std::ranges::transform(data, payload.begin(), [](std::byte byte) {
+        return static_cast<char>(std::to_integer<unsigned char>(byte));
+    });
+    return payload;
+}
 
 struct MockBackend : streamkit::StreamingBackend {
     int connect_calls = 0;
@@ -52,18 +61,17 @@ struct MockBackend : streamkit::StreamingBackend {
     void StopCamera() override { ++stop_camera_calls; }
     void Send(std::span<const std::byte> data, bool, std::string_view topic) override {
         sent_topics.emplace_back(topic);
-        sent_payloads.emplace_back(reinterpret_cast<const char*>(data.data()), data.size());
+        sent_payloads.emplace_back(BytesToString(data));
     }
 
     // Helpers for tests to drive the event hooks the backend would normally
     // fire from its event loop.
-    void fire_data(std::string_view topic, std::string_view payload) {
+    void fire_data(std::string_view topic, std::string_view payload) const {
         if (!on_data_received) return;
-        std::span<const std::byte> bytes(
-            reinterpret_cast<const std::byte*>(payload.data()), payload.size());
+        auto bytes = std::as_bytes(std::span<const char>(payload.data(), payload.size()));
         on_data_received(topic, bytes);
     }
-    void fire_agent_status(std::string_view status) {
+    void fire_agent_status(std::string_view status) const {
         if (on_agent_status) on_agent_status(status);
     }
 };
@@ -71,6 +79,9 @@ struct MockBackend : streamkit::StreamingBackend {
 }  // namespace
 
 int main() {
+    using streamkit::test::Expect;
+    using streamkit::test::ExpectEq;
+
     auto backend = std::make_unique<MockBackend>();
     auto* raw = backend.get();
     streamkit::StreamSession session(std::move(backend));
@@ -78,7 +89,8 @@ int main() {
     // ── Wire session-level callbacks ───────────────────────────────────────
     int state_changes = 0;
     streamkit::ConnectionState last_state = streamkit::ConnectionState::kDisconnected;
-    session.on_connection_state_changed = [&](streamkit::ConnectionState s) {
+    session.on_connection_state_changed =
+        [&state_changes, &last_state](streamkit::ConnectionState s) {
         ++state_changes;
         last_state = s;
     };
@@ -86,62 +98,63 @@ int main() {
     int data_calls = 0;
     std::string last_topic;
     std::string last_payload;
-    session.on_data_received = [&](std::string_view topic,
-                                   std::span<const std::byte> data) {
+    session.on_data_received =
+        [&data_calls, &last_topic, &last_payload](
+            std::string_view topic,
+            std::span<const std::byte> data) {
         ++data_calls;
         last_topic = std::string(topic);
-        last_payload.assign(reinterpret_cast<const char*>(data.data()), data.size());
+        last_payload = BytesToString(data);
     };
 
     int agent_calls = 0;
     std::string last_agent_status;
-    session.on_agent_status = [&](std::string_view status) {
+    session.on_agent_status = [&agent_calls, &last_agent_status](std::string_view status) {
         ++agent_calls;
         last_agent_status = std::string(status);
     };
 
     // ── Connect lifecycle ──────────────────────────────────────────────────
-    SK_EXPECT(session.connection_state() == streamkit::ConnectionState::kDisconnected);
+    Expect(session.connection_state() == streamkit::ConnectionState::kDisconnected);
     session.Connect(streamkit::SessionConfig{"test-identity"});
-    SK_EXPECT_EQ(raw->connect_calls, 1);
-    SK_EXPECT_EQ(state_changes, 2);
-    SK_EXPECT(last_state == streamkit::ConnectionState::kConnected);
-    SK_EXPECT(session.connection_state() == streamkit::ConnectionState::kConnected);
+    ExpectEq(raw->connect_calls, 1);
+    ExpectEq(state_changes, 2);
+    Expect(last_state == streamkit::ConnectionState::kConnected);
+    Expect(session.connection_state() == streamkit::ConnectionState::kConnected);
 
     // ── Media independent of connection ────────────────────────────────────
     session.StartAudio();
     session.StartCamera();
-    SK_EXPECT_EQ(raw->start_audio_calls, 1);
-    SK_EXPECT_EQ(raw->start_camera_calls, 1);
+    ExpectEq(raw->start_audio_calls, 1);
+    ExpectEq(raw->start_camera_calls, 1);
 
     // ── Send + data delivery ───────────────────────────────────────────────
     const std::string msg = "hello";
-    std::vector<std::byte> payload(msg.size());
-    std::memcpy(payload.data(), msg.data(), msg.size());
+    auto payload = std::as_bytes(std::span<const char>(msg.data(), msg.size()));
     session.Send(payload, /*reliable=*/true, "test.topic");
-    SK_EXPECT_EQ(raw->sent_topics.size(), std::size_t{1});
-    SK_EXPECT_EQ(raw->sent_topics[0], std::string("test.topic"));
-    SK_EXPECT_EQ(raw->sent_payloads[0], std::string("hello"));
+    ExpectEq(raw->sent_topics.size(), std::size_t{1});
+    ExpectEq(raw->sent_topics[0], std::string("test.topic"));
+    ExpectEq(raw->sent_payloads[0], std::string("hello"));
 
     raw->fire_data("incoming.topic", "world");
-    SK_EXPECT_EQ(data_calls, 1);
-    SK_EXPECT_EQ(last_topic, std::string("incoming.topic"));
-    SK_EXPECT_EQ(last_payload, std::string("world"));
+    ExpectEq(data_calls, 1);
+    ExpectEq(last_topic, std::string("incoming.topic"));
+    ExpectEq(last_payload, std::string("world"));
 
     raw->fire_agent_status("processing");
-    SK_EXPECT_EQ(agent_calls, 1);
-    SK_EXPECT_EQ(last_agent_status, std::string("processing"));
+    ExpectEq(agent_calls, 1);
+    ExpectEq(last_agent_status, std::string("processing"));
 
     // ── Stop media + disconnect ────────────────────────────────────────────
     session.StopAudio();
     session.StopCamera();
-    SK_EXPECT_EQ(raw->stop_audio_calls, 1);
-    SK_EXPECT_EQ(raw->stop_camera_calls, 1);
+    ExpectEq(raw->stop_audio_calls, 1);
+    ExpectEq(raw->stop_camera_calls, 1);
 
     session.Disconnect();
-    SK_EXPECT_EQ(raw->disconnect_calls, 1);
-    SK_EXPECT(last_state == streamkit::ConnectionState::kDisconnected);
-    SK_EXPECT(session.connection_state() == streamkit::ConnectionState::kDisconnected);
+    ExpectEq(raw->disconnect_calls, 1);
+    Expect(last_state == streamkit::ConnectionState::kDisconnected);
+    Expect(session.connection_state() == streamkit::ConnectionState::kDisconnected);
 
     return 0;
 }

--- a/client-samples/native/StreamKit/Tests/StreamKitTests/test_assert.h
+++ b/client-samples/native/StreamKit/Tests/StreamKitTests/test_assert.h
@@ -4,7 +4,7 @@
 #pragma once
 
 /*
- * Tiny test assertion macros. Each test executable runs its checks in main()
+ * Tiny test assertion helpers. Each test executable runs its checks in main()
  * and exits non-zero on the first failure. Keeps the test-runtime dependency
  * surface at zero (no GoogleTest, no Catch2) and the per-test wiring trivial.
  *
@@ -13,23 +13,28 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <source_location>
 
-#define SK_EXPECT(cond)                                                      \
-    do {                                                                     \
-        if (!(cond)) {                                                       \
-            std::fprintf(stderr, "%s:%d: EXPECT failed: %s\n",               \
-                         __FILE__, __LINE__, #cond);                         \
-            std::exit(1);                                                    \
-        }                                                                    \
-    } while (0)
+namespace streamkit::test {
 
-#define SK_EXPECT_EQ(a, b)                                                   \
-    do {                                                                     \
-        auto _sk_a = (a);                                                    \
-        auto _sk_b = (b);                                                    \
-        if (!(_sk_a == _sk_b)) {                                             \
-            std::fprintf(stderr, "%s:%d: EXPECT_EQ failed: %s != %s\n",      \
-                         __FILE__, __LINE__, #a, #b);                        \
-            std::exit(1);                                                    \
-        }                                                                    \
-    } while (0)
+inline void Expect(bool condition,
+                   std::source_location where = std::source_location::current()) {
+    if (!condition) {
+        std::fprintf(stderr, "%s:%u: EXPECT failed\n",
+                     where.file_name(), where.line());
+        std::exit(1);
+    }
+}
+
+template <typename A, typename B>
+void ExpectEq(const A& a,
+              const B& b,
+              std::source_location where = std::source_location::current()) {
+    if (!(a == b)) {
+        std::fprintf(stderr, "%s:%u: EXPECT_EQ failed\n",
+                     where.file_name(), where.line());
+        std::exit(1);
+    }
+}
+
+}  // namespace streamkit::test

--- a/client-samples/native/StreamKit/include/streamkit/AudioSink.h
+++ b/client-samples/native/StreamKit/include/streamkit/AudioSink.h
@@ -15,13 +15,13 @@
  *
  * ## Workflow
  *
- *   // 1. Connect to the session.
+ *   1. Connect to the session.
  *   session.Connect();
  *
- *   // 2. Arm the audio track.
+ *   2. Arm the audio track.
  *   session.StartAudio();
  *
- *   // 3. In your mic callback, push each buffer:
+ *   3. In your mic callback, push each buffer:
  *   if (auto* sink = dynamic_cast<AudioSink*>(session.GetBackend())) {
  *       sink->InjectAudioFrame(pcm, sample_rate, channels,
  *                              samples_per_channel, timestamp_us);

--- a/client-samples/native/StreamKit/include/streamkit/Backends/LiveKit/LiveKitBackend.h
+++ b/client-samples/native/StreamKit/include/streamkit/Backends/LiveKit/LiveKitBackend.h
@@ -62,7 +62,7 @@ class LiveKitBackend : public StreamingBackend,
                        public AudioSink {
 public:
     explicit LiveKitBackend(const LiveKitConfig& config);
-    ~LiveKitBackend() override;
+    ~LiveKitBackend() noexcept override;
 
     LiveKitBackend(const LiveKitBackend&)            = delete;
     LiveKitBackend& operator=(const LiveKitBackend&) = delete;
@@ -127,7 +127,8 @@ private:
 
     /// Fetches a LiveKit JWT from `config_.token_url`.
     /// GET <url>?identity=<identity> → plain string or {"token":"eyJ…"}.
-    std::string FetchToken(const std::string& url, const std::string& identity);
+    [[noreturn]] void FetchToken(const std::string& url,
+                                 const std::string& identity) const;
 
     /// Maps livekit::ConnectionState → StreamKit's ConnectionState and fires
     /// on_connection_state_changed. Called by the Delegate's event hooks.
@@ -144,7 +145,7 @@ private:
     /// Routes incoming data packets: intercepts "_agent.status",
     /// fires on_data_received for everything else.
     void HandleDataReceived(std::string_view topic,
-                            std::span<const std::byte> payload);
+                            std::span<const std::byte> payload) const;
 
     LiveKitConfig config_;
     SessionConfig session_config_;

--- a/client-samples/native/StreamKit/include/streamkit/Backends/LiveKit/LiveKitBackend.h
+++ b/client-samples/native/StreamKit/include/streamkit/Backends/LiveKit/LiveKitBackend.h
@@ -125,8 +125,8 @@ private:
     /// Disconnects the room, stops all tracks, fires kDisconnected.
     void TearDown();
 
-    /// Fetches a LiveKit JWT from `config_.token_url`.
-    /// GET <url>?identity=<identity> → plain string or {"token":"eyJ…"}.
+    /// Always throws `TokenFetchFailedError` — supply `config_.token`
+    /// instead. This backend ships no HTTP client.
     [[noreturn]] void FetchToken(const std::string& url,
                                  const std::string& identity) const;
 

--- a/client-samples/native/StreamKit/include/streamkit/Config/SessionConfig.h
+++ b/client-samples/native/StreamKit/include/streamkit/Config/SessionConfig.h
@@ -3,8 +3,10 @@
 
 #pragma once
 
+#include <atomic>
+#include <chrono>
 #include <cstdint>
-#include <random>
+#include <format>
 #include <string>
 
 namespace streamkit {
@@ -20,11 +22,14 @@ struct SessionConfig {
     /// A unique label for this participant in the session.
     std::string identity;
 
-    /// Returns a config with a random participant ID.
+    /// Returns a config with a process-local unique participant ID.
     static SessionConfig Default() {
-        static std::mt19937 rng{std::random_device{}()};
-        static std::uniform_int_distribution<uint32_t> dist{100000, 999999};
-        return SessionConfig{"participant-" + std::to_string(dist(rng))};
+        static std::atomic_uint64_t sequence{0};
+        const auto timestamp =
+            std::chrono::steady_clock::now().time_since_epoch().count();
+        return SessionConfig{std::format(
+            "participant-{}-{}", timestamp,
+            sequence.fetch_add(1, std::memory_order_relaxed))};
     }
 };
 

--- a/client-samples/native/StreamKit/include/streamkit/FrameSink.h
+++ b/client-samples/native/StreamKit/include/streamkit/FrameSink.h
@@ -14,10 +14,10 @@
  *
  * ## Workflow
  *
- *   // 1. Connect to the session.
+ *   1. Connect to the session.
  *   session.Connect();
  *
- *   // 2. In your frame callback, inject each buffer:
+ *   2. In your frame callback, inject each buffer:
  *   if (auto* sink = dynamic_cast<FrameSink*>(session.GetBackend())) {
  *       sink->InjectVideoFrame(pixels, width, height, format, timestamp_us);
  *   }
@@ -115,8 +115,9 @@ public:
                                   int height,
                                   PixelFormat format,
                                   int64_t timestamp_us) {
+        auto owned = std::move(data);
         std::span<const std::byte> as_span(
-            reinterpret_cast<const std::byte*>(data.data()), data.size());
+            reinterpret_cast<const std::byte*>(owned.data()), owned.size());
         InjectVideoFrame(as_span, width, height, format, timestamp_us);
     }
 };

--- a/client-samples/native/StreamKit/include/streamkit/StreamSession.h
+++ b/client-samples/native/StreamKit/include/streamkit/StreamSession.h
@@ -13,19 +13,19 @@
  *
  * ## Lifecycle
  *
- *   // 1. Connect — WebRTC peer connection + data channel only.
+ *   1. Connect — WebRTC peer connection + data channel only.
  *   session.Connect(SessionConfig{.identity = "workstation-1"});
  *
- *   // 2. Start media independently — each throws its own error,
- *   //    never drops the connection.
+ *   2. Start media independently — each throws its own error,
+ *      never drops the connection.
  *   session.StartAudio();
  *   session.StartCamera();
  *
- *   // 3. Send / receive data.
+ *   3. Send / receive data.
  *   session.on_data_received = [](auto topic, auto data) { ... };
  *   session.Send(payload);
  *
- *   // 4. Stop media / disconnect.
+ *   4. Stop media / disconnect.
  *   session.StopAudio();
  *   session.StopCamera();
  *   session.Disconnect();

--- a/client-samples/native/StreamKit/src/Backends/LiveKit/AgentStatusParser.h
+++ b/client-samples/native/StreamKit/src/Backends/LiveKit/AgentStatusParser.h
@@ -19,7 +19,7 @@
 namespace streamkit::internal {
 
 inline std::optional<std::string> ExtractAgentStatus(std::span<const std::byte> payload) {
-    std::string_view sv(reinterpret_cast<const char*>(payload.data()), payload.size());
+    std::string_view sv(reinterpret_cast<const char*>(payload.data()), payload.size());  // NOSONAR: payload bytes are JSON text.
     auto key = sv.find("\"status\"");
     if (key == std::string_view::npos) return std::nullopt;
     auto colon = sv.find(':', key + 8);

--- a/client-samples/native/StreamKit/src/Backends/LiveKit/LiveKitBackend.cpp
+++ b/client-samples/native/StreamKit/src/Backends/LiveKit/LiveKitBackend.cpp
@@ -21,6 +21,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <format>
 #include <mutex>
 #include <optional>
 #include <stdexcept>
@@ -68,11 +69,12 @@ ConnectionState MapState(livekit::ConnectionState lk) {
 }
 
 livekit::VideoBufferType MapPixelFormat(PixelFormat fmt) {
+    using enum PixelFormat;
     switch (fmt) {
-        case PixelFormat::kI420: return livekit::VideoBufferType::I420;
-        case PixelFormat::kNV12: return livekit::VideoBufferType::NV12;
-        case PixelFormat::kRGBA: return livekit::VideoBufferType::RGBA;
-        case PixelFormat::kBGRA: return livekit::VideoBufferType::BGRA;
+        case kI420: return livekit::VideoBufferType::I420;
+        case kNV12: return livekit::VideoBufferType::NV12;
+        case kRGBA: return livekit::VideoBufferType::RGBA;
+        case kBGRA: return livekit::VideoBufferType::BGRA;
     }
     return livekit::VideoBufferType::I420;
 }
@@ -159,8 +161,11 @@ LiveKitBackend::LiveKitBackend(const LiveKitConfig& config) : config_(config) {
 #endif
 }
 
-LiveKitBackend::~LiveKitBackend() {
-    TearDown();
+LiveKitBackend::~LiveKitBackend() noexcept {
+    try {
+        TearDown();
+    } catch (...) {
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -176,14 +181,14 @@ void LiveKitBackend::Connect(const SessionConfig& session_config) {
     }
 
     const std::string scheme = config_.secure ? "wss" : "ws";
-    const std::string ws_url = scheme + "://" + config_.host + ":"
-                               + std::to_string(config_.port);
+    const std::string ws_url =
+        std::format("{}://{}:{}", scheme, config_.host, config_.port);
 
     std::string token;
     if (config_.token.has_value() && !config_.token->empty()) {
         token = *config_.token;
     } else if (config_.token_url.has_value() && !config_.token_url->empty()) {
-        token = FetchToken(*config_.token_url, session_config_.identity);
+        FetchToken(*config_.token_url, session_config_.identity);
     } else {
         throw MissingTokenError{};
     }
@@ -205,7 +210,8 @@ void LiveKitBackend::Connect(const SessionConfig& session_config) {
         room_.reset();
         delegate_.reset();
         FireStateChanged(ConnectionState::kDisconnected);
-        throw StreamError("LiveKit Room::Connect returned false for " + ws_url);
+        throw StreamError(std::format(
+            "LiveKit Room::Connect returned false for {}", ws_url));
     }
     is_connected_.store(true);
     // The SDK delegate may have already fired kConnected during the
@@ -334,14 +340,14 @@ void LiveKitBackend::InjectVideoFrame(std::vector<std::uint8_t>&& data,
     // matches what a packed frame of the declared dimensions / format
     // requires. Catches the common "did the caller forget to repack
     // their padded HAL or GPU readback buffer?" mistake.
-    const auto expected = PackedFrameSize(width, height, format);
-    if (data.size() != expected) {
-        throw std::invalid_argument(
-            "InjectVideoFrame: buffer size " + std::to_string(data.size())
-            + " does not match the packed size " + std::to_string(expected)
-            + " expected for the given dimensions and format. "
-              "FrameSink requires tightly packed input — repack padded "
-              "buffers before calling.");
+    if (const auto expected = PackedFrameSize(width, height, format);
+        data.size() != expected) {
+        throw std::invalid_argument(std::format(
+            "InjectVideoFrame: buffer size {} does not match the packed size "
+            "{} expected for the given dimensions and format. FrameSink "
+            "requires tightly packed input - repack padded buffers before "
+            "calling.",
+            data.size(), expected));
     }
 
 #if STREAMKIT_HAVE_LIVEKIT
@@ -369,7 +375,8 @@ void LiveKitBackend::InjectVideoFrame(std::vector<std::uint8_t>&& data,
     }
     source->captureFrame(outgoing, timestamp_us);
 #else
-    (void)data;
+    std::vector<std::uint8_t> ignored = std::move(data);
+    (void)ignored;
     (void)width;
     (void)height;
     (void)format;
@@ -393,14 +400,14 @@ void LiveKitBackend::InjectAudioFrame(std::span<const std::int16_t> pcm,
         return;
     }
 
-    const auto expected =
-        static_cast<std::size_t>(channels) *
-        static_cast<std::size_t>(samples_per_channel);
-    if (pcm.size() != expected) {
-        throw std::invalid_argument(
-            "InjectAudioFrame: sample count " + std::to_string(pcm.size())
-            + " does not match channels * samples_per_channel = "
-            + std::to_string(expected));
+    if (const auto expected =
+            static_cast<std::size_t>(channels) *
+            static_cast<std::size_t>(samples_per_channel);
+        pcm.size() != expected) {
+        throw std::invalid_argument(std::format(
+            "InjectAudioFrame: sample count {} does not match channels * "
+            "samples_per_channel = {}",
+            pcm.size(), expected));
     }
 
 #if STREAMKIT_HAVE_LIVEKIT
@@ -433,8 +440,8 @@ void LiveKitBackend::Send(std::span<const std::byte> data,
         throw NotConnectedError{};
     }
     if (topic == kAgentStatusTopic) {
-        throw std::invalid_argument(
-            "topic '" + std::string(topic) + "' is reserved for internal SDK use");
+        throw std::invalid_argument(std::format(
+            "topic '{}' is reserved for internal SDK use", topic));
     }
 
 #if STREAMKIT_HAVE_LIVEKIT
@@ -472,7 +479,7 @@ void LiveKitBackend::FireStateChanged(ConnectionState state) {
 }
 
 void LiveKitBackend::HandleDataReceived(std::string_view topic,
-                                        std::span<const std::byte> payload) {
+                                        std::span<const std::byte> payload) const {
     if (topic == kAgentStatusTopic) {
         if (auto status = internal::ExtractAgentStatus(payload)) {
             if (!status->empty() && on_agent_status) {
@@ -520,16 +527,19 @@ void LiveKitBackend::TearDown() {
 // Token fetch
 // ─────────────────────────────────────────────────────────────────────────────
 
-std::string LiveKitBackend::FetchToken(const std::string& token_url,
-                                       const std::string& /*identity*/) {
+[[noreturn]] void LiveKitBackend::FetchToken(
+    const std::string& token_url,
+    const std::string& /*identity*/) const {
     // Token-fetch over HTTP is deliberately not implemented in this
     // backend. Embedded targets typically pass an inline token in
     // `LiveKitConfig::token` (computed server-side); desktop hosts that
     // need a token endpoint can subclass LiveKitBackend and override
     // FetchToken with their preferred HTTP client (libcurl, Poco::Net,
     // cpp-httplib). See `App/main.cpp` for the inline-token path.
-    throw TokenFetchFailedError(token_url + " — FetchToken is not implemented in this backend; "
-                                            "supply an inline token in LiveKitConfig::token");
+    throw TokenFetchFailedError(std::format(
+        "{} - FetchToken is not implemented in this backend; supply an "
+        "inline token in LiveKitConfig::token",
+        token_url));
 }
 
 } // namespace streamkit

--- a/client-samples/native/StreamKit/src/Backends/LiveKit/LiveKitBackend.cpp
+++ b/client-samples/native/StreamKit/src/Backends/LiveKit/LiveKitBackend.cpp
@@ -530,12 +530,8 @@ void LiveKitBackend::TearDown() {
 [[noreturn]] void LiveKitBackend::FetchToken(
     const std::string& token_url,
     const std::string& /*identity*/) const {
-    // Token-fetch over HTTP is deliberately not implemented in this
-    // backend. Embedded targets typically pass an inline token in
-    // `LiveKitConfig::token` (computed server-side); desktop hosts that
-    // need a token endpoint can subclass LiveKitBackend and override
-    // FetchToken with their preferred HTTP client (libcurl, Poco::Net,
-    // cpp-httplib). See `App/main.cpp` for the inline-token path.
+    // No HTTP client shipped — callers must pass an inline JWT via
+    // `LiveKitConfig::token` (computed server-side).
     throw TokenFetchFailedError(std::format(
         "{} - FetchToken is not implemented in this backend; supply an "
         "inline token in LiveKitConfig::token",

--- a/client-samples/native/StreamKit/src/StreamSession.cpp
+++ b/client-samples/native/StreamKit/src/StreamSession.cpp
@@ -6,6 +6,7 @@
 #include "streamkit/Config/BackendConfiguration.h"
 
 #include <stdexcept>
+#include <type_traits>
 #include <utility>
 
 namespace streamkit {
@@ -15,8 +16,7 @@ namespace streamkit {
 // ─────────────────────────────────────────────────────────────────────────────
 
 std::unique_ptr<StreamingBackend> MakeBackend(const BackendConfiguration& config) {
-    return std::visit([](auto&& cfg) -> std::unique_ptr<StreamingBackend> {
-        using T = std::decay_t<decltype(cfg)>;
+    return std::visit([]<typename T>(const T& cfg) -> std::unique_ptr<StreamingBackend> {
         if constexpr (std::is_same_v<T, LiveKitConfig>) {
             return std::make_unique<LiveKitBackend>(cfg);
         }


### PR DESCRIPTION
## Summary

- resolve valid Sonar findings across StreamKit native code/tests and the xr-render-demo eval watcher
- make LiveKitBackend destruction non-throwing and clean up byte/string boundaries in native tests and samples
- replace non-secret random participant labels with process-local unique IDs
- modernize C++20 style findings with std::format, std::ranges, using enum, explicit lambda captures, and std::source_location

## Sonar notes

- Leaves `cpp:S5414` on `StreamSession` accepted rather than changing the public callback-field API.
- Leaves `cpp:S5817` on `LiveKitBackend::HandleConnectionStateChange` as a Sonar false positive: the function mutates connection state in real LiveKit builds; the analyzer appears to report the stub-build path.

## Testing

- `bash -n agent-samples/xr-render-demo/eval/eval_watch.sh`
- `clang++ -std=c++20 -Wall -Wextra` compile of touched StreamKit translation units
- manual compile and run of all six native StreamKit test executables
- manual compile of native sample app
- `git diff --check`

`cmake` was not available in the local shell, so I could not run the normal CMake/CTest path.
