### PR TITLE
refactor(xr-render-demo, pipecat): move codec helpers into xr-ai-conversation; share gate wiring

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -44,9 +44,10 @@ xr-ai-agent  (agent-sdk/)
     └── msgpack >=1.0
 
 xr-ai-pipecat  (agent-sdk/xr-ai-pipecat/)
-    └── xr-ai-agent   [editable: ..]
-    └── xr-ai-logging [editable: ../../utils/xr-ai-logging]
-    └── xr-ai-models  [editable: ../xr-ai-models]
+    └── xr-ai-agent        [editable: ..]
+    └── xr-ai-conversation [editable: ../xr-ai-conversation]
+    └── xr-ai-logging      [editable: ../../utils/xr-ai-logging]
+    └── xr-ai-models       [editable: ../xr-ai-models]
     └── pipecat-ai >=0.0.46
     └── numpy >=1.24
     └── scipy >=1.11
@@ -58,6 +59,11 @@ xr-ai-pipecat  (agent-sdk/xr-ai-pipecat/)
     SttClient / TtsClient are thin wrappers around xr-ai-models'
     OpenAICompatSTT / OpenAICompatTTS — PCM→WAV conversion is handled by
     the SDK. httpx is retained for http_probe() readiness checks.
+    The codec helpers in ``xr_ai_pipecat.audio`` (``wav_to_chunks``,
+    ``chunks_to_wav``, ``int16_pcm_to_wav``, ``split_sentences``,
+    ``now_us``) are re-exports of the canonical implementations in
+    ``xr_ai_conversation.audio``; ``stream_sentences_to_audio`` and
+    ``rms_float32`` stay here (pipecat-flavored).
     Not a dep of xr-ai-agent itself — import only in workers that use Pipecat.
 
 xr-ai-conversation  (agent-sdk/xr-ai-conversation/)
@@ -72,8 +78,11 @@ xr-ai-conversation  (agent-sdk/xr-ai-conversation/)
     streaming. Workers supply the ``ProcessorEndpoint``, STT/TTS services,
     a ``VoiceGateConfig``, and one ``on_query`` callback returning either
     a ``str`` (one-shot reply) or an ``AsyncIterator[str]`` (streamed
-    tokens). Codec helpers (int16 PCM ↔ WAV, sentence split) are exported
-    for consumers that want pieces without the full loop.
+    tokens). Codec helpers (int16 PCM ↔ WAV, sentence split) live in
+    ``xr_ai_conversation.audio`` as the canonical home — ``xr-ai-pipecat``
+    re-exports them for backward compatibility. ``wire_voice_gate`` is the
+    one-call helper Pipecat-flavored workers use to register all five
+    ``VoiceGate`` handlers without the loop.
 
 xr-ai-models  (agent-sdk/xr-ai-models/)
     └── xr-ai-logging [editable: ../../utils/xr-ai-logging]
@@ -423,7 +432,7 @@ forwarding.
 | Sub-project | Package | Internal deps | External deps |
 |---|---|---|---|
 | Orchestrator | `xr-render-demo` | `xr-ai-launcher`, `xr-ai-logging` | — |
-| Worker | `xr-render-demo-worker` | `xr-ai-agent`, `xr-ai-models` [editable], `xr-ai-pipecat` [editable], `xr-ai-logging` [editable], `xr-ai-vad` [editable], `xr-ai-voicegate` [editable] | numpy >=1.24, httpx >=0.27, fastmcp >=0.4, pyyaml >=6.0 (silero-vad pulled in via xr-ai-vad) |
+| Worker | `xr-render-demo-worker` | `xr-ai-agent`, `xr-ai-conversation` [editable], `xr-ai-models` [editable], `xr-ai-pipecat` [editable], `xr-ai-logging` [editable], `xr-ai-vad` [editable], `xr-ai-voicegate` [editable] | numpy >=1.24, httpx >=0.27, fastmcp >=0.4, pyyaml >=6.0 (silero-vad pulled in via xr-ai-vad) |
 
 Model endpoints (llm, agent_llm, stt, tts, vlm) are declared in
 `yaml/models.yaml` and loaded via `xr-ai-models` `load_models_config` /

--- a/agent-samples/xr-render-demo/worker/processors.py
+++ b/agent-samples/xr-render-demo/worker/processors.py
@@ -45,9 +45,11 @@ from pipecat.pipeline.task import PipelineParams, PipelineTask
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 
 from xr_ai_agent import DataMessage, ProcessorEndpoint
+from xr_ai_conversation import wire_voice_gate
+from xr_ai_conversation.audio import wav_to_chunks
 from xr_ai_logging import print_task_done_banner
 from xr_ai_models import ChatMessage, LLMService, STTService, TTSService, ToolCall, ToolDef
-from xr_ai_pipecat.audio import stream_sentences_to_audio, wav_to_chunks
+from xr_ai_pipecat.audio import stream_sentences_to_audio
 from xr_ai_pipecat.transport import XRMediaHubTransport, SAMPLE_RATE
 from xr_ai_vad import VadDetector
 from xr_ai_voicegate import VoiceGate
@@ -266,16 +268,21 @@ class RenderSceneProcessor(FrameProcessor):
 
         # Voice gate owns magic-phrase / STOP / follow-up / chime / greeting.
         # The processor only feeds STT transcripts and handles the events.
+        # ``wire_voice_gate`` collapses the five ``gate.on_*`` registrations
+        # into one call and provides a sensible default ``on_drop`` (DEBUG
+        # log), so the worker doesn't have to repeat that boilerplate.
         self._gate = VoiceGate(
             cfg.voice_gate,
             audio_sink=_EpSink(transport.endpoint),
             tts=tts,
         )
-        self._gate.on_query(self._on_voice_query)
-        self._gate.on_stop(self._on_voice_stop)
-        self._gate.on_phrase_only(self._on_voice_phrase_only)
-        self._gate.on_drop(self._on_voice_drop)
-        self._gate.on_participant_joined(self._on_voice_participant_joined)
+        wire_voice_gate(
+            self._gate,
+            on_query              = self._on_voice_query,
+            on_stop               = self._on_voice_stop,
+            on_phrase_only        = self._on_voice_phrase_only,
+            on_participant_joined = self._on_voice_participant_joined,
+        )
 
     @property
     def gate(self) -> VoiceGate:
@@ -342,9 +349,6 @@ class RenderSceneProcessor(FrameProcessor):
         else to do here; the gate has already opened the window."""
         await self._gate.play_chime(pid)
         logger.info("voice gate awaiting follow-up pid={!r}", pid)
-
-    async def _on_voice_drop(self, pid: str, text: str) -> None:
-        logger.info("voice gate dropped pid={!r} text={!r}", pid, text[:80])
 
     async def _on_voice_participant_joined(self, pid: str) -> None:
         """Voice-gate ``on_participant_joined`` — speak a one-shot

--- a/agent-samples/xr-render-demo/worker/pyproject.toml
+++ b/agent-samples/xr-render-demo/worker/pyproject.toml
@@ -11,6 +11,7 @@ version = "0.1.0"
 requires-python = ">=3.11,<3.13"
 dependencies = [
     "xr-ai-agent",
+    "xr-ai-conversation",
     "xr-ai-models",
     "xr-ai-pipecat",
     "xr-ai-logging",
@@ -25,12 +26,13 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-xr-ai-agent     = { path = "../../../agent-sdk",                    editable = true }
-xr-ai-models    = { path = "../../../agent-sdk/xr-ai-models",       editable = true }
-xr-ai-pipecat   = { path = "../../../agent-sdk/xr-ai-pipecat",      editable = true }
-xr-ai-logging   = { path = "../../../utils/xr-ai-logging",          editable = true }
-xr-ai-vad       = { path = "../../../utils/xr-ai-vad",              editable = true }
-xr-ai-voicegate = { path = "../../../utils/xr-ai-voicegate",        editable = true }
+xr-ai-agent        = { path = "../../../agent-sdk",                    editable = true }
+xr-ai-conversation = { path = "../../../agent-sdk/xr-ai-conversation", editable = true }
+xr-ai-models       = { path = "../../../agent-sdk/xr-ai-models",       editable = true }
+xr-ai-pipecat      = { path = "../../../agent-sdk/xr-ai-pipecat",      editable = true }
+xr-ai-logging      = { path = "../../../utils/xr-ai-logging",          editable = true }
+xr-ai-vad          = { path = "../../../utils/xr-ai-vad",              editable = true }
+xr-ai-voicegate    = { path = "../../../utils/xr-ai-voicegate",        editable = true }
 
 [project.scripts]
 xr_render_demo_worker = "xr_render_demo_worker:run"

--- a/agent-sdk/xr-ai-conversation/xr_ai_conversation/__init__.py
+++ b/agent-sdk/xr-ai-conversation/xr_ai_conversation/__init__.py
@@ -11,7 +11,7 @@ from .audio import (
     split_sentences,
     wav_to_chunks,
 )
-from .gate_wiring import GateBindings, QueryHandler, QueryResult
+from .gate_wiring import GateBindings, QueryHandler, QueryResult, wire_voice_gate
 from .loop import ConversationLoop, VadConfig
 from .state import VoiceState
 from .streaming import stream_text_to_audio
@@ -26,6 +26,7 @@ __all__ = [
     "QueryResult",
     "VoiceState",
     "stream_text_to_audio",
+    "wire_voice_gate",
     # audio codec helpers
     "chunks_to_wav",
     "int16_pcm_to_wav",

--- a/agent-sdk/xr-ai-conversation/xr_ai_conversation/gate_wiring.py
+++ b/agent-sdk/xr-ai-conversation/xr_ai_conversation/gate_wiring.py
@@ -1,18 +1,29 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Voice-gate handler bundle used by the conversation loop.
+"""Voice-gate handler bundle + one-shot wiring helper.
 
-Workers do not normally construct this directly — :class:`ConversationLoop`
-builds it from the keyword args passed to its constructor. The dataclass
-is exposed so a Pipecat-style consumer that wants the same wiring
-pattern without the full loop (e.g. for a custom transport) can reuse
-the binding shape.
+:class:`GateBindings` is the dataclass the :class:`ConversationLoop`
+builds internally from its constructor kwargs. It groups the handlers
+the loop registers on its private ``VoiceGate``.
+
+:func:`wire_voice_gate` is the public escape hatch for Pipecat-flavored
+workers that own their own ``VoiceGate`` (because they have a real
+frame pipeline rather than the loop's audio-callback path) but still
+want to skip the five ``gate.on_*`` registration lines. The default
+``on_drop`` logs at DEBUG so the gate's own drop-reason logging stays
+authoritative.
 """
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import AsyncIterator, Awaitable, Callable
+
+from xr_ai_voicegate import VoiceGate
+
+
+logger = logging.getLogger("xr_ai_conversation.gate_wiring")
 
 
 QueryResult  = str | AsyncIterator[str]
@@ -30,3 +41,55 @@ class GateBindings:
     on_stop_extra:         Callable[[str], Awaitable[None]] | None = None
     on_participant_joined: Callable[[str], Awaitable[None]] | None = None
     on_participant_left:   Callable[[str], Awaitable[None]] | None = None
+
+
+async def _default_drop_logger(pid: str, text: str) -> None:
+    """Default ``on_drop`` handler — DEBUG-level log only.
+
+    The voice gate already logs the drop reason at its own preferred
+    level; we just emit a paired DEBUG line so the loop's logger shows
+    the same event when tracing is enabled."""
+    logger.debug("voice gate dropped pid=%r text=%r", pid, text[:80])
+
+
+def wire_voice_gate(
+    gate: VoiceGate,
+    *,
+    on_query:              Callable[[str, str, bool], Awaitable[None]],
+    on_stop:               Callable[[str], Awaitable[None]],
+    on_phrase_only:        Callable[[str], Awaitable[None]] | None = None,
+    on_drop:               Callable[[str, str], Awaitable[None]] | None = None,
+    on_participant_joined: Callable[[str], Awaitable[None]] | None = None,
+) -> None:
+    """Register all five voice-gate handlers in one call.
+
+    Pipecat-style workers that own their own ``VoiceGate`` (because they
+    have a real frame pipeline rather than the loop's audio-callback
+    path) use this to skip five lines of boilerplate. The
+    :class:`ConversationLoop` does its own equivalent wiring internally
+    and does not call this helper.
+
+    ``on_query`` and ``on_stop`` are required — every voice-gate
+    consumer at least dispatches queries and acknowledges STOP. The
+    other three are optional:
+
+    * ``on_phrase_only`` — fired when a magic phrase opens the
+      follow-up window without a payload. No default (callers that
+      want a chime supply ``lambda pid: gate.play_chime(pid)``).
+    * ``on_drop`` — fired when the gate refused to dispatch. Defaults
+      to a DEBUG log; pass ``None`` to keep the default or a callable
+      to override.
+    * ``on_participant_joined`` — fired once per joined participant.
+      No default (the loop owns its own greeting path; pipecat workers
+      typically send a custom greeting).
+    """
+    gate.on_query(on_query)
+    gate.on_stop(on_stop)
+    if on_phrase_only is not None:
+        gate.on_phrase_only(on_phrase_only)
+    if on_drop is not None:
+        gate.on_drop(on_drop)
+    else:
+        gate.on_drop(_default_drop_logger)
+    if on_participant_joined is not None:
+        gate.on_participant_joined(on_participant_joined)

--- a/agent-sdk/xr-ai-pipecat/pyproject.toml
+++ b/agent-sdk/xr-ai-pipecat/pyproject.toml
@@ -11,6 +11,7 @@ version = "0.1.0"
 requires-python = ">=3.11,<3.13"
 dependencies = [
     "xr-ai-agent",
+    "xr-ai-conversation",
     "xr-ai-logging",
     "xr-ai-models",
     "pipecat-ai>=0.0.46",
@@ -21,9 +22,10 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-xr-ai-agent   = { path = "..", editable = true }
-xr-ai-logging = { path = "../../utils/xr-ai-logging", editable = true }
-xr-ai-models  = { path = "../xr-ai-models", editable = true }
+xr-ai-agent        = { path = "..", editable = true }
+xr-ai-conversation = { path = "../xr-ai-conversation", editable = true }
+xr-ai-logging      = { path = "../../utils/xr-ai-logging", editable = true }
+xr-ai-models       = { path = "../xr-ai-models", editable = true }
 
 [tool.hatch.build.targets.wheel]
 packages = ["xr_ai_pipecat"]

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/audio.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/audio.py
@@ -1,81 +1,53 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-Audio helpers: PCM ↔ WAV conversion, sentence-batched TTS, VAD bookkeeping.
+"""Pipecat audio helpers — codec is re-exported from xr-ai-conversation.
+
+The canonical home for the PCM ↔ WAV codec helpers is
+``xr_ai_conversation.audio``; this module re-exports them for
+backwards compatibility with existing pipecat consumers. The
+pipecat-flavored ``stream_sentences_to_audio`` stays here because it
+pushes pipecat-style audio frames and depends on
+``xr_ai_agent.ProcessorEndpoint``.
 """
 from __future__ import annotations
 
 import asyncio
-import io
-import re
-import time
-import wave
 
 import numpy as np
 from loguru import logger
 
-from xr_ai_agent import AudioChunk, ProcessorEndpoint
+from xr_ai_agent import ProcessorEndpoint
 
-SENTENCE_RE = re.compile(r"(?<=[.!?])\s+")
+# Re-exported codec + sentence helpers — canonical location is
+# ``xr_ai_conversation.audio``. Importing from here continues to work
+# for backwards compatibility with workers that pre-date PR-C.
+from xr_ai_conversation.audio import (
+    chunks_to_wav,
+    int16_pcm_to_wav,
+    now_us,
+    split_sentences,
+    wav_to_chunks,
+)
 
-_CHUNK_MS = 20
-_CHUNK_US = _CHUNK_MS * 1_000
 
-
-def now_us() -> int:
-    return time.time_ns() // 1_000
+__all__ = [
+    # re-exports
+    "chunks_to_wav",
+    "int16_pcm_to_wav",
+    "now_us",
+    "split_sentences",
+    "wav_to_chunks",
+    # pipecat-only
+    "rms_float32",
+    "stream_sentences_to_audio",
+]
 
 
 def rms_float32(data: bytes) -> float:
+    """RMS amplitude of float32 PCM bytes — pipecat-only utility."""
     arr = np.frombuffer(data, dtype=np.float32)
     return float(np.sqrt(np.mean(arr ** 2))) if len(arr) else 0.0
-
-
-def chunks_to_wav(chunks: list[AudioChunk]) -> bytes:
-    """Concatenate float32 IPC chunks into a single 16-bit PCM WAV blob."""
-    raw = b"".join(c.data for c in chunks)
-    arr = np.frombuffer(raw, dtype=np.float32)
-    pcm = (np.clip(arr, -1.0, 1.0) * 32767).astype(np.int16)
-    buf = io.BytesIO()
-    with wave.open(buf, "wb") as wf:
-        wf.setnchannels(chunks[0].channels)
-        wf.setsampwidth(2)
-        wf.setframerate(chunks[0].sample_rate)
-        wf.writeframes(pcm.tobytes())
-    return buf.getvalue()
-
-
-def wav_to_chunks(wav_bytes: bytes, participant_id: str) -> list[AudioChunk]:
-    """Decode a WAV blob into 20 ms float32 AudioChunks at native sample rate."""
-    buf = io.BytesIO(wav_bytes)
-    with wave.open(buf, "rb") as wf:
-        sr  = wf.getframerate()
-        ch  = wf.getnchannels()
-        raw = wf.readframes(wf.getnframes())
-    arr = np.frombuffer(raw, dtype=np.int16).astype(np.float32) / 32768.0
-    chunk_frames = max(1, sr // (1000 // _CHUNK_MS))
-    pts = now_us()
-    out: list[AudioChunk] = []
-    for i in range(0, len(arr), chunk_frames * ch):
-        seg = arr[i : i + chunk_frames * ch]
-        if not len(seg):
-            break
-        out.append(AudioChunk(
-            pts_us=pts,
-            sample_rate=sr,
-            channels=ch,
-            samples=len(seg) // ch,
-            data=seg.tobytes(),
-            participant_id=participant_id,
-        ))
-        pts += _CHUNK_US
-    return out
-
-
-def split_sentences(text: str) -> list[str]:
-    parts = SENTENCE_RE.split(text.strip())
-    return [s.strip() for s in parts if s.strip()]
 
 
 async def stream_sentences_to_audio(

--- a/tests/test_xr_ai_conversation_loop.py
+++ b/tests/test_xr_ai_conversation_loop.py
@@ -27,7 +27,7 @@ import pytest
 
 from xr_ai_agent      import AudioChunk, DataMessage, ParticipantEvent
 from xr_ai_voicegate  import VoiceGate, VoiceGateConfig
-from xr_ai_conversation import ConversationLoop, VadConfig
+from xr_ai_conversation import ConversationLoop, VadConfig, wire_voice_gate
 
 
 # ── test doubles ────────────────────────────────────────────────────────────
@@ -543,3 +543,97 @@ async def test_data_channel_dispatch_sets_fresh_match_true():
     await loop._voice["p1"].current_task
 
     assert seen == [True]
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 13. wire_voice_gate registers the five handlers in one call
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_wire_voice_gate_registers_handlers_and_defaults_on_drop():
+    """Case 13: ``wire_voice_gate`` is the pipecat-side escape hatch that
+    collapses the five ``gate.on_*`` registration lines into one call.
+
+    Asserts: (a) the four explicitly-passed handlers fire when their
+    corresponding gate event runs, and (b) ``on_drop`` defaults to a
+    DEBUG logger when the caller doesn't supply one — i.e. the gate's
+    ``_on_drop_h`` slot is populated, not left ``None``."""
+    gate = VoiceGate(
+        VoiceGateConfig(magic_phrases=("agent",)),
+        audio_sink=None,
+        tts=None,
+    )
+
+    seen_query:          list[tuple[str, str, bool]] = []
+    seen_stop:           list[str]                   = []
+    seen_phrase_only:    list[str]                   = []
+    seen_join:           list[str]                   = []
+
+    async def on_query(pid: str, text: str, fresh_match: bool) -> None:
+        seen_query.append((pid, text, fresh_match))
+
+    async def on_stop(pid: str) -> None:
+        seen_stop.append(pid)
+
+    async def on_phrase_only(pid: str) -> None:
+        seen_phrase_only.append(pid)
+
+    async def on_participant_joined(pid: str) -> None:
+        seen_join.append(pid)
+
+    wire_voice_gate(
+        gate,
+        on_query              = on_query,
+        on_stop               = on_stop,
+        on_phrase_only        = on_phrase_only,
+        on_participant_joined = on_participant_joined,
+    )
+
+    # Handlers slot in.
+    assert gate._on_query_h               is on_query
+    assert gate._on_stop_h                is on_stop
+    assert gate._on_phrase_only_h         is on_phrase_only
+    assert gate._on_participant_joined_h  is on_participant_joined
+
+    # Default on_drop is installed (not None), and it's awaitable.
+    assert gate._on_drop_h is not None
+    await gate._on_drop_h("p1", "anything dropped")  # should not raise
+
+    # End-to-end: feed "agent, hello" — case 2 (phrase + payload) →
+    # on_query fires with fresh_match=True. "agent stop" → on_stop. A
+    # bare "agent" opens the window → on_phrase_only.
+    await gate.feed("p1", "agent hello")
+    await gate.feed("p2", "agent")
+    await gate.feed("p3", "agent stop")
+
+    assert seen_query        == [("p1", "hello", True)]
+    assert seen_phrase_only  == ["p2"]
+    assert seen_stop         == ["p3"]
+
+
+@pytest.mark.asyncio
+async def test_wire_voice_gate_custom_on_drop_overrides_default():
+    """Case 14: passing ``on_drop`` explicitly overrides the default
+    DEBUG-logger handler. Verified by checking the slot identity, since
+    the gate's drop-path is exercised by xr-ai-voicegate's own tests."""
+    gate = VoiceGate(
+        VoiceGateConfig(magic_phrases=("agent",)),
+        audio_sink=None,
+        tts=None,
+    )
+
+    async def custom_drop(pid: str, text: str) -> None:
+        pass
+
+    async def on_query(pid: str, text: str, fresh_match: bool) -> None: ...
+    async def on_stop(pid: str) -> None: ...
+
+    wire_voice_gate(
+        gate,
+        on_query = on_query,
+        on_stop  = on_stop,
+        on_drop  = custom_drop,
+    )
+
+    assert gate._on_drop_h is custom_drop


### PR DESCRIPTION
## Summary

Phase 2, PR-C of the voice-pipeline extraction. Two slices:

1. **Codec helpers move down.** ``int16_pcm_to_wav`` / ``wav_to_chunks`` / ``chunks_to_wav`` / ``split_sentences`` / ``now_us`` are now canonical in ``xr_ai_conversation.audio`` (already live there from #166); ``xr_ai_pipecat.audio`` becomes a re-export module so existing pipecat consumers don't change. ``stream_sentences_to_audio`` and ``rms_float32`` stay in pipecat (the former pushes through ``ProcessorEndpoint``; the latter has no callers but isn't a codec helper either).
2. **``wire_voice_gate`` helper + xr-render-demo migration.** New ``xr_ai_conversation.wire_voice_gate(gate, on_query=..., on_stop=..., ...)`` collapses the five ``gate.on_*`` registration lines into one call for pipecat-style consumers that own a ``VoiceGate`` directly (without the full ``ConversationLoop``). ``xr-render-demo`` worker uses it.

## Branch context

* Sibling to #167 (simple-vlm-example on ConversationLoop). Both branch off #166 (ConversationLoop foundation).
* PR-C does NOT depend on PR-B. Either can merge first after #166.
* **Cannot merge until #166 merges.**

## Honest accounting

Realistic shrinkage in ``processors.py`` from this PR is **+4 lines net** (1127 vs 1123). The 5-handler collapse saves 4 lines but the explanatory comment + keyword-form ``wire_voice_gate(...)`` call gives some back. Most of ``RenderSceneProcessor`` is agent brain — agentic loop, scene-state caching, MCP tool routing, quick-ack, still-working messages, validation, JSON sanitizer, rolling history — and is not extractable into a generic SDK package. The substantive win of this phase is the **API consolidation**: codec helpers have one canonical home and the 5-handler boilerplate is reusable. Pipecat's backward-compat re-exports mean no existing pipecat caller has to change.

## Behavior change to flag

The voice-gate ``on_drop`` log level drops from **INFO → DEBUG**. Old ``_on_voice_drop`` was ``logger.info(...)``; the new default ``_default_drop_logger`` in ``xr_ai_conversation.gate_wiring`` is ``logger.debug(...)``. The voice gate's own drop-reason log is unchanged. If anything greps INFO logs for "voice gate dropped" it should grep at DEBUG or pass a custom ``on_drop`` callable to ``wire_voice_gate``.

## Test plan

- [x] ``tests/test_xr_ai_conversation_loop.py`` — 14 passed on Python 3.11 + 3.12 (12 PR-A + 2 new for ``wire_voice_gate``).
- [x] ``tests/test_xr_ai_voicegate.py`` — 50 passed.
- [x] ``tests/test_xr_render_demo_wire.py`` — 9 passed.
- [x] ``tests/test_xr_ai_vad.py`` — 6 passed.
- [x] ``tests/test_simple_vlm_example_wire.py`` — 12 passed (untouched by this PR).
- [x] Worker import smoke clean: ``from xr_render_demo_worker import main; from processors import RenderSceneProcessor, TtsProcessor, build_pipeline; from config import load_config`` → OK.
- [x] Pipecat re-export smoke clean: ``from xr_ai_pipecat.audio import wav_to_chunks, chunks_to_wav, int16_pcm_to_wav, split_sentences, now_us`` → OK.
- [x] ``uv lock`` clean on ``xr-ai-pipecat``, ``xr-ai-conversation``, ``xr-render-demo-worker``, ``tests``.
- [ ] CI green across the Python 3.11 + 3.12 matrix.

## Out of scope (intentional)

- The agentic loop, scene-state cache, MCP tool routing, quick-ack, still-working messages, validation, JSON sanitizer, ``_recent_moves``, the ``eval/`` directory, and ``system.txt``. These are the agent brain and not generic.
- The ``_FILLER_PHRASES`` pre-gate filter is a pre-existing xr-render-demo concern (flagged out-of-scope in #164).
- ``stream_sentences_to_audio`` stays in ``xr-ai-pipecat`` — it's pipecat-flavored. ``stream_text_to_audio`` in ``xr-ai-conversation`` is the non-pipecat streaming helper.