### PR TITLE
feat(voicegate): extract shared wake-word/STOP/chime/greeting module; migrate simple-vlm-example + xr-render-demo

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -103,6 +103,7 @@ xr-ai-vad  (utils/xr-ai-vad/)
 
 xr-ai-voicegate  (utils/xr-ai-voicegate/)
     └── numpy >=1.24
+    └── pyyaml >=6.0
     Speech-only opt-in gate shared by agent workers that consume STT
     transcripts.  Owns the magic-phrase + follow-up + STOP ladder, the
     lazy listening chime (numpy-synthesized at the consumer's TTS sample
@@ -111,7 +112,9 @@ xr-ai-voicegate  (utils/xr-ai-voicegate/)
     ``on_phrase_only`` / ``on_drop`` / ``on_participant_joined``
     handlers.  Audio + TTS are consumed via duck-typed ``AudioSink`` /
     ``TTSLike`` Protocols so the package stays free of xr-ai-models /
-    xr-ai-agent / pipecat deps.
+    xr-ai-agent / pipecat deps.  pyyaml is used by
+    ``load_voice_gate_config`` to parse the standalone ``voice_gate.yaml``
+    file each sample's worker YAML references.
 
 xr-media-hub  (server-runtime/)
     └── xr-ai-agent  [editable: ../agent-sdk]

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -195,6 +195,7 @@ xr-ai-tests  (tests/)
     └── xr-ai-logging           [editable: ../utils/xr-ai-logging]
     └── xr-ai-vad               [editable: ../utils/xr-ai-vad]
     └── xr-ai-vllm              [editable: ../utils/xr-ai-vllm]
+    └── xr-ai-voicegate         [editable: ../utils/xr-ai-voicegate]
     └── transcript-mcp-server   [editable: ../agent-mcp-servers/transcript-mcp]
     └── vlm-mcp-server          [editable: ../agent-mcp-servers/vlm-mcp]
     └── render-mcp              [editable: ../agent-mcp-servers/render-mcp]

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -101,6 +101,18 @@ xr-ai-vad  (utils/xr-ai-vad/)
     for speculative downstream warmup (e.g. start the camera before STT
     completes).
 
+xr-ai-voicegate  (utils/xr-ai-voicegate/)
+    └── numpy >=1.24
+    Speech-only opt-in gate shared by agent workers that consume STT
+    transcripts.  Owns the magic-phrase + follow-up + STOP ladder, the
+    lazy listening chime (numpy-synthesized at the consumer's TTS sample
+    rate), and the participant-joined greeting hook.  Workers feed
+    transcripts via ``feed`` and register ``on_query`` / ``on_stop`` /
+    ``on_phrase_only`` / ``on_drop`` / ``on_participant_joined``
+    handlers.  Audio + TTS are consumed via duck-typed ``AudioSink`` /
+    ``TTSLike`` Protocols so the package stays free of xr-ai-models /
+    xr-ai-agent / pipecat deps.
+
 xr-media-hub  (server-runtime/)
     └── xr-ai-agent  [editable: ../agent-sdk]
     └── pyzmq >=26.0
@@ -358,7 +370,7 @@ the latest video frame via streaming VLM and replies with both
 | Sub-project | Package | Internal deps | External deps |
 |---|---|---|---|
 | Orchestrator | `simple-vlm-example` | `xr-ai-launcher` | — |
-| Worker | `simple-vlm-example-worker` | `xr-ai-agent`, `xr-ai-models [editable]`, `xr-ai-vad [editable]` | numpy >=1.24, Pillow >=10.0, pyyaml >=6.0 (silero-vad pulled in via xr-ai-vad) |
+| Worker | `simple-vlm-example-worker` | `xr-ai-agent`, `xr-ai-models [editable]`, `xr-ai-vad [editable]`, `xr-ai-voicegate [editable]` | numpy >=1.24, Pillow >=10.0, pyyaml >=6.0 (silero-vad pulled in via xr-ai-vad) |
 
 Worker calls stt-server (8103), vlm-server (8100), and piper-tts-server
 (8105) over HTTP via `xr-ai-models` SDK — no model weights loaded

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -404,7 +404,7 @@ forwarding.
 | Sub-project | Package | Internal deps | External deps |
 |---|---|---|---|
 | Orchestrator | `xr-render-demo` | `xr-ai-launcher`, `xr-ai-logging` | — |
-| Worker | `xr-render-demo-worker` | `xr-ai-agent`, `xr-ai-models` [editable], `xr-ai-pipecat` [editable], `xr-ai-logging` [editable], `xr-ai-vad` [editable] | numpy >=1.24, httpx >=0.27, fastmcp >=0.4, pyyaml >=6.0 (silero-vad pulled in via xr-ai-vad) |
+| Worker | `xr-render-demo-worker` | `xr-ai-agent`, `xr-ai-models` [editable], `xr-ai-pipecat` [editable], `xr-ai-logging` [editable], `xr-ai-vad` [editable], `xr-ai-voicegate` [editable] | numpy >=1.24, httpx >=0.27, fastmcp >=0.4, pyyaml >=6.0 (silero-vad pulled in via xr-ai-vad) |
 
 Model endpoints (llm, agent_llm, stt, tts, vlm) are declared in
 `yaml/models.yaml` and loaded via `xr-ai-models` `load_models_config` /

--- a/agent-samples/simple-vlm-example/worker/agent.py
+++ b/agent-samples/simple-vlm-example/worker/agent.py
@@ -241,7 +241,8 @@ class SimpleVlmAgent:
         self._schedule_camera_off(pid)
 
     async def _on_drop(self, pid: str, text: str) -> None:
-        logger.info("voice gate dropped pid={!r} text={!r}", pid, text[:80])
+        logger.info("voice gate dropped pid={!r} (text suppressed)", pid)
+        logger.debug("voice gate dropped pid={!r} text={!r}", pid, text[:80])
         self._schedule_camera_off(pid)
 
     # ── data path: text → query (with "ping" → default prompt) ────────────────
@@ -253,7 +254,8 @@ class SimpleVlmAgent:
             return
         if not text:
             return
-        logger.info("data query  pid={!r}  {!r}", msg.participant_id, text[:80])
+        logger.info("data query  pid={!r} (text suppressed)", msg.participant_id)
+        logger.debug("data query  pid={!r}  {!r}", msg.participant_id, text[:80])
         await self._dispatch_query(msg.participant_id, text, pts_us=msg.pts_us)
 
     # ── interruptable query dispatch ──────────────────────────────────────────

--- a/agent-samples/simple-vlm-example/worker/agent.py
+++ b/agent-samples/simple-vlm-example/worker/agent.py
@@ -220,9 +220,15 @@ class SimpleVlmAgent:
 
     # ── voice-gate handlers ───────────────────────────────────────────────────
 
-    async def _dispatch_from_voice(self, pid: str, query: str) -> None:
-        """Voice-gate ``on_query`` handler — chime + dispatch."""
-        asyncio.create_task(self._gate.play_chime(pid))
+    async def _dispatch_from_voice(self, pid: str, query: str, fresh_match: bool) -> None:
+        """Voice-gate ``on_query`` handler — chime + dispatch.
+
+        Only chimes on a *fresh* magic-phrase match. Follow-up window
+        continuations (``fresh_match=False``) skip the chime; the original
+        pre-extraction code only chimed on case 2 and case 4, never on
+        case 3, and this matches that behavior."""
+        if fresh_match:
+            asyncio.create_task(self._gate.play_chime(pid))
         await self._dispatch_query(pid, query, pts_us=now_us())
 
     async def _on_phrase_only(self, pid: str) -> None:

--- a/agent-samples/simple-vlm-example/worker/agent.py
+++ b/agent-samples/simple-vlm-example/worker/agent.py
@@ -7,28 +7,17 @@ SimpleVlmAgent — vision Q&A driven by voice, text, or "ping".
 Inputs
 ------
 * Audio chunks (mic):  VAD detects an utterance, STT turns it into text,
-                       which is then dispatched as a query.  If any
-                       ``magic_phrases`` are configured, the transcript
-                       must begin with one of them (case-insensitive,
-                       strict prefix — no leading filler words) or the
-                       utterance is dropped.  Configure several phrases
-                       to accept multiple wordings (e.g. "agent" and
-                       "hey agent") without resorting to fuzzy matching.
-                       This is the opt-in gate that keeps ambient
-                       conversation from triggering the agent.  When a
-                       phrase matches, the prefix is stripped before
-                       dispatch and a short follow-up window opens — the
-                       next utterance from that participant within
-                       ``followup_grace_s`` seconds bypasses the gate so
-                       a natural pause between the phrase and the
-                       question still works.  ``stop`` and related
-                       interrupt phrases always pass through and do not
-                       extend the follow-up window.
+                       which is then handed to ``xr-ai-voicegate``. The
+                       gate owns the magic-phrase, STOP, and follow-up
+                       ladder — see ``utils/xr-ai-voicegate``. This
+                       worker only wires handlers (``on_query``,
+                       ``on_stop``, ``on_phrase_only``, ``on_drop``,
+                       ``on_participant_joined``) and feeds transcripts.
 * Data messages:       text payload is dispatched as a query directly.
-                       The magic-phrase gate does not apply to this path.
+                       The voice gate does not apply to this path.
 * "ping" data message: literal text "ping" (case-insensitive) is replaced
                        with the configured default prompt before dispatch.
-                       Note: a *spoken* "ping" is gated by the magic phrase
+                       Note: a *spoken* "ping" is gated by the voice gate
                        like any other utterance; only the data-channel
                        shortcut is unaffected.
 
@@ -61,7 +50,6 @@ rapid follow-up queries don't cause a stop/start cycle.
 from __future__ import annotations
 
 import asyncio
-import dataclasses
 import json
 import re
 import time
@@ -74,47 +62,11 @@ from xr_ai_agent import (AudioChunk, DataMessage, FrameSignal,
 from xr_ai_logging import print_task_done_banner
 from xr_ai_models import STTService, TTSService, VLMService
 from xr_ai_vad import VadDetector
+from xr_ai_voicegate import VoiceGate, VoiceGateConfig
 
 from audio import int16_pcm_to_wav, now_us, wav_to_chunks
 from pixels import encode_image, frame_to_pil
 from voice import VoiceState
-
-# Transcripts matching this pattern bypass the magic-phrase gate so the
-# user can interrupt a response mid-flight without having to start with
-# the configured phrase.
-_STOP_RE = re.compile(
-    r'^\s*(?:\S+\s+){0,2}'               # up to 2 optional filler words
-    r'(?:stop(?:\s+\w+){0,2}|be\s+quiet|quiet|shut\s+up)'
-    r'\s*[.!?]?\s*$',
-    re.IGNORECASE,
-)
-
-
-def _build_chime_chunks(sample_rate: int) -> list[AudioChunk]:
-    """Synthesize the listening-chime and pre-slice into AudioChunks at
-    ``sample_rate``.
-
-    Two-tone perfect-fifth ding (880 + 1320 Hz) with exponential decay,
-    ~250 ms total, mono int16 PCM. The sample rate MUST match the rate
-    of the rest of the return audio track (TTS) because LiveKit's
-    AudioSource is locked to the first chunk's params and rejects later
-    frames at a different rate (InvalidState).
-    The `participant_id` is patched per-send in `_send_chime`.
-    """
-    dur  = 0.25
-    t    = np.linspace(0.0, dur, int(sample_rate * dur), endpoint=False, dtype=np.float32)
-    tone = 0.55 * np.sin(2 * np.pi * 880.0 * t) + 0.30 * np.sin(2 * np.pi * 1320.0 * t)
-    env  = np.exp(-t * 8.0).astype(np.float32)
-    pcm  = (tone * env * 0.5 * 32767.0).clip(-32768, 32767).astype(np.int16)
-    wav  = int16_pcm_to_wav(pcm.tobytes(), sample_rate, channels=1)
-    return wav_to_chunks(wav, participant_id="")
-
-
-def _read_wav_sample_rate(wav_bytes: bytes) -> int:
-    """Pull the sample rate from a WAV blob without decoding the audio."""
-    import io, wave
-    with wave.open(io.BytesIO(wav_bytes), "rb") as wf:
-        return wf.getframerate()
 
 
 DEFAULT_SYSTEM_PROMPT = (
@@ -143,6 +95,19 @@ DEFAULT_SYSTEM_PROMPT = (
 )
 
 
+class _EpSink:
+    """Adapter implementing ``xr_ai_voicegate.AudioSink`` over the hub's
+    return-audio fan-out: explode the WAV into 20 ms AudioChunks via the
+    worker's ``wav_to_chunks`` and stream them through ``send_return_audio``."""
+
+    def __init__(self, ep: ProcessorEndpoint) -> None:
+        self._ep = ep
+
+    async def play_wav(self, pid: str, wav_bytes: bytes) -> None:
+        for chunk in wav_to_chunks(wav_bytes, pid):
+            await self._ep.send_return_audio(chunk)
+
+
 class SimpleVlmAgent:
 
     def __init__(
@@ -152,14 +117,12 @@ class SimpleVlmAgent:
         vlm: VLMService,
         tts: TTSService,
         *,
-        default_prompt:     str   = "Describe what you see.",
-        system_prompt:      str   = DEFAULT_SYSTEM_PROMPT,
-        magic_phrases:      list[str] | tuple[str, ...] | str = (),
-        listening_chime:    bool  = False,
-        followup_grace_s:   float = 5.0,
-        silence_duration:   float = 0.8,
-        min_speech:         float = 0.3,
-        silero_threshold:   float = 0.5,
+        voice_gate_cfg:      VoiceGateConfig,
+        default_prompt:      str   = "Describe what you see.",
+        system_prompt:       str   = DEFAULT_SYSTEM_PROMPT,
+        silence_duration:    float = 0.8,
+        min_speech:          float = 0.3,
+        silero_threshold:    float = 0.5,
         frame_max_age_s:     float = 2.0,
         camera_on_timeout_s: float = 15.0,
         camera_grace_s:      float = 5.0,
@@ -176,48 +139,6 @@ class SimpleVlmAgent:
 
         self._default_prompt    = default_prompt
         self._system_prompt     = system_prompt
-        # Accept a single string OR a list of phrases. Normalize to a
-        # tuple of lowercased, non-empty phrases. Defensive: empty YAML
-        # values parse as None and would otherwise crash .strip().
-        if isinstance(magic_phrases, str):
-            _raw = [magic_phrases]
-        else:
-            _raw = list(magic_phrases) if magic_phrases else []
-        self._magic_phrases: tuple[str, ...] = tuple(
-            p.strip().lower() for p in _raw if p and p.strip()
-        )
-        # Pre-compile one regex covering every configured phrase.
-        # Longest-first ordering picks the most specific match when one
-        # phrase is a prefix of another (e.g., "agent" vs "agent buddy").
-        # Inside each phrase, the literal space between words is treated
-        # as "whitespace OR punctuation" so STT transcripts like
-        # "Hey, agent." still match the configured "hey agent".
-        self._magic_re: re.Pattern | None = None
-        if self._magic_phrases:
-            sep = r'[\s,.:;!?-]+'
-            alts = "|".join(
-                sep.join(re.escape(w) for w in p.split())
-                for p in sorted(self._magic_phrases, key=len, reverse=True)
-            )
-            self._magic_re = re.compile(
-                rf'^\s*(?:{alts})\b[\s,.:;!?-]*', re.IGNORECASE,
-            )
-        # Chime is built lazily at the TTS sample rate the first time
-        # any TTS WAV passes through (greeting or VLM reply). That
-        # guarantees the chime matches the rate the LiveKit AudioSource
-        # is locked to and avoids probing TTS with a dummy synthesize
-        # call (Piper crashes on whitespace input). See
-        # _maybe_build_chime. Disabled without a configured phrase.
-        self._listening_chime_enabled = listening_chime and bool(self._magic_phrases)
-        self._chime_chunks: list[AudioChunk] | None = None
-        # Follow-up grace: after a successful magic-phrase match, the
-        # next utterance from the same pid within this window bypasses
-        # the gate. Lets users say "hey agent" → pause → "what am I
-        # looking at?" naturally instead of mashing the phrase onto the
-        # front of every question. The window resets each time an
-        # utterance is accepted so a conversation keeps flowing.
-        self._followup_grace_s      = followup_grace_s
-        self._followup_until: dict[str, float] = {}
         self._vad_silence_s         = silence_duration
         self._vad_min_s             = min_speech
         self._vad_silero_threshold  = silero_threshold
@@ -234,7 +155,15 @@ class SimpleVlmAgent:
         self._camera_off_timers: dict[str, asyncio.Task] = {}  # pid → delayed-off task
         self._frame_events: dict[str, asyncio.Event]     = {}  # pid → event set on new frame
 
-    # ── audio path: VAD → STT → query ─────────────────────────────────────────
+        # Speech gating + greeting are owned by the voice gate.
+        self._gate = VoiceGate(voice_gate_cfg, audio_sink=_EpSink(ep), tts=tts)
+        self._gate.on_query(self._dispatch_from_voice)
+        self._gate.on_stop(self._handle_stop)
+        self._gate.on_phrase_only(self._on_phrase_only)
+        self._gate.on_drop(self._on_drop)
+        self._gate.on_participant_joined(self._greet)
+
+    # ── audio path: VAD → STT → gate ──────────────────────────────────────────
 
     async def _on_audio(self, chunk: AudioChunk) -> None:
         vs = self._get_voice(chunk.participant_id)
@@ -283,79 +212,31 @@ class SimpleVlmAgent:
             text = (await self._stt.transcribe(wav)).strip()
             if not text:
                 return
-            # Gate priority:
-            #   0. STOP — always wins. Cancels in-flight + canned ack,
-            #      regardless of magic-phrase or followup state. Matched
-            #      on both the raw transcript ("stop") AND on the
-            #      magic-phrase-stripped tail ("hey agent, stop") so the
-            #      fast path triggers either way.
-            #   1. strict-prefix magic phrase match (new conversation)
-            #   2. follow-up grace window still open (continuation)
-            now_mono       = time.monotonic()
-            in_followup    = self._followup_until.get(pid, 0.0) > now_mono
-            stripped       = self._strip_magic_phrase(text)
-            matched_magic  = stripped is not None
-            stop_candidate = stripped if (matched_magic and stripped) else text
-            if _STOP_RE.match(stop_candidate):
-                logger.info("stop bypass pid={!r}  {!r}", pid, stop_candidate[:80])
-                self._followup_until.pop(pid, None)
-                await self._handle_stop(pid)
-                self._schedule_camera_off(pid)
-                return
-            if matched_magic:
-                query = stripped
-            elif in_followup:
-                query = text
-                logger.info("followup query pid={!r} {!r}", pid, text[:80])
-            else:
-                logger.info("magic phrase missing pid={!r} text={!r}", pid, text[:80])
-                self._followup_until.pop(pid, None)
-                self._schedule_camera_off(pid)
-                return
-            # Chime on a fresh magic-phrase match only — follow-ups are
-            # already inside the conversation and STOP is a different signal.
-            if matched_magic and self._listening_chime_enabled:
-                asyncio.create_task(self._send_chime(pid))
-            if not query:
-                # Magic phrase with no follow-up payload yet — open the
-                # window so the user's next utterance counts as the
-                # actual query without needing the phrase again.
-                self._followup_until[pid] = now_mono + self._followup_grace_s
-                logger.info(
-                    "magic phrase only pid={!r} — awaiting followup ({:.1f}s)",
-                    pid, self._followup_grace_s,
-                )
-                self._schedule_camera_off(pid)
-                return
-            # Real query about to be dispatched. Close the window — the
-            # next utterance must re-introduce a magic phrase. Keeps
-            # ambient speech after the answer from re-entering.
-            self._followup_until.pop(pid, None)
-            logger.info("audio query  pid={!r}  {!r}", pid, query[:80])
-            await self._dispatch_query(pid, query, pts_us=now_us())
+            await self._gate.feed(pid, text)
         except httpx.HTTPError as exc:
             logger.error("stt error pid={!r}: {}", pid, exc)
         finally:
             vs.transcribing = False
 
-    def _strip_magic_phrase(self, text: str) -> str | None:
-        """Gate STT output on the configured magic phrase(s).
+    # ── voice-gate handlers ───────────────────────────────────────────────────
 
-        Strict-prefix match (case-insensitive): the transcript must begin
-        with one of the configured phrases as a whole word — no leading
-        filler words and no mid-sentence matches. Configure multiple
-        phrases (e.g. "agent", "hey agent") to accept several wordings
-        without falling back to fuzzy matching.
+    async def _dispatch_from_voice(self, pid: str, query: str) -> None:
+        """Voice-gate ``on_query`` handler — chime + dispatch."""
+        asyncio.create_task(self._gate.play_chime(pid))
+        await self._dispatch_query(pid, query, pts_us=now_us())
 
-        Returns the remainder of the transcript with the matched phrase
-        and any adjacent punctuation stripped, or ``None`` if no phrase
-        is the strict prefix. With no phrases configured the gate is
-        disabled and ``text`` is returned unchanged.
-        """
-        if self._magic_re is None:
-            return text
-        m = self._magic_re.match(text)
-        return None if m is None else text[m.end():]
+    async def _on_phrase_only(self, pid: str) -> None:
+        """Voice-gate ``on_phrase_only`` handler — chime the
+        acknowledgement so the user knows the wake word was heard while
+        the follow-up window is open, then schedule a camera-off in case
+        the user never follows up. ``_handle_query`` (case 2/3) cancels
+        a pending off-timer when the next query lands."""
+        await self._gate.play_chime(pid)
+        self._schedule_camera_off(pid)
+
+    async def _on_drop(self, pid: str, text: str) -> None:
+        logger.info("voice gate dropped pid={!r} text={!r}", pid, text[:80])
+        self._schedule_camera_off(pid)
 
     # ── data path: text → query (with "ping" → default prompt) ────────────────
 
@@ -469,7 +350,7 @@ class SimpleVlmAgent:
                     break
                 try:
                     wav = await task
-                    self._maybe_build_chime(wav)
+                    self._gate.observe_tts_wav(wav)
                     for chunk in wav_to_chunks(wav, pid):
                         await self._ep.send_return_audio(chunk)
                 except asyncio.CancelledError:
@@ -651,7 +532,7 @@ class SimpleVlmAgent:
         await self._reply(pid, text, pts_us)
         try:
             wav = await self._tts.synthesize(text)
-            self._maybe_build_chime(wav)
+            self._gate.observe_tts_wav(wav)
             for chunk in wav_to_chunks(wav, pid):
                 await self._ep.send_return_audio(chunk)
         except asyncio.CancelledError:
@@ -660,21 +541,6 @@ class SimpleVlmAgent:
             logger.opt(exception=True).error(
                 "tts error pid={!r}: {}", pid, exc,
             )
-
-    def _maybe_build_chime(self, wav_bytes: bytes) -> None:
-        """Build the chime at the TTS sample rate the first time we see
-        a real TTS WAV. No-op once built or when chime is disabled."""
-        if self._chime_chunks is not None or not self._listening_chime_enabled:
-            return
-        try:
-            sr = _read_wav_sample_rate(wav_bytes)
-            self._chime_chunks = _build_chime_chunks(sr)
-            logger.info("listening chime ready (sr={} Hz)", sr)
-        except Exception as exc:
-            logger.opt(exception=True).warning(
-                "listening chime disabled (bad TTS wav header): {}", exc,
-            )
-            self._listening_chime_enabled = False
 
     async def _handle_stop(self, pid: str) -> None:
         """Cancel any in-flight response for this participant and play a
@@ -701,48 +567,21 @@ class SimpleVlmAgent:
                         )
                 await self._ep.flush_return_audio(pid)
                 vs.current_task = None
-        await self._say(pid, "Okay, I will stop.", now_us())
-
-    async def _send_chime(self, pid: str) -> None:
-        """Emit the listening-chime on the return audio track. No-op
-        when chime is disabled."""
-        if self._chime_chunks is None:
-            return
-        pts0 = now_us()
-        try:
-            for i, ch in enumerate(self._chime_chunks):
-                chunk = dataclasses.replace(
-                    ch, participant_id=pid, pts_us=pts0 + i * 20_000,
-                )
-                await self._ep.send_return_audio(chunk)
-        except asyncio.CancelledError:
-            raise
-        except Exception as exc:
-            logger.opt(exception=True).error(
-                "chime send error pid={!r}: {}", pid, exc,
-            )
+        # Preserve the visible reply on ``vlm.response`` (clients listen
+        # on it for the assistant's text) while letting the gate handle
+        # the canned TTS + chime sample-rate observation.
+        self._schedule_camera_off(pid)
+        await self._reply(pid, "Okay, I will stop.", now_us())
+        await self._gate.say_stop_ack(pid)
 
     async def _greet(self, pid: str) -> None:
         """Speak a one-shot connection greeting that tells the user how to
-        address the agent given the current magic-phrase setting."""
-        phrases = list(self._magic_phrases)
-        if not phrases:
+        address the agent given the current voice-gate setting."""
+        help_text = self._gate.format_phrase_help()
+        if help_text is None:
             text = "Hi, I'm listening. Ask me anything about what you see."
         else:
-            if len(phrases) == 1:
-                phrase_list = f'"{phrases[0]}"'
-            elif len(phrases) == 2:
-                phrase_list = f'"{phrases[0]}" or "{phrases[1]}"'
-            else:
-                phrase_list = (
-                    ", ".join(f'"{p}"' for p in phrases[:-1])
-                    + f', or "{phrases[-1]}"'
-                )
-            text = (
-                f"Hi, I'm listening. To talk to me, start your question "
-                f"with {phrase_list}. For example, "
-                f"\"{phrases[0]}, what am I looking at?\""
-            )
+            text = f"Hi, I'm listening. {help_text}"
         try:
             await self._say(pid, text, now_us())
         except asyncio.CancelledError:
@@ -784,7 +623,7 @@ class SimpleVlmAgent:
             # a magic phrase is configured, how to address it. The speech
             # path is gated by default now, so without this hint a user
             # can easily think the agent is broken when it ignores them.
-            asyncio.create_task(self._greet(event.participant_id))
+            asyncio.create_task(self._gate.participant_joined(event.participant_id))
             return
         pid = event.participant_id
         vs  = self._voice.pop(pid, None)
@@ -795,7 +634,7 @@ class SimpleVlmAgent:
         self._frame_events.pop(pid, None)
         self._camera_on.pop(pid, None)
         self._camera_held.discard(pid)
-        self._followup_until.pop(pid, None)
+        self._gate.forget(pid)
         timer = self._camera_off_timers.pop(pid, None)
         if timer and not timer.done():
             timer.cancel()

--- a/agent-samples/simple-vlm-example/worker/pyproject.toml
+++ b/agent-samples/simple-vlm-example/worker/pyproject.toml
@@ -14,16 +14,18 @@ dependencies = [
     "xr-ai-logging",
     "xr-ai-models",
     "xr-ai-vad",
+    "xr-ai-voicegate",
     "numpy>=1.24",
     "Pillow>=10.0",
     "pyyaml>=6.0",
 ]
 
 [tool.uv.sources]
-xr-ai-agent   = { path = "../../../agent-sdk", editable = true }
-xr-ai-logging = { path = "../../../utils/xr-ai-logging", editable = true }
-xr-ai-models  = { path = "../../../agent-sdk/xr-ai-models", editable = true }
-xr-ai-vad     = { path = "../../../utils/xr-ai-vad", editable = true }
+xr-ai-agent     = { path = "../../../agent-sdk", editable = true }
+xr-ai-logging   = { path = "../../../utils/xr-ai-logging", editable = true }
+xr-ai-models    = { path = "../../../agent-sdk/xr-ai-models", editable = true }
+xr-ai-vad       = { path = "../../../utils/xr-ai-vad", editable = true }
+xr-ai-voicegate = { path = "../../../utils/xr-ai-voicegate", editable = true }
 
 [project.scripts]
 simple_vlm_example_worker = "simple_vlm_example_worker:run"

--- a/agent-samples/simple-vlm-example/worker/simple_vlm_example_worker.py
+++ b/agent-samples/simple-vlm-example/worker/simple_vlm_example_worker.py
@@ -16,7 +16,8 @@ Client → agent  (LiveKit data channel, any topic):
 Audio in (mic) → STT → text → ``xr-ai-voicegate`` → query.
 The voice gate owns the magic-phrase, STOP, and follow-up ladder; the
 worker only feeds STT transcripts and wires handlers. Configure phrases
-via ``voice_gate.magic_phrases`` (empty/omit disables the gate); see
+via ``yaml/voice_gate.yaml`` (referenced by ``voice_gate_yaml`` in the
+worker YAML; an empty ``magic_phrases`` list disables the gate). See
 ``utils/xr-ai-voicegate`` for the full event ladder. The text data
 channel is never gated.
 
@@ -29,10 +30,7 @@ Config (simple_vlm_example_worker.yaml — auto-passed by the launcher)
     models_yaml:           yaml/models.yaml   # path to models config (relative to yaml dir)
     default_prompt:        "Describe what you see."
     system_prompt:              <multiline string>   # role/style guidance for the VLM
-    voice_gate:                 # forwarded to ``xr-ai-voicegate.VoiceGateConfig``
-      magic_phrases:            []      # opt-in speech prefixes; empty = always-on
-      followup_grace_s:         5.0     # after a match, next utterance within Xs bypasses gate
-      listening_chime:          false   # play a short bell when a magic phrase matches
+    voice_gate_yaml:       voice_gate.yaml   # path to standalone voice_gate config (relative to yaml dir)
     frame_max_age_s:           2.0      # frames older than this trigger a camera-on request
     camera_on_timeout_s:      15.0      # how long to wait for a fresh frame after startCamera
     camera_grace_s:            5.0      # keep camera on this long after a query (avoids restart on follow-ups)
@@ -52,31 +50,12 @@ from loguru import logger
 from xr_ai_agent import ProcessorEndpoint
 from xr_ai_logging import setup_logging
 from xr_ai_models import load_models_config, make_stt, make_tts, make_vlm
-from xr_ai_voicegate import VoiceGateConfig
+from xr_ai_voicegate import load_voice_gate_config
 
 from agent import DEFAULT_SYSTEM_PROMPT, SimpleVlmAgent
 
 _HUB_PUB  = "ipc:///tmp/xr_hub_pub"
 _HUB_PUSH = "ipc:///tmp/xr_hub_in"
-
-
-def _build_voice_gate_cfg(raw: dict | None) -> VoiceGateConfig:
-    """Parse the ``voice_gate:`` YAML block into a ``VoiceGateConfig``.
-
-    Defensive: an absent or empty (``None``) block degrades to defaults
-    (gate disabled, no chime, 5 s follow-up). An empty ``magic_phrases``
-    list also degrades cleanly — the gate dispatches every utterance.
-    """
-    raw = raw or {}
-    phrases_raw = raw.get("magic_phrases") or []
-    if isinstance(phrases_raw, str):
-        phrases_raw = [phrases_raw]
-    phrases = tuple(p for p in (s.strip() for s in phrases_raw) if p)
-    return VoiceGateConfig(
-        magic_phrases    = phrases,
-        followup_grace_s = float(raw.get("followup_grace_s", 5.0)),
-        listening_chime  = bool(raw.get("listening_chime", False)),
-    )
 
 
 async def main(
@@ -96,6 +75,14 @@ async def main(
         models_yaml_path = config_path.parent / models_yaml_path
     models_cfg = load_models_config(models_yaml_path)
 
+    # Resolve `voice_gate_yaml` the same way as `models_yaml`. A missing
+    # file degrades to gate defaults (always-on); see load_voice_gate_config.
+    voice_gate_yaml_raw  = cfg.get("voice_gate_yaml", "voice_gate.yaml")
+    voice_gate_yaml_path = pathlib.Path(voice_gate_yaml_raw)
+    if config_path and not voice_gate_yaml_path.is_absolute():
+        voice_gate_yaml_path = config_path.parent / voice_gate_yaml_path
+    voice_gate_cfg = load_voice_gate_config(voice_gate_yaml_path)
+
     stt = make_stt(models_cfg, "stt")
     vlm = make_vlm(models_cfg, "vlm")
     tts = make_tts(models_cfg, "tts")
@@ -108,7 +95,7 @@ async def main(
     ep    = ProcessorEndpoint(sub_addr=_HUB_PUB, push_addr=_HUB_PUSH)
     agent = SimpleVlmAgent(
         ep, stt, vlm, tts,
-        voice_gate_cfg        =_build_voice_gate_cfg(cfg.get("voice_gate")),
+        voice_gate_cfg        =voice_gate_cfg,
         default_prompt        =cfg.get("default_prompt",        "Describe what you see."),
         system_prompt         =cfg.get("system_prompt",         DEFAULT_SYSTEM_PROMPT),
         frame_max_age_s       =float(cfg.get("frame_max_age_s",       2.0)),

--- a/agent-samples/simple-vlm-example/worker/simple_vlm_example_worker.py
+++ b/agent-samples/simple-vlm-example/worker/simple_vlm_example_worker.py
@@ -13,16 +13,12 @@ Client → agent  (LiveKit data channel, any topic):
     "ping"      — case-insensitive trigger for the configured default prompt
     Any other UTF-8 text — used verbatim as the query
 
-Audio in (mic) → STT → text → query (same path as a data message).
-If any ``magic_phrases`` are configured, STT transcripts must begin
-with one of them (case-insensitive, strict prefix) or the utterance is
-dropped; the matched phrase is stripped before the query is dispatched.
-Multiple phrases enable several wordings ("agent", "hey agent", …)
-without falling back to fuzzy matching. After a match, the next
-utterance from the same participant within ``followup_grace_s`` seconds
-bypasses the gate so the conversation flows naturally. The text data
-channel is not gated; a *spoken* "ping" is gated, but the data-channel
-"ping" shortcut is unaffected.
+Audio in (mic) → STT → text → ``xr-ai-voicegate`` → query.
+The voice gate owns the magic-phrase, STOP, and follow-up ladder; the
+worker only feeds STT transcripts and wires handlers. Configure phrases
+via ``voice_gate.magic_phrases`` (empty/omit disables the gate); see
+``utils/xr-ai-voicegate`` for the full event ladder. The text data
+channel is never gated.
 
 Agent → client:
     Topic "vlm.response"        — assembled UTF-8 text reply
@@ -33,15 +29,16 @@ Config (simple_vlm_example_worker.yaml — auto-passed by the launcher)
     models_yaml:           yaml/models.yaml   # path to models config (relative to yaml dir)
     default_prompt:        "Describe what you see."
     system_prompt:              <multiline string>   # role/style guidance for the VLM
-    magic_phrases:              []    # list of speech-only opt-in prefixes; empty = always-on
-    listening_chime:           false  # play a short bell when a magic phrase matches
-    followup_grace_s:          5.0    # after a match, next utterance within Xs bypasses gate
-    frame_max_age_s:           2.0   # frames older than this trigger a camera-on request
-    camera_on_timeout_s:      15.0   # how long to wait for a fresh frame after startCamera
-    camera_grace_s:            5.0   # keep camera on this long after a query (avoids restart on follow-ups)
-    silero_threshold:           0.5   # Silero speech probability gate (0..1)
-    silence_duration:           0.8   # seconds of silence that ends an utterance
-    min_speech:                 0.1   # minimum seconds of speech before STT fires
+    voice_gate:                 # forwarded to ``xr-ai-voicegate.VoiceGateConfig``
+      magic_phrases:            []      # opt-in speech prefixes; empty = always-on
+      followup_grace_s:         5.0     # after a match, next utterance within Xs bypasses gate
+      listening_chime:          false   # play a short bell when a magic phrase matches
+    frame_max_age_s:           2.0      # frames older than this trigger a camera-on request
+    camera_on_timeout_s:      15.0      # how long to wait for a fresh frame after startCamera
+    camera_grace_s:            5.0      # keep camera on this long after a query (avoids restart on follow-ups)
+    silero_threshold:           0.5     # Silero speech probability gate (0..1)
+    silence_duration:           0.8     # seconds of silence that ends an utterance
+    min_speech:                 0.1     # minimum seconds of speech before STT fires
 """
 from __future__ import annotations
 
@@ -55,11 +52,31 @@ from loguru import logger
 from xr_ai_agent import ProcessorEndpoint
 from xr_ai_logging import setup_logging
 from xr_ai_models import load_models_config, make_stt, make_tts, make_vlm
+from xr_ai_voicegate import VoiceGateConfig
 
 from agent import DEFAULT_SYSTEM_PROMPT, SimpleVlmAgent
 
 _HUB_PUB  = "ipc:///tmp/xr_hub_pub"
 _HUB_PUSH = "ipc:///tmp/xr_hub_in"
+
+
+def _build_voice_gate_cfg(raw: dict | None) -> VoiceGateConfig:
+    """Parse the ``voice_gate:`` YAML block into a ``VoiceGateConfig``.
+
+    Defensive: an absent or empty (``None``) block degrades to defaults
+    (gate disabled, no chime, 5 s follow-up). An empty ``magic_phrases``
+    list also degrades cleanly — the gate dispatches every utterance.
+    """
+    raw = raw or {}
+    phrases_raw = raw.get("magic_phrases") or []
+    if isinstance(phrases_raw, str):
+        phrases_raw = [phrases_raw]
+    phrases = tuple(p for p in (s.strip() for s in phrases_raw) if p)
+    return VoiceGateConfig(
+        magic_phrases    = phrases,
+        followup_grace_s = float(raw.get("followup_grace_s", 5.0)),
+        listening_chime  = bool(raw.get("listening_chime", False)),
+    )
 
 
 async def main(
@@ -91,13 +108,9 @@ async def main(
     ep    = ProcessorEndpoint(sub_addr=_HUB_PUB, push_addr=_HUB_PUSH)
     agent = SimpleVlmAgent(
         ep, stt, vlm, tts,
+        voice_gate_cfg        =_build_voice_gate_cfg(cfg.get("voice_gate")),
         default_prompt        =cfg.get("default_prompt",        "Describe what you see."),
         system_prompt         =cfg.get("system_prompt",         DEFAULT_SYSTEM_PROMPT),
-        # Accept `magic_phrases:` as a YAML list of strict-prefix
-        # phrases. `or []` handles the empty-YAML-value (None) case.
-        magic_phrases         =cfg.get("magic_phrases") or [],
-        listening_chime       =bool(cfg.get("listening_chime", False)),
-        followup_grace_s      =float(cfg.get("followup_grace_s",      5.0)),
         frame_max_age_s       =float(cfg.get("frame_max_age_s",       2.0)),
         camera_on_timeout_s   =float(cfg.get("camera_on_timeout_s",  10.0)),
         camera_grace_s        =float(cfg.get("camera_grace_s",         5.0)),

--- a/agent-samples/simple-vlm-example/yaml/simple_vlm_example_worker.yaml
+++ b/agent-samples/simple-vlm-example/yaml/simple_vlm_example_worker.yaml
@@ -51,28 +51,6 @@ min_speech:        0.1    # minimum seconds of speech before STT is called; 0.1s
 
 # Speech-only opt-in gate. Owned by the `xr-ai-voicegate` package; the
 # worker forwards STT transcripts and lets the gate decide whether they
-# become queries, are dropped, or open a follow-up window.
-voice_gate:
-  # Strict-prefix phrases (case-insensitive, no leading filler words).
-  # The matched phrase is stripped before the query is dispatched.
-  # Configure several wordings to support multiple natural greetings.
-  # Empty list ([]) or omit to disable the gate so every STT transcript
-  # is dispatched — only use this for solo testing.
-  # Scope: speech path only. The text data channel is never gated; a
-  # spoken "ping" is gated, but the data-channel "ping" shortcut is not.
-  magic_phrases:
-    - "agent"
-    - "hey agent"
-
-  # Follow-up grace window. After a successful magic-phrase match, the
-  # next utterance from the same participant within this many seconds
-  # bypasses the gate — so "hey agent" → pause → "what am I looking
-  # at?" works as one natural interaction. Set to 0 to disable.
-  followup_grace_s: 5.0
-
-  # Audible "I heard you" feedback. When true and `magic_phrases` is
-  # non-empty, the worker plays a short two-tone chime on the return
-  # audio track the moment a phrase is matched. Synthesized server-side
-  # at the TTS sample rate to match the locked LiveKit audio track.
-  # Has no effect when `magic_phrases` is empty.
-  listening_chime: false
+# become queries, are dropped, or open a follow-up window. Path is
+# resolved relative to THIS file's directory.
+voice_gate_yaml: voice_gate.yaml

--- a/agent-samples/simple-vlm-example/yaml/simple_vlm_example_worker.yaml
+++ b/agent-samples/simple-vlm-example/yaml/simple_vlm_example_worker.yaml
@@ -49,36 +49,30 @@ silero_threshold:  0.5    # Silero speech-probability gate (0..1); lower = more 
 silence_duration:  0.4    # seconds of silence that ends an utterance (lower = snappier, but may split utterances with natural pauses)
 min_speech:        0.1    # minimum seconds of speech before STT is called; 0.1s captures short commands like "stop"
 
-# Speech-only opt-in phrases. STT transcripts must begin with one of
-# these (case-insensitive, strict prefix — no leading filler words
-# allowed) or they are dropped, so ambient conversation never triggers
-# the agent. The matched phrase is stripped before the VLM sees the
-# query. Configure several wordings to support multiple natural
-# greetings without resorting to fuzzy matching.
-#
-# Use an empty list ([]) or omit to disable the gate (agent answers
-# every utterance — only use this for solo testing where no ambient
-# speech is present).
-#
-# Scope: applies to the speech path only. The text data channel is never
-# gated. Note that a *spoken* "ping" is also gated by these phrases; the
-# "ping" data-channel shortcut is unaffected.
-magic_phrases:
-  - "agent"
-  - "hey agent"
+# Speech-only opt-in gate. Owned by the `xr-ai-voicegate` package; the
+# worker forwards STT transcripts and lets the gate decide whether they
+# become queries, are dropped, or open a follow-up window.
+voice_gate:
+  # Strict-prefix phrases (case-insensitive, no leading filler words).
+  # The matched phrase is stripped before the query is dispatched.
+  # Configure several wordings to support multiple natural greetings.
+  # Empty list ([]) or omit to disable the gate so every STT transcript
+  # is dispatched — only use this for solo testing.
+  # Scope: speech path only. The text data channel is never gated; a
+  # spoken "ping" is gated, but the data-channel "ping" shortcut is not.
+  magic_phrases:
+    - "agent"
+    - "hey agent"
 
-# Audible "I heard you" feedback. When true and `magic_phrases` is
-# non-empty, the server plays a short two-tone chime on the return
-# audio track the moment a phrase is matched — before STT+VLM finish —
-# so the user knows the agent is processing. Synthesized server-side
-# (no client asset needed) at the TTS sample rate to match the locked
-# LiveKit audio track. Has no effect when `magic_phrases` is empty.
-listening_chime: false
+  # Follow-up grace window. After a successful magic-phrase match, the
+  # next utterance from the same participant within this many seconds
+  # bypasses the gate — so "hey agent" → pause → "what am I looking
+  # at?" works as one natural interaction. Set to 0 to disable.
+  followup_grace_s: 5.0
 
-# Follow-up grace window. After a successful magic-phrase match, the
-# next utterance from the same participant within this many seconds
-# bypasses the gate — so "hey agent" → pause → "what am I looking at?"
-# works as one natural interaction instead of needing the phrase on
-# every utterance. The window refreshes each time an utterance is
-# accepted so a conversation keeps flowing. Set to 0 to disable.
-followup_grace_s: 5.0
+  # Audible "I heard you" feedback. When true and `magic_phrases` is
+  # non-empty, the worker plays a short two-tone chime on the return
+  # audio track the moment a phrase is matched. Synthesized server-side
+  # at the TTS sample rate to match the locked LiveKit audio track.
+  # Has no effect when `magic_phrases` is empty.
+  listening_chime: false

--- a/agent-samples/simple-vlm-example/yaml/voice_gate.yaml
+++ b/agent-samples/simple-vlm-example/yaml/voice_gate.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Speech-only opt-in gate. Loaded by ``xr-ai-voicegate.load_voice_gate_config``;
+# the worker forwards STT transcripts and lets the gate decide whether they
+# become queries, are dropped, or open a follow-up window. Scope: speech
+# path only. The text data channel is never gated; a spoken "ping" is
+# gated, but the data-channel "ping" shortcut is not.
+
+# Strict-prefix phrases (case-insensitive, no leading filler words).
+# The matched phrase is stripped before the query is dispatched.
+# Configure several wordings to support multiple natural greetings.
+# Empty list ([]) or omit to disable the gate so every STT transcript
+# is dispatched — only use this for solo testing.
+magic_phrases:
+  - "agent"
+  - "hey agent"
+
+# Audible "I heard you" feedback. When true and ``magic_phrases`` is
+# non-empty, the worker plays a short two-tone chime on the return
+# audio track the moment a phrase is matched. Synthesized server-side
+# at the TTS sample rate to match the locked LiveKit audio track.
+# Has no effect when ``magic_phrases`` is empty.
+listening_chime:  false
+
+# Follow-up grace window. After a successful magic-phrase match, the
+# next utterance from the same participant within this many seconds
+# bypasses the gate — so "hey agent" → pause → "what am I looking
+# at?" works as one natural interaction. Set to 0 to disable.
+followup_grace_s: 5.0

--- a/agent-samples/xr-render-demo/worker/agent.py
+++ b/agent-samples/xr-render-demo/worker/agent.py
@@ -58,7 +58,7 @@ class RenderDemoAgent:
 
         self._scene = RenderSceneProcessor(
             self._transport, cfg, render, oxr, vlm, video,
-            prompt_path, tools=tools, llm=llm, agent_llm=agent_llm,
+            prompt_path, tools=tools, llm=llm, agent_llm=agent_llm, tts=tts,
         )
         self._pipeline, self._pipeline_task = build_pipeline(
             self._transport, stt, tts, self._scene,
@@ -129,8 +129,15 @@ class RenderDemoAgent:
     async def _on_participant(self, event: ParticipantEvent) -> None:
         if event.joined:
             self._transport.set_target_participant(event.participant_id)
+            # Greet the user and (when phrases are configured) tell them
+            # how to address the agent. Without this hint, the gated speech
+            # path can look like the agent is broken when it ignores them.
+            asyncio.create_task(
+                self._scene.gate.participant_joined(event.participant_id)
+            )
         else:
             self._transport.cleanup_participant(event.participant_id)
+            self._scene.gate.forget(event.participant_id)
 
     # ── render-mcp helper ─────────────────────────────────────────────────────
 

--- a/agent-samples/xr-render-demo/worker/config.py
+++ b/agent-samples/xr-render-demo/worker/config.py
@@ -8,7 +8,7 @@ import pathlib
 from dataclasses import dataclass
 
 import yaml
-from xr_ai_voicegate import VoiceGateConfig
+from xr_ai_voicegate import VoiceGateConfig, load_voice_gate_config
 
 
 @dataclass(frozen=True)
@@ -33,25 +33,6 @@ class WorkerConfig:
     voice_gate: VoiceGateConfig
 
 
-def _build_voice_gate_cfg(raw: dict | None) -> VoiceGateConfig:
-    """Parse the ``voice_gate:`` YAML block into a ``VoiceGateConfig``.
-
-    Absent / empty block degrades to defaults (no phrases, no chime,
-    5 s follow-up grace) — i.e. the gate is in always-on mode and every
-    STT transcript passes through to ``on_query``.
-    """
-    raw = raw or {}
-    phrases_raw = raw.get("magic_phrases") or []
-    if isinstance(phrases_raw, str):
-        phrases_raw = [phrases_raw]
-    phrases = tuple(p for p in (s.strip() for s in phrases_raw) if p)
-    return VoiceGateConfig(
-        magic_phrases    = phrases,
-        followup_grace_s = float(raw.get("followup_grace_s", 5.0)),
-        listening_chime  = bool(raw.get("listening_chime", False)),
-    )
-
-
 def load_config(path: pathlib.Path | None) -> WorkerConfig:
     data: dict = {}
     if path and path.exists():
@@ -70,6 +51,13 @@ def load_config(path: pathlib.Path | None) -> WorkerConfig:
     else:
         models_yaml = models_yaml_raw
 
+    # Resolve voice_gate_yaml the same way; a missing file degrades to the
+    # always-on gate defaults via load_voice_gate_config.
+    voice_gate_yaml_raw = data.get("voice_gate_yaml", "voice_gate.yaml")
+    voice_gate_path = pathlib.Path(voice_gate_yaml_raw)
+    if path and not voice_gate_path.is_absolute():
+        voice_gate_path = path.parent / voice_gate_path
+
     return WorkerConfig(
         models_yaml = models_yaml,
         render_mcp  = data.get("render_mcp_url",  "http://localhost:8220"),
@@ -79,5 +67,5 @@ def load_config(path: pathlib.Path | None) -> WorkerConfig:
         silence_duration  = float(data.get("silence_duration",  0.8)),
         min_speech        = float(data.get("min_speech",        0.15)),
         silero_threshold  = float(data.get("silero_threshold",  0.5)),
-        voice_gate        = _build_voice_gate_cfg(data.get("voice_gate")),
+        voice_gate        = load_voice_gate_config(voice_gate_path),
     )

--- a/agent-samples/xr-render-demo/worker/config.py
+++ b/agent-samples/xr-render-demo/worker/config.py
@@ -8,6 +8,7 @@ import pathlib
 from dataclasses import dataclass
 
 import yaml
+from xr_ai_voicegate import VoiceGateConfig
 
 
 @dataclass(frozen=True)
@@ -25,6 +26,30 @@ class WorkerConfig:
     silence_duration:  float
     min_speech:        float
     silero_threshold:  float   # Silero speech probability gate (0..1)
+
+    # Speech-only opt-in gate. Owned by ``xr-ai-voicegate``. Empty
+    # ``magic_phrases`` keeps the original always-on behavior so the
+    # default YAML config matches the pre-gate worker.
+    voice_gate: VoiceGateConfig
+
+
+def _build_voice_gate_cfg(raw: dict | None) -> VoiceGateConfig:
+    """Parse the ``voice_gate:`` YAML block into a ``VoiceGateConfig``.
+
+    Absent / empty block degrades to defaults (no phrases, no chime,
+    5 s follow-up grace) — i.e. the gate is in always-on mode and every
+    STT transcript passes through to ``on_query``.
+    """
+    raw = raw or {}
+    phrases_raw = raw.get("magic_phrases") or []
+    if isinstance(phrases_raw, str):
+        phrases_raw = [phrases_raw]
+    phrases = tuple(p for p in (s.strip() for s in phrases_raw) if p)
+    return VoiceGateConfig(
+        magic_phrases    = phrases,
+        followup_grace_s = float(raw.get("followup_grace_s", 5.0)),
+        listening_chime  = bool(raw.get("listening_chime", False)),
+    )
 
 
 def load_config(path: pathlib.Path | None) -> WorkerConfig:
@@ -54,4 +79,5 @@ def load_config(path: pathlib.Path | None) -> WorkerConfig:
         silence_duration  = float(data.get("silence_duration",  0.8)),
         min_speech        = float(data.get("min_speech",        0.15)),
         silero_threshold  = float(data.get("silero_threshold",  0.5)),
+        voice_gate        = _build_voice_gate_cfg(data.get("voice_gate")),
     )

--- a/agent-samples/xr-render-demo/worker/processors.py
+++ b/agent-samples/xr-render-demo/worker/processors.py
@@ -44,12 +44,13 @@ from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.task import PipelineParams, PipelineTask
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 
-from xr_ai_agent import DataMessage
+from xr_ai_agent import DataMessage, ProcessorEndpoint
 from xr_ai_logging import print_task_done_banner
 from xr_ai_models import ChatMessage, LLMService, STTService, TTSService, ToolCall, ToolDef
-from xr_ai_pipecat.audio import stream_sentences_to_audio
+from xr_ai_pipecat.audio import stream_sentences_to_audio, wav_to_chunks
 from xr_ai_pipecat.transport import XRMediaHubTransport, SAMPLE_RATE
 from xr_ai_vad import VadDetector
+from xr_ai_voicegate import VoiceGate
 
 from config import WorkerConfig
 
@@ -97,6 +98,19 @@ _TOOL_PROGRESS: dict[str, str] = {
 
 _AGENT_RESPONSE_TOPIC  = "agent.response"
 _AGENT_PROGRESS_TOPIC  = "agent.progress"
+
+
+class _EpSink:
+    """``xr_ai_voicegate.AudioSink`` adapter over the hub's return-audio
+    fan-out: explode the WAV into 20 ms float32 ``AudioChunk``s via the
+    pipecat helper and stream them through ``send_return_audio``."""
+
+    def __init__(self, ep: ProcessorEndpoint) -> None:
+        self._ep = ep
+
+    async def play_wav(self, pid: str, wav_bytes: bytes) -> None:
+        for chunk in wav_to_chunks(wav_bytes, pid):
+            await self._ep.send_return_audio(chunk)
 
 
 class _SceneNotReadyError(Exception):
@@ -189,7 +203,15 @@ class RenderSceneProcessor(FrameProcessor):
     reasoning loop — guaranteed syntactically valid tool calls every iteration.
     Uses Minitron (port 8101) for the parallel quick-ack (fast, cheap).
 
-    On each utterance:
+    Speech ingress is layered behind an ``xr-ai-voicegate.VoiceGate``: each
+    ``TranscriptionFrame`` is handed to ``gate.feed(pid, text)``, and the
+    gate decides whether it dispatches to ``on_query`` (agentic loop),
+    ``on_stop`` (cancel + canned ack), ``on_phrase_only`` (log + chime
+    on the open follow-up window), or ``on_drop`` (log). Empty
+    ``magic_phrases`` keeps the original always-on behavior — every
+    transcript is a fresh query. The text data channel is never gated.
+
+    On each utterance dispatched by the gate:
       1. Quick-ack fires immediately (parallel, max 25 tokens) → agent.progress
       2. Agentic loop: model calls tools via OpenAI tool_calls protocol until
          it returns a text response (finish_reason != "tool_calls")
@@ -209,6 +231,7 @@ class RenderSceneProcessor(FrameProcessor):
         tools:       list[ToolDef],  # ToolDef list built from MCP discovery
         llm:         LLMService,
         agent_llm:   LLMService,
+        tts:         TTSService,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -230,6 +253,7 @@ class RenderSceneProcessor(FrameProcessor):
         self._tools            = tools
         self._llm              = llm
         self._agent_llm        = agent_llm
+        self._tts              = tts
 
         self._pending:    tuple[str, str, int] | None = None  # (text, pid, ref_us)
         self._lock        = asyncio.Lock()
@@ -239,6 +263,23 @@ class RenderSceneProcessor(FrameProcessor):
         # Injected as context so the agent understands "fix that", "undo", "the one I just added".
         self._history:    list[tuple[str, str]] = []
         self._history_max = 4
+
+        # Voice gate owns magic-phrase / STOP / follow-up / chime / greeting.
+        # The processor only feeds STT transcripts and handles the events.
+        self._gate = VoiceGate(
+            cfg.voice_gate,
+            audio_sink=_EpSink(transport.endpoint),
+            tts=tts,
+        )
+        self._gate.on_query(self._on_voice_query)
+        self._gate.on_stop(self._on_voice_stop)
+        self._gate.on_phrase_only(self._on_voice_phrase_only)
+        self._gate.on_drop(self._on_voice_drop)
+        self._gate.on_participant_joined(self._on_voice_participant_joined)
+
+    @property
+    def gate(self) -> VoiceGate:
+        return self._gate
 
 
     def _read_prompt(self, path: Path, cache_attr: str) -> str:
@@ -253,21 +294,83 @@ class RenderSceneProcessor(FrameProcessor):
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         await super().process_frame(frame, direction)
         if isinstance(frame, TranscriptionFrame):
-            await self._enqueue(frame)
+            text = frame.text.strip()
+            if text:
+                pid = self._transport.target_participant
+                await self._gate.feed(pid, text)
         else:
             await self.push_frame(frame, direction)
 
-    async def _enqueue(self, frame: TranscriptionFrame) -> None:
-        text = frame.text.strip()
-        if not text:
-            return
-        pid = self._transport.target_participant
-        # Capture the moment the user finished speaking so visual tool calls
-        # can be anchored to that timestamp (not to when the tool fires).
+    # ── voice-gate handlers ───────────────────────────────────────────────────
+
+    async def _on_voice_query(self, pid: str, text: str, fresh_match: bool) -> None:
+        """Voice-gate ``on_query`` handler — chime + dispatch to the agentic loop.
+
+        Only chimes on a *fresh* magic-phrase match. Follow-up-window
+        continuations (``fresh_match=False``) skip the chime to avoid a
+        double bell on the same logical interaction.
+        """
+        if fresh_match:
+            asyncio.create_task(self._gate.play_chime(pid))
+        await self._enqueue(text, pid)
+
+    async def _on_voice_stop(self, pid: str) -> None:
+        """Voice-gate ``on_stop`` handler — cancel the in-flight agentic
+        loop, drop any queued utterance, flush queued return audio, and
+        play the gate's canned stop ack so the user hears the interrupt
+        was acknowledged. Mirrors ``vlm.response`` semantics by also
+        sending the ack text on ``agent.response``."""
+        async with self._lock:
+            self._pending = None
+            if self._agentic_task and not self._agentic_task.done():
+                self._agentic_task.cancel()
+        send_pid = pid or self._transport.target_participant
+        if send_pid:
+            try:
+                await self._transport.endpoint.flush_return_audio(send_pid)
+            except Exception:
+                logger.opt(exception=True).debug(
+                    "flush_return_audio failed during stop",
+                )
+            await self._send(send_pid, "Okay, I will stop.", topic=_AGENT_RESPONSE_TOPIC)
+            await self._gate.say_stop_ack(send_pid)
+
+    async def _on_voice_phrase_only(self, pid: str) -> None:
+        """Voice-gate ``on_phrase_only`` handler — open the follow-up
+        window with an audible chime so the user knows the wake word was
+        heard. xr-render-demo has no camera-on-demand so there's nothing
+        else to do here; the gate has already opened the window."""
+        await self._gate.play_chime(pid)
+        logger.info("voice gate awaiting follow-up pid={!r}", pid)
+
+    async def _on_voice_drop(self, pid: str, text: str) -> None:
+        logger.info("voice gate dropped pid={!r} text={!r}", pid, text[:80])
+
+    async def _on_voice_participant_joined(self, pid: str) -> None:
+        """Voice-gate ``on_participant_joined`` — speak a one-shot
+        greeting that tells the user how to address the agent given the
+        configured magic phrases (or that it's listening to everything
+        when no phrases are configured)."""
+        help_text = self._gate.format_phrase_help()
+        if help_text is None:
+            greeting = "Hi, I'm listening. Tell me what you'd like to render."
+        else:
+            greeting = f"Hi, I'm listening. {help_text}"
+        await self._send(pid, greeting, topic=_AGENT_RESPONSE_TOPIC)
         try:
-            ref_us = int(frame.timestamp) if frame.timestamp else _now_us()
-        except (TypeError, ValueError):
-            ref_us = _now_us()
+            wav = await self._tts.synthesize(greeting)
+        except Exception:
+            logger.opt(exception=True).warning("greeting tts failed pid={!r}", pid)
+            return
+        self._gate.observe_tts_wav(wav)
+        try:
+            for chunk in wav_to_chunks(wav, pid):
+                await self._transport.endpoint.send_return_audio(chunk)
+        except Exception:
+            logger.opt(exception=True).warning("greeting audio send failed pid={!r}", pid)
+
+    async def _enqueue(self, text: str, pid: str) -> None:
+        ref_us = _now_us()
         async with self._lock:
             self._pending = (text, pid, ref_us)
             # Cancel any in-flight agentic loop so the new utterance is handled
@@ -844,17 +947,29 @@ class RenderSceneProcessor(FrameProcessor):
 # ── TtsProcessor ─────────────────────────────────────────────────────────────
 
 class TtsProcessor(FrameProcessor):
-    """TextFrame → sentence-batched TTS → hub return audio."""
+    """TextFrame → sentence-batched TTS → hub return audio.
+
+    Every synthesized WAV is observed by the voice gate so it can build
+    the listening chime at the matching TTS sample rate the first time
+    a WAV passes through.
+    """
 
     def __init__(
         self,
         tts: TTSService,
         transport: XRMediaHubTransport,
+        gate: VoiceGate,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self._tts       = tts
         self._transport = transport
+        self._gate      = gate
+
+    async def _synthesize(self, text: str) -> bytes:
+        wav = await self._tts.synthesize(text)
+        self._gate.observe_tts_wav(wav)
+        return wav
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         await super().process_frame(frame, direction)
@@ -871,7 +986,7 @@ class TtsProcessor(FrameProcessor):
             return
         try:
             await stream_sentences_to_audio(
-                self._transport.endpoint, self._tts.synthesize, text, pid,
+                self._transport.endpoint, self._synthesize, text, pid,
             )
         except Exception:
             logger.exception("TTS failed  pid={!r}", pid)
@@ -887,7 +1002,7 @@ def build_pipeline(
     scene:       RenderSceneProcessor,
 ) -> tuple[Pipeline, PipelineTask]:
     stt_proc = SttProcessor(stt, transport, scene._cfg)
-    tts_proc = TtsProcessor(tts, transport)
+    tts_proc = TtsProcessor(tts, transport, scene.gate)
 
     pipeline = Pipeline([
         transport.input(),

--- a/agent-samples/xr-render-demo/worker/pyproject.toml
+++ b/agent-samples/xr-render-demo/worker/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "xr-ai-pipecat",
     "xr-ai-logging",
     "xr-ai-vad",
+    "xr-ai-voicegate",
     "numpy>=1.24",
     "scipy>=1.11",
     "pyyaml>=6.0",
@@ -24,11 +25,12 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-xr-ai-agent   = { path = "../../../agent-sdk",                    editable = true }
-xr-ai-models  = { path = "../../../agent-sdk/xr-ai-models",       editable = true }
-xr-ai-pipecat = { path = "../../../agent-sdk/xr-ai-pipecat",      editable = true }
-xr-ai-logging = { path = "../../../utils/xr-ai-logging",          editable = true }
-xr-ai-vad     = { path = "../../../utils/xr-ai-vad",              editable = true }
+xr-ai-agent     = { path = "../../../agent-sdk",                    editable = true }
+xr-ai-models    = { path = "../../../agent-sdk/xr-ai-models",       editable = true }
+xr-ai-pipecat   = { path = "../../../agent-sdk/xr-ai-pipecat",      editable = true }
+xr-ai-logging   = { path = "../../../utils/xr-ai-logging",          editable = true }
+xr-ai-vad       = { path = "../../../utils/xr-ai-vad",              editable = true }
+xr-ai-voicegate = { path = "../../../utils/xr-ai-voicegate",        editable = true }
 
 [project.scripts]
 xr_render_demo_worker = "xr_render_demo_worker:run"

--- a/agent-samples/xr-render-demo/yaml/voice_gate.yaml
+++ b/agent-samples/xr-render-demo/yaml/voice_gate.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Speech-only opt-in gate (xr-ai-voicegate). The gate sits between STT
+# and the agentic loop; only the speech path is affected — the text
+# data channel is never gated.
+#
+# Default is always-on (empty ``magic_phrases``): every STT transcript
+# becomes a query, matching the pre-gate worker behavior. Populate the
+# list to require a wake word before the agent responds.
+
+# Strict-prefix phrases (case-insensitive, no leading filler words).
+# The matched phrase is stripped before the query reaches the agentic
+# loop. Configure several wordings to support multiple natural
+# greetings, e.g.:
+#   magic_phrases:
+#     - "agent"
+#     - "hey agent"
+magic_phrases:    []
+
+# Follow-up grace window. After a magic-phrase match, the next
+# utterance from the same participant within this many seconds
+# bypasses the gate.
+followup_grace_s: 5.0
+
+# Audible "I heard you" feedback. When true AND ``magic_phrases`` is
+# non-empty, a short two-tone chime plays on the return audio track
+# the moment a phrase is matched. No effect when ``magic_phrases`` is
+# empty (always-on mode has no fresh-match event to ride).
+listening_chime:  false

--- a/agent-samples/xr-render-demo/yaml/xr_render_demo_worker.yaml
+++ b/agent-samples/xr-render-demo/yaml/xr_render_demo_worker.yaml
@@ -28,30 +28,8 @@ min_speech:        0.15
 silero_threshold:  0.3
 
 # ── Speech-only opt-in gate (xr-ai-voicegate) ────────────────────────────────
-# Forwarded to ``xr-ai-voicegate.VoiceGateConfig``. The gate sits between
-# STT and the agentic loop; only the speech path is affected — the text
-# data channel is never gated.
-#
-# Default is always-on (empty ``magic_phrases``): every STT transcript
-# becomes a query, matching the pre-gate worker behavior. Populate the
-# list to require a wake word before the agent responds.
-voice_gate:
-  # Strict-prefix phrases (case-insensitive, no leading filler words).
-  # The matched phrase is stripped before the query reaches the agentic
-  # loop. Configure several wordings to support multiple natural
-  # greetings, e.g.:
-  #   magic_phrases:
-  #     - "agent"
-  #     - "hey agent"
-  magic_phrases:    []
-
-  # Follow-up grace window. After a magic-phrase match, the next
-  # utterance from the same participant within this many seconds
-  # bypasses the gate.
-  followup_grace_s: 5.0
-
-  # Audible "I heard you" feedback. When true AND ``magic_phrases`` is
-  # non-empty, a short two-tone chime plays on the return audio track
-  # the moment a phrase is matched. No effect when ``magic_phrases`` is
-  # empty (always-on mode has no fresh-match event to ride).
-  listening_chime:  false
+# Loaded by ``xr-ai-voicegate.load_voice_gate_config``. The gate sits
+# between STT and the agentic loop; only the speech path is affected —
+# the text data channel is never gated. Path is resolved relative to
+# THIS file's directory.
+voice_gate_yaml: voice_gate.yaml

--- a/agent-samples/xr-render-demo/yaml/xr_render_demo_worker.yaml
+++ b/agent-samples/xr-render-demo/yaml/xr_render_demo_worker.yaml
@@ -26,3 +26,32 @@ video_mcp_url:  http://localhost:8210
 silence_duration:  0.8
 min_speech:        0.15
 silero_threshold:  0.3
+
+# ── Speech-only opt-in gate (xr-ai-voicegate) ────────────────────────────────
+# Forwarded to ``xr-ai-voicegate.VoiceGateConfig``. The gate sits between
+# STT and the agentic loop; only the speech path is affected — the text
+# data channel is never gated.
+#
+# Default is always-on (empty ``magic_phrases``): every STT transcript
+# becomes a query, matching the pre-gate worker behavior. Populate the
+# list to require a wake word before the agent responds.
+voice_gate:
+  # Strict-prefix phrases (case-insensitive, no leading filler words).
+  # The matched phrase is stripped before the query reaches the agentic
+  # loop. Configure several wordings to support multiple natural
+  # greetings, e.g.:
+  #   magic_phrases:
+  #     - "agent"
+  #     - "hey agent"
+  magic_phrases:    []
+
+  # Follow-up grace window. After a magic-phrase match, the next
+  # utterance from the same participant within this many seconds
+  # bypasses the gate.
+  followup_grace_s: 5.0
+
+  # Audible "I heard you" feedback. When true AND ``magic_phrases`` is
+  # non-empty, a short two-tone chime plays on the return audio track
+  # the moment a phrase is matched. No effect when ``magic_phrases`` is
+  # empty (always-on mode has no fresh-match event to ride).
+  listening_chime:  false

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "xr-ai-logging",
     "xr-ai-vad",
     "xr-ai-vllm",
+    "xr-ai-voicegate",
     # MCP servers exercised by subprocess tests (fastmcp pulled in transitively).
     "transcript-mcp-server",
     "vlm-mcp-server",
@@ -44,6 +45,7 @@ xr-ai-launcher        = { path = "../utils/xr-ai-launcher",             editable
 xr-ai-logging         = { path = "../utils/xr-ai-logging",              editable = true }
 xr-ai-vad             = { path = "../utils/xr-ai-vad",                  editable = true }
 xr-ai-vllm            = { path = "../utils/xr-ai-vllm",                 editable = true }
+xr-ai-voicegate       = { path = "../utils/xr-ai-voicegate",            editable = true }
 transcript-mcp-server = { path = "../agent-mcp-servers/transcript-mcp", editable = true }
 vlm-mcp-server        = { path = "../agent-mcp-servers/vlm-mcp",        editable = true }
 render-mcp            = { path = "../agent-mcp-servers/render-mcp",     editable = true }

--- a/tests/test_xr_ai_voicegate.py
+++ b/tests/test_xr_ai_voicegate.py
@@ -1,0 +1,609 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the xr-ai-voicegate package.
+
+Covers the phrase matcher, STOP regex, lazy chime synthesis, the per-pid
+event ladder in ``VoiceGate.feed`` (STOP / fresh-match / followup /
+phrase-only / drop), and the listening-chime + stop-ack side effects.
+
+Everything is local: a no-op ``AudioSink`` and an in-memory ``TTSLike``
+stub that returns a minimal WAV blob synthesized via the same primitive
+the chime uses. No GPU, no network, no model loads.
+"""
+from __future__ import annotations
+
+import asyncio
+import io
+import wave
+
+import numpy as np
+import pytest
+
+from xr_ai_voicegate import VoiceGate, VoiceGateConfig
+from xr_ai_voicegate._chime import build_chime_wav, read_wav_sample_rate
+from xr_ai_voicegate._phrases import STOP_RE, build_magic_pattern, strip_magic
+
+
+# ── test doubles ────────────────────────────────────────────────────────────
+
+
+def _silence_wav(sample_rate: int, ms: int = 10) -> bytes:
+    """Return a tiny but well-formed WAV blob at ``sample_rate`` Hz so the
+    chime's ``read_wav_sample_rate`` has something to parse."""
+    n = max(1, int(sample_rate * ms / 1000))
+    pcm = np.zeros(n, dtype=np.int16).tobytes()
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm)
+    return buf.getvalue()
+
+
+class _FakeAudioSink:
+    """No-op audio sink that records every (pid, wav_bytes) it receives."""
+
+    def __init__(self) -> None:
+        self.plays: list[tuple[str, bytes]] = []
+
+    async def play_wav(self, pid: str, wav_bytes: bytes) -> None:
+        self.plays.append((pid, wav_bytes))
+
+
+class _FakeTTS:
+    """TTS double returning a tiny but valid WAV at a configurable rate."""
+
+    def __init__(self, sample_rate: int = 22050) -> None:
+        self.sample_rate     = sample_rate
+        self.synth_calls:    list[str] = []
+        self.raise_on_synth: bool      = False
+
+    async def synthesize(self, text: str) -> bytes:
+        self.synth_calls.append(text)
+        if self.raise_on_synth:
+            raise RuntimeError("tts down")
+        return _silence_wav(self.sample_rate)
+
+
+def _gate(
+    *,
+    phrases:          tuple[str, ...] = (),
+    followup_grace_s: float           = 5.0,
+    listening_chime:  bool            = False,
+    tts_rate:         int             = 22050,
+) -> tuple[VoiceGate, _FakeAudioSink, _FakeTTS]:
+    cfg  = VoiceGateConfig(
+        magic_phrases    = phrases,
+        followup_grace_s = followup_grace_s,
+        listening_chime  = listening_chime,
+    )
+    sink = _FakeAudioSink()
+    tts  = _FakeTTS(sample_rate=tts_rate)
+    return VoiceGate(cfg, audio_sink=sink, tts=tts), sink, tts
+
+
+def _recording_handlers(gate: VoiceGate) -> list[tuple]:
+    """Wire all five handler slots to a single events list and return it.
+
+    ``on_query`` exposes the post-chime-fix signature ``(pid, text, fresh_match)``
+    so tests can assert that case 2 (fresh magic-phrase match) and case 3
+    (follow-up window continuation) are distinguishable."""
+    events: list[tuple] = []
+
+    async def on_query(pid: str, text: str, fresh_match: bool) -> None:
+        events.append(("query", pid, text, fresh_match))
+
+    async def on_stop(pid: str) -> None:
+        events.append(("stop", pid))
+
+    async def on_phrase_only(pid: str) -> None:
+        events.append(("phrase_only", pid))
+
+    async def on_drop(pid: str, text: str) -> None:
+        events.append(("drop", pid, text))
+
+    async def on_join(pid: str) -> None:
+        events.append(("join", pid))
+
+    gate.on_query(on_query)
+    gate.on_stop(on_stop)
+    gate.on_phrase_only(on_phrase_only)
+    gate.on_drop(on_drop)
+    gate.on_participant_joined(on_join)
+    return events
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 1. Phrase matcher (`_phrases.py`)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+def test_phrase_strict_prefix_strip_returns_query_tail():
+    """Case 1: 'agent, what am I looking at?' strips to the query tail."""
+    pat = build_magic_pattern(["agent"])
+    assert strip_magic(pat, "agent, what am I looking at?") == "what am I looking at?"
+
+
+def test_phrase_multi_phrase_both_forms_match():
+    """Case 2: with ['agent', 'hey agent'] both prefixes match and strip."""
+    pat = build_magic_pattern(["agent", "hey agent"])
+    assert strip_magic(pat, "agent, hi")     == "hi"
+    assert strip_magic(pat, "hey agent, hi") == "hi"
+
+
+def test_phrase_case_insensitive_match():
+    """Case 3: STT may upper-case the first letter — must still match."""
+    pat = build_magic_pattern(["hey agent"])
+    assert strip_magic(pat, "Hey Agent, what's up?") == "what's up?"
+
+
+def test_phrase_tolerates_internal_and_trailing_punctuation():
+    """Case 4: 'Hey, agent.' has a comma between words and a period at the
+    end. The matcher must still treat it as the configured 'hey agent'
+    prefix and strip it cleanly."""
+    pat = build_magic_pattern(["hey agent"])
+    stripped = strip_magic(pat, "Hey, agent.")
+    # The configured "hey agent" is matched even with STT punctuation
+    # spliced in; nothing follows so the tail is empty.
+    assert stripped == ""
+
+
+def test_phrase_mid_sentence_does_not_match():
+    """Case 5: strict-prefix only — 'the agent told me ...' must not strip."""
+    pat = build_magic_pattern(["agent"])
+    assert strip_magic(pat, "the agent told me to wait") is None
+
+
+def test_phrase_no_filler_allowance_before_phrase():
+    """Case 6: even one filler word before the phrase ('hello agent') is
+    rejected. Strict prefix means literally first token after whitespace."""
+    pat = build_magic_pattern(["agent"])
+    assert strip_magic(pat, "hello agent") is None
+
+
+def test_phrase_empty_list_yields_none_pattern_and_passthrough_strip():
+    """Case 7: no phrases → ``build_magic_pattern`` returns None; with the
+    None pattern ``strip_magic`` is the identity on the input text."""
+    assert build_magic_pattern([]) is None
+    assert strip_magic(None, "anything goes here") == "anything goes here"
+
+
+def test_phrase_only_utterance_strips_to_empty_string():
+    """Case 8: 'agent' on its own — match succeeds, payload is empty
+    string (NOT None, which means 'no match')."""
+    pat = build_magic_pattern(["agent"])
+    assert strip_magic(pat, "agent") == ""
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 2. STOP regex (`_phrases.STOP_RE`)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.parametrize("text", [
+    "stop",
+    "Stop.",
+    "be quiet",
+    "shut up",
+    "stop talking",
+])
+def test_stop_regex_canonical_forms_match(text: str):
+    """Case 9: all the canonical interruption phrases match."""
+    assert STOP_RE.match(text) is not None
+
+
+def test_stop_regex_suffix_with_too_much_filler_does_not_match():
+    """Case 10 (locked to actual behavior): 'the agent told me to stop'
+    has 4 filler words before 'stop'; the regex allows {0,2} filler
+    words, so this does NOT match.
+
+    The original brief speculated this would match as a "suffix STOP" —
+    the impl says no. We lock the impl's behavior in as the contract."""
+    assert STOP_RE.match("the agent told me to stop") is None
+
+
+def test_stop_regex_mid_sentence_real_question_does_not_match():
+    """Case 11: 'what should we stop doing about climate change' is a
+    genuine question that mentions 'stop' mid-sentence; must not trigger."""
+    assert STOP_RE.match("what should we stop doing about climate change") is None
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 3. Chime synthesis (`_chime.py`)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+def test_chime_24khz_header_shape_and_duration():
+    """Case 12: 24 kHz chime is a parseable mono int16 WAV ~250 ms long."""
+    wav = build_chime_wav(24_000)
+    with wave.open(io.BytesIO(wav), "rb") as wf:
+        assert wf.getframerate()  == 24_000
+        assert wf.getnchannels()  == 1
+        assert wf.getsampwidth()  == 2          # int16 → 2 bytes/sample
+        # 250 ms ± one frame (the chime uses int(sr * 0.25) samples).
+        assert wf.getnframes() == int(24_000 * 0.25)
+
+
+def test_chime_16khz_header_shape_and_duration():
+    """Case 13: same contract at 16 kHz."""
+    wav = build_chime_wav(16_000)
+    with wave.open(io.BytesIO(wav), "rb") as wf:
+        assert wf.getframerate()  == 16_000
+        assert wf.getnchannels()  == 1
+        assert wf.getsampwidth()  == 2
+        assert wf.getnframes() == int(16_000 * 0.25)
+
+
+@pytest.mark.parametrize("sample_rate", [16_000, 24_000])
+def test_chime_read_wav_sample_rate_round_trip(sample_rate: int):
+    """Case 14: ``read_wav_sample_rate`` recovers the rate the chime was
+    built at — round-trip guard for the WAV header parsing path that
+    ``observe_tts_wav`` relies on."""
+    wav = build_chime_wav(sample_rate)
+    assert read_wav_sample_rate(wav) == sample_rate
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 4. Event ladder (`gate.feed`)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_feed_no_phrases_routes_every_utterance_to_on_drop():
+    """Case 15 (locked to actual behavior): with magic_phrases=() the gate
+    does NOT pass-through to on_query; every non-STOP utterance falls
+    through the ladder to on_drop.
+
+    NOTE: ``VoiceGateConfig`` docstring says empty phrases 'disables the
+    gate so every STT transcript is dispatched' — readers may interpret
+    that as on_query pass-through. The impl routes to on_drop instead.
+    This test pins the impl's actual behavior; if the docstring is the
+    intended contract, that's a code bug, not a test bug."""
+    gate, _, _ = _gate(phrases=())
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "what am I looking at")
+    await gate.feed("p1", "tell me about this")
+
+    assert events == [
+        ("drop", "p1", "what am I looking at"),
+        ("drop", "p1", "tell me about this"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_feed_raw_stop_fires_on_stop():
+    """Case 16: with phrases configured, the raw word 'stop' bypasses the
+    magic-phrase requirement and fires on_stop."""
+    gate, _, _ = _gate(phrases=("agent",))
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "stop")
+
+    assert events == [("stop", "p1")]
+
+
+@pytest.mark.asyncio
+async def test_feed_magic_phrase_with_query_fires_on_query_with_fresh_match_true():
+    """Case 17: 'agent, what is this?' → on_query(pid, 'what is this?', fresh_match=True).
+
+    ``fresh_match=True`` is the signal consumers use to drive one-shot
+    side effects like the listening chime that should fire on case 2 but
+    not on case 3 (the followup-window continuation)."""
+    gate, _, _ = _gate(phrases=("agent",))
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "agent, what is this?")
+
+    assert events == [("query", "p1", "what is this?", True)]
+
+
+@pytest.mark.asyncio
+async def test_feed_no_phrase_and_no_followup_fires_on_drop():
+    """Case 18: with phrases configured but no magic phrase in the
+    transcript and no open followup window, the gate drops the utterance."""
+    gate, _, _ = _gate(phrases=("agent",))
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "what am I looking at")
+
+    assert events == [("drop", "p1", "what am I looking at")]
+
+
+@pytest.mark.asyncio
+async def test_feed_phrase_only_opens_followup_window_and_dispatches_with_fresh_match_false():
+    """Case 19: bare 'agent' fires on_phrase_only; the next utterance
+    within the followup grace fires on_query with the raw text AND
+    ``fresh_match=False`` so consumers can suppress the chime on the
+    continuation (the chime already played when phrase-only opened the
+    window — repeating it on the dispatch would be a double chime)."""
+    gate, _, _ = _gate(phrases=("agent",), followup_grace_s=5.0)
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "agent")
+    await gate.feed("p1", "what am I looking at")
+
+    assert events == [
+        ("phrase_only", "p1"),
+        ("query", "p1", "what am I looking at", False),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_feed_followup_window_closes_after_one_dispatch():
+    """Case 20: each dispatch (fresh-match or followup-accepted) closes
+    the window; subsequent utterances must reintroduce a magic phrase."""
+    gate, _, _ = _gate(phrases=("agent",), followup_grace_s=5.0)
+    events = _recording_handlers(gate)
+
+    # Followup path: opens window, then next utterance consumes it.
+    await gate.feed("p1", "agent")
+    await gate.feed("p1", "what am I looking at")
+    # Window is now closed — this third utterance must drop.
+    await gate.feed("p1", "and another question")
+
+    assert events == [
+        ("phrase_only", "p1"),
+        ("query", "p1", "what am I looking at", False),
+        ("drop", "p1", "and another question"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_feed_fresh_match_with_payload_closes_window_too():
+    """Case 20 (b): a fresh-match dispatch ALSO closes the window so
+    ambient speech after the answer doesn't ride a stale followup."""
+    gate, _, _ = _gate(phrases=("agent",), followup_grace_s=5.0)
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "agent, what is this")
+    await gate.feed("p1", "and another question")
+
+    assert events == [
+        ("query", "p1", "what is this", True),
+        ("drop", "p1", "and another question"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_feed_followup_window_expires_after_grace(monkeypatch):
+    """Case 21: once ``followup_grace_s`` seconds elapse, the window is
+    closed; the next utterance drops instead of dispatching."""
+    gate, _, _ = _gate(phrases=("agent",), followup_grace_s=2.0)
+    events = _recording_handlers(gate)
+
+    # Drive ``time.monotonic`` by hand so the test is deterministic and
+    # doesn't sleep. Patch the symbol on the ``gate`` module — that's
+    # where the lookup happens.
+    from xr_ai_voicegate import gate as gate_module
+
+    fake_now = [1000.0]
+    monkeypatch.setattr(gate_module.time, "monotonic", lambda: fake_now[0])
+
+    await gate.feed("p1", "agent")          # opens window until t=1002
+    fake_now[0] = 1002.5                    # 0.5s past the grace deadline
+    await gate.feed("p1", "what is this")   # window expired → must drop
+
+    assert events == [
+        ("phrase_only", "p1"),
+        ("drop", "p1", "what is this"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_feed_stop_wins_over_open_followup_window():
+    """Case 22: 'stop' inside an open followup window must NOT be treated
+    as a followup query — STOP_RE check sits above the followup branch."""
+    gate, _, _ = _gate(phrases=("agent",), followup_grace_s=5.0)
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "agent")  # opens window
+    await gate.feed("p1", "stop")   # must fire on_stop, NOT on_query
+
+    assert events == [
+        ("phrase_only", "p1"),
+        ("stop", "p1"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_feed_stop_matched_on_magic_stripped_tail():
+    """Case 23: 'hey agent stop' — the gate strips the magic prefix to
+    'stop' and the STOP regex matches the tail. on_stop fires."""
+    gate, _, _ = _gate(phrases=("hey agent",))
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "hey agent stop")
+
+    assert events == [("stop", "p1")]
+
+
+@pytest.mark.asyncio
+async def test_feed_fresh_match_flag_distinguishes_case_2_from_case_3():
+    """Regression guard for the chime fix at 665faaf — case 2 (fresh
+    magic-phrase + payload) must dispatch with ``fresh_match=True`` and
+    case 3 (followup window continuation) must dispatch with
+    ``fresh_match=False``. The original extraction collapsed both onto
+    a single ``on_query(pid, text)`` signature so the consumer chimed
+    twice per question; the flag is the contract that keeps the
+    listening-chime side effect one-shot."""
+    gate, _, _ = _gate(phrases=("agent",), followup_grace_s=5.0)
+    events = _recording_handlers(gate)
+
+    # Case 2: phrase + payload in the same utterance.
+    await gate.feed("p1", "agent, what is this")
+    # Case 3: phrase-only opens window, next utterance is the continuation.
+    await gate.feed("p2", "agent")
+    await gate.feed("p2", "what is this")
+
+    assert events == [
+        ("query",       "p1", "what is this", True),
+        ("phrase_only", "p2"),
+        ("query",       "p2", "what is this", False),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_feed_forget_clears_followup_window_for_pid():
+    """Case 24: forget(pid) drops the open followup; the next utterance
+    from that pid must be re-gated."""
+    gate, _, _ = _gate(phrases=("agent",), followup_grace_s=5.0)
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "agent")
+    gate.forget("p1")
+    await gate.feed("p1", "what is this")
+
+    assert events == [
+        ("phrase_only", "p1"),
+        ("drop", "p1", "what is this"),
+    ]
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 5. Chime lifecycle
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_play_chime_before_tts_observed_is_noop_not_crash():
+    """Case 25: chime is built lazily after the first TTS WAV is observed.
+    Calling play_chime before that point logs and returns — does not
+    crash and does not push anything onto the audio sink."""
+    gate, sink, _ = _gate(phrases=("agent",), listening_chime=True)
+
+    await gate.play_chime("p1")
+
+    assert sink.plays == []
+
+
+@pytest.mark.asyncio
+async def test_play_chime_after_observe_tts_wav_emits_built_chime():
+    """Case 26: once a TTS WAV is observed, the chime is built at that
+    sample rate and subsequent play_chime calls push the WAV bytes to
+    the audio sink at the matching rate."""
+    gate, sink, _ = _gate(phrases=("agent",), listening_chime=True)
+
+    gate.observe_tts_wav(_silence_wav(22_050))
+    await gate.play_chime("p1")
+
+    assert len(sink.plays) == 1
+    pid, wav = sink.plays[0]
+    assert pid == "p1"
+    assert read_wav_sample_rate(wav) == 22_050
+
+
+@pytest.mark.asyncio
+async def test_play_chime_disabled_when_listening_chime_false():
+    """Case 27: listening_chime=False disables the chime even after a TTS
+    WAV is observed."""
+    gate, sink, _ = _gate(phrases=("agent",), listening_chime=False)
+
+    gate.observe_tts_wav(_silence_wav(22_050))
+    await gate.play_chime("p1")
+
+    assert sink.plays == []
+
+
+@pytest.mark.asyncio
+async def test_play_chime_disabled_when_no_magic_phrases_configured():
+    """Case 27 (b): even with listening_chime=True, an empty phrase list
+    disables the chime — the chime is meant to ride a fresh-match event,
+    and there are no fresh-matches without phrases."""
+    gate, sink, _ = _gate(phrases=(), listening_chime=True)
+
+    gate.observe_tts_wav(_silence_wav(22_050))
+    await gate.play_chime("p1")
+
+    assert sink.plays == []
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 6. Greeting + stop ack
+# ════════════════════════════════════════════════════════════════════════════
+
+
+def test_format_phrase_help_returns_none_with_no_phrases():
+    """Case 28: no phrases → no help string (caller picks generic greeting)."""
+    gate, _, _ = _gate(phrases=())
+    assert gate.format_phrase_help() is None
+
+
+def test_format_phrase_help_one_phrase():
+    """Case 29: single-phrase form."""
+    gate, _, _ = _gate(phrases=("agent",))
+    assert gate.format_phrase_help() == (
+        'To talk to me, start your question with "agent". '
+        'For example, "agent, what am I looking at?"'
+    )
+
+
+def test_format_phrase_help_two_phrases():
+    """Case 30: two-phrase form uses 'or', not a comma."""
+    gate, _, _ = _gate(phrases=("agent", "hey agent"))
+    assert gate.format_phrase_help() == (
+        'To talk to me, start your question with "agent" or "hey agent". '
+        'For example, "agent, what am I looking at?"'
+    )
+
+
+def test_format_phrase_help_three_phrases():
+    """Case 31: three-or-more form uses commas with a final ', or'."""
+    gate, _, _ = _gate(phrases=("a", "b", "c"))
+    assert gate.format_phrase_help() == (
+        'To talk to me, start your question with "a", "b", or "c". '
+        'For example, "a, what am I looking at?"'
+    )
+
+
+@pytest.mark.asyncio
+async def test_say_stop_ack_synthesizes_observes_and_plays():
+    """Case 32: say_stop_ack runs the full three-step flow —
+    tts.synthesize → observe_tts_wav (so the chime can build) → audio_sink.play_wav."""
+    gate, sink, tts = _gate(phrases=("agent",), listening_chime=True, tts_rate=22_050)
+
+    await gate.say_stop_ack("p1")
+
+    # 1. TTS was called with the canned ack text.
+    assert tts.synth_calls == ["Okay, I will stop."]
+    # 2. The same WAV the TTS returned was pushed to the audio sink.
+    assert len(sink.plays) == 1
+    ack_pid, ack_wav = sink.plays[0]
+    assert ack_pid == "p1"
+    assert read_wav_sample_rate(ack_wav) == 22_050
+    # 3. observe_tts_wav was called as part of the flow — confirm by
+    #    playing the chime now and asserting it lands at the right rate.
+    await gate.play_chime("p1")
+    assert len(sink.plays) == 2
+    _, chime_wav = sink.plays[1]
+    assert read_wav_sample_rate(chime_wav) == 22_050
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 7. Handler exception swallowing
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_handler_exceptions_are_swallowed_and_gate_keeps_working():
+    """Case 33: when on_query raises, the gate logs and continues —
+    subsequent feed() calls still dispatch normally."""
+    gate, _, _ = _gate(phrases=("agent",))
+
+    calls: list[str] = []
+
+    async def flaky_on_query(pid: str, text: str, fresh_match: bool) -> None:
+        calls.append(text)
+        if text == "boom":
+            raise RuntimeError("handler exploded")
+
+    gate.on_query(flaky_on_query)
+
+    # First call raises inside the handler — must not propagate.
+    await gate.feed("p1", "agent, boom")
+    # Second call still works — gate state is intact.
+    await gate.feed("p1", "agent, second time")
+
+    assert calls == ["boom", "second time"]

--- a/tests/test_xr_ai_voicegate.py
+++ b/tests/test_xr_ai_voicegate.py
@@ -13,7 +13,6 @@ the chime uses. No GPU, no network, no model loads.
 """
 from __future__ import annotations
 
-import asyncio
 import io
 import pathlib
 import wave

--- a/tests/test_xr_ai_voicegate.py
+++ b/tests/test_xr_ai_voicegate.py
@@ -15,12 +15,13 @@ from __future__ import annotations
 
 import asyncio
 import io
+import pathlib
 import wave
 
 import numpy as np
 import pytest
 
-from xr_ai_voicegate import VoiceGate, VoiceGateConfig
+from xr_ai_voicegate import VoiceGate, VoiceGateConfig, load_voice_gate_config
 from xr_ai_voicegate._chime import build_chime_wav, read_wav_sample_rate
 from xr_ai_voicegate._phrases import STOP_RE, build_magic_pattern, strip_magic
 
@@ -660,3 +661,120 @@ async def test_handler_exceptions_are_swallowed_and_gate_keeps_working():
     await gate.feed("p1", "agent, second time")
 
     assert calls == ["boom", "second time"]
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 8. YAML loader (`load_voice_gate_config`)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+def test_load_voice_gate_config_full_file(tmp_path: pathlib.Path):
+    """Case 34: a populated file parses into a VoiceGateConfig with every
+    field set as written."""
+    p = tmp_path / "voice_gate.yaml"
+    p.write_text(
+        "magic_phrases:\n"
+        '  - "agent"\n'
+        '  - "hey agent"\n'
+        "listening_chime:  true\n"
+        "followup_grace_s: 7.5\n"
+    )
+    cfg = load_voice_gate_config(p)
+    assert cfg == VoiceGateConfig(
+        magic_phrases    = ("agent", "hey agent"),
+        followup_grace_s = 7.5,
+        listening_chime  = True,
+    )
+
+
+def test_load_voice_gate_config_missing_file_returns_defaults(tmp_path: pathlib.Path):
+    """Case 35: a path that does not exist degrades to the dataclass
+    defaults (always-on, no chime, 5 s follow-up grace) — same behavior
+    the inline-block parser had for an absent block."""
+    assert load_voice_gate_config(tmp_path / "nope.yaml") == VoiceGateConfig()
+
+
+def test_load_voice_gate_config_empty_file_returns_defaults(tmp_path: pathlib.Path):
+    """Case 36: an empty file (``yaml.safe_load`` → None) degrades to
+    defaults, matching the ``raw or {}`` normalization."""
+    p = tmp_path / "empty.yaml"
+    p.write_text("")
+    assert load_voice_gate_config(p) == VoiceGateConfig()
+
+
+def test_load_voice_gate_config_bare_string_phrase_normalizes(tmp_path: pathlib.Path):
+    """Case 37: ``magic_phrases: agent`` (bare string, not a list) is
+    normalized to a single-element tuple, matching the inline parser."""
+    p = tmp_path / "voice_gate.yaml"
+    p.write_text("magic_phrases: agent\n")
+    cfg = load_voice_gate_config(p)
+    assert cfg.magic_phrases == ("agent",)
+
+
+def test_load_voice_gate_config_null_phrases_normalizes_to_empty(tmp_path: pathlib.Path):
+    """Case 38: ``magic_phrases: null`` (or omitted) is normalized to an
+    empty tuple — the gate's always-on mode."""
+    p = tmp_path / "voice_gate.yaml"
+    p.write_text("magic_phrases: null\nfollowup_grace_s: 3.0\n")
+    cfg = load_voice_gate_config(p)
+    assert cfg.magic_phrases == ()
+    assert cfg.followup_grace_s == 3.0
+
+
+def test_load_voice_gate_config_strips_whitespace_and_drops_empty(tmp_path: pathlib.Path):
+    """Case 39: phrase entries are stripped, and empty entries (after
+    strip) are dropped — same normalization the inline parser ran."""
+    p = tmp_path / "voice_gate.yaml"
+    p.write_text(
+        "magic_phrases:\n"
+        '  - "  agent  "\n'
+        '  - ""\n'
+        '  - "hey agent"\n'
+    )
+    cfg = load_voice_gate_config(p)
+    assert cfg.magic_phrases == ("agent", "hey agent")
+
+
+def test_load_voice_gate_config_rejects_non_mapping_top_level(tmp_path: pathlib.Path):
+    """Case 40: a top-level list (or any non-mapping) raises ValueError —
+    catches typo'd files that would otherwise silently degrade."""
+    p = tmp_path / "voice_gate.yaml"
+    p.write_text("- agent\n- hey agent\n")
+    with pytest.raises(ValueError):
+        load_voice_gate_config(p)
+
+
+# ── Round-trip checks against the in-tree sample voice_gate.yaml files ──────
+#
+# Skipped when the tests are run from an environment where the agent-samples
+# tree isn't reachable on disk (e.g. a published wheel install). When reachable,
+# these guard against accidental drift between the loader's accepted schema
+# and the YAML the samples actually ship.
+
+
+def _repo_root() -> pathlib.Path:
+    return pathlib.Path(__file__).resolve().parents[1]
+
+
+def test_load_voice_gate_config_simple_vlm_sample_round_trip():
+    """Case 41: the simple-vlm-example sample ships with the wake-word
+    config — confirm the file parses and exposes the documented phrases."""
+    p = _repo_root() / "agent-samples" / "simple-vlm-example" / "yaml" / "voice_gate.yaml"
+    if not p.exists():
+        pytest.skip(f"sample voice_gate.yaml not reachable at {p}")
+    cfg = load_voice_gate_config(p)
+    assert cfg.magic_phrases    == ("agent", "hey agent")
+    assert cfg.listening_chime  is False
+    assert cfg.followup_grace_s == 5.0
+
+
+def test_load_voice_gate_config_xr_render_demo_sample_round_trip():
+    """Case 42: the xr-render-demo sample ships with the empty-list
+    default (always-on) — confirm the file parses to defaults."""
+    p = _repo_root() / "agent-samples" / "xr-render-demo" / "yaml" / "voice_gate.yaml"
+    if not p.exists():
+        pytest.skip(f"sample voice_gate.yaml not reachable at {p}")
+    cfg = load_voice_gate_config(p)
+    assert cfg.magic_phrases    == ()
+    assert cfg.listening_chime  is False
+    assert cfg.followup_grace_s == 5.0

--- a/tests/test_xr_ai_voicegate.py
+++ b/tests/test_xr_ai_voicegate.py
@@ -251,16 +251,13 @@ def test_chime_read_wav_sample_rate_round_trip(sample_rate: int):
 
 
 @pytest.mark.asyncio
-async def test_feed_no_phrases_routes_every_utterance_to_on_drop():
-    """Case 15 (locked to actual behavior): with magic_phrases=() the gate
-    does NOT pass-through to on_query; every non-STOP utterance falls
-    through the ladder to on_drop.
-
-    NOTE: ``VoiceGateConfig`` docstring says empty phrases 'disables the
-    gate so every STT transcript is dispatched' — readers may interpret
-    that as on_query pass-through. The impl routes to on_drop instead.
-    This test pins the impl's actual behavior; if the docstring is the
-    intended contract, that's a code bug, not a test bug."""
+async def test_feed_no_phrases_passes_every_utterance_through_to_on_query():
+    """Case 15: with ``magic_phrases=()`` the gate is in always-on mode —
+    every non-STOP utterance dispatches to ``on_query`` with
+    ``fresh_match=True``. Matches the original simple-vlm-example
+    behavior the gate was extracted from, and what ``VoiceGateConfig``'s
+    docstring promises ("empty tuple disables the gate so every STT
+    transcript is dispatched")."""
     gate, _, _ = _gate(phrases=())
     events = _recording_handlers(gate)
 
@@ -268,9 +265,21 @@ async def test_feed_no_phrases_routes_every_utterance_to_on_drop():
     await gate.feed("p1", "tell me about this")
 
     assert events == [
-        ("drop", "p1", "what am I looking at"),
-        ("drop", "p1", "tell me about this"),
+        ("query", "p1", "what am I looking at", True),
+        ("query", "p1", "tell me about this", True),
     ]
+
+
+@pytest.mark.asyncio
+async def test_feed_no_phrases_stop_still_routes_to_on_stop():
+    """Case 15 (b): even in always-on mode, the STOP regex must still
+    fire ``on_stop`` so an interrupt works without a wake word."""
+    gate, _, _ = _gate(phrases=())
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "stop")
+
+    assert events == [("stop", "p1")]
 
 
 @pytest.mark.asyncio

--- a/tests/test_xr_ai_voicegate.py
+++ b/tests/test_xr_ai_voicegate.py
@@ -245,6 +245,50 @@ def test_chime_read_wav_sample_rate_round_trip(sample_rate: int):
     assert read_wav_sample_rate(wav) == sample_rate
 
 
+def test_chime_clamp_accepts_upper_bound_192khz():
+    """Case 14 (b): 192 kHz is at the documented upper bound and must
+    still build — the clamp is inclusive on both ends so legitimate
+    high-rate TTS outputs are not rejected."""
+    wav = build_chime_wav(192_000)
+    assert read_wav_sample_rate(wav) == 192_000
+
+
+def test_chime_clamp_rejects_just_above_upper_bound():
+    """Case 14 (c): one Hz past the upper bound raises ValueError. Guards
+    against a hostile or corrupted WAV header that declares a multi-GHz
+    rate from driving a multi-GB ``np.linspace`` allocation."""
+    with pytest.raises(ValueError):
+        build_chime_wav(192_001)
+
+
+@pytest.mark.asyncio
+async def test_observe_tts_wav_with_out_of_range_rate_disables_chime_without_crash():
+    """Case 14 (d): a malicious or corrupted TTS WAV declaring an
+    absurdly high sample rate (here 1 GHz, the kind of value an attacker
+    might splice into a uint32 header) must not crash the gate. The
+    chime caller swallows the ValueError, logs "sample rate out of
+    range", and disables the chime so subsequent ``play_chime`` calls
+    are no-ops.
+
+    1 GHz is comfortably above the 192 kHz clamp but stays under the
+    uint32-byterate limit Python's ``wave`` module enforces on the WAV
+    header, so the malformed blob is round-trip parseable and the
+    failure happens inside ``build_chime_wav`` exactly where the clamp
+    is meant to fire."""
+    gate, sink, _ = _gate(phrases=("agent",), listening_chime=True)
+
+    # _silence_wav uses int16 PCM so the 1-frame buffer is 2 bytes
+    # regardless of the (fictitious) sample rate stored in the header.
+    bad_wav = _silence_wav(1_000_000_000, ms=0)
+
+    gate.observe_tts_wav(bad_wav)        # must not raise
+    await gate.play_chime("p1")          # must not crash, must not emit
+
+    assert gate._chime_wav is None
+    assert gate._chime_enabled is False
+    assert sink.plays == []
+
+
 # ════════════════════════════════════════════════════════════════════════════
 # 4. Event ladder (`gate.feed`)
 # ════════════════════════════════════════════════════════════════════════════

--- a/utils/xr-ai-voicegate/pyproject.toml
+++ b/utils/xr-ai-voicegate/pyproject.toml
@@ -13,9 +13,11 @@ requires-python = ">=3.11,<3.13"
 # audio.  Owns the magic-phrase + follow-up + STOP ladder, the lazy
 # listening chime, and the participant-joined greeting hook so each
 # worker only wires handlers and feeds STT transcripts.  numpy is used
-# for the chime tone synthesis; everything else is stdlib.
+# for the chime tone synthesis; pyyaml parses the standalone
+# voice_gate.yaml file referenced from each worker YAML.
 dependencies = [
     "numpy>=1.24",
+    "pyyaml>=6.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/utils/xr-ai-voicegate/pyproject.toml
+++ b/utils/xr-ai-voicegate/pyproject.toml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "xr-ai-voicegate"
+version = "0.1.0"
+requires-python = ">=3.11,<3.13"
+# Speech-only opt-in gate shared by agent workers that ingest microphone
+# audio.  Owns the magic-phrase + follow-up + STOP ladder, the lazy
+# listening chime, and the participant-joined greeting hook so each
+# worker only wires handlers and feeds STT transcripts.  numpy is used
+# for the chime tone synthesis; everything else is stdlib.
+dependencies = [
+    "numpy>=1.24",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["xr_ai_voicegate"]

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/__init__.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/__init__.py
@@ -4,7 +4,7 @@
 """Public surface of the xr-ai-voicegate package."""
 from __future__ import annotations
 
-from .config import AudioSink, TTSLike, VoiceGateConfig
+from .config import AudioSink, TTSLike, VoiceGateConfig, load_voice_gate_config
 from .gate import VoiceGate
 
 __all__ = [
@@ -12,4 +12,5 @@ __all__ = [
     "TTSLike",
     "VoiceGate",
     "VoiceGateConfig",
+    "load_voice_gate_config",
 ]

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/__init__.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/__init__.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public surface of the xr-ai-voicegate package."""
+from __future__ import annotations
+
+from .config import AudioSink, TTSLike, VoiceGateConfig
+from .gate import VoiceGate
+
+__all__ = [
+    "AudioSink",
+    "TTSLike",
+    "VoiceGate",
+    "VoiceGateConfig",
+]

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/_chime.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/_chime.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Listening-chime synthesis and WAV header parsing for the voice gate."""
+from __future__ import annotations
+
+import io
+import wave
+
+import numpy as np
+
+
+def build_chime_wav(sample_rate: int) -> bytes:
+    """Synthesize the listening-chime as a self-contained WAV blob.
+
+    Two-tone perfect-fifth ding (880 + 1320 Hz) with exponential decay,
+    ~250 ms total, mono int16 PCM. ``sample_rate`` MUST match the rate
+    of the return audio track the consumer plays into (e.g. TTS sample
+    rate) so the underlying transport doesn't reject frames at a
+    different rate.
+    """
+    dur  = 0.25
+    t    = np.linspace(0.0, dur, int(sample_rate * dur), endpoint=False, dtype=np.float32)
+    tone = 0.55 * np.sin(2 * np.pi * 880.0 * t) + 0.30 * np.sin(2 * np.pi * 1320.0 * t)
+    env  = np.exp(-t * 8.0).astype(np.float32)
+    pcm  = (tone * env * 0.5 * 32767.0).clip(-32768, 32767).astype(np.int16)
+
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm.tobytes())
+    return buf.getvalue()
+
+
+def read_wav_sample_rate(wav_bytes: bytes) -> int:
+    """Pull the sample rate from a WAV blob without decoding the audio."""
+    with wave.open(io.BytesIO(wav_bytes), "rb") as wf:
+        return wf.getframerate()

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/_chime.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/_chime.py
@@ -18,7 +18,15 @@ def build_chime_wav(sample_rate: int) -> bytes:
     of the return audio track the consumer plays into (e.g. TTS sample
     rate) so the underlying transport doesn't reject frames at a
     different rate.
+
+    Clamped to a sane audio range. A WAV header is uint32 and a hostile
+    or corrupted blob can claim a multi-GHz rate, which would drive
+    ``np.linspace`` into a multi-GB allocation. Reject outside [8 kHz,
+    192 kHz] — the chime caller (``observe_tts_wav``) treats ValueError
+    as "disable the chime", so the worst case is no chime.
     """
+    if not 8000 <= sample_rate <= 192000:
+        raise ValueError(f"unsupported chime sample rate: {sample_rate}")
     dur  = 0.25
     t    = np.linspace(0.0, dur, int(sample_rate * dur), endpoint=False, dtype=np.float32)
     tone = 0.55 * np.sin(2 * np.pi * 880.0 * t) + 0.30 * np.sin(2 * np.pi * 1320.0 * t)

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/_phrases.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/_phrases.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Magic-phrase and STOP pattern matching for the voice gate."""
+from __future__ import annotations
+
+import re
+from typing import Sequence
+
+
+# Transcripts matching this pattern bypass the magic-phrase gate so the
+# user can interrupt a response mid-flight without having to start with
+# the configured phrase.
+STOP_RE: re.Pattern = re.compile(
+    r'^\s*(?:\S+\s+){0,2}'               # up to 2 optional filler words
+    r'(?:stop(?:\s+\w+){0,2}|be\s+quiet|quiet|shut\s+up)'
+    r'\s*[.!?]?\s*$',
+    re.IGNORECASE,
+)
+
+
+def build_magic_pattern(phrases: Sequence[str]) -> re.Pattern | None:
+    """Compile one strict-prefix regex covering every configured phrase.
+
+    Longest-first ordering picks the most specific match when one phrase
+    is a prefix of another (e.g. "agent" vs "agent buddy"). Inside each
+    phrase, the literal space between words is treated as "whitespace OR
+    punctuation" so STT transcripts like "Hey, agent." still match the
+    configured "hey agent". Returns ``None`` when ``phrases`` is empty
+    so the gate degrades to always-on.
+    """
+    cleaned = tuple(p.strip().lower() for p in phrases if p and p.strip())
+    if not cleaned:
+        return None
+    sep = r'[\s,.:;!?-]+'
+    alts = "|".join(
+        sep.join(re.escape(w) for w in p.split())
+        for p in sorted(cleaned, key=len, reverse=True)
+    )
+    return re.compile(rf'^\s*(?:{alts})\b[\s,.:;!?-]*', re.IGNORECASE)
+
+
+def strip_magic(pattern: re.Pattern | None, text: str) -> str | None:
+    """Return the transcript with the matched phrase stripped, or ``None``
+    when no phrase is the strict prefix. With ``pattern is None`` the gate
+    is disabled and ``text`` is returned unchanged."""
+    if pattern is None:
+        return text
+    m = pattern.match(text)
+    return None if m is None else text[m.end():]

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/config.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/config.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration dataclass and consumer-facing Protocols for the voice gate."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class VoiceGateConfig:
+    """Voice-gate behaviour knobs.
+
+    ``magic_phrases``    — strict-prefix opt-in words; empty tuple disables
+                           the gate so every STT transcript is dispatched.
+    ``followup_grace_s`` — seconds after a phrase match during which the
+                           next utterance from the same participant
+                           bypasses the gate.
+    ``listening_chime``  — when true AND ``magic_phrases`` is non-empty,
+                           a short two-tone chime plays on the consumer's
+                           audio sink whenever the worker invokes
+                           ``VoiceGate.play_chime``.
+    """
+    magic_phrases:    tuple[str, ...] = ()
+    followup_grace_s: float           = 5.0
+    listening_chime:  bool            = False
+
+
+class AudioSink(Protocol):
+    """Consumer-supplied return-audio writer."""
+
+    async def play_wav(self, pid: str, wav_bytes: bytes) -> None: ...
+
+
+class TTSLike(Protocol):
+    """Duck-typed text-to-speech client used for ``say_stop_ack``."""
+
+    async def synthesize(self, text: str) -> bytes: ...

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/config.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/config.py
@@ -1,11 +1,15 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Configuration dataclass and consumer-facing Protocols for the voice gate."""
+"""Configuration dataclass, YAML loader, and consumer-facing Protocols
+for the voice gate."""
 from __future__ import annotations
 
+import pathlib
 from dataclasses import dataclass
 from typing import Protocol
+
+import yaml
 
 
 @dataclass(frozen=True)
@@ -25,6 +29,33 @@ class VoiceGateConfig:
     magic_phrases:    tuple[str, ...] = ()
     followup_grace_s: float           = 5.0
     listening_chime:  bool            = False
+
+
+def load_voice_gate_config(path: pathlib.Path) -> VoiceGateConfig:
+    """Load + parse a voice_gate YAML file into a :class:`VoiceGateConfig`.
+
+    Schema: a top-level mapping with keys ``magic_phrases`` (list[str] or
+    bare str), ``listening_chime`` (bool), ``followup_grace_s`` (float).
+    Missing file or empty file → returns the dataclass defaults (gate
+    disabled / always-on). ``magic_phrases: null`` and trailing whitespace
+    in phrases are normalized the same way the inline-block parser did.
+    """
+    if not path.exists():
+        return VoiceGateConfig()
+    raw = yaml.safe_load(path.read_text()) or {}
+    if not isinstance(raw, dict):
+        raise ValueError(f"{path}: top-level must be a mapping")
+
+    phrases_raw = raw.get("magic_phrases") or []
+    if isinstance(phrases_raw, str):
+        phrases_raw = [phrases_raw]
+    phrases = tuple(p for p in (s.strip() for s in phrases_raw) if p)
+
+    return VoiceGateConfig(
+        magic_phrases    = phrases,
+        followup_grace_s = float(raw.get("followup_grace_s", 5.0)),
+        listening_chime  = bool(raw.get("listening_chime", False)),
+    )
 
 
 class AudioSink(Protocol):

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/gate.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/gate.py
@@ -249,6 +249,9 @@ class VoiceGate:
             sr = read_wav_sample_rate(wav_bytes)
             self._chime_wav = build_chime_wav(sr)
             logger.info("listening chime ready (sr=%d Hz)", sr)
+        except ValueError:
+            logger.exception("listening chime disabled (sample rate out of range)")
+            self._chime_enabled = False
         except Exception:
             logger.exception("listening chime disabled (bad TTS wav header)")
             self._chime_enabled = False

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/gate.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/gate.py
@@ -15,7 +15,6 @@ race through ``feed`` at the same time.
 """
 from __future__ import annotations
 
-import asyncio
 import logging
 import time
 from typing import Awaitable, Callable

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/gate.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/gate.py
@@ -125,10 +125,12 @@ class VoiceGate:
         # other utterance is a fresh query.
         if self._magic_re is None:
             if STOP_RE.match(text):
-                logger.info("stop bypass pid=%r %r", pid, text[:80])
+                logger.info("stop bypass pid=%r (text suppressed)", pid)
+                logger.debug("stop bypass pid=%r %r", pid, text[:80])
                 await self._invoke(self._on_stop_h, "on_stop", pid)
                 return
-            logger.info("audio query pid=%r %r", pid, text[:80])
+            logger.info("audio query pid=%r (text suppressed)", pid)
+            logger.debug("audio query pid=%r %r", pid, text[:80])
             await self._invoke(self._on_query_h, "on_query", pid, text, True)
             return
 
@@ -142,7 +144,8 @@ class VoiceGate:
         #    ("stop") AND on the magic-phrase-stripped tail ("hey agent,
         #    stop") so the fast path triggers either way.
         if STOP_RE.match(stop_candidate):
-            logger.info("stop bypass pid=%r %r", pid, stop_candidate[:80])
+            logger.info("stop bypass pid=%r (text suppressed)", pid)
+            logger.debug("stop bypass pid=%r %r", pid, stop_candidate[:80])
             self._followup_until.pop(pid, None)
             await self._invoke(self._on_stop_h, "on_stop", pid)
             return
@@ -154,7 +157,8 @@ class VoiceGate:
                 #    immediately and close the window so ambient speech
                 #    after the answer must re-introduce a phrase.
                 self._followup_until.pop(pid, None)
-                logger.info("audio query pid=%r %r", pid, query[:80])
+                logger.info("audio query pid=%r (text suppressed)", pid)
+                logger.debug("audio query pid=%r %r", pid, query[:80])
                 await self._invoke(self._on_query_h, "on_query", pid, query, True)
                 return
             # 4. Magic phrase with no follow-up payload — open the window
@@ -173,12 +177,14 @@ class VoiceGate:
             #    consumer can decide to re-open by calling back via a
             #    fresh magic-phrase match.
             self._followup_until.pop(pid, None)
-            logger.info("followup query pid=%r %r", pid, text[:80])
+            logger.info("followup query pid=%r (text suppressed)", pid)
+            logger.debug("followup query pid=%r %r", pid, text[:80])
             await self._invoke(self._on_query_h, "on_query", pid, text, False)
             return
 
         # 5. Default drop — log and close the window defensively.
-        logger.info("drop pid=%r %r", pid, text[:80])
+        logger.info("drop pid=%r (text suppressed)", pid)
+        logger.debug("drop pid=%r %r", pid, text[:80])
         self._followup_until.pop(pid, None)
         await self._invoke(self._on_drop_h, "on_drop", pid, text)
 

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/gate.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/gate.py
@@ -56,6 +56,13 @@ class VoiceGate:
     5. Otherwise → ``on_drop(pid, raw_text)``; closes the window
        defensively.
 
+    When ``magic_phrases`` is empty the gate is in always-on mode: STOP
+    still wins (interrupts must work without a phrase) and every other
+    utterance dispatches straight to ``on_query`` with
+    ``fresh_match=True``. The follow-up / phrase-only / drop branches
+    are inert in this mode — they only make sense once a phrase exists
+    to gate against.
+
     Handler exceptions are logged and swallowed so one bad handler does
     not kill the gate.
     """
@@ -112,10 +119,23 @@ class VoiceGate:
     # ── event ladder ──────────────────────────────────────────────────────────
 
     async def feed(self, pid: str, text: str) -> None:
+        # Always-on mode: no phrases configured, so the magic-phrase /
+        # follow-up / phrase-only / drop branches don't apply. STOP still
+        # wins (interrupts must work even without a phrase), and every
+        # other utterance is a fresh query.
+        if self._magic_re is None:
+            if STOP_RE.match(text):
+                logger.info("stop bypass pid=%r %r", pid, text[:80])
+                await self._invoke(self._on_stop_h, "on_stop", pid)
+                return
+            logger.info("audio query pid=%r %r", pid, text[:80])
+            await self._invoke(self._on_query_h, "on_query", pid, text, True)
+            return
+
         now_mono       = time.monotonic()
         in_followup    = self._followup_until.get(pid, 0.0) > now_mono
         stripped       = strip_magic(self._magic_re, text)
-        matched_magic  = self._magic_re is not None and stripped is not None
+        matched_magic  = stripped is not None
         stop_candidate = stripped if (matched_magic and stripped) else text
 
         # 1. STOP — always wins. Matched on both the raw transcript

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/gate.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/gate.py
@@ -28,7 +28,7 @@ from .config import AudioSink, TTSLike, VoiceGateConfig
 logger = logging.getLogger("xr_ai_voicegate")
 
 
-QueryHandler             = Callable[[str, str], Awaitable[None]]
+QueryHandler             = Callable[[str, str, bool], Awaitable[None]]   # (pid, query, fresh_match)
 StopHandler              = Callable[[str], Awaitable[None]]
 PhraseOnlyHandler        = Callable[[str], Awaitable[None]]
 DropHandler              = Callable[[str, str], Awaitable[None]]
@@ -44,9 +44,13 @@ class VoiceGate:
     1. STOP detected on raw text OR on the magic-phrase-stripped tail
        → ``on_stop(pid)``; closes the follow-up window.
     2. Magic phrase matched AND query non-empty
-       → ``on_query(pid, query)``; closes the follow-up window.
+       → ``on_query(pid, query, fresh_match=True)``; closes the follow-up
+       window.
     3. Follow-up window still open (and not STOP)
-       → ``on_query(pid, raw_text)``; closes the follow-up window.
+       → ``on_query(pid, raw_text, fresh_match=False)``; closes the
+       follow-up window. ``fresh_match`` distinguishes this continuation
+       from case 2 so consumers can suppress one-shot side effects
+       (e.g. the listening chime) on the follow-up dispatch.
     4. Magic phrase matched AND query empty
        → ``on_phrase_only(pid)``; opens the follow-up window.
     5. Otherwise → ``on_drop(pid, raw_text)``; closes the window
@@ -131,7 +135,7 @@ class VoiceGate:
                 #    after the answer must re-introduce a phrase.
                 self._followup_until.pop(pid, None)
                 logger.info("audio query pid=%r %r", pid, query[:80])
-                await self._invoke(self._on_query_h, "on_query", pid, query)
+                await self._invoke(self._on_query_h, "on_query", pid, query, True)
                 return
             # 4. Magic phrase with no follow-up payload — open the window
             #    so the user's next utterance counts as the actual query.
@@ -150,7 +154,7 @@ class VoiceGate:
             #    fresh magic-phrase match.
             self._followup_until.pop(pid, None)
             logger.info("followup query pid=%r %r", pid, text[:80])
-            await self._invoke(self._on_query_h, "on_query", pid, text)
+            await self._invoke(self._on_query_h, "on_query", pid, text, False)
             return
 
         # 5. Default drop — log and close the window defensively.

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/gate.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/gate.py
@@ -1,0 +1,240 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Speech-only opt-in gate shared by agent workers.
+
+Owns the magic-phrase + follow-up + STOP ladder, the lazy listening
+chime, and the participant-joined greeting hook. Workers feed STT
+transcripts via ``feed`` and register handlers for the events the gate
+emits (query, stop, phrase-only, drop, participant-joined).
+
+The gate does NOT serialize calls per-pid. Consumers are expected to
+gate concurrency themselves (e.g. a per-pid ``transcribing`` flag while
+STT is in flight) so two utterances from the same participant don't
+race through ``feed`` at the same time.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Awaitable, Callable
+
+from ._chime import build_chime_wav, read_wav_sample_rate
+from ._phrases import STOP_RE, build_magic_pattern, strip_magic
+from .config import AudioSink, TTSLike, VoiceGateConfig
+
+
+logger = logging.getLogger("xr_ai_voicegate")
+
+
+QueryHandler             = Callable[[str, str], Awaitable[None]]
+StopHandler              = Callable[[str], Awaitable[None]]
+PhraseOnlyHandler        = Callable[[str], Awaitable[None]]
+DropHandler              = Callable[[str, str], Awaitable[None]]
+ParticipantJoinedHandler = Callable[[str], Awaitable[None]]
+
+
+class VoiceGate:
+    """Speech-input gating state machine.
+
+    Event ladder in ``feed`` — exactly one event fires per call, in this
+    deterministic priority order:
+
+    1. STOP detected on raw text OR on the magic-phrase-stripped tail
+       → ``on_stop(pid)``; closes the follow-up window.
+    2. Magic phrase matched AND query non-empty
+       → ``on_query(pid, query)``; closes the follow-up window.
+    3. Follow-up window still open (and not STOP)
+       → ``on_query(pid, raw_text)``; closes the follow-up window.
+    4. Magic phrase matched AND query empty
+       → ``on_phrase_only(pid)``; opens the follow-up window.
+    5. Otherwise → ``on_drop(pid, raw_text)``; closes the window
+       defensively.
+
+    Handler exceptions are logged and swallowed so one bad handler does
+    not kill the gate.
+    """
+
+    def __init__(
+        self,
+        cfg: VoiceGateConfig,
+        *,
+        audio_sink: AudioSink,
+        tts: TTSLike,
+    ) -> None:
+        self._cfg          = cfg
+        self._audio_sink   = audio_sink
+        self._tts          = tts
+        self._magic_re     = build_magic_pattern(cfg.magic_phrases)
+        # Without a phrase the chime would have no fresh-match event to
+        # ride; mirror the original simple-vlm-example wiring rather than
+        # firing on every utterance.
+        self._chime_enabled: bool = bool(cfg.listening_chime) and self._magic_re is not None
+        self._chime_wav: bytes | None = None
+        self._followup_until: dict[str, float] = {}
+
+        self._on_query_h:               QueryHandler | None             = None
+        self._on_stop_h:                StopHandler | None              = None
+        self._on_phrase_only_h:         PhraseOnlyHandler | None        = None
+        self._on_drop_h:                DropHandler | None              = None
+        self._on_participant_joined_h:  ParticipantJoinedHandler | None = None
+
+    # ── handler registration ──────────────────────────────────────────────────
+
+    def on_query(self, h: QueryHandler) -> None:
+        self._on_query_h = h
+
+    def on_stop(self, h: StopHandler) -> None:
+        self._on_stop_h = h
+
+    def on_phrase_only(self, h: PhraseOnlyHandler) -> None:
+        self._on_phrase_only_h = h
+
+    def on_drop(self, h: DropHandler) -> None:
+        self._on_drop_h = h
+
+    def on_participant_joined(self, h: ParticipantJoinedHandler) -> None:
+        self._on_participant_joined_h = h
+
+    # ── per-participant lifecycle ─────────────────────────────────────────────
+
+    async def participant_joined(self, pid: str) -> None:
+        await self._invoke(self._on_participant_joined_h, "on_participant_joined", pid)
+
+    def forget(self, pid: str) -> None:
+        self._followup_until.pop(pid, None)
+
+    # ── event ladder ──────────────────────────────────────────────────────────
+
+    async def feed(self, pid: str, text: str) -> None:
+        now_mono       = time.monotonic()
+        in_followup    = self._followup_until.get(pid, 0.0) > now_mono
+        stripped       = strip_magic(self._magic_re, text)
+        matched_magic  = self._magic_re is not None and stripped is not None
+        stop_candidate = stripped if (matched_magic and stripped) else text
+
+        # 1. STOP — always wins. Matched on both the raw transcript
+        #    ("stop") AND on the magic-phrase-stripped tail ("hey agent,
+        #    stop") so the fast path triggers either way.
+        if STOP_RE.match(stop_candidate):
+            logger.info("stop bypass pid=%r %r", pid, stop_candidate[:80])
+            self._followup_until.pop(pid, None)
+            await self._invoke(self._on_stop_h, "on_stop", pid)
+            return
+
+        if matched_magic:
+            query = stripped or ""
+            if query:
+                # 2. Fresh magic-phrase match with a payload — dispatch
+                #    immediately and close the window so ambient speech
+                #    after the answer must re-introduce a phrase.
+                self._followup_until.pop(pid, None)
+                logger.info("audio query pid=%r %r", pid, query[:80])
+                await self._invoke(self._on_query_h, "on_query", pid, query)
+                return
+            # 4. Magic phrase with no follow-up payload — open the window
+            #    so the user's next utterance counts as the actual query.
+            self._followup_until[pid] = now_mono + self._cfg.followup_grace_s
+            logger.info(
+                "magic phrase only pid=%r — awaiting followup (%.1fs)",
+                pid, self._cfg.followup_grace_s,
+            )
+            await self._invoke(self._on_phrase_only_h, "on_phrase_only", pid)
+            return
+
+        if in_followup:
+            # 3. Followup continuation — dispatch raw text and close the
+            #    window. Refreshing it on accept happens implicitly: the
+            #    consumer can decide to re-open by calling back via a
+            #    fresh magic-phrase match.
+            self._followup_until.pop(pid, None)
+            logger.info("followup query pid=%r %r", pid, text[:80])
+            await self._invoke(self._on_query_h, "on_query", pid, text)
+            return
+
+        # 5. Default drop — log and close the window defensively.
+        logger.info("drop pid=%r %r", pid, text[:80])
+        self._followup_until.pop(pid, None)
+        await self._invoke(self._on_drop_h, "on_drop", pid, text)
+
+    # ── worker-callable side effects ──────────────────────────────────────────
+
+    async def play_chime(self, pid: str) -> None:
+        """Emit the listening chime on the consumer's audio sink.
+
+        No-op when the chime is disabled or has not been built yet (the
+        chime is lazily synthesized to match the TTS sample rate the
+        first time ``observe_tts_wav`` is called).
+        """
+        if not self._chime_enabled:
+            return
+        if self._chime_wav is None:
+            logger.debug("play_chime no-op pid=%r — chime not yet built", pid)
+            return
+        try:
+            await self._audio_sink.play_wav(pid, self._chime_wav)
+        except Exception:
+            logger.exception("chime send error pid=%r", pid)
+
+    def format_phrase_help(self) -> str | None:
+        """Return a sentence fragment telling the user how to address the
+        agent given the configured phrases. ``None`` when no phrases are
+        configured (the caller picks a generic greeting). The wording
+        carries over from the original ``_greet`` implementation."""
+        phrases = list(self._cfg.magic_phrases)
+        if not phrases:
+            return None
+        if len(phrases) == 1:
+            phrase_list = f'"{phrases[0]}"'
+        elif len(phrases) == 2:
+            phrase_list = f'"{phrases[0]}" or "{phrases[1]}"'
+        else:
+            phrase_list = (
+                ", ".join(f'"{p}"' for p in phrases[:-1])
+                + f', or "{phrases[-1]}"'
+            )
+        return (
+            f'To talk to me, start your question with {phrase_list}. '
+            f'For example, "{phrases[0]}, what am I looking at?"'
+        )
+
+    async def say_stop_ack(self, pid: str) -> None:
+        """Synthesize a short canned stop acknowledgement and play it on
+        the consumer's audio sink. Also observes the WAV so the lazy
+        chime build can pick up the sample rate from this path."""
+        try:
+            wav = await self._tts.synthesize("Okay, I will stop.")
+        except Exception:
+            logger.exception("stop-ack tts error pid=%r", pid)
+            return
+        self.observe_tts_wav(wav)
+        try:
+            await self._audio_sink.play_wav(pid, wav)
+        except Exception:
+            logger.exception("stop-ack audio error pid=%r", pid)
+
+    def observe_tts_wav(self, wav_bytes: bytes) -> None:
+        """Build the chime at the TTS sample rate the first time a real
+        TTS WAV passes through. No-op once built or when chime is
+        disabled. A malformed WAV header disables the chime so the
+        consumer doesn't keep paying for failed builds."""
+        if self._chime_wav is not None or not self._chime_enabled:
+            return
+        try:
+            sr = read_wav_sample_rate(wav_bytes)
+            self._chime_wav = build_chime_wav(sr)
+            logger.info("listening chime ready (sr=%d Hz)", sr)
+        except Exception:
+            logger.exception("listening chime disabled (bad TTS wav header)")
+            self._chime_enabled = False
+
+    # ── handler dispatch ──────────────────────────────────────────────────────
+
+    async def _invoke(self, handler, name: str, *args) -> None:
+        if handler is None:
+            return
+        try:
+            await handler(*args)
+        except Exception:
+            logger.exception("voicegate handler %s raised", name)


### PR DESCRIPTION
## Summary

Extracts the magic-phrase / STOP fast-path / listening-chime / connect-greeting
mechanism out of simple-vlm-example into a reusable `xr-ai-voicegate` utility
package. Migrates both simple-vlm-example and xr-render-demo onto it so the
"how a user starts talking to the agent" surface is consistent across samples.

Event-driven module: consumers feed STT transcripts in, register handlers for
typed events (on_query, on_stop, on_phrase_only, on_drop, on_participant_joined),
and call the gate's audio helpers (play_chime, format_phrase_help, say_stop_ack)
on their own schedule. No asyncio.Task ownership inside the gate, no LiveKit or
pipecat coupling — drops cleanly into both the simple-vlm callback model and the
xr-render-demo pipecat-pipeline model. Configurable via a nested `voice_gate:`
YAML block; opt-in (default empty phrase list = always-on pass-through).

## What's in this PR

- New package `utils/xr-ai-voicegate/` (gate.py, config.py, _phrases.py, _chime.py).
- simple-vlm-example migrated: agent.py slimmed by 153 lines (233 deletions, 80
  additions); YAML moved to nested `voice_gate:` block.
- xr-render-demo migrated: gate wired in `RenderSceneProcessor`; `TtsProcessor`
  routes every synthesize() through `gate.observe_tts_wav`; default config ships
  with empty phrase list to preserve current always-on behavior.
- 45 unit tests covering the gate's event ladder, regex semantics, chime
  synthesis, lifecycle, and the security-audit guards (sample-rate clamp,
  hostile-WAV chime disable).

## What's NOT in this PR

- Glasses-NAT agent (not yet checked in) — will adopt the same API when it lands.
- Pre-existing xr-render-demo issues surfaced during migration but explicitly
  out of scope: `RenderSceneProcessor._lock` is per-processor not per-pid;
  `SttProcessor._is_filler` filters before the gate sees transcripts; `agent.py`
  reaches into `_scene._history` privately; `eval/eval.py` references a
  non-existent `agent_llm_server` field. Tracked separately.

## Test plan

- [x] 45 voicegate unit tests pass on Python 3.11 + 3.12
- [x] Existing xr-render-demo wire tests pass (9/9)
- [x] Existing simple-vlm-example wire tests pass (8/8)
- [x] Security audit: chime sample-rate clamp, STT log-level reduction (both fixed)
- [ ] Boot simple-vlm-example end-to-end against real services (board to verify)
- [ ] Boot xr-render-demo end-to-end against real services (board to verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)