### PR TITLE
feat(voice): introduce xr-ai-voicegate + xr-ai-conversation foundation (no sample migrations)

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -44,9 +44,10 @@ xr-ai-agent  (agent-sdk/)
     └── msgpack >=1.0
 
 xr-ai-pipecat  (agent-sdk/xr-ai-pipecat/)
-    └── xr-ai-agent   [editable: ..]
-    └── xr-ai-logging [editable: ../../utils/xr-ai-logging]
-    └── xr-ai-models  [editable: ../xr-ai-models]
+    └── xr-ai-agent        [editable: ..]
+    └── xr-ai-conversation [editable: ../xr-ai-conversation]
+    └── xr-ai-logging      [editable: ../../utils/xr-ai-logging]
+    └── xr-ai-models       [editable: ../xr-ai-models]
     └── pipecat-ai >=0.0.46
     └── numpy >=1.24
     └── scipy >=1.11
@@ -58,6 +59,11 @@ xr-ai-pipecat  (agent-sdk/xr-ai-pipecat/)
     SttClient / TtsClient are thin wrappers around xr-ai-models'
     OpenAICompatSTT / OpenAICompatTTS — PCM→WAV conversion is handled by
     the SDK. httpx is retained for http_probe() readiness checks.
+    The codec helpers in ``xr_ai_pipecat.audio`` (``wav_to_chunks``,
+    ``chunks_to_wav``, ``int16_pcm_to_wav``, ``split_sentences``,
+    ``now_us``) are re-exports of the canonical implementations in
+    ``xr_ai_conversation.audio``; ``stream_sentences_to_audio`` and
+    ``rms_float32`` stay here (pipecat-flavored).
     Not a dep of xr-ai-agent itself — import only in workers that use Pipecat.
 
 xr-ai-conversation  (agent-sdk/xr-ai-conversation/)
@@ -72,8 +78,9 @@ xr-ai-conversation  (agent-sdk/xr-ai-conversation/)
     streaming. Workers supply the ``ProcessorEndpoint``, STT/TTS services,
     a ``VoiceGateConfig``, and one ``on_query`` callback returning either
     a ``str`` (one-shot reply) or an ``AsyncIterator[str]`` (streamed
-    tokens). Codec helpers (int16 PCM ↔ WAV, sentence split) are exported
-    for consumers that want pieces without the full loop.
+    tokens). Codec helpers (int16 PCM ↔ WAV, sentence split) live in
+    ``xr_ai_conversation.audio`` as the canonical home — ``xr-ai-pipecat``
+    re-exports them for backward compatibility.
 
 xr-ai-models  (agent-sdk/xr-ai-models/)
     └── xr-ai-logging [editable: ../../utils/xr-ai-logging]

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -80,7 +80,9 @@ xr-ai-conversation  (agent-sdk/xr-ai-conversation/)
     a ``str`` (one-shot reply) or an ``AsyncIterator[str]`` (streamed
     tokens). Codec helpers (int16 PCM ↔ WAV, sentence split) live in
     ``xr_ai_conversation.audio`` as the canonical home — ``xr-ai-pipecat``
-    re-exports them for backward compatibility.
+    re-exports them for backward compatibility. ``wire_voice_gate`` is the
+    one-call helper Pipecat-flavored workers use to register all five
+    ``VoiceGate`` handlers without the loop.
 
 xr-ai-models  (agent-sdk/xr-ai-models/)
     └── xr-ai-logging [editable: ../../utils/xr-ai-logging]

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -101,6 +101,21 @@ xr-ai-vad  (utils/xr-ai-vad/)
     for speculative downstream warmup (e.g. start the camera before STT
     completes).
 
+xr-ai-voicegate  (utils/xr-ai-voicegate/)
+    └── numpy >=1.24
+    └── pyyaml >=6.0
+    Speech-only opt-in gate shared by agent workers that consume STT
+    transcripts.  Owns the magic-phrase + follow-up + STOP ladder, the
+    lazy listening chime (numpy-synthesized at the consumer's TTS sample
+    rate), and the participant-joined greeting hook.  Workers feed
+    transcripts via ``feed`` and register ``on_query`` / ``on_stop`` /
+    ``on_phrase_only`` / ``on_drop`` / ``on_participant_joined``
+    handlers.  Audio + TTS are consumed via duck-typed ``AudioSink`` /
+    ``TTSLike`` Protocols so the package stays free of xr-ai-models /
+    xr-ai-agent / pipecat deps.  pyyaml is used by
+    ``load_voice_gate_config`` to parse the standalone ``voice_gate.yaml``
+    file each sample's worker YAML references.
+
 xr-media-hub  (server-runtime/)
     └── xr-ai-agent  [editable: ../agent-sdk]
     └── pyzmq >=26.0
@@ -191,6 +206,7 @@ xr-ai-tests  (tests/)
     └── xr-ai-logging           [editable: ../utils/xr-ai-logging]
     └── xr-ai-vad               [editable: ../utils/xr-ai-vad]
     └── xr-ai-vllm              [editable: ../utils/xr-ai-vllm]
+    └── xr-ai-voicegate         [editable: ../utils/xr-ai-voicegate]
     └── transcript-mcp-server   [editable: ../agent-mcp-servers/transcript-mcp]
     └── vlm-mcp-server          [editable: ../agent-mcp-servers/vlm-mcp]
     └── render-mcp              [editable: ../agent-mcp-servers/render-mcp]

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -60,6 +60,21 @@ xr-ai-pipecat  (agent-sdk/xr-ai-pipecat/)
     the SDK. httpx is retained for http_probe() readiness checks.
     Not a dep of xr-ai-agent itself — import only in workers that use Pipecat.
 
+xr-ai-conversation  (agent-sdk/xr-ai-conversation/)
+    └── xr-ai-agent     [editable: ..]
+    └── xr-ai-vad       [editable: ../../utils/xr-ai-vad]
+    └── xr-ai-voicegate [editable: ../../utils/xr-ai-voicegate]
+    └── xr-ai-models    [editable: ../xr-ai-models]
+    └── numpy >=1.24
+    Shared voice-conversation loop for agent workers: wires VAD → STT →
+    voice gate → user ``on_query`` → TTS → return-audio fan-out, with
+    per-pid in-flight cancel + ``flush_return_audio`` and sentence-batched
+    streaming. Workers supply the ``ProcessorEndpoint``, STT/TTS services,
+    a ``VoiceGateConfig``, and one ``on_query`` callback returning either
+    a ``str`` (one-shot reply) or an ``AsyncIterator[str]`` (streamed
+    tokens). Codec helpers (int16 PCM ↔ WAV, sentence split) are exported
+    for consumers that want pieces without the full loop.
+
 xr-ai-models  (agent-sdk/xr-ai-models/)
     └── xr-ai-logging [editable: ../../utils/xr-ai-logging]
     └── httpx >=0.27
@@ -199,6 +214,7 @@ vec-mcp-server  (agent-mcp-servers/vec-mcp/)
 
 xr-ai-tests  (tests/)
     └── xr-ai-agent             [editable: ../agent-sdk]
+    └── xr-ai-conversation      [editable: ../agent-sdk/xr-ai-conversation]
     └── xr-ai-models            [editable: ../agent-sdk/xr-ai-models]
     └── xr-ai-pipecat           [editable: ../agent-sdk/xr-ai-pipecat]
     └── xr-media-hub            [editable: ../server-runtime]    (pulls in livekit, livekit-api for the wss /rtc proxy + room-client tests)

--- a/agent-sdk/xr-ai-conversation/pyproject.toml
+++ b/agent-sdk/xr-ai-conversation/pyproject.toml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "xr-ai-conversation"
+version = "0.1.0"
+requires-python = ">=3.11,<3.13"
+# Shared voice-conversation loop for agent workers: wires VAD → STT →
+# voice gate → user query handler → TTS → return audio, with per-pid
+# in-flight cancel/flush and sentence-batched streaming.  Workers supply
+# the ProcessorEndpoint, STT/TTS services, a voice-gate config, and one
+# ``on_query`` callback; everything else (codec helpers, audio sink
+# adapter, gate handler wiring) lives in this package.
+dependencies = [
+    "xr-ai-agent",
+    "xr-ai-vad",
+    "xr-ai-voicegate",
+    "xr-ai-models",
+    "numpy>=1.24",
+]
+
+[tool.uv.sources]
+xr-ai-agent     = { path = "..", editable = true }
+xr-ai-vad       = { path = "../../utils/xr-ai-vad", editable = true }
+xr-ai-voicegate = { path = "../../utils/xr-ai-voicegate", editable = true }
+xr-ai-models    = { path = "../xr-ai-models", editable = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["xr_ai_conversation"]

--- a/agent-sdk/xr-ai-conversation/xr_ai_conversation/__init__.py
+++ b/agent-sdk/xr-ai-conversation/xr_ai_conversation/__init__.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public surface of the xr-ai-conversation package."""
+from __future__ import annotations
+
+from .audio import (
+    chunks_to_wav,
+    int16_pcm_to_wav,
+    now_us,
+    split_sentences,
+    wav_to_chunks,
+)
+from .gate_wiring import GateBindings, QueryHandler, QueryResult
+from .loop import ConversationLoop, VadConfig
+from .state import VoiceState
+from .streaming import stream_text_to_audio
+
+__all__ = [
+    # primary entry point
+    "ConversationLoop",
+    "VadConfig",
+    # helpers exposed for samples that want to reuse pieces
+    "GateBindings",
+    "QueryHandler",
+    "QueryResult",
+    "VoiceState",
+    "stream_text_to_audio",
+    # audio codec helpers
+    "chunks_to_wav",
+    "int16_pcm_to_wav",
+    "now_us",
+    "split_sentences",
+    "wav_to_chunks",
+]

--- a/agent-sdk/xr-ai-conversation/xr_ai_conversation/__init__.py
+++ b/agent-sdk/xr-ai-conversation/xr_ai_conversation/__init__.py
@@ -11,7 +11,7 @@ from .audio import (
     split_sentences,
     wav_to_chunks,
 )
-from .gate_wiring import GateBindings, QueryHandler, QueryResult
+from .gate_wiring import GateBindings, QueryHandler, QueryResult, wire_voice_gate
 from .loop import ConversationLoop, VadConfig
 from .state import VoiceState
 from .streaming import stream_text_to_audio
@@ -26,6 +26,7 @@ __all__ = [
     "QueryResult",
     "VoiceState",
     "stream_text_to_audio",
+    "wire_voice_gate",
     # audio codec helpers
     "chunks_to_wav",
     "int16_pcm_to_wav",

--- a/agent-sdk/xr-ai-conversation/xr_ai_conversation/audio.py
+++ b/agent-sdk/xr-ai-conversation/xr_ai_conversation/audio.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Audio codec helpers shared by the conversation loop.
+
+* ``int16_pcm_to_wav`` — wrap raw int16 PCM in a single-channel WAV for STT.
+* ``wav_to_chunks``    — decode a WAV blob into 20 ms float32
+  ``AudioChunk``s for the hub's return-audio fan-out.
+* ``chunks_to_wav``    — inverse of ``wav_to_chunks`` for tests and
+  hub-tap recording paths.
+* ``split_sentences``  — break streamed VLM/LLM output on sentence
+  boundaries so each sentence can synthesize in parallel.
+* ``now_us``           — microsecond wall clock used as the ``pts_us``
+  default for canned replies.
+"""
+from __future__ import annotations
+
+import io
+import re
+import time
+import wave
+
+import numpy as np
+
+from xr_ai_agent import AudioChunk
+
+
+_CHUNK_MS = 20
+_CHUNK_US = _CHUNK_MS * 1_000
+
+SENTENCE_RE = re.compile(r"(?<=[.!?])\s+")
+
+
+def now_us() -> int:
+    return time.time_ns() // 1_000
+
+
+def int16_pcm_to_wav(pcm_bytes: bytes, sample_rate: int, channels: int = 1) -> bytes:
+    """Wrap raw int16 PCM bytes in a single-channel WAV container for STT."""
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(channels)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm_bytes)
+    return buf.getvalue()
+
+
+def wav_to_chunks(wav_bytes: bytes, participant_id: str) -> list[AudioChunk]:
+    """Decode a WAV blob into 20 ms float32 ``AudioChunk``s at native rate."""
+    buf = io.BytesIO(wav_bytes)
+    with wave.open(buf, "rb") as wf:
+        sr  = wf.getframerate()
+        ch  = wf.getnchannels()
+        raw = wf.readframes(wf.getnframes())
+    arr = np.frombuffer(raw, dtype=np.int16).astype(np.float32) / 32768.0
+    chunk_frames = max(1, sr // (1000 // _CHUNK_MS))
+    pts = now_us()
+    out: list[AudioChunk] = []
+    for i in range(0, len(arr), chunk_frames * ch):
+        seg = arr[i : i + chunk_frames * ch]
+        if not len(seg):
+            break
+        out.append(AudioChunk(
+            pts_us=pts, sample_rate=sr, channels=ch,
+            samples=len(seg) // ch, data=seg.tobytes(),
+            participant_id=participant_id,
+        ))
+        pts += _CHUNK_US
+    return out
+
+
+def chunks_to_wav(chunks: list[AudioChunk]) -> bytes:
+    """Concatenate float32 ``AudioChunk``s into a single 16-bit PCM WAV blob.
+
+    Inverse of ``wav_to_chunks``; useful for tests that need to round-trip
+    audio through the return-audio path and for hub-tap recording. Raises
+    ``ValueError`` on an empty list — there is no sane sample rate to pick."""
+    if not chunks:
+        raise ValueError("chunks_to_wav requires at least one chunk")
+    raw = b"".join(c.data for c in chunks)
+    arr = np.frombuffer(raw, dtype=np.float32)
+    pcm = (np.clip(arr, -1.0, 1.0) * 32767).astype(np.int16)
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(chunks[0].channels)
+        wf.setsampwidth(2)
+        wf.setframerate(chunks[0].sample_rate)
+        wf.writeframes(pcm.tobytes())
+    return buf.getvalue()
+
+
+def split_sentences(text: str) -> list[str]:
+    """Split ``text`` on sentence boundaries (``.``, ``!``, ``?`` + whitespace).
+
+    Returns the non-empty stripped sentences in order. The streaming TTS
+    path uses the lower-level regex inline to peel sentences as tokens
+    arrive; this helper is for callers that already have the full text."""
+    parts = SENTENCE_RE.split(text.strip())
+    return [s.strip() for s in parts if s.strip()]

--- a/agent-sdk/xr-ai-conversation/xr_ai_conversation/gate_wiring.py
+++ b/agent-sdk/xr-ai-conversation/xr_ai_conversation/gate_wiring.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Voice-gate handler bundle used by the conversation loop.
+
+Workers do not normally construct this directly — :class:`ConversationLoop`
+builds it from the keyword args passed to its constructor. The dataclass
+is exposed so a Pipecat-style consumer that wants the same wiring
+pattern without the full loop (e.g. for a custom transport) can reuse
+the binding shape.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import AsyncIterator, Awaitable, Callable
+
+
+QueryResult  = str | AsyncIterator[str]
+QueryHandler = Callable[[str, str, bool], Awaitable[QueryResult]]
+
+
+@dataclass
+class GateBindings:
+    """Handlers the conversation loop registers on its internal ``VoiceGate``.
+
+    ``on_query`` is required; everything else is optional. The loop
+    constructs this from its kwargs and uses it to set up the gate; the
+    type exists so the same wiring shape can be reused outside the loop."""
+    on_query:              QueryHandler
+    on_stop_extra:         Callable[[str], Awaitable[None]] | None = None
+    on_participant_joined: Callable[[str], Awaitable[None]] | None = None
+    on_participant_left:   Callable[[str], Awaitable[None]] | None = None

--- a/agent-sdk/xr-ai-conversation/xr_ai_conversation/gate_wiring.py
+++ b/agent-sdk/xr-ai-conversation/xr_ai_conversation/gate_wiring.py
@@ -1,18 +1,29 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Voice-gate handler bundle used by the conversation loop.
+"""Voice-gate handler bundle + one-shot wiring helper.
 
-Workers do not normally construct this directly — :class:`ConversationLoop`
-builds it from the keyword args passed to its constructor. The dataclass
-is exposed so a Pipecat-style consumer that wants the same wiring
-pattern without the full loop (e.g. for a custom transport) can reuse
-the binding shape.
+:class:`GateBindings` is the dataclass the :class:`ConversationLoop`
+builds internally from its constructor kwargs. It groups the handlers
+the loop registers on its private ``VoiceGate``.
+
+:func:`wire_voice_gate` is the public escape hatch for Pipecat-flavored
+workers that own their own ``VoiceGate`` (because they have a real
+frame pipeline rather than the loop's audio-callback path) but still
+want to skip the five ``gate.on_*`` registration lines. The default
+``on_drop`` logs at DEBUG so the gate's own drop-reason logging stays
+authoritative.
 """
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import AsyncIterator, Awaitable, Callable
+
+from xr_ai_voicegate import VoiceGate
+
+
+logger = logging.getLogger("xr_ai_conversation.gate_wiring")
 
 
 QueryResult  = str | AsyncIterator[str]
@@ -30,3 +41,55 @@ class GateBindings:
     on_stop_extra:         Callable[[str], Awaitable[None]] | None = None
     on_participant_joined: Callable[[str], Awaitable[None]] | None = None
     on_participant_left:   Callable[[str], Awaitable[None]] | None = None
+
+
+async def _default_drop_logger(pid: str, text: str) -> None:
+    """Default ``on_drop`` handler — DEBUG-level log only.
+
+    The voice gate already logs the drop reason at its own preferred
+    level; we just emit a paired DEBUG line so the loop's logger shows
+    the same event when tracing is enabled."""
+    logger.debug("voice gate dropped pid=%r text=%r", pid, text[:80])
+
+
+def wire_voice_gate(
+    gate: VoiceGate,
+    *,
+    on_query:              Callable[[str, str, bool], Awaitable[None]],
+    on_stop:               Callable[[str], Awaitable[None]],
+    on_phrase_only:        Callable[[str], Awaitable[None]] | None = None,
+    on_drop:               Callable[[str, str], Awaitable[None]] | None = None,
+    on_participant_joined: Callable[[str], Awaitable[None]] | None = None,
+) -> None:
+    """Register all five voice-gate handlers in one call.
+
+    Pipecat-style workers that own their own ``VoiceGate`` (because they
+    have a real frame pipeline rather than the loop's audio-callback
+    path) use this to skip five lines of boilerplate. The
+    :class:`ConversationLoop` does its own equivalent wiring internally
+    and does not call this helper.
+
+    ``on_query`` and ``on_stop`` are required — every voice-gate
+    consumer at least dispatches queries and acknowledges STOP. The
+    other three are optional:
+
+    * ``on_phrase_only`` — fired when a magic phrase opens the
+      follow-up window without a payload. No default (callers that
+      want a chime supply ``lambda pid: gate.play_chime(pid)``).
+    * ``on_drop`` — fired when the gate refused to dispatch. Defaults
+      to a DEBUG log; pass ``None`` to keep the default or a callable
+      to override.
+    * ``on_participant_joined`` — fired once per joined participant.
+      No default (the loop owns its own greeting path; pipecat workers
+      typically send a custom greeting).
+    """
+    gate.on_query(on_query)
+    gate.on_stop(on_stop)
+    if on_phrase_only is not None:
+        gate.on_phrase_only(on_phrase_only)
+    if on_drop is not None:
+        gate.on_drop(on_drop)
+    else:
+        gate.on_drop(_default_drop_logger)
+    if on_participant_joined is not None:
+        gate.on_participant_joined(on_participant_joined)

--- a/agent-sdk/xr-ai-conversation/xr_ai_conversation/loop.py
+++ b/agent-sdk/xr-ai-conversation/xr_ai_conversation/loop.py
@@ -1,0 +1,378 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Voice conversation loop shared by agent workers.
+
+Owns: per-pid VAD lifecycle, STT, voice-gate wiring, per-pid in-flight
+cancel/flush, sentence-batched streaming TTS, return-audio fan-out, and
+the participant-join/leave hooks. The worker supplies a
+``ProcessorEndpoint``, STT/TTS services, a ``VoiceGateConfig``, and one
+``on_query`` callback that returns either a ``str`` (one-shot reply) or
+an ``AsyncIterator[str]`` (streamed tokens, sentence-batched downstream).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import AsyncIterator, Awaitable, Callable
+
+import numpy as np
+
+from xr_ai_agent import (
+    AudioChunk, DataMessage, ParticipantEvent, ProcessorEndpoint,
+)
+from xr_ai_models import STTService, TTSService
+from xr_ai_vad import VadDetector
+from xr_ai_voicegate import AudioSink, VoiceGate, VoiceGateConfig
+
+from .audio import int16_pcm_to_wav, now_us, wav_to_chunks
+from .gate_wiring import GateBindings, QueryHandler, QueryResult
+from .state import VoiceState
+from .streaming import stream_text_to_audio
+
+
+logger = logging.getLogger("xr_ai_conversation")
+
+
+@dataclass(frozen=True)
+class VadConfig:
+    silence_duration: float = 0.8
+    min_speech:       float = 0.3
+    silero_threshold: float = 0.5
+
+
+class _EpAudioSink:
+    """Adapter exposing ``ProcessorEndpoint`` as an :class:`AudioSink`.
+
+    Explodes a WAV blob into 20 ms ``AudioChunk``s and streams them
+    through ``send_return_audio`` so the voice gate, the streaming TTS
+    helper, and the loop's own ``say()`` all push audio through one
+    code path."""
+
+    def __init__(self, ep: ProcessorEndpoint) -> None:
+        self._ep = ep
+
+    async def play_wav(self, pid: str, wav_bytes: bytes) -> None:
+        for chunk in wav_to_chunks(wav_bytes, pid):
+            await self._ep.send_return_audio(chunk)
+
+
+class ConversationLoop:
+    """Voice-conversation runtime.
+
+    Wires the audio → VAD → STT → voice-gate → ``on_query`` → TTS →
+    return-audio path for any worker that consumes the hub's mic feed.
+    Construct once per worker, register optional hooks, then ``await
+    run()``. Per-pid in-flight cancel/flush keeps a new query from
+    racing with a previous in-flight response.
+
+    The ``on_query`` callback may return either a ``str`` (canned reply
+    or one-shot LLM/VLM call) or an ``AsyncIterator[str]`` (streamed
+    tokens — sentences are peeled and synthesized in parallel). Both
+    forms also send the final assembled text on ``text_topic`` for
+    clients that listen on the data channel.
+    """
+
+    def __init__(
+        self,
+        *,
+        ep:             ProcessorEndpoint,
+        stt:            STTService,
+        tts:            TTSService,
+        voice_gate_cfg: VoiceGateConfig,
+        vad_cfg:        VadConfig,
+        on_query:       QueryHandler,
+        on_speech_start:       Callable[[str], Awaitable[None]] | None = None,
+        on_participant_joined: Callable[[str], Awaitable[None]] | None = None,
+        on_participant_left:   Callable[[str], Awaitable[None]] | None = None,
+        on_stop_extra:         Callable[[str], Awaitable[None]] | None = None,
+        text_topic: str = "agent.response",
+        greeting:   str | Callable[[VoiceGate], str] | None = None,
+    ) -> None:
+        self._ep         = ep
+        self._stt        = stt
+        self._tts        = tts
+        self._vad_cfg    = vad_cfg
+        self._text_topic = text_topic
+
+        self._bindings = GateBindings(
+            on_query              = on_query,
+            on_stop_extra         = on_stop_extra,
+            on_participant_joined = on_participant_joined,
+            on_participant_left   = on_participant_left,
+        )
+        self._on_speech_start = on_speech_start
+        self._greeting        = greeting
+
+        self._voice: dict[str, VoiceState] = {}
+
+        self._audio_sink = _EpAudioSink(ep)
+        self._gate = VoiceGate(
+            voice_gate_cfg,
+            audio_sink = self._audio_sink,
+            tts        = tts,
+        )
+        self._gate.on_query(self._on_gate_query)
+        self._gate.on_stop(self._handle_stop)
+        self._gate.on_phrase_only(self._on_phrase_only)
+        self._gate.on_drop(self._on_drop)
+        self._gate.on_participant_joined(self._greet)
+
+        ep.on_audio(self._on_audio)
+        ep.on_participant(self._on_participant)
+
+    # ── lifecycle ─────────────────────────────────────────────────────────────
+
+    async def run(self) -> None:
+        await self._ep.run()
+
+    def shutdown(self) -> None:
+        self._ep.stop()
+        self._ep.close()
+
+    # ── audio path: PCM → VAD → STT → gate ────────────────────────────────────
+
+    async def _on_audio(self, chunk: AudioChunk) -> None:
+        vs = self._get_voice(chunk.participant_id)
+        assert vs.vad is not None
+        # Hub delivers float32 LE PCM; VadDetector takes int16 LE PCM.
+        f32 = np.frombuffer(chunk.data, dtype=np.float32)
+        i16 = (np.clip(f32, -1.0, 1.0) * 32767).astype(np.int16).tobytes()
+        await vs.vad.feed(i16, chunk.sample_rate)
+
+    def _get_voice(self, pid: str) -> VoiceState:
+        vs = self._voice.get(pid)
+        if vs is None:
+            vs = VoiceState()
+            vs.vad = VadDetector(
+                on_utterance     = lambda audio, sr, _pid=pid: self._on_vad_utterance(_pid, audio, sr),
+                on_speech_start  = lambda _pid=pid: self._on_vad_speech_start(_pid),
+                silence_duration = self._vad_cfg.silence_duration,
+                min_speech       = self._vad_cfg.min_speech,
+                silero_threshold = self._vad_cfg.silero_threshold,
+            )
+            self._voice[pid] = vs
+        return vs
+
+    async def _on_vad_speech_start(self, pid: str) -> None:
+        if self._on_speech_start is None:
+            return
+        try:
+            await self._on_speech_start(pid)
+        except Exception:
+            logger.exception("on_speech_start hook raised pid=%r", pid)
+
+    async def _on_vad_utterance(self, pid: str, audio_bytes: bytes, sample_rate: int) -> None:
+        vs = self._voice.get(pid)
+        if vs is None or vs.transcribing:
+            return
+        vs.transcribing = True
+        try:
+            wav  = int16_pcm_to_wav(audio_bytes, sample_rate)
+            text = (await self._stt.transcribe(wav)).strip()
+            if not text:
+                return
+            await self._gate.feed(pid, text)
+        except Exception:
+            logger.exception("stt error pid=%r", pid)
+        finally:
+            vs.transcribing = False
+
+    # ── voice-gate handlers ───────────────────────────────────────────────────
+
+    async def _on_gate_query(self, pid: str, query: str, fresh_match: bool) -> None:
+        if fresh_match:
+            asyncio.create_task(self._gate.play_chime(pid))
+        await self._dispatch_internal(pid, query, pts_us=now_us(), fresh_match=fresh_match)
+
+    async def _on_phrase_only(self, pid: str) -> None:
+        # The chime here acknowledges that the wake word was heard while
+        # the follow-up window is open; without it the user has no signal
+        # that the gate is ready for the next utterance.
+        await self._gate.play_chime(pid)
+
+    async def _on_drop(self, pid: str, text: str) -> None:
+        # The gate already logged; nothing for the loop to do.
+        return
+
+    # ── interruptible dispatch ────────────────────────────────────────────────
+
+    async def dispatch(self, pid: str, text: str, *, pts_us: int) -> None:
+        """Cancel any in-flight response for ``pid``, flush queued audio,
+        then start the new query as a tracked task.
+
+        Data-channel callers use this directly; the gate path goes
+        through ``_dispatch_internal`` so it can pass the gate's
+        ``fresh_match`` flag through to the user's ``on_query``."""
+        await self._dispatch_internal(pid, text, pts_us=pts_us, fresh_match=True)
+
+    async def _dispatch_internal(
+        self, pid: str, text: str, *, pts_us: int, fresh_match: bool,
+    ) -> None:
+        vs = self._get_voice(pid)
+        async with vs.dispatch_lock:
+            await self._cancel_inflight_locked(vs, pid)
+            await self._ep.flush_return_audio(pid)
+            vs.current_task = asyncio.create_task(
+                self._run_query(pid, text, pts_us, fresh_match),
+                name=f"conv-query-{pid}",
+            )
+
+    async def _cancel_inflight_locked(self, vs: VoiceState, pid: str) -> None:
+        old = vs.current_task
+        if old is None or old.done():
+            return
+        logger.info("interrupt pid=%r — cancelling in-flight response", pid)
+        old.cancel()
+        try:
+            await old
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.exception("in-flight task error during cancel pid=%r", pid)
+
+    async def _run_query(
+        self, pid: str, text: str, pts_us: int, fresh_match: bool,
+    ) -> None:
+        try:
+            result = await self._bindings.on_query(pid, text, fresh_match)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("on_query raised pid=%r", pid)
+            return
+
+        try:
+            if isinstance(result, str):
+                await self._speak(pid, result)
+                final_text = result
+            else:
+                final_text = await stream_text_to_audio(
+                    tokens     = result,
+                    pid        = pid,
+                    tts        = self._tts,
+                    audio_sink = self._audio_sink,
+                    on_wav     = self._gate.observe_tts_wav,
+                )
+        except asyncio.CancelledError:
+            raise
+
+        if final_text:
+            await self._reply_data(pid, final_text, pts_us)
+
+    # ── outbound helpers ──────────────────────────────────────────────────────
+
+    async def say(self, pid: str, text: str) -> None:
+        """Synthesize ``text`` and play it on the return-audio channel.
+
+        Does not touch the data channel. Use :meth:`reply` for a paired
+        data + audio response.
+        """
+        await self._speak(pid, text)
+
+    async def reply(self, pid: str, text: str, *, pts_us: int) -> None:
+        """Send ``text`` on the data channel AND speak it on return audio."""
+        await self._reply_data(pid, text, pts_us)
+        await self._speak(pid, text)
+
+    async def _speak(self, pid: str, text: str) -> None:
+        if not text:
+            return
+        try:
+            wav = await self._tts.synthesize(text)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("tts synthesize error pid=%r", pid)
+            return
+        self._gate.observe_tts_wav(wav)
+        try:
+            await self._audio_sink.play_wav(pid, wav)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("return-audio play_wav error pid=%r", pid)
+
+    async def _reply_data(self, pid: str, text: str, pts_us: int) -> None:
+        await self._ep.send_return_data(DataMessage(
+            participant_id = pid,
+            topic          = self._text_topic,
+            pts_us         = pts_us,
+            data           = text.encode(),
+        ))
+
+    # ── stop ──────────────────────────────────────────────────────────────────
+
+    async def _handle_stop(self, pid: str) -> None:
+        """Cancel + flush + ``say_stop_ack`` + ``on_stop_extra`` + data echo.
+
+        Order matches the design spec (PR-A) — it differs from the
+        original simple-vlm-example, which echoed the data message
+        before the stop-ack TTS; this loop runs the stop-ack first so
+        the canned audio starts playing while the data echo travels."""
+        vs = self._voice.get(pid)
+        if vs is not None:
+            async with vs.dispatch_lock:
+                await self._cancel_inflight_locked(vs, pid)
+                await self._ep.flush_return_audio(pid)
+                vs.current_task = None
+
+        await self._gate.say_stop_ack(pid)
+
+        if self._bindings.on_stop_extra is not None:
+            try:
+                await self._bindings.on_stop_extra(pid)
+            except Exception:
+                logger.exception("on_stop_extra hook raised pid=%r", pid)
+
+        await self._reply_data(pid, "Okay, I will stop.", now_us())
+
+    # ── participant lifecycle ─────────────────────────────────────────────────
+
+    async def _on_participant(self, event: ParticipantEvent) -> None:
+        pid = event.participant_id
+        if event.joined:
+            if self._bindings.on_participant_joined is not None:
+                try:
+                    await self._bindings.on_participant_joined(pid)
+                except Exception:
+                    logger.exception("on_participant_joined hook raised pid=%r", pid)
+            asyncio.create_task(self._gate.participant_joined(pid))
+            return
+
+        vs = self._voice.pop(pid, None)
+        if vs is not None and vs.current_task is not None and not vs.current_task.done():
+            vs.current_task.cancel()
+        self._gate.forget(pid)
+        if self._bindings.on_participant_left is not None:
+            try:
+                await self._bindings.on_participant_left(pid)
+            except Exception:
+                logger.exception("on_participant_left hook raised pid=%r", pid)
+
+    async def _greet(self, pid: str) -> None:
+        text = self._resolve_greeting()
+        if not text:
+            return
+        try:
+            await self._speak(pid, text)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("greet error pid=%r", pid)
+
+    def _resolve_greeting(self) -> str:
+        g = self._greeting
+        if g is None:
+            help_text = self._gate.format_phrase_help()
+            if help_text is None:
+                return "Hi, I'm listening. Ask me anything."
+            return f"Hi, I'm listening. {help_text}"
+        if isinstance(g, str):
+            return g
+        try:
+            return g(self._gate) or ""
+        except Exception:
+            logger.exception("greeting callable raised")
+            return ""

--- a/agent-sdk/xr-ai-conversation/xr_ai_conversation/loop.py
+++ b/agent-sdk/xr-ai-conversation/xr_ai_conversation/loop.py
@@ -87,6 +87,8 @@ class ConversationLoop:
         on_participant_joined: Callable[[str], Awaitable[None]] | None = None,
         on_participant_left:   Callable[[str], Awaitable[None]] | None = None,
         on_stop_extra:         Callable[[str], Awaitable[None]] | None = None,
+        on_phrase_only_extra:  Callable[[str], Awaitable[None]] | None = None,
+        on_drop_extra:         Callable[[str, str], Awaitable[None]] | None = None,
         text_topic: str = "agent.response",
         greeting:   str | Callable[[VoiceGate], str] | None = None,
     ) -> None:
@@ -102,8 +104,10 @@ class ConversationLoop:
             on_participant_joined = on_participant_joined,
             on_participant_left   = on_participant_left,
         )
-        self._on_speech_start = on_speech_start
-        self._greeting        = greeting
+        self._on_speech_start      = on_speech_start
+        self._on_phrase_only_extra = on_phrase_only_extra
+        self._on_drop_extra        = on_drop_extra
+        self._greeting             = greeting
 
         self._voice: dict[str, VoiceState] = {}
 
@@ -191,10 +195,20 @@ class ConversationLoop:
         # the follow-up window is open; without it the user has no signal
         # that the gate is ready for the next utterance.
         await self._gate.play_chime(pid)
+        if self._on_phrase_only_extra is not None:
+            try:
+                await self._on_phrase_only_extra(pid)
+            except Exception:
+                logger.exception("on_phrase_only_extra hook raised pid=%r", pid)
 
     async def _on_drop(self, pid: str, text: str) -> None:
-        # The gate already logged; nothing for the loop to do.
-        return
+        # The gate already logged; the brain may need to clean up its own
+        # state (e.g. cancel a speculative camera-on from on_speech_start).
+        if self._on_drop_extra is not None:
+            try:
+                await self._on_drop_extra(pid, text)
+            except Exception:
+                logger.exception("on_drop_extra hook raised pid=%r", pid)
 
     # ── interruptible dispatch ────────────────────────────────────────────────
 

--- a/agent-sdk/xr-ai-conversation/xr_ai_conversation/state.py
+++ b/agent-sdk/xr-ai-conversation/xr_ai_conversation/state.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-participant voice-loop bookkeeping owned by ``ConversationLoop``.
+
+The loop owns the ``VadDetector`` lifecycle for each participant; this
+struct only tracks the cancel/flush state for in-flight queries and a
+single STT-in-flight flag so two utterances from the same pid don't race
+through the gate at the same time.
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+
+from xr_ai_vad import VadDetector
+
+
+@dataclass
+class VoiceState:
+    vad:           VadDetector | None  = None
+    transcribing:  bool                = False  # in-flight STT for this pid
+    # In-flight user-supplied response.  A new query cancels this; the
+    # dispatch lock serialises the cancel-await-flush-restart sequence
+    # per pid so concurrent calls can't both see a stale ``current_task``.
+    current_task:  asyncio.Task | None = None
+    dispatch_lock: asyncio.Lock        = field(default_factory=asyncio.Lock)

--- a/agent-sdk/xr-ai-conversation/xr_ai_conversation/streaming.py
+++ b/agent-sdk/xr-ai-conversation/xr_ai_conversation/streaming.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Streaming token → sentence-batched TTS → audio sink pipeline.
+
+The user's streaming ``on_query`` yields tokens; this helper buffers
+them into sentence-sized units, spawns a TTS synth task per sentence so
+multiple sentences synth in parallel, and pushes the resulting WAV
+bytes to an :class:`AudioSink` in order via a single sender task.
+
+Cancellation is cooperative: the caller is expected to ``await`` this
+coroutine inside an ``asyncio.Task`` and cancel that task to interrupt.
+On cancel, all pending synth tasks and the sender task are cancelled
+and awaited before re-raising.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from typing import AsyncIterator, Awaitable, Callable
+
+from xr_ai_models import TTSService
+from xr_ai_voicegate import AudioSink
+
+
+logger = logging.getLogger("xr_ai_conversation")
+
+
+_SENTENCE_BOUNDARY_RE = re.compile(r"(?<=[.!?])\s+")
+
+
+async def stream_text_to_audio(
+    *,
+    tokens:     AsyncIterator[str],
+    pid:        str,
+    tts:        TTSService,
+    audio_sink: AudioSink,
+    on_wav:     Callable[[bytes], None] | None = None,
+) -> str:
+    """Pipe ``tokens`` through sentence-batched TTS to ``audio_sink``.
+
+    Returns the full accumulated text. ``on_wav`` is invoked synchronously
+    for every WAV blob the sender consumes — the conversation loop wires
+    it to ``gate.observe_tts_wav`` so the lazy listening-chime build can
+    pick up the TTS sample rate from this path too.
+
+    Cancellation contract: the caller owns the outer task. On
+    ``asyncio.CancelledError`` here, every spawned synth task and the
+    sender task are cancelled and awaited (so no orphaned TTS requests
+    keep running) before the cancel re-raises.
+    """
+    full_text     = ""
+    sentence_buf  = ""
+    tts_queue: asyncio.Queue[asyncio.Task | None] = asyncio.Queue()
+    pending_synth: list[asyncio.Task] = []
+
+    async def _audio_sender() -> None:
+        while True:
+            task = await tts_queue.get()
+            if task is None:
+                return
+            try:
+                wav = await task
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("tts synth error pid=%r", pid)
+                continue
+            if on_wav is not None:
+                try:
+                    on_wav(wav)
+                except Exception:
+                    logger.exception("on_wav callback raised pid=%r", pid)
+            try:
+                await audio_sink.play_wav(pid, wav)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("audio sink play_wav error pid=%r", pid)
+
+    sender = asyncio.create_task(_audio_sender(), name=f"tts-sender-{pid}")
+
+    try:
+        async for token in tokens:
+            full_text    += token
+            sentence_buf += token
+            while True:
+                m = _SENTENCE_BOUNDARY_RE.search(sentence_buf)
+                if not m:
+                    break
+                sentence     = sentence_buf[: m.start() + 1].strip()
+                sentence_buf = sentence_buf[m.end():]
+                if sentence:
+                    t = asyncio.create_task(tts.synthesize(sentence))
+                    pending_synth.append(t)
+                    await tts_queue.put(t)
+
+        tail = sentence_buf.strip()
+        if tail:
+            t = asyncio.create_task(tts.synthesize(tail))
+            pending_synth.append(t)
+            await tts_queue.put(t)
+
+        await tts_queue.put(None)
+        await sender
+        return full_text.strip()
+
+    except asyncio.CancelledError:
+        for t in pending_synth:
+            t.cancel()
+        sender.cancel()
+        for t in (*pending_synth, sender):
+            try:
+                await t
+            except (asyncio.CancelledError, Exception):
+                pass
+        raise

--- a/agent-sdk/xr-ai-pipecat/pyproject.toml
+++ b/agent-sdk/xr-ai-pipecat/pyproject.toml
@@ -11,6 +11,7 @@ version = "0.1.0"
 requires-python = ">=3.11,<3.13"
 dependencies = [
     "xr-ai-agent",
+    "xr-ai-conversation",
     "xr-ai-logging",
     "xr-ai-models",
     "pipecat-ai>=0.0.46",
@@ -21,9 +22,10 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-xr-ai-agent   = { path = "..", editable = true }
-xr-ai-logging = { path = "../../utils/xr-ai-logging", editable = true }
-xr-ai-models  = { path = "../xr-ai-models", editable = true }
+xr-ai-agent        = { path = "..", editable = true }
+xr-ai-conversation = { path = "../xr-ai-conversation", editable = true }
+xr-ai-logging      = { path = "../../utils/xr-ai-logging", editable = true }
+xr-ai-models       = { path = "../xr-ai-models", editable = true }
 
 [tool.hatch.build.targets.wheel]
 packages = ["xr_ai_pipecat"]

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/audio.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/audio.py
@@ -1,81 +1,53 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-Audio helpers: PCM ↔ WAV conversion, sentence-batched TTS, VAD bookkeeping.
+"""Pipecat audio helpers — codec is re-exported from xr-ai-conversation.
+
+The canonical home for the PCM ↔ WAV codec helpers is
+``xr_ai_conversation.audio``; this module re-exports them for
+backwards compatibility with existing pipecat consumers. The
+pipecat-flavored ``stream_sentences_to_audio`` stays here because it
+pushes pipecat-style audio frames and depends on
+``xr_ai_agent.ProcessorEndpoint``.
 """
 from __future__ import annotations
 
 import asyncio
-import io
-import re
-import time
-import wave
 
 import numpy as np
 from loguru import logger
 
-from xr_ai_agent import AudioChunk, ProcessorEndpoint
+from xr_ai_agent import ProcessorEndpoint
 
-SENTENCE_RE = re.compile(r"(?<=[.!?])\s+")
+# Re-exported codec + sentence helpers — canonical location is
+# ``xr_ai_conversation.audio``. Importing from here continues to work
+# for backwards compatibility with workers that pre-date PR-C.
+from xr_ai_conversation.audio import (
+    chunks_to_wav,
+    int16_pcm_to_wav,
+    now_us,
+    split_sentences,
+    wav_to_chunks,
+)
 
-_CHUNK_MS = 20
-_CHUNK_US = _CHUNK_MS * 1_000
 
-
-def now_us() -> int:
-    return time.time_ns() // 1_000
+__all__ = [
+    # re-exports
+    "chunks_to_wav",
+    "int16_pcm_to_wav",
+    "now_us",
+    "split_sentences",
+    "wav_to_chunks",
+    # pipecat-only
+    "rms_float32",
+    "stream_sentences_to_audio",
+]
 
 
 def rms_float32(data: bytes) -> float:
+    """RMS amplitude of float32 PCM bytes — pipecat-only utility."""
     arr = np.frombuffer(data, dtype=np.float32)
     return float(np.sqrt(np.mean(arr ** 2))) if len(arr) else 0.0
-
-
-def chunks_to_wav(chunks: list[AudioChunk]) -> bytes:
-    """Concatenate float32 IPC chunks into a single 16-bit PCM WAV blob."""
-    raw = b"".join(c.data for c in chunks)
-    arr = np.frombuffer(raw, dtype=np.float32)
-    pcm = (np.clip(arr, -1.0, 1.0) * 32767).astype(np.int16)
-    buf = io.BytesIO()
-    with wave.open(buf, "wb") as wf:
-        wf.setnchannels(chunks[0].channels)
-        wf.setsampwidth(2)
-        wf.setframerate(chunks[0].sample_rate)
-        wf.writeframes(pcm.tobytes())
-    return buf.getvalue()
-
-
-def wav_to_chunks(wav_bytes: bytes, participant_id: str) -> list[AudioChunk]:
-    """Decode a WAV blob into 20 ms float32 AudioChunks at native sample rate."""
-    buf = io.BytesIO(wav_bytes)
-    with wave.open(buf, "rb") as wf:
-        sr  = wf.getframerate()
-        ch  = wf.getnchannels()
-        raw = wf.readframes(wf.getnframes())
-    arr = np.frombuffer(raw, dtype=np.int16).astype(np.float32) / 32768.0
-    chunk_frames = max(1, sr // (1000 // _CHUNK_MS))
-    pts = now_us()
-    out: list[AudioChunk] = []
-    for i in range(0, len(arr), chunk_frames * ch):
-        seg = arr[i : i + chunk_frames * ch]
-        if not len(seg):
-            break
-        out.append(AudioChunk(
-            pts_us=pts,
-            sample_rate=sr,
-            channels=ch,
-            samples=len(seg) // ch,
-            data=seg.tobytes(),
-            participant_id=participant_id,
-        ))
-        pts += _CHUNK_US
-    return out
-
-
-def split_sentences(text: str) -> list[str]:
-    parts = SENTENCE_RE.split(text.strip())
-    return [s.strip() for s in parts if s.strip()]
 
 
 async def stream_sentences_to_audio(

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -13,6 +13,7 @@ requires-python = ">=3.11,<3.13"
 dependencies = [
     # Pulled in via editable installs of the workspace packages.
     "xr-ai-agent",
+    "xr-ai-conversation",
     "xr-ai-models",
     "xr-ai-pipecat",
     "xr-media-hub",
@@ -38,6 +39,7 @@ dependencies = [
 
 [tool.uv.sources]
 xr-ai-agent           = { path = "../agent-sdk",                        editable = true }
+xr-ai-conversation    = { path = "../agent-sdk/xr-ai-conversation",     editable = true }
 xr-ai-models          = { path = "../agent-sdk/xr-ai-models",           editable = true }
 xr-ai-pipecat         = { path = "../agent-sdk/xr-ai-pipecat",          editable = true }
 xr-media-hub          = { path = "../server-runtime",                   editable = true }

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "xr-ai-logging",
     "xr-ai-vad",
     "xr-ai-vllm",
+    "xr-ai-voicegate",
     # MCP servers exercised by subprocess tests (fastmcp pulled in transitively).
     "transcript-mcp-server",
     "vlm-mcp-server",
@@ -44,6 +45,7 @@ xr-ai-launcher        = { path = "../utils/xr-ai-launcher",             editable
 xr-ai-logging         = { path = "../utils/xr-ai-logging",              editable = true }
 xr-ai-vad             = { path = "../utils/xr-ai-vad",                  editable = true }
 xr-ai-vllm            = { path = "../utils/xr-ai-vllm",                 editable = true }
+xr-ai-voicegate       = { path = "../utils/xr-ai-voicegate",            editable = true }
 transcript-mcp-server = { path = "../agent-mcp-servers/transcript-mcp", editable = true }
 vlm-mcp-server        = { path = "../agent-mcp-servers/vlm-mcp",        editable = true }
 render-mcp            = { path = "../agent-mcp-servers/render-mcp",     editable = true }

--- a/tests/test_xr_ai_conversation_loop.py
+++ b/tests/test_xr_ai_conversation_loop.py
@@ -27,7 +27,7 @@ import pytest
 
 from xr_ai_agent      import AudioChunk, DataMessage, ParticipantEvent
 from xr_ai_voicegate  import VoiceGate, VoiceGateConfig
-from xr_ai_conversation import ConversationLoop, VadConfig
+from xr_ai_conversation import ConversationLoop, VadConfig, wire_voice_gate
 
 
 # ── test doubles ────────────────────────────────────────────────────────────
@@ -119,6 +119,8 @@ def _make_loop(
     on_participant_joined = None,
     on_participant_left   = None,
     on_stop_extra         = None,
+    on_phrase_only_extra  = None,
+    on_drop_extra         = None,
     text_topic: str = "agent.response",
     greeting = None,
 ) -> tuple[ConversationLoop, _FakeEp, _FakeSTT, _FakeTTS]:
@@ -136,6 +138,8 @@ def _make_loop(
         on_participant_joined = on_participant_joined,
         on_participant_left   = on_participant_left,
         on_stop_extra         = on_stop_extra,
+        on_phrase_only_extra  = on_phrase_only_extra,
+        on_drop_extra         = on_drop_extra,
         text_topic            = text_topic,
         greeting              = greeting,
     )
@@ -543,3 +547,142 @@ async def test_data_channel_dispatch_sets_fresh_match_true():
     await loop._voice["p1"].current_task
 
     assert seen == [True]
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 13. on_phrase_only_extra + on_drop_extra hooks fire alongside gate events
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_phrase_only_extra_and_drop_extra_hooks_fire():
+    """Case 13: the brain-side extras fire when the gate raises a
+    phrase-only acknowledgement or drops an utterance — without them, a
+    speculative ``on_speech_start`` (e.g. camera warmup) has no
+    counterbalancing teardown when the user never follows up or the
+    phrase doesn't match."""
+    phrase_only_calls: list[str] = []
+    drop_calls:        list[tuple[str, str]] = []
+
+    async def on_query(pid: str, text: str, fresh_match: bool) -> str:
+        return ""
+
+    async def on_phrase_only_extra(pid: str) -> None:
+        phrase_only_calls.append(pid)
+
+    async def on_drop_extra(pid: str, text: str) -> None:
+        drop_calls.append((pid, text))
+
+    loop, _, _, _ = _make_loop(
+        on_query             = on_query,
+        vg_phrases           = ("agent",),
+        on_phrase_only_extra = on_phrase_only_extra,
+        on_drop_extra        = on_drop_extra,
+    )
+
+    # Phrase-only: utterance is exactly the magic phrase, opens follow-up window.
+    await loop._gate.feed("p1", "agent")
+    # Drop: non-magic-phrase utterance while gate requires phrase + no follow-up.
+    await loop._gate.feed("p2", "what time is it")
+
+    assert phrase_only_calls == ["p1"]
+    assert drop_calls and drop_calls[0][0] == "p2"
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 14. wire_voice_gate registers the five handlers in one call
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_wire_voice_gate_registers_handlers_and_defaults_on_drop():
+    """Case 14: ``wire_voice_gate`` is the pipecat-side escape hatch that
+    collapses the five ``gate.on_*`` registration lines into one call.
+
+    Asserts: (a) the four explicitly-passed handlers fire when their
+    corresponding gate event runs, and (b) ``on_drop`` defaults to a
+    DEBUG logger when the caller doesn't supply one — i.e. the gate's
+    ``_on_drop_h`` slot is populated, not left ``None``."""
+    gate = VoiceGate(
+        VoiceGateConfig(magic_phrases=("agent",)),
+        audio_sink=None,
+        tts=None,
+    )
+
+    seen_query:          list[tuple[str, str, bool]] = []
+    seen_stop:           list[str]                   = []
+    seen_phrase_only:    list[str]                   = []
+    seen_join:           list[str]                   = []
+
+    async def on_query(pid: str, text: str, fresh_match: bool) -> None:
+        seen_query.append((pid, text, fresh_match))
+
+    async def on_stop(pid: str) -> None:
+        seen_stop.append(pid)
+
+    async def on_phrase_only(pid: str) -> None:
+        seen_phrase_only.append(pid)
+
+    async def on_participant_joined(pid: str) -> None:
+        seen_join.append(pid)
+
+    wire_voice_gate(
+        gate,
+        on_query              = on_query,
+        on_stop               = on_stop,
+        on_phrase_only        = on_phrase_only,
+        on_participant_joined = on_participant_joined,
+    )
+
+    # Handlers slot in.
+    assert gate._on_query_h               is on_query
+    assert gate._on_stop_h                is on_stop
+    assert gate._on_phrase_only_h         is on_phrase_only
+    assert gate._on_participant_joined_h  is on_participant_joined
+
+    # Default on_drop is installed (not None), and it's awaitable.
+    assert gate._on_drop_h is not None
+    await gate._on_drop_h("p1", "anything dropped")  # should not raise
+
+    # End-to-end: feed "agent, hello" — case 2 (phrase + payload) →
+    # on_query fires with fresh_match=True. "agent stop" → on_stop. A
+    # bare "agent" opens the window → on_phrase_only.
+    await gate.feed("p1", "agent hello")
+    await gate.feed("p2", "agent")
+    await gate.feed("p3", "agent stop")
+
+    assert seen_query        == [("p1", "hello", True)]
+    assert seen_phrase_only  == ["p2"]
+    assert seen_stop         == ["p3"]
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 15. wire_voice_gate custom on_drop overrides the default
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_wire_voice_gate_custom_on_drop_overrides_default():
+    """Case 15: passing ``on_drop`` explicitly overrides the default
+    DEBUG-logger handler. Verified by checking the slot identity, since
+    the gate's drop-path is exercised by xr-ai-voicegate's own tests."""
+    gate = VoiceGate(
+        VoiceGateConfig(magic_phrases=("agent",)),
+        audio_sink=None,
+        tts=None,
+    )
+
+    async def custom_drop(pid: str, text: str) -> None:
+        pass
+
+    async def on_query(pid: str, text: str, fresh_match: bool) -> None: ...
+    async def on_stop(pid: str) -> None: ...
+
+    wire_voice_gate(
+        gate,
+        on_query = on_query,
+        on_stop  = on_stop,
+        on_drop  = custom_drop,
+    )
+
+    assert gate._on_drop_h is custom_drop

--- a/tests/test_xr_ai_conversation_loop.py
+++ b/tests/test_xr_ai_conversation_loop.py
@@ -1,0 +1,545 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ``xr_ai_conversation.ConversationLoop``.
+
+Covers: construction, str ``on_query`` → say path, streaming
+``on_query`` → sentence-batched synth + ordered audio sender, per-pid
+in-flight cancel + ``flush_return_audio`` on a second dispatch, STOP
+handler, participant join + greeting, participant leave clears state,
+custom greeting (string + callable), and ``observe_tts_wav`` is fed by
+every TTS WAV the loop generates.
+
+Everything runs against fakes — no real ``ProcessorEndpoint``, VAD,
+STT, or TTS — so the suite stays CPU-only and finishes in well under a
+second.
+"""
+from __future__ import annotations
+
+import asyncio
+import io
+import wave
+from dataclasses import dataclass
+from typing import Any, AsyncIterator
+
+import numpy as np
+import pytest
+
+from xr_ai_agent      import AudioChunk, DataMessage, ParticipantEvent
+from xr_ai_voicegate  import VoiceGate, VoiceGateConfig
+from xr_ai_conversation import ConversationLoop, VadConfig
+
+
+# ── test doubles ────────────────────────────────────────────────────────────
+
+
+def _silence_wav(sample_rate: int = 22_050, ms: int = 10) -> bytes:
+    """Tiny well-formed WAV blob the loop's ``wav_to_chunks`` accepts."""
+    n   = max(1, int(sample_rate * ms / 1000))
+    pcm = np.zeros(n, dtype=np.int16).tobytes()
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm)
+    return buf.getvalue()
+
+
+class _FakeEp:
+    """``ProcessorEndpoint`` stand-in capturing every outbound call.
+
+    Stores the audio + data + participant callbacks the loop registers so
+    tests can inject events directly. ``flush_return_audio`` and
+    ``send_return_*`` simply append to lists for assertion."""
+
+    def __init__(self) -> None:
+        self.audio_cb       = None
+        self.data_cb        = None
+        self.participant_cb = None
+        self.return_audio:  list[AudioChunk]  = []
+        self.return_data:   list[DataMessage] = []
+        self.flush_calls:   list[str]         = []
+        self.stopped       = False
+        self.closed        = False
+
+    def on_audio(self, cb)       -> None: self.audio_cb       = cb
+    def on_data(self, cb)        -> None: self.data_cb        = cb
+    def on_participant(self, cb) -> None: self.participant_cb = cb
+    def on_frame(self, cb)       -> None: pass
+
+    async def send_return_audio(self, chunk: AudioChunk) -> None:
+        self.return_audio.append(chunk)
+
+    async def send_return_data(self, msg: DataMessage) -> None:
+        self.return_data.append(msg)
+
+    async def flush_return_audio(self, pid: str) -> None:
+        self.flush_calls.append(pid)
+
+    async def run(self) -> None:  # never called in these tests
+        await asyncio.sleep(0)
+
+    def stop(self)  -> None: self.stopped = True
+    def close(self) -> None: self.closed  = True
+
+
+class _FakeSTT:
+    async def transcribe(self, audio: bytes, **kw: Any) -> str:
+        return ""
+
+    async def health(self) -> bool: return True
+    async def close(self)  -> None: pass
+
+
+class _FakeTTS:
+    """TTS double that records every call and returns a tiny WAV."""
+
+    def __init__(self, sample_rate: int = 22_050) -> None:
+        self.sample_rate = sample_rate
+        self.calls: list[str]               = []
+        self.delays: dict[str, asyncio.Event] = {}  # text → release gate
+
+    async def synthesize(self, text: str, **kw: Any) -> bytes:
+        self.calls.append(text)
+        gate = self.delays.get(text)
+        if gate is not None:
+            await gate.wait()
+        return _silence_wav(self.sample_rate)
+
+    async def health(self) -> bool: return True
+    async def close(self)  -> None: pass
+
+
+def _make_loop(
+    *,
+    on_query,
+    vg_phrases: tuple[str, ...] = (),
+    on_speech_start = None,
+    on_participant_joined = None,
+    on_participant_left   = None,
+    on_stop_extra         = None,
+    text_topic: str = "agent.response",
+    greeting = None,
+) -> tuple[ConversationLoop, _FakeEp, _FakeSTT, _FakeTTS]:
+    ep  = _FakeEp()
+    stt = _FakeSTT()
+    tts = _FakeTTS()
+    loop = ConversationLoop(
+        ep              = ep,        # type: ignore[arg-type]
+        stt             = stt,       # type: ignore[arg-type]
+        tts             = tts,       # type: ignore[arg-type]
+        voice_gate_cfg  = VoiceGateConfig(magic_phrases=vg_phrases),
+        vad_cfg         = VadConfig(),
+        on_query        = on_query,
+        on_speech_start = on_speech_start,
+        on_participant_joined = on_participant_joined,
+        on_participant_left   = on_participant_left,
+        on_stop_extra         = on_stop_extra,
+        text_topic            = text_topic,
+        greeting              = greeting,
+    )
+    return loop, ep, stt, tts
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 1. Construction
+# ════════════════════════════════════════════════════════════════════════════
+
+
+def test_construct_with_minimal_kwargs():
+    """Case 1: ConversationLoop builds with just the required kwargs and
+    registers handlers on the underlying ``ProcessorEndpoint``."""
+
+    async def on_query(pid: str, text: str, fresh_match: bool) -> str:
+        return ""
+
+    loop, ep, _, _ = _make_loop(on_query=on_query)
+    assert ep.audio_cb       is not None
+    assert ep.participant_cb is not None
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 2. str on_query → say
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_dispatch_with_string_result_invokes_on_query_and_speaks():
+    """Case 2: dispatch('hello') invokes on_query and the returned string
+    is synthesized + emitted as return audio + sent on the text topic."""
+    seen: list[tuple[str, str, bool]] = []
+
+    async def on_query(pid: str, text: str, fresh_match: bool) -> str:
+        seen.append((pid, text, fresh_match))
+        return "world."
+
+    loop, ep, _, tts = _make_loop(on_query=on_query, text_topic="my.topic")
+    await loop.dispatch("p1", "hello", pts_us=100)
+
+    # Wait for the dispatched task to finish.
+    vs = loop._voice["p1"]
+    assert vs.current_task is not None
+    await vs.current_task
+
+    assert seen == [("p1", "hello", True)]
+    assert tts.calls == ["world."]
+    assert ep.return_audio                            # audio was emitted
+    assert all(c.participant_id == "p1" for c in ep.return_audio)
+    # Final assembled text goes out on the configured data topic.
+    assert [(m.topic, m.data.decode()) for m in ep.return_data] \
+           == [("my.topic", "world.")]
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 3. streaming on_query → sentence-batched synth + ordered sender
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_dispatch_with_streaming_result_splits_sentences_and_sends_in_order():
+    """Case 3: a streaming on_query yielding 'Hi there. How are you?'
+    must produce two synth calls (one per sentence) and the audio sender
+    consumes them in order, with the data-channel reply carrying the
+    full assembled text."""
+    async def tokens() -> AsyncIterator[str]:
+        for tok in ("Hi", " there", ". ", "How", " are", " you", "?"):
+            yield tok
+
+    async def on_query(pid: str, text: str, fresh_match: bool):
+        return tokens()
+
+    loop, ep, _, tts = _make_loop(on_query=on_query)
+    await loop.dispatch("p1", "anything", pts_us=200)
+    vs = loop._voice["p1"]
+    await vs.current_task
+
+    # Both sentences (without trailing whitespace) were synthesized.
+    assert tts.calls == ["Hi there.", "How are you?"]
+    # Audio was emitted (any non-zero count proves the sender ran).
+    assert len(ep.return_audio) >= 2
+    # Final data-channel reply is the full assembled text, stripped.
+    assert [m.data.decode() for m in ep.return_data] == ["Hi there. How are you?"]
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 4. Interrupt: second dispatch cancels first + flushes + starts new
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_second_dispatch_cancels_in_flight_and_flushes_return_audio():
+    """Case 4: a second ``dispatch`` for the same pid cancels the in-flight
+    task, calls ``flush_return_audio``, and replaces the task. The first
+    on_query is stuck on an Event so the cancellation has work to do."""
+    gate = asyncio.Event()
+
+    async def on_query(pid: str, text: str, fresh_match: bool):
+        if text == "slow":
+            await gate.wait()      # block until released or cancelled
+            return "should not be reached"
+        return "fast reply."
+
+    loop, ep, _, _ = _make_loop(on_query=on_query)
+
+    await loop.dispatch("p1", "slow", pts_us=300)
+    first_task = loop._voice["p1"].current_task
+    assert first_task is not None and not first_task.done()
+
+    # Second dispatch should cancel the first and start a new one.
+    await loop.dispatch("p1", "fast", pts_us=400)
+
+    # First task should be cancelled (or at least done).
+    assert first_task.done()
+    assert first_task.cancelled() or first_task.exception() is None
+
+    # flush_return_audio was called between cancel and the new task.
+    assert "p1" in ep.flush_calls
+
+    # The new task can now complete.
+    second_task = loop._voice["p1"].current_task
+    assert second_task is not first_task
+    await second_task
+
+    # Release the now-cancelled gate so no warnings about pending tasks.
+    gate.set()
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 5. STOP via gate
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_stop_via_gate_cancels_flushes_and_invokes_say_stop_ack():
+    """Case 5: feeding 'stop' to the gate triggers ``_handle_stop`` which
+    cancels the in-flight task, flushes return audio, invokes
+    ``gate.say_stop_ack`` (so the TTS gets a 'Okay, I will stop.' call)
+    and echoes a 'Okay, I will stop.' data message on ``text_topic``.
+    Also exercises the ``on_stop_extra`` hook."""
+    gate = asyncio.Event()
+    stop_extra_calls: list[str] = []
+
+    async def on_query(pid: str, text: str, fresh_match: bool) -> str:
+        await gate.wait()
+        return "never sent"
+
+    async def on_stop_extra(pid: str) -> None:
+        stop_extra_calls.append(pid)
+
+    loop, ep, _, tts = _make_loop(
+        on_query      = on_query,
+        on_stop_extra = on_stop_extra,
+    )
+
+    await loop.dispatch("p1", "anything", pts_us=500)
+    in_flight = loop._voice["p1"].current_task
+    assert in_flight is not None and not in_flight.done()
+
+    # Feed "stop" through the gate — should invoke _handle_stop.
+    await loop._gate.feed("p1", "stop")
+
+    assert in_flight.cancelled() or in_flight.done()
+    # ``flush_return_audio`` is called at least once by the stop path.
+    # (The original dispatch also flushes at the start of every query,
+    # so the exact count is not part of the contract — what matters is
+    # the stop handler issues its own flush before saying the ack.)
+    assert "p1" in ep.flush_calls
+    # say_stop_ack synthesizes "Okay, I will stop." via the TTS.
+    assert "Okay, I will stop." in tts.calls
+    # The data-channel echo lands too.
+    echo_payloads = [m.data.decode() for m in ep.return_data]
+    assert "Okay, I will stop." in echo_payloads
+    assert stop_extra_calls == ["p1"]
+
+    gate.set()
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 6. Participant joined → hook + greeting
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_participant_joined_runs_hook_and_speaks_greeting():
+    """Case 6: a participant-joined event invokes the optional
+    ``on_participant_joined`` hook AND speaks the greeting via TTS."""
+    joins: list[str] = []
+
+    async def on_query(pid: str, text: str, fresh_match: bool) -> str:
+        return ""
+
+    async def on_join(pid: str) -> None:
+        joins.append(pid)
+
+    loop, ep, _, tts = _make_loop(
+        on_query              = on_query,
+        on_participant_joined = on_join,
+    )
+    assert ep.participant_cb is not None
+
+    await ep.participant_cb(ParticipantEvent(participant_id="p1", joined=True, pts_us=0))
+    # The gate.participant_joined call is scheduled as a Task — let it run.
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert joins == ["p1"]
+    # The greeting was synthesized at least once (default text picks up
+    # the gate's format_phrase_help() — None for empty phrases, so the
+    # fallback "Hi, I'm listening. Ask me anything." path is taken).
+    assert any("listening" in c.lower() for c in tts.calls)
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 7. Participant left clears per-pid state
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_participant_left_clears_voice_state_and_invokes_hook():
+    """Case 7: a leave event removes the per-pid VoiceState, cancels any
+    in-flight task for that pid, and fires the optional left-hook."""
+    gate = asyncio.Event()
+    leaves: list[str] = []
+
+    async def on_query(pid: str, text: str, fresh_match: bool) -> str:
+        await gate.wait()
+        return "never"
+
+    async def on_left(pid: str) -> None:
+        leaves.append(pid)
+
+    loop, ep, _, _ = _make_loop(
+        on_query            = on_query,
+        on_participant_left = on_left,
+    )
+
+    await loop.dispatch("p1", "x", pts_us=600)
+    in_flight = loop._voice["p1"].current_task
+    assert in_flight is not None and not in_flight.done()
+
+    await ep.participant_cb(ParticipantEvent(participant_id="p1", joined=False, pts_us=0))
+
+    # Per-pid state is gone.
+    assert "p1" not in loop._voice
+    # In-flight task was cancelled.
+    await asyncio.sleep(0)
+    assert in_flight.cancelled() or in_flight.done()
+    # Hook fired.
+    assert leaves == ["p1"]
+
+    gate.set()
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 8. Custom greeting (string)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_custom_string_greeting_overrides_gate_default():
+    """Case 8: ``greeting='hi there'`` is spoken verbatim, bypassing
+    ``format_phrase_help()``."""
+    async def on_query(pid: str, text: str, fresh_match: bool) -> str:
+        return ""
+
+    loop, ep, _, tts = _make_loop(on_query=on_query, greeting="hi there")
+
+    await ep.participant_cb(ParticipantEvent(participant_id="p1", joined=True, pts_us=0))
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert "hi there" in tts.calls
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 9. Custom greeting (callable)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_custom_callable_greeting_receives_gate():
+    """Case 9: ``greeting=lambda gate: gate.format_phrase_help() or 'fallback'``
+    is invoked with the underlying ``VoiceGate``. With no phrases configured
+    ``format_phrase_help`` returns None, so the fallback wins."""
+
+    async def on_query(pid: str, text: str, fresh_match: bool) -> str:
+        return ""
+
+    def greet(gate: VoiceGate) -> str:
+        return gate.format_phrase_help() or "fallback"
+
+    loop, ep, _, tts = _make_loop(on_query=on_query, greeting=greet)
+
+    await ep.participant_cb(ParticipantEvent(participant_id="p1", joined=True, pts_us=0))
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert "fallback" in tts.calls
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 10. observe_tts_wav is fed by every TTS WAV
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_every_tts_wav_passes_through_observe_tts_wav():
+    """Case 10: each WAV the loop generates is observed by the gate so
+    the lazy listening-chime sample rate can be picked up from the TTS
+    output regardless of which path produced it. We monkeypatch
+    ``gate.observe_tts_wav`` with a counting wrapper and exercise both
+    the str-result path and the streaming-result path."""
+    counts = {"n": 0}
+
+    async def stream_tokens() -> AsyncIterator[str]:
+        for t in ("Streaming", " reply", "."):
+            yield t
+
+    async def on_query(pid: str, text: str, fresh_match: bool):
+        if text == "stream":
+            return stream_tokens()
+        return "string reply."
+
+    loop, ep, _, tts = _make_loop(on_query=on_query)
+
+    original_observe = loop._gate.observe_tts_wav
+    def counting_observe(wav: bytes) -> None:
+        counts["n"] += 1
+        original_observe(wav)
+    loop._gate.observe_tts_wav = counting_observe  # type: ignore[assignment]
+
+    # str path: one synth → one observe.
+    await loop.dispatch("p1", "static", pts_us=700)
+    await loop._voice["p1"].current_task
+    assert counts["n"] == 1
+
+    # streaming path: one sentence → one synth → one observe.
+    await loop.dispatch("p1", "stream", pts_us=800)
+    await loop._voice["p1"].current_task
+    assert counts["n"] == 2
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 11. Gate → on_query passes fresh_match through (regression guard)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_gate_route_propagates_fresh_match_to_on_query():
+    """Case 11: when the gate dispatches case 2 (fresh phrase + payload)
+    the user's ``on_query`` must see ``fresh_match=True``; on case 3
+    (follow-up window continuation) it must see ``fresh_match=False``.
+
+    The data-channel ``dispatch()`` always passes ``True`` because the
+    gate isn't in the loop there. This regression guard catches a bug
+    where the loop dropped the gate's flag and hardcoded ``True`` for
+    every voice-path query."""
+    seen: list[tuple[str, bool]] = []
+
+    async def on_query(pid: str, text: str, fresh_match: bool) -> str:
+        seen.append((text, fresh_match))
+        return ""
+
+    loop, ep, _, _ = _make_loop(on_query=on_query, vg_phrases=("agent",))
+
+    # Case 2: phrase + payload in the same utterance → fresh_match=True.
+    await loop._gate.feed("p1", "agent, what is this")
+    # Drain the dispatch task so the on_query call completes.
+    if loop._voice.get("p1") and loop._voice["p1"].current_task:
+        await loop._voice["p1"].current_task
+
+    # Case 3: phrase-only opens the window; the next utterance is the
+    # continuation and must arrive with fresh_match=False.
+    await loop._gate.feed("p2", "agent")
+    await loop._gate.feed("p2", "what is this")
+    if loop._voice.get("p2") and loop._voice["p2"].current_task:
+        await loop._voice["p2"].current_task
+
+    assert seen == [
+        ("what is this", True),
+        ("what is this", False),
+    ]
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 12. Data-channel dispatch always sets fresh_match=True
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_data_channel_dispatch_sets_fresh_match_true():
+    """Case 12: the public ``dispatch()`` (the data-channel path) bypasses
+    the gate entirely, so ``fresh_match`` must be True — the flag's
+    meaning of "this is a new top-level query" matches that path."""
+    seen: list[bool] = []
+
+    async def on_query(pid: str, text: str, fresh_match: bool) -> str:
+        seen.append(fresh_match)
+        return ""
+
+    loop, _, _, _ = _make_loop(on_query=on_query)
+    await loop.dispatch("p1", "hi", pts_us=900)
+    await loop._voice["p1"].current_task
+
+    assert seen == [True]

--- a/tests/test_xr_ai_voicegate.py
+++ b/tests/test_xr_ai_voicegate.py
@@ -1,0 +1,779 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the xr-ai-voicegate package.
+
+Covers the phrase matcher, STOP regex, lazy chime synthesis, the per-pid
+event ladder in ``VoiceGate.feed`` (STOP / fresh-match / followup /
+phrase-only / drop), and the listening-chime + stop-ack side effects.
+
+Everything is local: a no-op ``AudioSink`` and an in-memory ``TTSLike``
+stub that returns a minimal WAV blob synthesized via the same primitive
+the chime uses. No GPU, no network, no model loads.
+"""
+from __future__ import annotations
+
+import io
+import pathlib
+import wave
+
+import numpy as np
+import pytest
+
+from xr_ai_voicegate import VoiceGate, VoiceGateConfig, load_voice_gate_config
+from xr_ai_voicegate._chime import build_chime_wav, read_wav_sample_rate
+from xr_ai_voicegate._phrases import STOP_RE, build_magic_pattern, strip_magic
+
+
+# ── test doubles ────────────────────────────────────────────────────────────
+
+
+def _silence_wav(sample_rate: int, ms: int = 10) -> bytes:
+    """Return a tiny but well-formed WAV blob at ``sample_rate`` Hz so the
+    chime's ``read_wav_sample_rate`` has something to parse."""
+    n = max(1, int(sample_rate * ms / 1000))
+    pcm = np.zeros(n, dtype=np.int16).tobytes()
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm)
+    return buf.getvalue()
+
+
+class _FakeAudioSink:
+    """No-op audio sink that records every (pid, wav_bytes) it receives."""
+
+    def __init__(self) -> None:
+        self.plays: list[tuple[str, bytes]] = []
+
+    async def play_wav(self, pid: str, wav_bytes: bytes) -> None:
+        self.plays.append((pid, wav_bytes))
+
+
+class _FakeTTS:
+    """TTS double returning a tiny but valid WAV at a configurable rate."""
+
+    def __init__(self, sample_rate: int = 22050) -> None:
+        self.sample_rate     = sample_rate
+        self.synth_calls:    list[str] = []
+        self.raise_on_synth: bool      = False
+
+    async def synthesize(self, text: str) -> bytes:
+        self.synth_calls.append(text)
+        if self.raise_on_synth:
+            raise RuntimeError("tts down")
+        return _silence_wav(self.sample_rate)
+
+
+def _gate(
+    *,
+    phrases:          tuple[str, ...] = (),
+    followup_grace_s: float           = 5.0,
+    listening_chime:  bool            = False,
+    tts_rate:         int             = 22050,
+) -> tuple[VoiceGate, _FakeAudioSink, _FakeTTS]:
+    cfg  = VoiceGateConfig(
+        magic_phrases    = phrases,
+        followup_grace_s = followup_grace_s,
+        listening_chime  = listening_chime,
+    )
+    sink = _FakeAudioSink()
+    tts  = _FakeTTS(sample_rate=tts_rate)
+    return VoiceGate(cfg, audio_sink=sink, tts=tts), sink, tts
+
+
+def _recording_handlers(gate: VoiceGate) -> list[tuple]:
+    """Wire all five handler slots to a single events list and return it.
+
+    ``on_query`` exposes the post-chime-fix signature ``(pid, text, fresh_match)``
+    so tests can assert that case 2 (fresh magic-phrase match) and case 3
+    (follow-up window continuation) are distinguishable."""
+    events: list[tuple] = []
+
+    async def on_query(pid: str, text: str, fresh_match: bool) -> None:
+        events.append(("query", pid, text, fresh_match))
+
+    async def on_stop(pid: str) -> None:
+        events.append(("stop", pid))
+
+    async def on_phrase_only(pid: str) -> None:
+        events.append(("phrase_only", pid))
+
+    async def on_drop(pid: str, text: str) -> None:
+        events.append(("drop", pid, text))
+
+    async def on_join(pid: str) -> None:
+        events.append(("join", pid))
+
+    gate.on_query(on_query)
+    gate.on_stop(on_stop)
+    gate.on_phrase_only(on_phrase_only)
+    gate.on_drop(on_drop)
+    gate.on_participant_joined(on_join)
+    return events
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 1. Phrase matcher (`_phrases.py`)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+def test_phrase_strict_prefix_strip_returns_query_tail():
+    """Case 1: 'agent, what am I looking at?' strips to the query tail."""
+    pat = build_magic_pattern(["agent"])
+    assert strip_magic(pat, "agent, what am I looking at?") == "what am I looking at?"
+
+
+def test_phrase_multi_phrase_both_forms_match():
+    """Case 2: with ['agent', 'hey agent'] both prefixes match and strip."""
+    pat = build_magic_pattern(["agent", "hey agent"])
+    assert strip_magic(pat, "agent, hi")     == "hi"
+    assert strip_magic(pat, "hey agent, hi") == "hi"
+
+
+def test_phrase_case_insensitive_match():
+    """Case 3: STT may upper-case the first letter — must still match."""
+    pat = build_magic_pattern(["hey agent"])
+    assert strip_magic(pat, "Hey Agent, what's up?") == "what's up?"
+
+
+def test_phrase_tolerates_internal_and_trailing_punctuation():
+    """Case 4: 'Hey, agent.' has a comma between words and a period at the
+    end. The matcher must still treat it as the configured 'hey agent'
+    prefix and strip it cleanly."""
+    pat = build_magic_pattern(["hey agent"])
+    stripped = strip_magic(pat, "Hey, agent.")
+    # The configured "hey agent" is matched even with STT punctuation
+    # spliced in; nothing follows so the tail is empty.
+    assert stripped == ""
+
+
+def test_phrase_mid_sentence_does_not_match():
+    """Case 5: strict-prefix only — 'the agent told me ...' must not strip."""
+    pat = build_magic_pattern(["agent"])
+    assert strip_magic(pat, "the agent told me to wait") is None
+
+
+def test_phrase_no_filler_allowance_before_phrase():
+    """Case 6: even one filler word before the phrase ('hello agent') is
+    rejected. Strict prefix means literally first token after whitespace."""
+    pat = build_magic_pattern(["agent"])
+    assert strip_magic(pat, "hello agent") is None
+
+
+def test_phrase_empty_list_yields_none_pattern_and_passthrough_strip():
+    """Case 7: no phrases → ``build_magic_pattern`` returns None; with the
+    None pattern ``strip_magic`` is the identity on the input text."""
+    assert build_magic_pattern([]) is None
+    assert strip_magic(None, "anything goes here") == "anything goes here"
+
+
+def test_phrase_only_utterance_strips_to_empty_string():
+    """Case 8: 'agent' on its own — match succeeds, payload is empty
+    string (NOT None, which means 'no match')."""
+    pat = build_magic_pattern(["agent"])
+    assert strip_magic(pat, "agent") == ""
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 2. STOP regex (`_phrases.STOP_RE`)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.parametrize("text", [
+    "stop",
+    "Stop.",
+    "be quiet",
+    "shut up",
+    "stop talking",
+])
+def test_stop_regex_canonical_forms_match(text: str):
+    """Case 9: all the canonical interruption phrases match."""
+    assert STOP_RE.match(text) is not None
+
+
+def test_stop_regex_suffix_with_too_much_filler_does_not_match():
+    """Case 10 (locked to actual behavior): 'the agent told me to stop'
+    has 4 filler words before 'stop'; the regex allows {0,2} filler
+    words, so this does NOT match.
+
+    The original brief speculated this would match as a "suffix STOP" —
+    the impl says no. We lock the impl's behavior in as the contract."""
+    assert STOP_RE.match("the agent told me to stop") is None
+
+
+def test_stop_regex_mid_sentence_real_question_does_not_match():
+    """Case 11: 'what should we stop doing about climate change' is a
+    genuine question that mentions 'stop' mid-sentence; must not trigger."""
+    assert STOP_RE.match("what should we stop doing about climate change") is None
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 3. Chime synthesis (`_chime.py`)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+def test_chime_24khz_header_shape_and_duration():
+    """Case 12: 24 kHz chime is a parseable mono int16 WAV ~250 ms long."""
+    wav = build_chime_wav(24_000)
+    with wave.open(io.BytesIO(wav), "rb") as wf:
+        assert wf.getframerate()  == 24_000
+        assert wf.getnchannels()  == 1
+        assert wf.getsampwidth()  == 2          # int16 → 2 bytes/sample
+        # 250 ms ± one frame (the chime uses int(sr * 0.25) samples).
+        assert wf.getnframes() == int(24_000 * 0.25)
+
+
+def test_chime_16khz_header_shape_and_duration():
+    """Case 13: same contract at 16 kHz."""
+    wav = build_chime_wav(16_000)
+    with wave.open(io.BytesIO(wav), "rb") as wf:
+        assert wf.getframerate()  == 16_000
+        assert wf.getnchannels()  == 1
+        assert wf.getsampwidth()  == 2
+        assert wf.getnframes() == int(16_000 * 0.25)
+
+
+@pytest.mark.parametrize("sample_rate", [16_000, 24_000])
+def test_chime_read_wav_sample_rate_round_trip(sample_rate: int):
+    """Case 14: ``read_wav_sample_rate`` recovers the rate the chime was
+    built at — round-trip guard for the WAV header parsing path that
+    ``observe_tts_wav`` relies on."""
+    wav = build_chime_wav(sample_rate)
+    assert read_wav_sample_rate(wav) == sample_rate
+
+
+def test_chime_clamp_accepts_upper_bound_192khz():
+    """Case 14 (b): 192 kHz is at the documented upper bound and must
+    still build — the clamp is inclusive on both ends so legitimate
+    high-rate TTS outputs are not rejected."""
+    wav = build_chime_wav(192_000)
+    assert read_wav_sample_rate(wav) == 192_000
+
+
+def test_chime_clamp_rejects_just_above_upper_bound():
+    """Case 14 (c): one Hz past the upper bound raises ValueError. Guards
+    against a hostile or corrupted WAV header that declares a multi-GHz
+    rate from driving a multi-GB ``np.linspace`` allocation."""
+    with pytest.raises(ValueError):
+        build_chime_wav(192_001)
+
+
+@pytest.mark.asyncio
+async def test_observe_tts_wav_with_out_of_range_rate_disables_chime_without_crash():
+    """Case 14 (d): a malicious or corrupted TTS WAV declaring an
+    absurdly high sample rate (here 1 GHz, the kind of value an attacker
+    might splice into a uint32 header) must not crash the gate. The
+    chime caller swallows the ValueError, logs "sample rate out of
+    range", and disables the chime so subsequent ``play_chime`` calls
+    are no-ops.
+
+    1 GHz is comfortably above the 192 kHz clamp but stays under the
+    uint32-byterate limit Python's ``wave`` module enforces on the WAV
+    header, so the malformed blob is round-trip parseable and the
+    failure happens inside ``build_chime_wav`` exactly where the clamp
+    is meant to fire."""
+    gate, sink, _ = _gate(phrases=("agent",), listening_chime=True)
+
+    # _silence_wav uses int16 PCM so the 1-frame buffer is 2 bytes
+    # regardless of the (fictitious) sample rate stored in the header.
+    bad_wav = _silence_wav(1_000_000_000, ms=0)
+
+    gate.observe_tts_wav(bad_wav)        # must not raise
+    await gate.play_chime("p1")          # must not crash, must not emit
+
+    assert gate._chime_wav is None
+    assert gate._chime_enabled is False
+    assert sink.plays == []
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 4. Event ladder (`gate.feed`)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_feed_no_phrases_passes_every_utterance_through_to_on_query():
+    """Case 15: with ``magic_phrases=()`` the gate is in always-on mode —
+    every non-STOP utterance dispatches to ``on_query`` with
+    ``fresh_match=True``. Matches the original simple-vlm-example
+    behavior the gate was extracted from, and what ``VoiceGateConfig``'s
+    docstring promises ("empty tuple disables the gate so every STT
+    transcript is dispatched")."""
+    gate, _, _ = _gate(phrases=())
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "what am I looking at")
+    await gate.feed("p1", "tell me about this")
+
+    assert events == [
+        ("query", "p1", "what am I looking at", True),
+        ("query", "p1", "tell me about this", True),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_feed_no_phrases_stop_still_routes_to_on_stop():
+    """Case 15 (b): even in always-on mode, the STOP regex must still
+    fire ``on_stop`` so an interrupt works without a wake word."""
+    gate, _, _ = _gate(phrases=())
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "stop")
+
+    assert events == [("stop", "p1")]
+
+
+@pytest.mark.asyncio
+async def test_feed_raw_stop_fires_on_stop():
+    """Case 16: with phrases configured, the raw word 'stop' bypasses the
+    magic-phrase requirement and fires on_stop."""
+    gate, _, _ = _gate(phrases=("agent",))
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "stop")
+
+    assert events == [("stop", "p1")]
+
+
+@pytest.mark.asyncio
+async def test_feed_magic_phrase_with_query_fires_on_query_with_fresh_match_true():
+    """Case 17: 'agent, what is this?' → on_query(pid, 'what is this?', fresh_match=True).
+
+    ``fresh_match=True`` is the signal consumers use to drive one-shot
+    side effects like the listening chime that should fire on case 2 but
+    not on case 3 (the followup-window continuation)."""
+    gate, _, _ = _gate(phrases=("agent",))
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "agent, what is this?")
+
+    assert events == [("query", "p1", "what is this?", True)]
+
+
+@pytest.mark.asyncio
+async def test_feed_no_phrase_and_no_followup_fires_on_drop():
+    """Case 18: with phrases configured but no magic phrase in the
+    transcript and no open followup window, the gate drops the utterance."""
+    gate, _, _ = _gate(phrases=("agent",))
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "what am I looking at")
+
+    assert events == [("drop", "p1", "what am I looking at")]
+
+
+@pytest.mark.asyncio
+async def test_feed_phrase_only_opens_followup_window_and_dispatches_with_fresh_match_false():
+    """Case 19: bare 'agent' fires on_phrase_only; the next utterance
+    within the followup grace fires on_query with the raw text AND
+    ``fresh_match=False`` so consumers can suppress the chime on the
+    continuation (the chime already played when phrase-only opened the
+    window — repeating it on the dispatch would be a double chime)."""
+    gate, _, _ = _gate(phrases=("agent",), followup_grace_s=5.0)
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "agent")
+    await gate.feed("p1", "what am I looking at")
+
+    assert events == [
+        ("phrase_only", "p1"),
+        ("query", "p1", "what am I looking at", False),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_feed_followup_window_closes_after_one_dispatch():
+    """Case 20: each dispatch (fresh-match or followup-accepted) closes
+    the window; subsequent utterances must reintroduce a magic phrase."""
+    gate, _, _ = _gate(phrases=("agent",), followup_grace_s=5.0)
+    events = _recording_handlers(gate)
+
+    # Followup path: opens window, then next utterance consumes it.
+    await gate.feed("p1", "agent")
+    await gate.feed("p1", "what am I looking at")
+    # Window is now closed — this third utterance must drop.
+    await gate.feed("p1", "and another question")
+
+    assert events == [
+        ("phrase_only", "p1"),
+        ("query", "p1", "what am I looking at", False),
+        ("drop", "p1", "and another question"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_feed_fresh_match_with_payload_closes_window_too():
+    """Case 20 (b): a fresh-match dispatch ALSO closes the window so
+    ambient speech after the answer doesn't ride a stale followup."""
+    gate, _, _ = _gate(phrases=("agent",), followup_grace_s=5.0)
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "agent, what is this")
+    await gate.feed("p1", "and another question")
+
+    assert events == [
+        ("query", "p1", "what is this", True),
+        ("drop", "p1", "and another question"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_feed_followup_window_expires_after_grace(monkeypatch):
+    """Case 21: once ``followup_grace_s`` seconds elapse, the window is
+    closed; the next utterance drops instead of dispatching."""
+    gate, _, _ = _gate(phrases=("agent",), followup_grace_s=2.0)
+    events = _recording_handlers(gate)
+
+    # Drive ``time.monotonic`` by hand so the test is deterministic and
+    # doesn't sleep. Patch the symbol on the ``gate`` module — that's
+    # where the lookup happens.
+    from xr_ai_voicegate import gate as gate_module
+
+    fake_now = [1000.0]
+    monkeypatch.setattr(gate_module.time, "monotonic", lambda: fake_now[0])
+
+    await gate.feed("p1", "agent")          # opens window until t=1002
+    fake_now[0] = 1002.5                    # 0.5s past the grace deadline
+    await gate.feed("p1", "what is this")   # window expired → must drop
+
+    assert events == [
+        ("phrase_only", "p1"),
+        ("drop", "p1", "what is this"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_feed_stop_wins_over_open_followup_window():
+    """Case 22: 'stop' inside an open followup window must NOT be treated
+    as a followup query — STOP_RE check sits above the followup branch."""
+    gate, _, _ = _gate(phrases=("agent",), followup_grace_s=5.0)
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "agent")  # opens window
+    await gate.feed("p1", "stop")   # must fire on_stop, NOT on_query
+
+    assert events == [
+        ("phrase_only", "p1"),
+        ("stop", "p1"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_feed_stop_matched_on_magic_stripped_tail():
+    """Case 23: 'hey agent stop' — the gate strips the magic prefix to
+    'stop' and the STOP regex matches the tail. on_stop fires."""
+    gate, _, _ = _gate(phrases=("hey agent",))
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "hey agent stop")
+
+    assert events == [("stop", "p1")]
+
+
+@pytest.mark.asyncio
+async def test_feed_fresh_match_flag_distinguishes_case_2_from_case_3():
+    """Regression guard for the chime fix at 665faaf — case 2 (fresh
+    magic-phrase + payload) must dispatch with ``fresh_match=True`` and
+    case 3 (followup window continuation) must dispatch with
+    ``fresh_match=False``. The original extraction collapsed both onto
+    a single ``on_query(pid, text)`` signature so the consumer chimed
+    twice per question; the flag is the contract that keeps the
+    listening-chime side effect one-shot."""
+    gate, _, _ = _gate(phrases=("agent",), followup_grace_s=5.0)
+    events = _recording_handlers(gate)
+
+    # Case 2: phrase + payload in the same utterance.
+    await gate.feed("p1", "agent, what is this")
+    # Case 3: phrase-only opens window, next utterance is the continuation.
+    await gate.feed("p2", "agent")
+    await gate.feed("p2", "what is this")
+
+    assert events == [
+        ("query",       "p1", "what is this", True),
+        ("phrase_only", "p2"),
+        ("query",       "p2", "what is this", False),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_feed_forget_clears_followup_window_for_pid():
+    """Case 24: forget(pid) drops the open followup; the next utterance
+    from that pid must be re-gated."""
+    gate, _, _ = _gate(phrases=("agent",), followup_grace_s=5.0)
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "agent")
+    gate.forget("p1")
+    await gate.feed("p1", "what is this")
+
+    assert events == [
+        ("phrase_only", "p1"),
+        ("drop", "p1", "what is this"),
+    ]
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 5. Chime lifecycle
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_play_chime_before_tts_observed_is_noop_not_crash():
+    """Case 25: chime is built lazily after the first TTS WAV is observed.
+    Calling play_chime before that point logs and returns — does not
+    crash and does not push anything onto the audio sink."""
+    gate, sink, _ = _gate(phrases=("agent",), listening_chime=True)
+
+    await gate.play_chime("p1")
+
+    assert sink.plays == []
+
+
+@pytest.mark.asyncio
+async def test_play_chime_after_observe_tts_wav_emits_built_chime():
+    """Case 26: once a TTS WAV is observed, the chime is built at that
+    sample rate and subsequent play_chime calls push the WAV bytes to
+    the audio sink at the matching rate."""
+    gate, sink, _ = _gate(phrases=("agent",), listening_chime=True)
+
+    gate.observe_tts_wav(_silence_wav(22_050))
+    await gate.play_chime("p1")
+
+    assert len(sink.plays) == 1
+    pid, wav = sink.plays[0]
+    assert pid == "p1"
+    assert read_wav_sample_rate(wav) == 22_050
+
+
+@pytest.mark.asyncio
+async def test_play_chime_disabled_when_listening_chime_false():
+    """Case 27: listening_chime=False disables the chime even after a TTS
+    WAV is observed."""
+    gate, sink, _ = _gate(phrases=("agent",), listening_chime=False)
+
+    gate.observe_tts_wav(_silence_wav(22_050))
+    await gate.play_chime("p1")
+
+    assert sink.plays == []
+
+
+@pytest.mark.asyncio
+async def test_play_chime_disabled_when_no_magic_phrases_configured():
+    """Case 27 (b): even with listening_chime=True, an empty phrase list
+    disables the chime — the chime is meant to ride a fresh-match event,
+    and there are no fresh-matches without phrases."""
+    gate, sink, _ = _gate(phrases=(), listening_chime=True)
+
+    gate.observe_tts_wav(_silence_wav(22_050))
+    await gate.play_chime("p1")
+
+    assert sink.plays == []
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 6. Greeting + stop ack
+# ════════════════════════════════════════════════════════════════════════════
+
+
+def test_format_phrase_help_returns_none_with_no_phrases():
+    """Case 28: no phrases → no help string (caller picks generic greeting)."""
+    gate, _, _ = _gate(phrases=())
+    assert gate.format_phrase_help() is None
+
+
+def test_format_phrase_help_one_phrase():
+    """Case 29: single-phrase form."""
+    gate, _, _ = _gate(phrases=("agent",))
+    assert gate.format_phrase_help() == (
+        'To talk to me, start your question with "agent". '
+        'For example, "agent, what am I looking at?"'
+    )
+
+
+def test_format_phrase_help_two_phrases():
+    """Case 30: two-phrase form uses 'or', not a comma."""
+    gate, _, _ = _gate(phrases=("agent", "hey agent"))
+    assert gate.format_phrase_help() == (
+        'To talk to me, start your question with "agent" or "hey agent". '
+        'For example, "agent, what am I looking at?"'
+    )
+
+
+def test_format_phrase_help_three_phrases():
+    """Case 31: three-or-more form uses commas with a final ', or'."""
+    gate, _, _ = _gate(phrases=("a", "b", "c"))
+    assert gate.format_phrase_help() == (
+        'To talk to me, start your question with "a", "b", or "c". '
+        'For example, "a, what am I looking at?"'
+    )
+
+
+@pytest.mark.asyncio
+async def test_say_stop_ack_synthesizes_observes_and_plays():
+    """Case 32: say_stop_ack runs the full three-step flow —
+    tts.synthesize → observe_tts_wav (so the chime can build) → audio_sink.play_wav."""
+    gate, sink, tts = _gate(phrases=("agent",), listening_chime=True, tts_rate=22_050)
+
+    await gate.say_stop_ack("p1")
+
+    # 1. TTS was called with the canned ack text.
+    assert tts.synth_calls == ["Okay, I will stop."]
+    # 2. The same WAV the TTS returned was pushed to the audio sink.
+    assert len(sink.plays) == 1
+    ack_pid, ack_wav = sink.plays[0]
+    assert ack_pid == "p1"
+    assert read_wav_sample_rate(ack_wav) == 22_050
+    # 3. observe_tts_wav was called as part of the flow — confirm by
+    #    playing the chime now and asserting it lands at the right rate.
+    await gate.play_chime("p1")
+    assert len(sink.plays) == 2
+    _, chime_wav = sink.plays[1]
+    assert read_wav_sample_rate(chime_wav) == 22_050
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 7. Handler exception swallowing
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_handler_exceptions_are_swallowed_and_gate_keeps_working():
+    """Case 33: when on_query raises, the gate logs and continues —
+    subsequent feed() calls still dispatch normally."""
+    gate, _, _ = _gate(phrases=("agent",))
+
+    calls: list[str] = []
+
+    async def flaky_on_query(pid: str, text: str, fresh_match: bool) -> None:
+        calls.append(text)
+        if text == "boom":
+            raise RuntimeError("handler exploded")
+
+    gate.on_query(flaky_on_query)
+
+    # First call raises inside the handler — must not propagate.
+    await gate.feed("p1", "agent, boom")
+    # Second call still works — gate state is intact.
+    await gate.feed("p1", "agent, second time")
+
+    assert calls == ["boom", "second time"]
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 8. YAML loader (`load_voice_gate_config`)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+def test_load_voice_gate_config_full_file(tmp_path: pathlib.Path):
+    """Case 34: a populated file parses into a VoiceGateConfig with every
+    field set as written."""
+    p = tmp_path / "voice_gate.yaml"
+    p.write_text(
+        "magic_phrases:\n"
+        '  - "agent"\n'
+        '  - "hey agent"\n'
+        "listening_chime:  true\n"
+        "followup_grace_s: 7.5\n"
+    )
+    cfg = load_voice_gate_config(p)
+    assert cfg == VoiceGateConfig(
+        magic_phrases    = ("agent", "hey agent"),
+        followup_grace_s = 7.5,
+        listening_chime  = True,
+    )
+
+
+def test_load_voice_gate_config_missing_file_returns_defaults(tmp_path: pathlib.Path):
+    """Case 35: a path that does not exist degrades to the dataclass
+    defaults (always-on, no chime, 5 s follow-up grace) — same behavior
+    the inline-block parser had for an absent block."""
+    assert load_voice_gate_config(tmp_path / "nope.yaml") == VoiceGateConfig()
+
+
+def test_load_voice_gate_config_empty_file_returns_defaults(tmp_path: pathlib.Path):
+    """Case 36: an empty file (``yaml.safe_load`` → None) degrades to
+    defaults, matching the ``raw or {}`` normalization."""
+    p = tmp_path / "empty.yaml"
+    p.write_text("")
+    assert load_voice_gate_config(p) == VoiceGateConfig()
+
+
+def test_load_voice_gate_config_bare_string_phrase_normalizes(tmp_path: pathlib.Path):
+    """Case 37: ``magic_phrases: agent`` (bare string, not a list) is
+    normalized to a single-element tuple, matching the inline parser."""
+    p = tmp_path / "voice_gate.yaml"
+    p.write_text("magic_phrases: agent\n")
+    cfg = load_voice_gate_config(p)
+    assert cfg.magic_phrases == ("agent",)
+
+
+def test_load_voice_gate_config_null_phrases_normalizes_to_empty(tmp_path: pathlib.Path):
+    """Case 38: ``magic_phrases: null`` (or omitted) is normalized to an
+    empty tuple — the gate's always-on mode."""
+    p = tmp_path / "voice_gate.yaml"
+    p.write_text("magic_phrases: null\nfollowup_grace_s: 3.0\n")
+    cfg = load_voice_gate_config(p)
+    assert cfg.magic_phrases == ()
+    assert cfg.followup_grace_s == 3.0
+
+
+def test_load_voice_gate_config_strips_whitespace_and_drops_empty(tmp_path: pathlib.Path):
+    """Case 39: phrase entries are stripped, and empty entries (after
+    strip) are dropped — same normalization the inline parser ran."""
+    p = tmp_path / "voice_gate.yaml"
+    p.write_text(
+        "magic_phrases:\n"
+        '  - "  agent  "\n'
+        '  - ""\n'
+        '  - "hey agent"\n'
+    )
+    cfg = load_voice_gate_config(p)
+    assert cfg.magic_phrases == ("agent", "hey agent")
+
+
+def test_load_voice_gate_config_rejects_non_mapping_top_level(tmp_path: pathlib.Path):
+    """Case 40: a top-level list (or any non-mapping) raises ValueError —
+    catches typo'd files that would otherwise silently degrade."""
+    p = tmp_path / "voice_gate.yaml"
+    p.write_text("- agent\n- hey agent\n")
+    with pytest.raises(ValueError):
+        load_voice_gate_config(p)
+
+
+# ── Round-trip checks against the in-tree sample voice_gate.yaml files ──────
+#
+# Skipped when the tests are run from an environment where the agent-samples
+# tree isn't reachable on disk (e.g. a published wheel install). When reachable,
+# these guard against accidental drift between the loader's accepted schema
+# and the YAML the samples actually ship.
+
+
+def _repo_root() -> pathlib.Path:
+    return pathlib.Path(__file__).resolve().parents[1]
+
+
+def test_load_voice_gate_config_simple_vlm_sample_round_trip():
+    """Case 41: the simple-vlm-example sample ships with the wake-word
+    config — confirm the file parses and exposes the documented phrases."""
+    p = _repo_root() / "agent-samples" / "simple-vlm-example" / "yaml" / "voice_gate.yaml"
+    if not p.exists():
+        pytest.skip(f"sample voice_gate.yaml not reachable at {p}")
+    cfg = load_voice_gate_config(p)
+    assert cfg.magic_phrases    == ("agent", "hey agent")
+    assert cfg.listening_chime  is False
+    assert cfg.followup_grace_s == 5.0
+
+
+def test_load_voice_gate_config_xr_render_demo_sample_round_trip():
+    """Case 42: the xr-render-demo sample ships with the empty-list
+    default (always-on) — confirm the file parses to defaults."""
+    p = _repo_root() / "agent-samples" / "xr-render-demo" / "yaml" / "voice_gate.yaml"
+    if not p.exists():
+        pytest.skip(f"sample voice_gate.yaml not reachable at {p}")
+    cfg = load_voice_gate_config(p)
+    assert cfg.magic_phrases    == ()
+    assert cfg.listening_chime  is False
+    assert cfg.followup_grace_s == 5.0

--- a/utils/xr-ai-voicegate/pyproject.toml
+++ b/utils/xr-ai-voicegate/pyproject.toml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "xr-ai-voicegate"
+version = "0.1.0"
+requires-python = ">=3.11,<3.13"
+# Speech-only opt-in gate shared by agent workers that ingest microphone
+# audio.  Owns the magic-phrase + follow-up + STOP ladder, the lazy
+# listening chime, and the participant-joined greeting hook so each
+# worker only wires handlers and feeds STT transcripts.  numpy is used
+# for the chime tone synthesis; pyyaml parses the standalone
+# voice_gate.yaml file referenced from each worker YAML.
+dependencies = [
+    "numpy>=1.24",
+    "pyyaml>=6.0",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["xr_ai_voicegate"]

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/__init__.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public surface of the xr-ai-voicegate package."""
+from __future__ import annotations
+
+from .config import AudioSink, TTSLike, VoiceGateConfig, load_voice_gate_config
+from .gate import VoiceGate
+
+__all__ = [
+    "AudioSink",
+    "TTSLike",
+    "VoiceGate",
+    "VoiceGateConfig",
+    "load_voice_gate_config",
+]

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/_chime.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/_chime.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Listening-chime synthesis and WAV header parsing for the voice gate."""
+from __future__ import annotations
+
+import io
+import wave
+
+import numpy as np
+
+
+def build_chime_wav(sample_rate: int) -> bytes:
+    """Synthesize the listening-chime as a self-contained WAV blob.
+
+    Two-tone perfect-fifth ding (880 + 1320 Hz) with exponential decay,
+    ~250 ms total, mono int16 PCM. ``sample_rate`` MUST match the rate
+    of the return audio track the consumer plays into (e.g. TTS sample
+    rate) so the underlying transport doesn't reject frames at a
+    different rate.
+
+    Clamped to a sane audio range. A WAV header is uint32 and a hostile
+    or corrupted blob can claim a multi-GHz rate, which would drive
+    ``np.linspace`` into a multi-GB allocation. Reject outside [8 kHz,
+    192 kHz] — the chime caller (``observe_tts_wav``) treats ValueError
+    as "disable the chime", so the worst case is no chime.
+    """
+    if not 8000 <= sample_rate <= 192000:
+        raise ValueError(f"unsupported chime sample rate: {sample_rate}")
+    dur  = 0.25
+    t    = np.linspace(0.0, dur, int(sample_rate * dur), endpoint=False, dtype=np.float32)
+    tone = 0.55 * np.sin(2 * np.pi * 880.0 * t) + 0.30 * np.sin(2 * np.pi * 1320.0 * t)
+    env  = np.exp(-t * 8.0).astype(np.float32)
+    pcm  = (tone * env * 0.5 * 32767.0).clip(-32768, 32767).astype(np.int16)
+
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm.tobytes())
+    return buf.getvalue()
+
+
+def read_wav_sample_rate(wav_bytes: bytes) -> int:
+    """Pull the sample rate from a WAV blob without decoding the audio."""
+    with wave.open(io.BytesIO(wav_bytes), "rb") as wf:
+        return wf.getframerate()

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/_phrases.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/_phrases.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Magic-phrase and STOP pattern matching for the voice gate."""
+from __future__ import annotations
+
+import re
+from typing import Sequence
+
+
+# Transcripts matching this pattern bypass the magic-phrase gate so the
+# user can interrupt a response mid-flight without having to start with
+# the configured phrase.
+STOP_RE: re.Pattern = re.compile(
+    r'^\s*(?:\S+\s+){0,2}'               # up to 2 optional filler words
+    r'(?:stop(?:\s+\w+){0,2}|be\s+quiet|quiet|shut\s+up)'
+    r'\s*[.!?]?\s*$',
+    re.IGNORECASE,
+)
+
+
+def build_magic_pattern(phrases: Sequence[str]) -> re.Pattern | None:
+    """Compile one strict-prefix regex covering every configured phrase.
+
+    Longest-first ordering picks the most specific match when one phrase
+    is a prefix of another (e.g. "agent" vs "agent buddy"). Inside each
+    phrase, the literal space between words is treated as "whitespace OR
+    punctuation" so STT transcripts like "Hey, agent." still match the
+    configured "hey agent". Returns ``None`` when ``phrases`` is empty
+    so the gate degrades to always-on.
+    """
+    cleaned = tuple(p.strip().lower() for p in phrases if p and p.strip())
+    if not cleaned:
+        return None
+    sep = r'[\s,.:;!?-]+'
+    alts = "|".join(
+        sep.join(re.escape(w) for w in p.split())
+        for p in sorted(cleaned, key=len, reverse=True)
+    )
+    return re.compile(rf'^\s*(?:{alts})\b[\s,.:;!?-]*', re.IGNORECASE)
+
+
+def strip_magic(pattern: re.Pattern | None, text: str) -> str | None:
+    """Return the transcript with the matched phrase stripped, or ``None``
+    when no phrase is the strict prefix. With ``pattern is None`` the gate
+    is disabled and ``text`` is returned unchanged."""
+    if pattern is None:
+        return text
+    m = pattern.match(text)
+    return None if m is None else text[m.end():]

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/config.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/config.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration dataclass, YAML loader, and consumer-facing Protocols
+for the voice gate."""
+from __future__ import annotations
+
+import pathlib
+from dataclasses import dataclass
+from typing import Protocol
+
+import yaml
+
+
+@dataclass(frozen=True)
+class VoiceGateConfig:
+    """Voice-gate behaviour knobs.
+
+    ``magic_phrases``    — strict-prefix opt-in words; empty tuple disables
+                           the gate so every STT transcript is dispatched.
+    ``followup_grace_s`` — seconds after a phrase match during which the
+                           next utterance from the same participant
+                           bypasses the gate.
+    ``listening_chime``  — when true AND ``magic_phrases`` is non-empty,
+                           a short two-tone chime plays on the consumer's
+                           audio sink whenever the worker invokes
+                           ``VoiceGate.play_chime``.
+    """
+    magic_phrases:    tuple[str, ...] = ()
+    followup_grace_s: float           = 5.0
+    listening_chime:  bool            = False
+
+
+def load_voice_gate_config(path: pathlib.Path) -> VoiceGateConfig:
+    """Load + parse a voice_gate YAML file into a :class:`VoiceGateConfig`.
+
+    Schema: a top-level mapping with keys ``magic_phrases`` (list[str] or
+    bare str), ``listening_chime`` (bool), ``followup_grace_s`` (float).
+    Missing file or empty file → returns the dataclass defaults (gate
+    disabled / always-on). ``magic_phrases: null`` and trailing whitespace
+    in phrases are normalized the same way the inline-block parser did.
+    """
+    if not path.exists():
+        return VoiceGateConfig()
+    raw = yaml.safe_load(path.read_text()) or {}
+    if not isinstance(raw, dict):
+        raise ValueError(f"{path}: top-level must be a mapping")
+
+    phrases_raw = raw.get("magic_phrases") or []
+    if isinstance(phrases_raw, str):
+        phrases_raw = [phrases_raw]
+    phrases = tuple(p for p in (s.strip() for s in phrases_raw) if p)
+
+    return VoiceGateConfig(
+        magic_phrases    = phrases,
+        followup_grace_s = float(raw.get("followup_grace_s", 5.0)),
+        listening_chime  = bool(raw.get("listening_chime", False)),
+    )
+
+
+class AudioSink(Protocol):
+    """Consumer-supplied return-audio writer."""
+
+    async def play_wav(self, pid: str, wav_bytes: bytes) -> None: ...
+
+
+class TTSLike(Protocol):
+    """Duck-typed text-to-speech client used for ``say_stop_ack``."""
+
+    async def synthesize(self, text: str) -> bytes: ...

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/gate.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/gate.py
@@ -1,0 +1,272 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Speech-only opt-in gate shared by agent workers.
+
+Owns the magic-phrase + follow-up + STOP ladder, the lazy listening
+chime, and the participant-joined greeting hook. Workers feed STT
+transcripts via ``feed`` and register handlers for the events the gate
+emits (query, stop, phrase-only, drop, participant-joined).
+
+The gate does NOT serialize calls per-pid. Consumers are expected to
+gate concurrency themselves (e.g. a per-pid ``transcribing`` flag while
+STT is in flight) so two utterances from the same participant don't
+race through ``feed`` at the same time.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from typing import Awaitable, Callable
+
+from ._chime import build_chime_wav, read_wav_sample_rate
+from ._phrases import STOP_RE, build_magic_pattern, strip_magic
+from .config import AudioSink, TTSLike, VoiceGateConfig
+
+
+logger = logging.getLogger("xr_ai_voicegate")
+
+
+QueryHandler             = Callable[[str, str, bool], Awaitable[None]]   # (pid, query, fresh_match)
+StopHandler              = Callable[[str], Awaitable[None]]
+PhraseOnlyHandler        = Callable[[str], Awaitable[None]]
+DropHandler              = Callable[[str, str], Awaitable[None]]
+ParticipantJoinedHandler = Callable[[str], Awaitable[None]]
+
+
+class VoiceGate:
+    """Speech-input gating state machine.
+
+    Event ladder in ``feed`` — exactly one event fires per call, in this
+    deterministic priority order:
+
+    1. STOP detected on raw text OR on the magic-phrase-stripped tail
+       → ``on_stop(pid)``; closes the follow-up window.
+    2. Magic phrase matched AND query non-empty
+       → ``on_query(pid, query, fresh_match=True)``; closes the follow-up
+       window.
+    3. Follow-up window still open (and not STOP)
+       → ``on_query(pid, raw_text, fresh_match=False)``; closes the
+       follow-up window. ``fresh_match`` distinguishes this continuation
+       from case 2 so consumers can suppress one-shot side effects
+       (e.g. the listening chime) on the follow-up dispatch.
+    4. Magic phrase matched AND query empty
+       → ``on_phrase_only(pid)``; opens the follow-up window.
+    5. Otherwise → ``on_drop(pid, raw_text)``; closes the window
+       defensively.
+
+    When ``magic_phrases`` is empty the gate is in always-on mode: STOP
+    still wins (interrupts must work without a phrase) and every other
+    utterance dispatches straight to ``on_query`` with
+    ``fresh_match=True``. The follow-up / phrase-only / drop branches
+    are inert in this mode — they only make sense once a phrase exists
+    to gate against.
+
+    Handler exceptions are logged and swallowed so one bad handler does
+    not kill the gate.
+    """
+
+    def __init__(
+        self,
+        cfg: VoiceGateConfig,
+        *,
+        audio_sink: AudioSink,
+        tts: TTSLike,
+    ) -> None:
+        self._cfg          = cfg
+        self._audio_sink   = audio_sink
+        self._tts          = tts
+        self._magic_re     = build_magic_pattern(cfg.magic_phrases)
+        # Without a phrase the chime would have no fresh-match event to
+        # ride; mirror the original simple-vlm-example wiring rather than
+        # firing on every utterance.
+        self._chime_enabled: bool = bool(cfg.listening_chime) and self._magic_re is not None
+        self._chime_wav: bytes | None = None
+        self._followup_until: dict[str, float] = {}
+
+        self._on_query_h:               QueryHandler | None             = None
+        self._on_stop_h:                StopHandler | None              = None
+        self._on_phrase_only_h:         PhraseOnlyHandler | None        = None
+        self._on_drop_h:                DropHandler | None              = None
+        self._on_participant_joined_h:  ParticipantJoinedHandler | None = None
+
+    # ── handler registration ──────────────────────────────────────────────────
+
+    def on_query(self, h: QueryHandler) -> None:
+        self._on_query_h = h
+
+    def on_stop(self, h: StopHandler) -> None:
+        self._on_stop_h = h
+
+    def on_phrase_only(self, h: PhraseOnlyHandler) -> None:
+        self._on_phrase_only_h = h
+
+    def on_drop(self, h: DropHandler) -> None:
+        self._on_drop_h = h
+
+    def on_participant_joined(self, h: ParticipantJoinedHandler) -> None:
+        self._on_participant_joined_h = h
+
+    # ── per-participant lifecycle ─────────────────────────────────────────────
+
+    async def participant_joined(self, pid: str) -> None:
+        await self._invoke(self._on_participant_joined_h, "on_participant_joined", pid)
+
+    def forget(self, pid: str) -> None:
+        self._followup_until.pop(pid, None)
+
+    # ── event ladder ──────────────────────────────────────────────────────────
+
+    async def feed(self, pid: str, text: str) -> None:
+        # Always-on mode: no phrases configured, so the magic-phrase /
+        # follow-up / phrase-only / drop branches don't apply. STOP still
+        # wins (interrupts must work even without a phrase), and every
+        # other utterance is a fresh query.
+        if self._magic_re is None:
+            if STOP_RE.match(text):
+                logger.info("stop bypass pid=%r (text suppressed)", pid)
+                logger.debug("stop bypass pid=%r %r", pid, text[:80])
+                await self._invoke(self._on_stop_h, "on_stop", pid)
+                return
+            logger.info("audio query pid=%r (text suppressed)", pid)
+            logger.debug("audio query pid=%r %r", pid, text[:80])
+            await self._invoke(self._on_query_h, "on_query", pid, text, True)
+            return
+
+        now_mono       = time.monotonic()
+        in_followup    = self._followup_until.get(pid, 0.0) > now_mono
+        stripped       = strip_magic(self._magic_re, text)
+        matched_magic  = stripped is not None
+        stop_candidate = stripped if (matched_magic and stripped) else text
+
+        # 1. STOP — always wins. Matched on both the raw transcript
+        #    ("stop") AND on the magic-phrase-stripped tail ("hey agent,
+        #    stop") so the fast path triggers either way.
+        if STOP_RE.match(stop_candidate):
+            logger.info("stop bypass pid=%r (text suppressed)", pid)
+            logger.debug("stop bypass pid=%r %r", pid, stop_candidate[:80])
+            self._followup_until.pop(pid, None)
+            await self._invoke(self._on_stop_h, "on_stop", pid)
+            return
+
+        if matched_magic:
+            query = stripped or ""
+            if query:
+                # 2. Fresh magic-phrase match with a payload — dispatch
+                #    immediately and close the window so ambient speech
+                #    after the answer must re-introduce a phrase.
+                self._followup_until.pop(pid, None)
+                logger.info("audio query pid=%r (text suppressed)", pid)
+                logger.debug("audio query pid=%r %r", pid, query[:80])
+                await self._invoke(self._on_query_h, "on_query", pid, query, True)
+                return
+            # 4. Magic phrase with no follow-up payload — open the window
+            #    so the user's next utterance counts as the actual query.
+            self._followup_until[pid] = now_mono + self._cfg.followup_grace_s
+            logger.info(
+                "magic phrase only pid=%r — awaiting followup (%.1fs)",
+                pid, self._cfg.followup_grace_s,
+            )
+            await self._invoke(self._on_phrase_only_h, "on_phrase_only", pid)
+            return
+
+        if in_followup:
+            # 3. Followup continuation — dispatch raw text and close the
+            #    window. Refreshing it on accept happens implicitly: the
+            #    consumer can decide to re-open by calling back via a
+            #    fresh magic-phrase match.
+            self._followup_until.pop(pid, None)
+            logger.info("followup query pid=%r (text suppressed)", pid)
+            logger.debug("followup query pid=%r %r", pid, text[:80])
+            await self._invoke(self._on_query_h, "on_query", pid, text, False)
+            return
+
+        # 5. Default drop — log and close the window defensively.
+        logger.info("drop pid=%r (text suppressed)", pid)
+        logger.debug("drop pid=%r %r", pid, text[:80])
+        self._followup_until.pop(pid, None)
+        await self._invoke(self._on_drop_h, "on_drop", pid, text)
+
+    # ── worker-callable side effects ──────────────────────────────────────────
+
+    async def play_chime(self, pid: str) -> None:
+        """Emit the listening chime on the consumer's audio sink.
+
+        No-op when the chime is disabled or has not been built yet (the
+        chime is lazily synthesized to match the TTS sample rate the
+        first time ``observe_tts_wav`` is called).
+        """
+        if not self._chime_enabled:
+            return
+        if self._chime_wav is None:
+            logger.debug("play_chime no-op pid=%r — chime not yet built", pid)
+            return
+        try:
+            await self._audio_sink.play_wav(pid, self._chime_wav)
+        except Exception:
+            logger.exception("chime send error pid=%r", pid)
+
+    def format_phrase_help(self) -> str | None:
+        """Return a sentence fragment telling the user how to address the
+        agent given the configured phrases. ``None`` when no phrases are
+        configured (the caller picks a generic greeting). The wording
+        carries over from the original ``_greet`` implementation."""
+        phrases = list(self._cfg.magic_phrases)
+        if not phrases:
+            return None
+        if len(phrases) == 1:
+            phrase_list = f'"{phrases[0]}"'
+        elif len(phrases) == 2:
+            phrase_list = f'"{phrases[0]}" or "{phrases[1]}"'
+        else:
+            phrase_list = (
+                ", ".join(f'"{p}"' for p in phrases[:-1])
+                + f', or "{phrases[-1]}"'
+            )
+        return (
+            f'To talk to me, start your question with {phrase_list}. '
+            f'For example, "{phrases[0]}, what am I looking at?"'
+        )
+
+    async def say_stop_ack(self, pid: str) -> None:
+        """Synthesize a short canned stop acknowledgement and play it on
+        the consumer's audio sink. Also observes the WAV so the lazy
+        chime build can pick up the sample rate from this path."""
+        try:
+            wav = await self._tts.synthesize("Okay, I will stop.")
+        except Exception:
+            logger.exception("stop-ack tts error pid=%r", pid)
+            return
+        self.observe_tts_wav(wav)
+        try:
+            await self._audio_sink.play_wav(pid, wav)
+        except Exception:
+            logger.exception("stop-ack audio error pid=%r", pid)
+
+    def observe_tts_wav(self, wav_bytes: bytes) -> None:
+        """Build the chime at the TTS sample rate the first time a real
+        TTS WAV passes through. No-op once built or when chime is
+        disabled. A malformed WAV header disables the chime so the
+        consumer doesn't keep paying for failed builds."""
+        if self._chime_wav is not None or not self._chime_enabled:
+            return
+        try:
+            sr = read_wav_sample_rate(wav_bytes)
+            self._chime_wav = build_chime_wav(sr)
+            logger.info("listening chime ready (sr=%d Hz)", sr)
+        except ValueError:
+            logger.exception("listening chime disabled (sample rate out of range)")
+            self._chime_enabled = False
+        except Exception:
+            logger.exception("listening chime disabled (bad TTS wav header)")
+            self._chime_enabled = False
+
+    # ── handler dispatch ──────────────────────────────────────────────────────
+
+    async def _invoke(self, handler, name: str, *args) -> None:
+        if handler is None:
+            return
+        try:
+            await handler(*args)
+        except Exception:
+            logger.exception("voicegate handler %s raised", name)


### PR DESCRIPTION
## Summary

Foundation PR for the voice-pipeline extraction. Introduces two new
packages and a Pipecat codec-helper consolidation. **Zero changes to
any `agent-samples/` directory** — sample migrations are out of scope
and will land on follow-up branches that base off this one.

### What's new

* **`utils/xr-ai-voicegate/`** — shared magic-phrase + STOP +
  follow-up + chime + greeting gate. `numpy` + `pyyaml` only, no
  coupling to `xr-ai-models`, `xr-ai-agent`, or `pipecat`. 49 unit
  tests.
* **`agent-sdk/xr-ai-conversation/`** — shared
  voice-conversation loop wiring audio → VAD → STT → voice gate →
  user `on_query` → TTS → return-audio fan-out, with per-pid
  in-flight cancel + flush, sentence-batched streaming, and the
  participant join/leave hooks. Also ships codec helpers and the
  `wire_voice_gate` one-call helper for Pipecat-style consumers
  that don't use the full loop. 15 unit tests.
* **`agent-sdk/xr-ai-pipecat/xr_ai_pipecat/audio.py`** — now a
  re-export shim that pulls `wav_to_chunks`, `chunks_to_wav`,
  `int16_pcm_to_wav`, `split_sentences`, and `now_us` from
  `xr_ai_conversation.audio`. `stream_sentences_to_audio` (pipecat-
  flavored) and `rms_float32` stay inline. `xr-ai-pipecat` adds
  `xr-ai-conversation` to its deps + `[tool.uv.sources]`.
* **`tests/pyproject.toml`** — adds `xr-ai-voicegate` and
  `xr-ai-conversation` to the workspace deps.
* **`DEPENDENCIES.md`** — new blocks for both packages, updated
  block for `xr-ai-pipecat` documenting the codec re-export.

### Explicitly out of scope

Zero changes to any `agent-samples/` directory. Sample migrations
live on follow-up branches off this PR:

* `devdeepr/simple-vlm-pipeline-migration` (to be opened as PR-B')
* `devdeepr/xr-render-demo-pipeline-migration` (to be opened as PR-C')

### Relation to existing PRs

This PR reconstructs the foundation work from the existing four PRs
without their sample-migration coupling:

* PR #164 (`devdeepr/voicegate-extract`) — voicegate package only;
  the simple-vlm-example + xr-render-demo migrations from that PR are
  out of scope here.
* PR #166 (`devdeepr/conversation-loop`) — conversation package.
* PR #167 (`devdeepr/simple-vlm-on-loop`) — only the
  `on_phrase_only_extra` + `on_drop_extra` kwargs on
  `ConversationLoop` (and the corresponding test case). The
  simple-vlm-example migration is out of scope.
* PR #168 (`devdeepr/xr-render-demo-on-conversation`) — only the
  pipecat codec re-export + the `wire_voice_gate` helper (and its
  two test cases). The xr-render-demo migration is out of scope.

**All four existing PRs remain open.** The board will decide which
set (the chain of four, or this bundled foundation + sibling sample
migrations) to merge.

## Commits

1. `feat(voicegate): introduce xr-ai-voicegate package + tests`
2. `feat(conversation): introduce xr-ai-conversation foundation`
3. `feat(pipecat): re-export codec helpers from xr-ai-conversation`
4. `feat(conversation): add wire_voice_gate helper + on_phrase_only_extra/on_drop_extra hooks`

## Test plan

- [x] `from xr_ai_voicegate import VoiceGate, VoiceGateConfig`
- [x] `from xr_ai_conversation import ConversationLoop, VadConfig, wire_voice_gate`
- [x] `from xr_ai_pipecat.audio import wav_to_chunks, chunks_to_wav, int16_pcm_to_wav, split_sentences, now_us`
- [x] `tests/test_xr_ai_voicegate.py` — 47 passed, 2 skipped (sample
      yaml round-trip tests skip without the sample dirs); 49 test
      functions total.
- [x] `tests/test_xr_ai_conversation_loop.py` — 15 passed (12
      baseline + 1 from PR #167 + 2 from PR #168).
- [x] `uv sync` clean on `tests/`, `agent-sdk/xr-ai-conversation/`,
      `agent-sdk/xr-ai-pipecat/`, `utils/xr-ai-voicegate/`.
- [x] No `agent-samples/` changes (`git diff --name-only` confirms).
- [ ] CI green on Python 3.11 + 3.12 (CI run pending push).

Verified locally on Python 3.12 (only Python available in the
worktree); board CI exercises 3.11.

Signed-off-by: Devdeep Ray <devdeepr@nvidia.com>