### PR TITLE
Pin CloudXR and LOVR to the GPU with the most free VRAM

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -149,6 +149,7 @@ video-mcp-server  (agent-mcp-servers/video-mcp/)
     re-encodes selected frames as PNG via Pillow.
 
 cloudxr-runtime  (cloudxr-runtime/)
+    └── xr-ai-launcher  [editable: ../utils/xr-ai-launcher] (pick_freest_gpu_env)
     └── isaacteleop[cloudxr]
     └── pyyaml
 

--- a/agent-mcp-servers/render-mcp/render_mcp/__main__.py
+++ b/agent-mcp-servers/render-mcp/render_mcp/__main__.py
@@ -41,7 +41,12 @@ import zmq.asyncio
 from fastmcp import FastMCP
 from loguru import logger
 
-from xr_ai_launcher import ManagedProcess, XR_RUNTIME_VAR, load_cloudxr_env
+from xr_ai_launcher import (
+    ManagedProcess,
+    XR_RUNTIME_VAR,
+    load_cloudxr_env,
+    pick_freest_gpu_env,
+)
 from xr_ai_logging import setup_logging
 
 _DEFAULT_YAML = Path(__file__).resolve().parent.parent / "render_mcp.yaml"
@@ -216,8 +221,19 @@ class SceneDispatcher:
             logger.info(
                 "render-mcp: starting LOVR  bin={}  app={}", cfg.lovr_bin, cfg.xr_app_dir,
             )
+
+            # Pin LOVR to the NVIDIA GPU with the most free VRAM. Avoids OOM
+            # when local LLM/STT/VLM services have eaten most of one card.
+            # Falls back to inheriting parent env when nvidia-smi is
+            # unavailable or there is only one GPU.
+            gpu_env, gpu_msg = pick_freest_gpu_env()
+            logger.info("render-mcp: lovr gpu select  {}", gpu_msg)
+            child_env: dict[str, str] | None = None
+            if gpu_env:
+                child_env = {**os.environ, **gpu_env}
+
             lovr_proc = await self._stack.enter_async_context(
-                ManagedProcess("lovr", lovr_cmd, cwd=cfg.xr_app_dir)
+                ManagedProcess("lovr", lovr_cmd, cwd=cfg.xr_app_dir, env=child_env)
             )
 
             async def _watch() -> None:

--- a/cloudxr-runtime/cloudxr_runtime/__main__.py
+++ b/cloudxr-runtime/cloudxr_runtime/__main__.py
@@ -33,6 +33,7 @@ from isaacteleop.cloudxr.runtime import (
 )
 from isaacteleop.cloudxr.wss import run as wss_run
 from loguru import logger
+from xr_ai_launcher import pick_freest_gpu_env
 from xr_ai_logging import setup_logging
 
 
@@ -69,6 +70,16 @@ async def _run(cfg: dict, ready_file: Path | None = None) -> None:
 
     for key, val in cfg.get("cloudxr_env", {}).items():
         os.environ[key] = str(val)
+
+    # Pin the CloudXR runtime daemon to the NVIDIA GPU with the most free
+    # VRAM. The daemon's compositor allocates per-eye Vulkan images at
+    # client-connect time; if the GPU it picked at startup is full of
+    # vLLM/etc. weights it OOMs the LOVR client with XRT_ERROR_VULKAN.
+    # Set BEFORE the multiprocessing fork so the runtime subprocess inherits.
+    gpu_env, gpu_msg = pick_freest_gpu_env()
+    logger.info("cloudxr gpu select  {}", gpu_msg)
+    if gpu_env:
+        os.environ.update(gpu_env)
 
     env_cfg = EnvConfig.from_args(install_dir, env_file)
     check_eula(accept_eula=cfg.get("accept_eula") or None)

--- a/cloudxr-runtime/pyproject.toml
+++ b/cloudxr-runtime/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.11,<3.13"
 dependencies = [
     "isaacteleop[cloudxr]",
     "pyyaml",
+    "xr-ai-launcher",
     "xr-ai-logging",
 ]
 
@@ -19,6 +20,7 @@ dependencies = [
 cloudxr_runtime = "cloudxr_runtime.__main__:run"
 
 [tool.uv.sources]
+xr-ai-launcher = { path = "../utils/xr-ai-launcher", editable = true }
 xr-ai-logging = { path = "../utils/xr-ai-logging", editable = true }
 
 [tool.hatch.build.targets.wheel]

--- a/utils/xr-ai-launcher/xr_ai_launcher/__init__.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/__init__.py
@@ -28,7 +28,7 @@ Typical usage::
 
 from ._cloudxr_env import XR_RUNTIME_VAR, load_cloudxr_env
 from ._credentials import ensure_credentials, load_credentials
-from ._gpu import detect_gpu_config
+from ._gpu import detect_gpu_config, pick_freest_gpu_env
 from ._processes import ManagedProcess
 from ._stack import Parallel, Process, run_stack
 
@@ -36,6 +36,7 @@ __all__ = [
     "XR_RUNTIME_VAR", "load_cloudxr_env",
     "ensure_credentials", "load_credentials",
     "detect_gpu_config",
+    "pick_freest_gpu_env",
     "ManagedProcess",
     "Parallel", "Process", "run_stack",
 ]

--- a/utils/xr-ai-launcher/xr_ai_launcher/_gpu.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/_gpu.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import logging
+import shutil
 import subprocess
 
 log = logging.getLogger(__name__)
@@ -81,3 +82,71 @@ def detect_gpu_config() -> str:
         cfg, n_gpus, gpus[0][0].upper(), mem_display, first_cap,
     )
     return cfg
+
+
+def pick_freest_gpu_env() -> tuple[dict[str, str] | None, str]:
+    """Pick the NVIDIA GPU with the most free VRAM and return env vars that
+    pin a Vulkan child process to it.
+
+    Returns ``(env_overlay, log_msg)``. ``env_overlay`` is a dict to merge
+    into ``os.environ`` (or ``None`` if we couldn't query the GPUs / there
+    is nothing to choose from). Failure to pick is non-fatal; callers should
+    just not pin.
+
+    Sets ``DRI_PRIME=pci-DDDD_BB_DD_F`` (Mesa device-select implicit-layer
+    mechanism that disambiguates same-model GPUs without root),
+    ``VK_LOADER_DEVICE_SELECT=PCI:bus:dev:func`` for hosts on Vulkan-Loader
+    >= 1.3.207, and ``CUDA_VISIBLE_DEVICES`` for any incidental CUDA paths
+    the child or its libs might touch.
+    """
+    if not shutil.which("nvidia-smi"):
+        return None, "no nvidia-smi on PATH; not pinning GPU"
+
+    try:
+        out = subprocess.check_output(
+            ["nvidia-smi",
+             "--query-gpu=index,pci.bus_id,memory.free",
+             "--format=csv,noheader,nounits"],
+            text=True, timeout=5.0,
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        return None, f"nvidia-smi failed ({exc}); not pinning GPU"
+
+    rows: list[tuple[int, str, int]] = []
+    for line in out.strip().splitlines():
+        parts = [p.strip() for p in line.split(",")]
+        if len(parts) < 3:
+            continue
+        try:
+            idx = int(parts[0])
+            bus_id = parts[1]
+            free_mb = int(parts[2])
+        except ValueError:
+            continue
+        rows.append((idx, bus_id, free_mb))
+
+    if not rows:
+        return None, "nvidia-smi returned no GPUs; not pinning"
+    if len(rows) == 1:
+        return None, f"only one NVIDIA GPU visible (idx={rows[0][0]}); no pinning needed"
+
+    rows.sort(key=lambda r: r[2], reverse=True)
+    best_idx, best_bus, best_free = rows[0]
+
+    # nvidia-smi gives bus_id "00000000:41:00.0" with an 8-hex-digit domain;
+    # both pin envs want the standard 4-digit-domain PCI form.
+    try:
+        domain8, bus, dev_func = best_bus.split(":")
+        dev, func = dev_func.split(".")
+        domain = domain8[-4:]
+    except ValueError:
+        return None, f"couldn't parse PCI bus_id {best_bus!r}; not pinning"
+
+    env: dict[str, str] = {
+        "DRI_PRIME": f"pci-{domain}_{bus}_{dev}_{func}",
+        "VK_LOADER_DEVICE_SELECT": f"PCI:{bus}:{dev}:{func}",
+        "CUDA_VISIBLE_DEVICES": str(best_idx),
+    }
+    summary = (f"pinning to GPU {best_idx} (PCI {best_bus}, "
+               f"{best_free} MB free)")
+    return env, summary


### PR DESCRIPTION
On multi-GPU systems this make the CloudXR and sample app start up on the GPU with the most free VRAM.

Instead of autodetect we could do it via config as in https://github.com/NVIDIA/xr-ai/pull/163 (only merge one of the changes).