### PR TITLE
feat(conversation): introduce ConversationLoop foundation for shared STT/TTS pipeline

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -60,6 +60,21 @@ xr-ai-pipecat  (agent-sdk/xr-ai-pipecat/)
     the SDK. httpx is retained for http_probe() readiness checks.
     Not a dep of xr-ai-agent itself — import only in workers that use Pipecat.
 
+xr-ai-conversation  (agent-sdk/xr-ai-conversation/)
+    └── xr-ai-agent     [editable: ..]
+    └── xr-ai-vad       [editable: ../../utils/xr-ai-vad]
+    └── xr-ai-voicegate [editable: ../../utils/xr-ai-voicegate]
+    └── xr-ai-models    [editable: ../xr-ai-models]
+    └── numpy >=1.24
+    Shared voice-conversation loop for agent workers: wires VAD → STT →
+    voice gate → user ``on_query`` → TTS → return-audio fan-out, with
+    per-pid in-flight cancel + ``flush_return_audio`` and sentence-batched
+    streaming. Workers supply the ``ProcessorEndpoint``, STT/TTS services,
+    a ``VoiceGateConfig``, and one ``on_query`` callback returning either
+    a ``str`` (one-shot reply) or an ``AsyncIterator[str]`` (streamed
+    tokens). Codec helpers (int16 PCM ↔ WAV, sentence split) are exported
+    for consumers that want pieces without the full loop.
+
 xr-ai-models  (agent-sdk/xr-ai-models/)
     └── xr-ai-logging [editable: ../../utils/xr-ai-logging]
     └── httpx >=0.27
@@ -191,6 +206,7 @@ oxr-mcp-server  (agent-mcp-servers/oxr-mcp/)
 
 xr-ai-tests  (tests/)
     └── xr-ai-agent             [editable: ../agent-sdk]
+    └── xr-ai-conversation      [editable: ../agent-sdk/xr-ai-conversation]
     └── xr-ai-models            [editable: ../agent-sdk/xr-ai-models]
     └── xr-ai-pipecat           [editable: ../agent-sdk/xr-ai-pipecat]
     └── xr-media-hub            [editable: ../server-runtime]    (pulls in livekit, livekit-api for the wss /rtc proxy + room-client tests)

--- a/agent-sdk/xr-ai-conversation/pyproject.toml
+++ b/agent-sdk/xr-ai-conversation/pyproject.toml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "xr-ai-conversation"
+version = "0.1.0"
+requires-python = ">=3.11,<3.13"
+# Shared voice-conversation loop for agent workers: wires VAD → STT →
+# voice gate → user query handler → TTS → return audio, with per-pid
+# in-flight cancel/flush and sentence-batched streaming.  Workers supply
+# the ProcessorEndpoint, STT/TTS services, a voice-gate config, and one
+# ``on_query`` callback; everything else (codec helpers, audio sink
+# adapter, gate handler wiring) lives in this package.
+dependencies = [
+    "xr-ai-agent",
+    "xr-ai-vad",
+    "xr-ai-voicegate",
+    "xr-ai-models",
+    "numpy>=1.24",
+]
+
+[tool.uv.sources]
+xr-ai-agent     = { path = "..", editable = true }
+xr-ai-vad       = { path = "../../utils/xr-ai-vad", editable = true }
+xr-ai-voicegate = { path = "../../utils/xr-ai-voicegate", editable = true }
+xr-ai-models    = { path = "../xr-ai-models", editable = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["xr_ai_conversation"]

--- a/agent-sdk/xr-ai-conversation/xr_ai_conversation/__init__.py
+++ b/agent-sdk/xr-ai-conversation/xr_ai_conversation/__init__.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public surface of the xr-ai-conversation package."""
+from __future__ import annotations
+
+from .audio import (
+    chunks_to_wav,
+    int16_pcm_to_wav,
+    now_us,
+    split_sentences,
+    wav_to_chunks,
+)
+from .gate_wiring import GateBindings, QueryHandler, QueryResult
+from .loop import ConversationLoop, VadConfig
+from .state import VoiceState
+from .streaming import stream_text_to_audio
+
+__all__ = [
+    # primary entry point
+    "ConversationLoop",
+    "VadConfig",
+    # helpers exposed for samples that want to reuse pieces
+    "GateBindings",
+    "QueryHandler",
+    "QueryResult",
+    "VoiceState",
+    "stream_text_to_audio",
+    # audio codec helpers
+    "chunks_to_wav",
+    "int16_pcm_to_wav",
+    "now_us",
+    "split_sentences",
+    "wav_to_chunks",
+]

--- a/agent-sdk/xr-ai-conversation/xr_ai_conversation/audio.py
+++ b/agent-sdk/xr-ai-conversation/xr_ai_conversation/audio.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Audio codec helpers shared by the conversation loop.
+
+* ``int16_pcm_to_wav`` — wrap raw int16 PCM in a single-channel WAV for STT.
+* ``wav_to_chunks``    — decode a WAV blob into 20 ms float32
+  ``AudioChunk``s for the hub's return-audio fan-out.
+* ``chunks_to_wav``    — inverse of ``wav_to_chunks`` for tests and
+  hub-tap recording paths.
+* ``split_sentences``  — break streamed VLM/LLM output on sentence
+  boundaries so each sentence can synthesize in parallel.
+* ``now_us``           — microsecond wall clock used as the ``pts_us``
+  default for canned replies.
+"""
+from __future__ import annotations
+
+import io
+import re
+import time
+import wave
+
+import numpy as np
+
+from xr_ai_agent import AudioChunk
+
+
+_CHUNK_MS = 20
+_CHUNK_US = _CHUNK_MS * 1_000
+
+SENTENCE_RE = re.compile(r"(?<=[.!?])\s+")
+
+
+def now_us() -> int:
+    return time.time_ns() // 1_000
+
+
+def int16_pcm_to_wav(pcm_bytes: bytes, sample_rate: int, channels: int = 1) -> bytes:
+    """Wrap raw int16 PCM bytes in a single-channel WAV container for STT."""
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(channels)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm_bytes)
+    return buf.getvalue()
+
+
+def wav_to_chunks(wav_bytes: bytes, participant_id: str) -> list[AudioChunk]:
+    """Decode a WAV blob into 20 ms float32 ``AudioChunk``s at native rate."""
+    buf = io.BytesIO(wav_bytes)
+    with wave.open(buf, "rb") as wf:
+        sr  = wf.getframerate()
+        ch  = wf.getnchannels()
+        raw = wf.readframes(wf.getnframes())
+    arr = np.frombuffer(raw, dtype=np.int16).astype(np.float32) / 32768.0
+    chunk_frames = max(1, sr // (1000 // _CHUNK_MS))
+    pts = now_us()
+    out: list[AudioChunk] = []
+    for i in range(0, len(arr), chunk_frames * ch):
+        seg = arr[i : i + chunk_frames * ch]
+        if not len(seg):
+            break
+        out.append(AudioChunk(
+            pts_us=pts, sample_rate=sr, channels=ch,
+            samples=len(seg) // ch, data=seg.tobytes(),
+            participant_id=participant_id,
+        ))
+        pts += _CHUNK_US
+    return out
+
+
+def chunks_to_wav(chunks: list[AudioChunk]) -> bytes:
+    """Concatenate float32 ``AudioChunk``s into a single 16-bit PCM WAV blob.
+
+    Inverse of ``wav_to_chunks``; useful for tests that need to round-trip
+    audio through the return-audio path and for hub-tap recording. Raises
+    ``ValueError`` on an empty list — there is no sane sample rate to pick."""
+    if not chunks:
+        raise ValueError("chunks_to_wav requires at least one chunk")
+    raw = b"".join(c.data for c in chunks)
+    arr = np.frombuffer(raw, dtype=np.float32)
+    pcm = (np.clip(arr, -1.0, 1.0) * 32767).astype(np.int16)
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(chunks[0].channels)
+        wf.setsampwidth(2)
+        wf.setframerate(chunks[0].sample_rate)
+        wf.writeframes(pcm.tobytes())
+    return buf.getvalue()
+
+
+def split_sentences(text: str) -> list[str]:
+    """Split ``text`` on sentence boundaries (``.``, ``!``, ``?`` + whitespace).
+
+    Returns the non-empty stripped sentences in order. The streaming TTS
+    path uses the lower-level regex inline to peel sentences as tokens
+    arrive; this helper is for callers that already have the full text."""
+    parts = SENTENCE_RE.split(text.strip())
+    return [s.strip() for s in parts if s.strip()]

--- a/agent-sdk/xr-ai-conversation/xr_ai_conversation/gate_wiring.py
+++ b/agent-sdk/xr-ai-conversation/xr_ai_conversation/gate_wiring.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Voice-gate handler bundle used by the conversation loop.
+
+Workers do not normally construct this directly — :class:`ConversationLoop`
+builds it from the keyword args passed to its constructor. The dataclass
+is exposed so a Pipecat-style consumer that wants the same wiring
+pattern without the full loop (e.g. for a custom transport) can reuse
+the binding shape.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import AsyncIterator, Awaitable, Callable
+
+
+QueryResult  = str | AsyncIterator[str]
+QueryHandler = Callable[[str, str, bool], Awaitable[QueryResult]]
+
+
+@dataclass
+class GateBindings:
+    """Handlers the conversation loop registers on its internal ``VoiceGate``.
+
+    ``on_query`` is required; everything else is optional. The loop
+    constructs this from its kwargs and uses it to set up the gate; the
+    type exists so the same wiring shape can be reused outside the loop."""
+    on_query:              QueryHandler
+    on_stop_extra:         Callable[[str], Awaitable[None]] | None = None
+    on_participant_joined: Callable[[str], Awaitable[None]] | None = None
+    on_participant_left:   Callable[[str], Awaitable[None]] | None = None

--- a/agent-sdk/xr-ai-conversation/xr_ai_conversation/loop.py
+++ b/agent-sdk/xr-ai-conversation/xr_ai_conversation/loop.py
@@ -1,0 +1,378 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Voice conversation loop shared by agent workers.
+
+Owns: per-pid VAD lifecycle, STT, voice-gate wiring, per-pid in-flight
+cancel/flush, sentence-batched streaming TTS, return-audio fan-out, and
+the participant-join/leave hooks. The worker supplies a
+``ProcessorEndpoint``, STT/TTS services, a ``VoiceGateConfig``, and one
+``on_query`` callback that returns either a ``str`` (one-shot reply) or
+an ``AsyncIterator[str]`` (streamed tokens, sentence-batched downstream).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import AsyncIterator, Awaitable, Callable
+
+import numpy as np
+
+from xr_ai_agent import (
+    AudioChunk, DataMessage, ParticipantEvent, ProcessorEndpoint,
+)
+from xr_ai_models import STTService, TTSService
+from xr_ai_vad import VadDetector
+from xr_ai_voicegate import AudioSink, VoiceGate, VoiceGateConfig
+
+from .audio import int16_pcm_to_wav, now_us, wav_to_chunks
+from .gate_wiring import GateBindings, QueryHandler, QueryResult
+from .state import VoiceState
+from .streaming import stream_text_to_audio
+
+
+logger = logging.getLogger("xr_ai_conversation")
+
+
+@dataclass(frozen=True)
+class VadConfig:
+    silence_duration: float = 0.8
+    min_speech:       float = 0.3
+    silero_threshold: float = 0.5
+
+
+class _EpAudioSink:
+    """Adapter exposing ``ProcessorEndpoint`` as an :class:`AudioSink`.
+
+    Explodes a WAV blob into 20 ms ``AudioChunk``s and streams them
+    through ``send_return_audio`` so the voice gate, the streaming TTS
+    helper, and the loop's own ``say()`` all push audio through one
+    code path."""
+
+    def __init__(self, ep: ProcessorEndpoint) -> None:
+        self._ep = ep
+
+    async def play_wav(self, pid: str, wav_bytes: bytes) -> None:
+        for chunk in wav_to_chunks(wav_bytes, pid):
+            await self._ep.send_return_audio(chunk)
+
+
+class ConversationLoop:
+    """Voice-conversation runtime.
+
+    Wires the audio → VAD → STT → voice-gate → ``on_query`` → TTS →
+    return-audio path for any worker that consumes the hub's mic feed.
+    Construct once per worker, register optional hooks, then ``await
+    run()``. Per-pid in-flight cancel/flush keeps a new query from
+    racing with a previous in-flight response.
+
+    The ``on_query`` callback may return either a ``str`` (canned reply
+    or one-shot LLM/VLM call) or an ``AsyncIterator[str]`` (streamed
+    tokens — sentences are peeled and synthesized in parallel). Both
+    forms also send the final assembled text on ``text_topic`` for
+    clients that listen on the data channel.
+    """
+
+    def __init__(
+        self,
+        *,
+        ep:             ProcessorEndpoint,
+        stt:            STTService,
+        tts:            TTSService,
+        voice_gate_cfg: VoiceGateConfig,
+        vad_cfg:        VadConfig,
+        on_query:       QueryHandler,
+        on_speech_start:       Callable[[str], Awaitable[None]] | None = None,
+        on_participant_joined: Callable[[str], Awaitable[None]] | None = None,
+        on_participant_left:   Callable[[str], Awaitable[None]] | None = None,
+        on_stop_extra:         Callable[[str], Awaitable[None]] | None = None,
+        text_topic: str = "agent.response",
+        greeting:   str | Callable[[VoiceGate], str] | None = None,
+    ) -> None:
+        self._ep         = ep
+        self._stt        = stt
+        self._tts        = tts
+        self._vad_cfg    = vad_cfg
+        self._text_topic = text_topic
+
+        self._bindings = GateBindings(
+            on_query              = on_query,
+            on_stop_extra         = on_stop_extra,
+            on_participant_joined = on_participant_joined,
+            on_participant_left   = on_participant_left,
+        )
+        self._on_speech_start = on_speech_start
+        self._greeting        = greeting
+
+        self._voice: dict[str, VoiceState] = {}
+
+        self._audio_sink = _EpAudioSink(ep)
+        self._gate = VoiceGate(
+            voice_gate_cfg,
+            audio_sink = self._audio_sink,
+            tts        = tts,
+        )
+        self._gate.on_query(self._on_gate_query)
+        self._gate.on_stop(self._handle_stop)
+        self._gate.on_phrase_only(self._on_phrase_only)
+        self._gate.on_drop(self._on_drop)
+        self._gate.on_participant_joined(self._greet)
+
+        ep.on_audio(self._on_audio)
+        ep.on_participant(self._on_participant)
+
+    # ── lifecycle ─────────────────────────────────────────────────────────────
+
+    async def run(self) -> None:
+        await self._ep.run()
+
+    def shutdown(self) -> None:
+        self._ep.stop()
+        self._ep.close()
+
+    # ── audio path: PCM → VAD → STT → gate ────────────────────────────────────
+
+    async def _on_audio(self, chunk: AudioChunk) -> None:
+        vs = self._get_voice(chunk.participant_id)
+        assert vs.vad is not None
+        # Hub delivers float32 LE PCM; VadDetector takes int16 LE PCM.
+        f32 = np.frombuffer(chunk.data, dtype=np.float32)
+        i16 = (np.clip(f32, -1.0, 1.0) * 32767).astype(np.int16).tobytes()
+        await vs.vad.feed(i16, chunk.sample_rate)
+
+    def _get_voice(self, pid: str) -> VoiceState:
+        vs = self._voice.get(pid)
+        if vs is None:
+            vs = VoiceState()
+            vs.vad = VadDetector(
+                on_utterance     = lambda audio, sr, _pid=pid: self._on_vad_utterance(_pid, audio, sr),
+                on_speech_start  = lambda _pid=pid: self._on_vad_speech_start(_pid),
+                silence_duration = self._vad_cfg.silence_duration,
+                min_speech       = self._vad_cfg.min_speech,
+                silero_threshold = self._vad_cfg.silero_threshold,
+            )
+            self._voice[pid] = vs
+        return vs
+
+    async def _on_vad_speech_start(self, pid: str) -> None:
+        if self._on_speech_start is None:
+            return
+        try:
+            await self._on_speech_start(pid)
+        except Exception:
+            logger.exception("on_speech_start hook raised pid=%r", pid)
+
+    async def _on_vad_utterance(self, pid: str, audio_bytes: bytes, sample_rate: int) -> None:
+        vs = self._voice.get(pid)
+        if vs is None or vs.transcribing:
+            return
+        vs.transcribing = True
+        try:
+            wav  = int16_pcm_to_wav(audio_bytes, sample_rate)
+            text = (await self._stt.transcribe(wav)).strip()
+            if not text:
+                return
+            await self._gate.feed(pid, text)
+        except Exception:
+            logger.exception("stt error pid=%r", pid)
+        finally:
+            vs.transcribing = False
+
+    # ── voice-gate handlers ───────────────────────────────────────────────────
+
+    async def _on_gate_query(self, pid: str, query: str, fresh_match: bool) -> None:
+        if fresh_match:
+            asyncio.create_task(self._gate.play_chime(pid))
+        await self._dispatch_internal(pid, query, pts_us=now_us(), fresh_match=fresh_match)
+
+    async def _on_phrase_only(self, pid: str) -> None:
+        # The chime here acknowledges that the wake word was heard while
+        # the follow-up window is open; without it the user has no signal
+        # that the gate is ready for the next utterance.
+        await self._gate.play_chime(pid)
+
+    async def _on_drop(self, pid: str, text: str) -> None:
+        # The gate already logged; nothing for the loop to do.
+        return
+
+    # ── interruptible dispatch ────────────────────────────────────────────────
+
+    async def dispatch(self, pid: str, text: str, *, pts_us: int) -> None:
+        """Cancel any in-flight response for ``pid``, flush queued audio,
+        then start the new query as a tracked task.
+
+        Data-channel callers use this directly; the gate path goes
+        through ``_dispatch_internal`` so it can pass the gate's
+        ``fresh_match`` flag through to the user's ``on_query``."""
+        await self._dispatch_internal(pid, text, pts_us=pts_us, fresh_match=True)
+
+    async def _dispatch_internal(
+        self, pid: str, text: str, *, pts_us: int, fresh_match: bool,
+    ) -> None:
+        vs = self._get_voice(pid)
+        async with vs.dispatch_lock:
+            await self._cancel_inflight_locked(vs, pid)
+            await self._ep.flush_return_audio(pid)
+            vs.current_task = asyncio.create_task(
+                self._run_query(pid, text, pts_us, fresh_match),
+                name=f"conv-query-{pid}",
+            )
+
+    async def _cancel_inflight_locked(self, vs: VoiceState, pid: str) -> None:
+        old = vs.current_task
+        if old is None or old.done():
+            return
+        logger.info("interrupt pid=%r — cancelling in-flight response", pid)
+        old.cancel()
+        try:
+            await old
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.exception("in-flight task error during cancel pid=%r", pid)
+
+    async def _run_query(
+        self, pid: str, text: str, pts_us: int, fresh_match: bool,
+    ) -> None:
+        try:
+            result = await self._bindings.on_query(pid, text, fresh_match)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("on_query raised pid=%r", pid)
+            return
+
+        try:
+            if isinstance(result, str):
+                await self._speak(pid, result)
+                final_text = result
+            else:
+                final_text = await stream_text_to_audio(
+                    tokens     = result,
+                    pid        = pid,
+                    tts        = self._tts,
+                    audio_sink = self._audio_sink,
+                    on_wav     = self._gate.observe_tts_wav,
+                )
+        except asyncio.CancelledError:
+            raise
+
+        if final_text:
+            await self._reply_data(pid, final_text, pts_us)
+
+    # ── outbound helpers ──────────────────────────────────────────────────────
+
+    async def say(self, pid: str, text: str) -> None:
+        """Synthesize ``text`` and play it on the return-audio channel.
+
+        Does not touch the data channel. Use :meth:`reply` for a paired
+        data + audio response.
+        """
+        await self._speak(pid, text)
+
+    async def reply(self, pid: str, text: str, *, pts_us: int) -> None:
+        """Send ``text`` on the data channel AND speak it on return audio."""
+        await self._reply_data(pid, text, pts_us)
+        await self._speak(pid, text)
+
+    async def _speak(self, pid: str, text: str) -> None:
+        if not text:
+            return
+        try:
+            wav = await self._tts.synthesize(text)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("tts synthesize error pid=%r", pid)
+            return
+        self._gate.observe_tts_wav(wav)
+        try:
+            await self._audio_sink.play_wav(pid, wav)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("return-audio play_wav error pid=%r", pid)
+
+    async def _reply_data(self, pid: str, text: str, pts_us: int) -> None:
+        await self._ep.send_return_data(DataMessage(
+            participant_id = pid,
+            topic          = self._text_topic,
+            pts_us         = pts_us,
+            data           = text.encode(),
+        ))
+
+    # ── stop ──────────────────────────────────────────────────────────────────
+
+    async def _handle_stop(self, pid: str) -> None:
+        """Cancel + flush + ``say_stop_ack`` + ``on_stop_extra`` + data echo.
+
+        Order matches the design spec (PR-A) — it differs from the
+        original simple-vlm-example, which echoed the data message
+        before the stop-ack TTS; this loop runs the stop-ack first so
+        the canned audio starts playing while the data echo travels."""
+        vs = self._voice.get(pid)
+        if vs is not None:
+            async with vs.dispatch_lock:
+                await self._cancel_inflight_locked(vs, pid)
+                await self._ep.flush_return_audio(pid)
+                vs.current_task = None
+
+        await self._gate.say_stop_ack(pid)
+
+        if self._bindings.on_stop_extra is not None:
+            try:
+                await self._bindings.on_stop_extra(pid)
+            except Exception:
+                logger.exception("on_stop_extra hook raised pid=%r", pid)
+
+        await self._reply_data(pid, "Okay, I will stop.", now_us())
+
+    # ── participant lifecycle ─────────────────────────────────────────────────
+
+    async def _on_participant(self, event: ParticipantEvent) -> None:
+        pid = event.participant_id
+        if event.joined:
+            if self._bindings.on_participant_joined is not None:
+                try:
+                    await self._bindings.on_participant_joined(pid)
+                except Exception:
+                    logger.exception("on_participant_joined hook raised pid=%r", pid)
+            asyncio.create_task(self._gate.participant_joined(pid))
+            return
+
+        vs = self._voice.pop(pid, None)
+        if vs is not None and vs.current_task is not None and not vs.current_task.done():
+            vs.current_task.cancel()
+        self._gate.forget(pid)
+        if self._bindings.on_participant_left is not None:
+            try:
+                await self._bindings.on_participant_left(pid)
+            except Exception:
+                logger.exception("on_participant_left hook raised pid=%r", pid)
+
+    async def _greet(self, pid: str) -> None:
+        text = self._resolve_greeting()
+        if not text:
+            return
+        try:
+            await self._speak(pid, text)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("greet error pid=%r", pid)
+
+    def _resolve_greeting(self) -> str:
+        g = self._greeting
+        if g is None:
+            help_text = self._gate.format_phrase_help()
+            if help_text is None:
+                return "Hi, I'm listening. Ask me anything."
+            return f"Hi, I'm listening. {help_text}"
+        if isinstance(g, str):
+            return g
+        try:
+            return g(self._gate) or ""
+        except Exception:
+            logger.exception("greeting callable raised")
+            return ""

--- a/agent-sdk/xr-ai-conversation/xr_ai_conversation/state.py
+++ b/agent-sdk/xr-ai-conversation/xr_ai_conversation/state.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-participant voice-loop bookkeeping owned by ``ConversationLoop``.
+
+The loop owns the ``VadDetector`` lifecycle for each participant; this
+struct only tracks the cancel/flush state for in-flight queries and a
+single STT-in-flight flag so two utterances from the same pid don't race
+through the gate at the same time.
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+
+from xr_ai_vad import VadDetector
+
+
+@dataclass
+class VoiceState:
+    vad:           VadDetector | None  = None
+    transcribing:  bool                = False  # in-flight STT for this pid
+    # In-flight user-supplied response.  A new query cancels this; the
+    # dispatch lock serialises the cancel-await-flush-restart sequence
+    # per pid so concurrent calls can't both see a stale ``current_task``.
+    current_task:  asyncio.Task | None = None
+    dispatch_lock: asyncio.Lock        = field(default_factory=asyncio.Lock)

--- a/agent-sdk/xr-ai-conversation/xr_ai_conversation/streaming.py
+++ b/agent-sdk/xr-ai-conversation/xr_ai_conversation/streaming.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Streaming token → sentence-batched TTS → audio sink pipeline.
+
+The user's streaming ``on_query`` yields tokens; this helper buffers
+them into sentence-sized units, spawns a TTS synth task per sentence so
+multiple sentences synth in parallel, and pushes the resulting WAV
+bytes to an :class:`AudioSink` in order via a single sender task.
+
+Cancellation is cooperative: the caller is expected to ``await`` this
+coroutine inside an ``asyncio.Task`` and cancel that task to interrupt.
+On cancel, all pending synth tasks and the sender task are cancelled
+and awaited before re-raising.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from typing import AsyncIterator, Awaitable, Callable
+
+from xr_ai_models import TTSService
+from xr_ai_voicegate import AudioSink
+
+
+logger = logging.getLogger("xr_ai_conversation")
+
+
+_SENTENCE_BOUNDARY_RE = re.compile(r"(?<=[.!?])\s+")
+
+
+async def stream_text_to_audio(
+    *,
+    tokens:     AsyncIterator[str],
+    pid:        str,
+    tts:        TTSService,
+    audio_sink: AudioSink,
+    on_wav:     Callable[[bytes], None] | None = None,
+) -> str:
+    """Pipe ``tokens`` through sentence-batched TTS to ``audio_sink``.
+
+    Returns the full accumulated text. ``on_wav`` is invoked synchronously
+    for every WAV blob the sender consumes — the conversation loop wires
+    it to ``gate.observe_tts_wav`` so the lazy listening-chime build can
+    pick up the TTS sample rate from this path too.
+
+    Cancellation contract: the caller owns the outer task. On
+    ``asyncio.CancelledError`` here, every spawned synth task and the
+    sender task are cancelled and awaited (so no orphaned TTS requests
+    keep running) before the cancel re-raises.
+    """
+    full_text     = ""
+    sentence_buf  = ""
+    tts_queue: asyncio.Queue[asyncio.Task | None] = asyncio.Queue()
+    pending_synth: list[asyncio.Task] = []
+
+    async def _audio_sender() -> None:
+        while True:
+            task = await tts_queue.get()
+            if task is None:
+                return
+            try:
+                wav = await task
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("tts synth error pid=%r", pid)
+                continue
+            if on_wav is not None:
+                try:
+                    on_wav(wav)
+                except Exception:
+                    logger.exception("on_wav callback raised pid=%r", pid)
+            try:
+                await audio_sink.play_wav(pid, wav)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("audio sink play_wav error pid=%r", pid)
+
+    sender = asyncio.create_task(_audio_sender(), name=f"tts-sender-{pid}")
+
+    try:
+        async for token in tokens:
+            full_text    += token
+            sentence_buf += token
+            while True:
+                m = _SENTENCE_BOUNDARY_RE.search(sentence_buf)
+                if not m:
+                    break
+                sentence     = sentence_buf[: m.start() + 1].strip()
+                sentence_buf = sentence_buf[m.end():]
+                if sentence:
+                    t = asyncio.create_task(tts.synthesize(sentence))
+                    pending_synth.append(t)
+                    await tts_queue.put(t)
+
+        tail = sentence_buf.strip()
+        if tail:
+            t = asyncio.create_task(tts.synthesize(tail))
+            pending_synth.append(t)
+            await tts_queue.put(t)
+
+        await tts_queue.put(None)
+        await sender
+        return full_text.strip()
+
+    except asyncio.CancelledError:
+        for t in pending_synth:
+            t.cancel()
+        sender.cancel()
+        for t in (*pending_synth, sender):
+            try:
+                await t
+            except (asyncio.CancelledError, Exception):
+                pass
+        raise

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -13,6 +13,7 @@ requires-python = ">=3.11,<3.13"
 dependencies = [
     # Pulled in via editable installs of the workspace packages.
     "xr-ai-agent",
+    "xr-ai-conversation",
     "xr-ai-models",
     "xr-ai-pipecat",
     "xr-media-hub",
@@ -38,6 +39,7 @@ dependencies = [
 
 [tool.uv.sources]
 xr-ai-agent           = { path = "../agent-sdk",                        editable = true }
+xr-ai-conversation    = { path = "../agent-sdk/xr-ai-conversation",     editable = true }
 xr-ai-models          = { path = "../agent-sdk/xr-ai-models",           editable = true }
 xr-ai-pipecat         = { path = "../agent-sdk/xr-ai-pipecat",          editable = true }
 xr-media-hub          = { path = "../server-runtime",                   editable = true }

--- a/tests/test_xr_ai_conversation_loop.py
+++ b/tests/test_xr_ai_conversation_loop.py
@@ -1,0 +1,545 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ``xr_ai_conversation.ConversationLoop``.
+
+Covers: construction, str ``on_query`` → say path, streaming
+``on_query`` → sentence-batched synth + ordered audio sender, per-pid
+in-flight cancel + ``flush_return_audio`` on a second dispatch, STOP
+handler, participant join + greeting, participant leave clears state,
+custom greeting (string + callable), and ``observe_tts_wav`` is fed by
+every TTS WAV the loop generates.
+
+Everything runs against fakes — no real ``ProcessorEndpoint``, VAD,
+STT, or TTS — so the suite stays CPU-only and finishes in well under a
+second.
+"""
+from __future__ import annotations
+
+import asyncio
+import io
+import wave
+from dataclasses import dataclass
+from typing import Any, AsyncIterator
+
+import numpy as np
+import pytest
+
+from xr_ai_agent      import AudioChunk, DataMessage, ParticipantEvent
+from xr_ai_voicegate  import VoiceGate, VoiceGateConfig
+from xr_ai_conversation import ConversationLoop, VadConfig
+
+
+# ── test doubles ────────────────────────────────────────────────────────────
+
+
+def _silence_wav(sample_rate: int = 22_050, ms: int = 10) -> bytes:
+    """Tiny well-formed WAV blob the loop's ``wav_to_chunks`` accepts."""
+    n   = max(1, int(sample_rate * ms / 1000))
+    pcm = np.zeros(n, dtype=np.int16).tobytes()
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm)
+    return buf.getvalue()
+
+
+class _FakeEp:
+    """``ProcessorEndpoint`` stand-in capturing every outbound call.
+
+    Stores the audio + data + participant callbacks the loop registers so
+    tests can inject events directly. ``flush_return_audio`` and
+    ``send_return_*`` simply append to lists for assertion."""
+
+    def __init__(self) -> None:
+        self.audio_cb       = None
+        self.data_cb        = None
+        self.participant_cb = None
+        self.return_audio:  list[AudioChunk]  = []
+        self.return_data:   list[DataMessage] = []
+        self.flush_calls:   list[str]         = []
+        self.stopped       = False
+        self.closed        = False
+
+    def on_audio(self, cb)       -> None: self.audio_cb       = cb
+    def on_data(self, cb)        -> None: self.data_cb        = cb
+    def on_participant(self, cb) -> None: self.participant_cb = cb
+    def on_frame(self, cb)       -> None: pass
+
+    async def send_return_audio(self, chunk: AudioChunk) -> None:
+        self.return_audio.append(chunk)
+
+    async def send_return_data(self, msg: DataMessage) -> None:
+        self.return_data.append(msg)
+
+    async def flush_return_audio(self, pid: str) -> None:
+        self.flush_calls.append(pid)
+
+    async def run(self) -> None:  # never called in these tests
+        await asyncio.sleep(0)
+
+    def stop(self)  -> None: self.stopped = True
+    def close(self) -> None: self.closed  = True
+
+
+class _FakeSTT:
+    async def transcribe(self, audio: bytes, **kw: Any) -> str:
+        return ""
+
+    async def health(self) -> bool: return True
+    async def close(self)  -> None: pass
+
+
+class _FakeTTS:
+    """TTS double that records every call and returns a tiny WAV."""
+
+    def __init__(self, sample_rate: int = 22_050) -> None:
+        self.sample_rate = sample_rate
+        self.calls: list[str]               = []
+        self.delays: dict[str, asyncio.Event] = {}  # text → release gate
+
+    async def synthesize(self, text: str, **kw: Any) -> bytes:
+        self.calls.append(text)
+        gate = self.delays.get(text)
+        if gate is not None:
+            await gate.wait()
+        return _silence_wav(self.sample_rate)
+
+    async def health(self) -> bool: return True
+    async def close(self)  -> None: pass
+
+
+def _make_loop(
+    *,
+    on_query,
+    vg_phrases: tuple[str, ...] = (),
+    on_speech_start = None,
+    on_participant_joined = None,
+    on_participant_left   = None,
+    on_stop_extra         = None,
+    text_topic: str = "agent.response",
+    greeting = None,
+) -> tuple[ConversationLoop, _FakeEp, _FakeSTT, _FakeTTS]:
+    ep  = _FakeEp()
+    stt = _FakeSTT()
+    tts = _FakeTTS()
+    loop = ConversationLoop(
+        ep              = ep,        # type: ignore[arg-type]
+        stt             = stt,       # type: ignore[arg-type]
+        tts             = tts,       # type: ignore[arg-type]
+        voice_gate_cfg  = VoiceGateConfig(magic_phrases=vg_phrases),
+        vad_cfg         = VadConfig(),
+        on_query        = on_query,
+        on_speech_start = on_speech_start,
+        on_participant_joined = on_participant_joined,
+        on_participant_left   = on_participant_left,
+        on_stop_extra         = on_stop_extra,
+        text_topic            = text_topic,
+        greeting              = greeting,
+    )
+    return loop, ep, stt, tts
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 1. Construction
+# ════════════════════════════════════════════════════════════════════════════
+
+
+def test_construct_with_minimal_kwargs():
+    """Case 1: ConversationLoop builds with just the required kwargs and
+    registers handlers on the underlying ``ProcessorEndpoint``."""
+
+    async def on_query(pid: str, text: str, fresh_match: bool) -> str:
+        return ""
+
+    loop, ep, _, _ = _make_loop(on_query=on_query)
+    assert ep.audio_cb       is not None
+    assert ep.participant_cb is not None
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 2. str on_query → say
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_dispatch_with_string_result_invokes_on_query_and_speaks():
+    """Case 2: dispatch('hello') invokes on_query and the returned string
+    is synthesized + emitted as return audio + sent on the text topic."""
+    seen: list[tuple[str, str, bool]] = []
+
+    async def on_query(pid: str, text: str, fresh_match: bool) -> str:
+        seen.append((pid, text, fresh_match))
+        return "world."
+
+    loop, ep, _, tts = _make_loop(on_query=on_query, text_topic="my.topic")
+    await loop.dispatch("p1", "hello", pts_us=100)
+
+    # Wait for the dispatched task to finish.
+    vs = loop._voice["p1"]
+    assert vs.current_task is not None
+    await vs.current_task
+
+    assert seen == [("p1", "hello", True)]
+    assert tts.calls == ["world."]
+    assert ep.return_audio                            # audio was emitted
+    assert all(c.participant_id == "p1" for c in ep.return_audio)
+    # Final assembled text goes out on the configured data topic.
+    assert [(m.topic, m.data.decode()) for m in ep.return_data] \
+           == [("my.topic", "world.")]
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 3. streaming on_query → sentence-batched synth + ordered sender
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_dispatch_with_streaming_result_splits_sentences_and_sends_in_order():
+    """Case 3: a streaming on_query yielding 'Hi there. How are you?'
+    must produce two synth calls (one per sentence) and the audio sender
+    consumes them in order, with the data-channel reply carrying the
+    full assembled text."""
+    async def tokens() -> AsyncIterator[str]:
+        for tok in ("Hi", " there", ". ", "How", " are", " you", "?"):
+            yield tok
+
+    async def on_query(pid: str, text: str, fresh_match: bool):
+        return tokens()
+
+    loop, ep, _, tts = _make_loop(on_query=on_query)
+    await loop.dispatch("p1", "anything", pts_us=200)
+    vs = loop._voice["p1"]
+    await vs.current_task
+
+    # Both sentences (without trailing whitespace) were synthesized.
+    assert tts.calls == ["Hi there.", "How are you?"]
+    # Audio was emitted (any non-zero count proves the sender ran).
+    assert len(ep.return_audio) >= 2
+    # Final data-channel reply is the full assembled text, stripped.
+    assert [m.data.decode() for m in ep.return_data] == ["Hi there. How are you?"]
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 4. Interrupt: second dispatch cancels first + flushes + starts new
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_second_dispatch_cancels_in_flight_and_flushes_return_audio():
+    """Case 4: a second ``dispatch`` for the same pid cancels the in-flight
+    task, calls ``flush_return_audio``, and replaces the task. The first
+    on_query is stuck on an Event so the cancellation has work to do."""
+    gate = asyncio.Event()
+
+    async def on_query(pid: str, text: str, fresh_match: bool):
+        if text == "slow":
+            await gate.wait()      # block until released or cancelled
+            return "should not be reached"
+        return "fast reply."
+
+    loop, ep, _, _ = _make_loop(on_query=on_query)
+
+    await loop.dispatch("p1", "slow", pts_us=300)
+    first_task = loop._voice["p1"].current_task
+    assert first_task is not None and not first_task.done()
+
+    # Second dispatch should cancel the first and start a new one.
+    await loop.dispatch("p1", "fast", pts_us=400)
+
+    # First task should be cancelled (or at least done).
+    assert first_task.done()
+    assert first_task.cancelled() or first_task.exception() is None
+
+    # flush_return_audio was called between cancel and the new task.
+    assert "p1" in ep.flush_calls
+
+    # The new task can now complete.
+    second_task = loop._voice["p1"].current_task
+    assert second_task is not first_task
+    await second_task
+
+    # Release the now-cancelled gate so no warnings about pending tasks.
+    gate.set()
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 5. STOP via gate
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_stop_via_gate_cancels_flushes_and_invokes_say_stop_ack():
+    """Case 5: feeding 'stop' to the gate triggers ``_handle_stop`` which
+    cancels the in-flight task, flushes return audio, invokes
+    ``gate.say_stop_ack`` (so the TTS gets a 'Okay, I will stop.' call)
+    and echoes a 'Okay, I will stop.' data message on ``text_topic``.
+    Also exercises the ``on_stop_extra`` hook."""
+    gate = asyncio.Event()
+    stop_extra_calls: list[str] = []
+
+    async def on_query(pid: str, text: str, fresh_match: bool) -> str:
+        await gate.wait()
+        return "never sent"
+
+    async def on_stop_extra(pid: str) -> None:
+        stop_extra_calls.append(pid)
+
+    loop, ep, _, tts = _make_loop(
+        on_query      = on_query,
+        on_stop_extra = on_stop_extra,
+    )
+
+    await loop.dispatch("p1", "anything", pts_us=500)
+    in_flight = loop._voice["p1"].current_task
+    assert in_flight is not None and not in_flight.done()
+
+    # Feed "stop" through the gate — should invoke _handle_stop.
+    await loop._gate.feed("p1", "stop")
+
+    assert in_flight.cancelled() or in_flight.done()
+    # ``flush_return_audio`` is called at least once by the stop path.
+    # (The original dispatch also flushes at the start of every query,
+    # so the exact count is not part of the contract — what matters is
+    # the stop handler issues its own flush before saying the ack.)
+    assert "p1" in ep.flush_calls
+    # say_stop_ack synthesizes "Okay, I will stop." via the TTS.
+    assert "Okay, I will stop." in tts.calls
+    # The data-channel echo lands too.
+    echo_payloads = [m.data.decode() for m in ep.return_data]
+    assert "Okay, I will stop." in echo_payloads
+    assert stop_extra_calls == ["p1"]
+
+    gate.set()
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 6. Participant joined → hook + greeting
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_participant_joined_runs_hook_and_speaks_greeting():
+    """Case 6: a participant-joined event invokes the optional
+    ``on_participant_joined`` hook AND speaks the greeting via TTS."""
+    joins: list[str] = []
+
+    async def on_query(pid: str, text: str, fresh_match: bool) -> str:
+        return ""
+
+    async def on_join(pid: str) -> None:
+        joins.append(pid)
+
+    loop, ep, _, tts = _make_loop(
+        on_query              = on_query,
+        on_participant_joined = on_join,
+    )
+    assert ep.participant_cb is not None
+
+    await ep.participant_cb(ParticipantEvent(participant_id="p1", joined=True, pts_us=0))
+    # The gate.participant_joined call is scheduled as a Task — let it run.
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert joins == ["p1"]
+    # The greeting was synthesized at least once (default text picks up
+    # the gate's format_phrase_help() — None for empty phrases, so the
+    # fallback "Hi, I'm listening. Ask me anything." path is taken).
+    assert any("listening" in c.lower() for c in tts.calls)
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 7. Participant left clears per-pid state
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_participant_left_clears_voice_state_and_invokes_hook():
+    """Case 7: a leave event removes the per-pid VoiceState, cancels any
+    in-flight task for that pid, and fires the optional left-hook."""
+    gate = asyncio.Event()
+    leaves: list[str] = []
+
+    async def on_query(pid: str, text: str, fresh_match: bool) -> str:
+        await gate.wait()
+        return "never"
+
+    async def on_left(pid: str) -> None:
+        leaves.append(pid)
+
+    loop, ep, _, _ = _make_loop(
+        on_query            = on_query,
+        on_participant_left = on_left,
+    )
+
+    await loop.dispatch("p1", "x", pts_us=600)
+    in_flight = loop._voice["p1"].current_task
+    assert in_flight is not None and not in_flight.done()
+
+    await ep.participant_cb(ParticipantEvent(participant_id="p1", joined=False, pts_us=0))
+
+    # Per-pid state is gone.
+    assert "p1" not in loop._voice
+    # In-flight task was cancelled.
+    await asyncio.sleep(0)
+    assert in_flight.cancelled() or in_flight.done()
+    # Hook fired.
+    assert leaves == ["p1"]
+
+    gate.set()
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 8. Custom greeting (string)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_custom_string_greeting_overrides_gate_default():
+    """Case 8: ``greeting='hi there'`` is spoken verbatim, bypassing
+    ``format_phrase_help()``."""
+    async def on_query(pid: str, text: str, fresh_match: bool) -> str:
+        return ""
+
+    loop, ep, _, tts = _make_loop(on_query=on_query, greeting="hi there")
+
+    await ep.participant_cb(ParticipantEvent(participant_id="p1", joined=True, pts_us=0))
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert "hi there" in tts.calls
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 9. Custom greeting (callable)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_custom_callable_greeting_receives_gate():
+    """Case 9: ``greeting=lambda gate: gate.format_phrase_help() or 'fallback'``
+    is invoked with the underlying ``VoiceGate``. With no phrases configured
+    ``format_phrase_help`` returns None, so the fallback wins."""
+
+    async def on_query(pid: str, text: str, fresh_match: bool) -> str:
+        return ""
+
+    def greet(gate: VoiceGate) -> str:
+        return gate.format_phrase_help() or "fallback"
+
+    loop, ep, _, tts = _make_loop(on_query=on_query, greeting=greet)
+
+    await ep.participant_cb(ParticipantEvent(participant_id="p1", joined=True, pts_us=0))
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert "fallback" in tts.calls
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 10. observe_tts_wav is fed by every TTS WAV
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_every_tts_wav_passes_through_observe_tts_wav():
+    """Case 10: each WAV the loop generates is observed by the gate so
+    the lazy listening-chime sample rate can be picked up from the TTS
+    output regardless of which path produced it. We monkeypatch
+    ``gate.observe_tts_wav`` with a counting wrapper and exercise both
+    the str-result path and the streaming-result path."""
+    counts = {"n": 0}
+
+    async def stream_tokens() -> AsyncIterator[str]:
+        for t in ("Streaming", " reply", "."):
+            yield t
+
+    async def on_query(pid: str, text: str, fresh_match: bool):
+        if text == "stream":
+            return stream_tokens()
+        return "string reply."
+
+    loop, ep, _, tts = _make_loop(on_query=on_query)
+
+    original_observe = loop._gate.observe_tts_wav
+    def counting_observe(wav: bytes) -> None:
+        counts["n"] += 1
+        original_observe(wav)
+    loop._gate.observe_tts_wav = counting_observe  # type: ignore[assignment]
+
+    # str path: one synth → one observe.
+    await loop.dispatch("p1", "static", pts_us=700)
+    await loop._voice["p1"].current_task
+    assert counts["n"] == 1
+
+    # streaming path: one sentence → one synth → one observe.
+    await loop.dispatch("p1", "stream", pts_us=800)
+    await loop._voice["p1"].current_task
+    assert counts["n"] == 2
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 11. Gate → on_query passes fresh_match through (regression guard)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_gate_route_propagates_fresh_match_to_on_query():
+    """Case 11: when the gate dispatches case 2 (fresh phrase + payload)
+    the user's ``on_query`` must see ``fresh_match=True``; on case 3
+    (follow-up window continuation) it must see ``fresh_match=False``.
+
+    The data-channel ``dispatch()`` always passes ``True`` because the
+    gate isn't in the loop there. This regression guard catches a bug
+    where the loop dropped the gate's flag and hardcoded ``True`` for
+    every voice-path query."""
+    seen: list[tuple[str, bool]] = []
+
+    async def on_query(pid: str, text: str, fresh_match: bool) -> str:
+        seen.append((text, fresh_match))
+        return ""
+
+    loop, ep, _, _ = _make_loop(on_query=on_query, vg_phrases=("agent",))
+
+    # Case 2: phrase + payload in the same utterance → fresh_match=True.
+    await loop._gate.feed("p1", "agent, what is this")
+    # Drain the dispatch task so the on_query call completes.
+    if loop._voice.get("p1") and loop._voice["p1"].current_task:
+        await loop._voice["p1"].current_task
+
+    # Case 3: phrase-only opens the window; the next utterance is the
+    # continuation and must arrive with fresh_match=False.
+    await loop._gate.feed("p2", "agent")
+    await loop._gate.feed("p2", "what is this")
+    if loop._voice.get("p2") and loop._voice["p2"].current_task:
+        await loop._voice["p2"].current_task
+
+    assert seen == [
+        ("what is this", True),
+        ("what is this", False),
+    ]
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 12. Data-channel dispatch always sets fresh_match=True
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_data_channel_dispatch_sets_fresh_match_true():
+    """Case 12: the public ``dispatch()`` (the data-channel path) bypasses
+    the gate entirely, so ``fresh_match`` must be True — the flag's
+    meaning of "this is a new top-level query" matches that path."""
+    seen: list[bool] = []
+
+    async def on_query(pid: str, text: str, fresh_match: bool) -> str:
+        seen.append(fresh_match)
+        return ""
+
+    loop, _, _, _ = _make_loop(on_query=on_query)
+    await loop.dispatch("p1", "hi", pts_us=900)
+    await loop._voice["p1"].current_task
+
+    assert seen == [True]


### PR DESCRIPTION
## Summary

Adds the `xr-ai-conversation` SDK package: a shared voice-conversation loop that wires the audio → VAD → STT → voice gate → user `on_query` → TTS → return-audio path so each worker only supplies a single callback.

- New package `agent-sdk/xr-ai-conversation/` exporting `ConversationLoop`, `VadConfig`, `GateBindings`, `QueryHandler`, `QueryResult`, `VoiceState`, `stream_text_to_audio`, and the audio codec helpers (`int16_pcm_to_wav`, `wav_to_chunks`, `chunks_to_wav`, `split_sentences`, `now_us`).
- Owns per-pid VAD lifecycle, `dispatch_lock` + `current_task` for in-flight cancel + `flush_return_audio`, sentence-batched streaming TTS (parallel synth + queued sender preserves audio order), and participant join/leave hooks.
- `on_query` returns either `str` (one-shot reply) or `AsyncIterator[str]` (streamed tokens). Both paths also send the assembled text on a configurable `text_topic` (default `agent.response`).
- 12 new unit tests run on CPU only (no real LiveKit / VAD / STT / TTS); 54 existing voicegate tests still pass.

## Builds on / merge order

- **Base branch: `devdeepr/voicegate-extract` (PR #164).** This PR cannot merge until #164 lands because `xr-ai-conversation` depends on `xr-ai-voicegate`, which lives on that branch.
- No sample migrations in this PR — those land as follow-ups:
  - PR-B: migrate `agent-samples/simple-vlm-example` worker to `ConversationLoop`.
  - PR-C: migrate `agent-samples/xr-render-demo` worker + move shared codec helpers out of `xr-ai-pipecat/audio.py`.

## Implementation notes worth review attention

- `pyproject.toml` uses `path = ...` editable workspace deps, matching the in-tree precedent (`agent-sdk/xr-ai-models`, `agent-sdk/xr-ai-pipecat`) rather than the spec's `workspace = true` shorthand.
- `_handle_stop` order is **cancel + flush + `gate.say_stop_ack` + `on_stop_extra` + data echo**, deliberately differing from the original `simple-vlm-example` which echoed the data message before the stop-ack TTS — this matches PR-A's design.
- `dispatch()` is the public data-channel entry point and always sets `fresh_match=True`; the gate-driven path goes through an internal `_dispatch_internal` so the gate's `fresh_match` flag (True for case 2 fresh match, False for case 3 follow-up continuation) reaches `on_query` unmodified. Regression tests cover both flags.
- `stream_text_to_audio` is cancel-safe: on `CancelledError` it cancels every pending synth task and the sender task and awaits them before re-raising so no orphaned TTS requests leak.

## Test plan

- [x] `python -c "from xr_ai_conversation import ConversationLoop, VadConfig, QueryHandler, QueryResult"` imports cleanly
- [x] `pytest tests/test_xr_ai_conversation_loop.py` — 12 passed
- [x] `pytest tests/test_xr_ai_voicegate.py` — 54 still pass (no regressions)
- [x] Tests run on Python 3.11 and 3.12
- [ ] PR-B (simple-vlm-example migration) demonstrates the loop swap on a real sample
- [ ] PR-C (xr-render-demo migration + pipecat codec move) closes the extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)