### PR TITLE
feat(xr-render-demo): migrate worker to xr-ai-voicegate via wire_voice_gate helper

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -441,7 +441,7 @@ forwarding.
 | Sub-project | Package | Internal deps | External deps |
 |---|---|---|---|
 | Orchestrator | `xr-render-demo` | `xr-ai-launcher`, `xr-ai-logging` | — |
-| Worker | `xr-render-demo-worker` | `xr-ai-agent`, `xr-ai-models` [editable], `xr-ai-pipecat` [editable], `xr-ai-logging` [editable], `xr-ai-vad` [editable] | numpy >=1.24, httpx >=0.27, fastmcp >=0.4, pyyaml >=6.0 (silero-vad pulled in via xr-ai-vad) |
+| Worker | `xr-render-demo-worker` | `xr-ai-agent`, `xr-ai-conversation` [editable], `xr-ai-models` [editable], `xr-ai-pipecat` [editable], `xr-ai-logging` [editable], `xr-ai-vad` [editable], `xr-ai-voicegate` [editable] | numpy >=1.24, httpx >=0.27, fastmcp >=0.4, pyyaml >=6.0 (silero-vad pulled in via xr-ai-vad) |
 
 Model endpoints (llm, agent_llm, stt, tts, vlm) are declared in
 `yaml/models.yaml` and loaded via `xr-ai-models` `load_models_config` /

--- a/agent-samples/xr-render-demo/worker/agent.py
+++ b/agent-samples/xr-render-demo/worker/agent.py
@@ -60,7 +60,7 @@ class RenderDemoAgent:
 
         self._scene = RenderSceneProcessor(
             self._transport, cfg, render, oxr, vlm, video, vec,
-            prompt_path, tools=tools, llm=llm, agent_llm=agent_llm,
+            prompt_path, tools=tools, llm=llm, agent_llm=agent_llm, tts=tts,
         )
         self._pipeline, self._pipeline_task = build_pipeline(
             self._transport, stt, tts, self._scene,
@@ -131,8 +131,15 @@ class RenderDemoAgent:
     async def _on_participant(self, event: ParticipantEvent) -> None:
         if event.joined:
             self._transport.set_target_participant(event.participant_id)
+            # Greet the user and (when phrases are configured) tell them
+            # how to address the agent. Without this hint, the gated speech
+            # path can look like the agent is broken when it ignores them.
+            asyncio.create_task(
+                self._scene.gate.participant_joined(event.participant_id)
+            )
         else:
             self._transport.cleanup_participant(event.participant_id)
+            self._scene.gate.forget(event.participant_id)
 
     # ── render-mcp helper ─────────────────────────────────────────────────────
 

--- a/agent-samples/xr-render-demo/worker/config.py
+++ b/agent-samples/xr-render-demo/worker/config.py
@@ -8,6 +8,7 @@ import pathlib
 from dataclasses import dataclass
 
 import yaml
+from xr_ai_voicegate import VoiceGateConfig, load_voice_gate_config
 
 
 @dataclass(frozen=True)
@@ -26,6 +27,11 @@ class WorkerConfig:
     silence_duration:  float
     min_speech:        float
     silero_threshold:  float   # Silero speech probability gate (0..1)
+
+    # Speech-only opt-in gate. Owned by ``xr-ai-voicegate``. Empty
+    # ``magic_phrases`` keeps the original always-on behavior so the
+    # default YAML config matches the pre-gate worker.
+    voice_gate: VoiceGateConfig
 
 
 def load_config(path: pathlib.Path | None) -> WorkerConfig:
@@ -46,6 +52,13 @@ def load_config(path: pathlib.Path | None) -> WorkerConfig:
     else:
         models_yaml = models_yaml_raw
 
+    # Resolve voice_gate_yaml the same way; a missing file degrades to the
+    # always-on gate defaults via load_voice_gate_config.
+    voice_gate_yaml_raw = data.get("voice_gate_yaml", "voice_gate.yaml")
+    voice_gate_path = pathlib.Path(voice_gate_yaml_raw)
+    if path and not voice_gate_path.is_absolute():
+        voice_gate_path = path.parent / voice_gate_path
+
     return WorkerConfig(
         models_yaml = models_yaml,
         render_mcp  = data.get("render_mcp_url",  "http://localhost:8220"),
@@ -56,4 +69,5 @@ def load_config(path: pathlib.Path | None) -> WorkerConfig:
         silence_duration  = float(data.get("silence_duration",  0.8)),
         min_speech        = float(data.get("min_speech",        0.15)),
         silero_threshold  = float(data.get("silero_threshold",  0.5)),
+        voice_gate        = load_voice_gate_config(voice_gate_path),
     )

--- a/agent-samples/xr-render-demo/worker/processors.py
+++ b/agent-samples/xr-render-demo/worker/processors.py
@@ -45,12 +45,15 @@ from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.task import PipelineParams, PipelineTask
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 
-from xr_ai_agent import DataMessage
+from xr_ai_agent import DataMessage, ProcessorEndpoint
+from xr_ai_conversation import wire_voice_gate
+from xr_ai_conversation.audio import wav_to_chunks
 from xr_ai_logging import print_task_done_banner
 from xr_ai_models import ChatMessage, LLMService, STTService, TTSService, ToolCall, ToolDef
 from xr_ai_pipecat.audio import stream_sentences_to_audio
 from xr_ai_pipecat.transport import XRMediaHubTransport, SAMPLE_RATE
 from xr_ai_vad import VadDetector
+from xr_ai_voicegate import VoiceGate
 
 from config import WorkerConfig
 
@@ -118,6 +121,19 @@ _TOOL_PROGRESS: dict[str, str] = {
 
 _AGENT_RESPONSE_TOPIC  = "agent.response"
 _AGENT_PROGRESS_TOPIC  = "agent.progress"
+
+
+class _EpSink:
+    """``xr_ai_voicegate.AudioSink`` adapter over the hub's return-audio
+    fan-out: explode the WAV into 20 ms float32 ``AudioChunk``s via the
+    pipecat helper and stream them through ``send_return_audio``."""
+
+    def __init__(self, ep: ProcessorEndpoint) -> None:
+        self._ep = ep
+
+    async def play_wav(self, pid: str, wav_bytes: bytes) -> None:
+        for chunk in wav_to_chunks(wav_bytes, pid):
+            await self._ep.send_return_audio(chunk)
 
 
 class _SceneNotReadyError(Exception):
@@ -210,7 +226,15 @@ class RenderSceneProcessor(FrameProcessor):
     reasoning loop — guaranteed syntactically valid tool calls every iteration.
     Uses Minitron (port 8101) for the parallel quick-ack (fast, cheap).
 
-    On each utterance:
+    Speech ingress is layered behind an ``xr-ai-voicegate.VoiceGate``: each
+    ``TranscriptionFrame`` is handed to ``gate.feed(pid, text)``, and the
+    gate decides whether it dispatches to ``on_query`` (agentic loop),
+    ``on_stop`` (cancel + canned ack), ``on_phrase_only`` (log + chime
+    on the open follow-up window), or ``on_drop`` (log). Empty
+    ``magic_phrases`` keeps the original always-on behavior — every
+    transcript is a fresh query. The text data channel is never gated.
+
+    On each utterance dispatched by the gate:
       1. Quick-ack fires immediately (parallel, max 25 tokens) → agent.progress
       2. Agentic loop: model calls tools via OpenAI tool_calls protocol until
          it returns a text response (finish_reason != "tool_calls")
@@ -231,6 +255,7 @@ class RenderSceneProcessor(FrameProcessor):
         tools:       list[ToolDef],  # ToolDef list built from MCP discovery
         llm:         LLMService,
         agent_llm:   LLMService,
+        tts:         TTSService,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -253,6 +278,7 @@ class RenderSceneProcessor(FrameProcessor):
         self._tools            = tools
         self._llm              = llm
         self._agent_llm        = agent_llm
+        self._tts              = tts
 
         self._pending:    tuple[str, str, int] | None = None  # (text, pid, ref_us)
         self._lock        = asyncio.Lock()
@@ -270,6 +296,28 @@ class RenderSceneProcessor(FrameProcessor):
         # Per-turn snapshot used to compute prev→new pairs on update_primitive.
         self._pre_move_positions: dict[str, tuple[float, float, float]] = {}
 
+        # Voice gate owns magic-phrase / STOP / follow-up / chime / greeting.
+        # The processor only feeds STT transcripts and handles the events.
+        # ``wire_voice_gate`` collapses the five ``gate.on_*`` registrations
+        # into one call and provides a sensible default ``on_drop`` (DEBUG
+        # log), so the worker doesn't have to repeat that boilerplate.
+        self._gate = VoiceGate(
+            cfg.voice_gate,
+            audio_sink=_EpSink(transport.endpoint),
+            tts=tts,
+        )
+        wire_voice_gate(
+            self._gate,
+            on_query              = self._on_voice_query,
+            on_stop               = self._on_voice_stop,
+            on_phrase_only        = self._on_voice_phrase_only,
+            on_participant_joined = self._on_voice_participant_joined,
+        )
+
+    @property
+    def gate(self) -> VoiceGate:
+        return self._gate
+
 
     def _read_prompt(self, path: Path, cache_attr: str) -> str:
         try:
@@ -283,21 +331,80 @@ class RenderSceneProcessor(FrameProcessor):
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         await super().process_frame(frame, direction)
         if isinstance(frame, TranscriptionFrame):
-            await self._enqueue(frame)
+            text = frame.text.strip()
+            if text:
+                pid = self._transport.target_participant
+                await self._gate.feed(pid, text)
         else:
             await self.push_frame(frame, direction)
 
-    async def _enqueue(self, frame: TranscriptionFrame) -> None:
-        text = frame.text.strip()
-        if not text:
-            return
-        pid = self._transport.target_participant
-        # Capture the moment the user finished speaking so visual tool calls
-        # can be anchored to that timestamp (not to when the tool fires).
+    # ── voice-gate handlers ───────────────────────────────────────────────────
+
+    async def _on_voice_query(self, pid: str, text: str, fresh_match: bool) -> None:
+        """Voice-gate ``on_query`` handler — chime + dispatch to the agentic loop.
+
+        Only chimes on a *fresh* magic-phrase match. Follow-up-window
+        continuations (``fresh_match=False``) skip the chime to avoid a
+        double bell on the same logical interaction.
+        """
+        if fresh_match:
+            asyncio.create_task(self._gate.play_chime(pid))
+        await self._enqueue(text, pid)
+
+    async def _on_voice_stop(self, pid: str) -> None:
+        """Voice-gate ``on_stop`` handler — cancel the in-flight agentic
+        loop, drop any queued utterance, flush queued return audio, and
+        play the gate's canned stop ack so the user hears the interrupt
+        was acknowledged. Mirrors ``vlm.response`` semantics by also
+        sending the ack text on ``agent.response``."""
+        async with self._lock:
+            self._pending = None
+            if self._agentic_task and not self._agentic_task.done():
+                self._agentic_task.cancel()
+        send_pid = pid or self._transport.target_participant
+        if send_pid:
+            try:
+                await self._transport.endpoint.flush_return_audio(send_pid)
+            except Exception:
+                logger.opt(exception=True).debug(
+                    "flush_return_audio failed during stop",
+                )
+            await self._send(send_pid, "Okay, I will stop.", topic=_AGENT_RESPONSE_TOPIC)
+            await self._gate.say_stop_ack(send_pid)
+
+    async def _on_voice_phrase_only(self, pid: str) -> None:
+        """Voice-gate ``on_phrase_only`` handler — open the follow-up
+        window with an audible chime so the user knows the wake word was
+        heard. xr-render-demo has no camera-on-demand so there's nothing
+        else to do here; the gate has already opened the window."""
+        await self._gate.play_chime(pid)
+        logger.info("voice gate awaiting follow-up pid={!r}", pid)
+
+    async def _on_voice_participant_joined(self, pid: str) -> None:
+        """Voice-gate ``on_participant_joined`` — speak a one-shot
+        greeting that tells the user how to address the agent given the
+        configured magic phrases (or that it's listening to everything
+        when no phrases are configured)."""
+        help_text = self._gate.format_phrase_help()
+        if help_text is None:
+            greeting = "Hi, I'm listening. Tell me what you'd like to render."
+        else:
+            greeting = f"Hi, I'm listening. {help_text}"
+        await self._send(pid, greeting, topic=_AGENT_RESPONSE_TOPIC)
         try:
-            ref_us = int(frame.timestamp) if frame.timestamp else _now_us()
-        except (TypeError, ValueError):
-            ref_us = _now_us()
+            wav = await self._tts.synthesize(greeting)
+        except Exception:
+            logger.opt(exception=True).warning("greeting tts failed pid={!r}", pid)
+            return
+        self._gate.observe_tts_wav(wav)
+        try:
+            for chunk in wav_to_chunks(wav, pid):
+                await self._transport.endpoint.send_return_audio(chunk)
+        except Exception:
+            logger.opt(exception=True).warning("greeting audio send failed pid={!r}", pid)
+
+    async def _enqueue(self, text: str, pid: str) -> None:
+        ref_us = _now_us()
         async with self._lock:
             self._pending = (text, pid, ref_us)
             # Cancel any in-flight agentic loop so the new utterance is handled
@@ -927,17 +1034,29 @@ class RenderSceneProcessor(FrameProcessor):
 # ── TtsProcessor ─────────────────────────────────────────────────────────────
 
 class TtsProcessor(FrameProcessor):
-    """TextFrame → sentence-batched TTS → hub return audio."""
+    """TextFrame → sentence-batched TTS → hub return audio.
+
+    Every synthesized WAV is observed by the voice gate so it can build
+    the listening chime at the matching TTS sample rate the first time
+    a WAV passes through.
+    """
 
     def __init__(
         self,
         tts: TTSService,
         transport: XRMediaHubTransport,
+        gate: VoiceGate,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self._tts       = tts
         self._transport = transport
+        self._gate      = gate
+
+    async def _synthesize(self, text: str) -> bytes:
+        wav = await self._tts.synthesize(text)
+        self._gate.observe_tts_wav(wav)
+        return wav
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         await super().process_frame(frame, direction)
@@ -954,7 +1073,7 @@ class TtsProcessor(FrameProcessor):
             return
         try:
             await stream_sentences_to_audio(
-                self._transport.endpoint, self._tts.synthesize, text, pid,
+                self._transport.endpoint, self._synthesize, text, pid,
             )
         except Exception:
             logger.exception("TTS failed  pid={!r}", pid)
@@ -970,7 +1089,7 @@ def build_pipeline(
     scene:       RenderSceneProcessor,
 ) -> tuple[Pipeline, PipelineTask]:
     stt_proc = SttProcessor(stt, transport, scene._cfg)
-    tts_proc = TtsProcessor(tts, transport)
+    tts_proc = TtsProcessor(tts, transport, scene.gate)
 
     pipeline = Pipeline([
         transport.input(),

--- a/agent-samples/xr-render-demo/worker/pyproject.toml
+++ b/agent-samples/xr-render-demo/worker/pyproject.toml
@@ -11,10 +11,12 @@ version = "0.1.0"
 requires-python = ">=3.11,<3.13"
 dependencies = [
     "xr-ai-agent",
+    "xr-ai-conversation",
     "xr-ai-models",
     "xr-ai-pipecat",
     "xr-ai-logging",
     "xr-ai-vad",
+    "xr-ai-voicegate",
     "numpy>=1.24",
     "scipy>=1.11",
     "pyyaml>=6.0",
@@ -24,11 +26,13 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-xr-ai-agent   = { path = "../../../agent-sdk",                    editable = true }
-xr-ai-models  = { path = "../../../agent-sdk/xr-ai-models",       editable = true }
-xr-ai-pipecat = { path = "../../../agent-sdk/xr-ai-pipecat",      editable = true }
-xr-ai-logging = { path = "../../../utils/xr-ai-logging",          editable = true }
-xr-ai-vad     = { path = "../../../utils/xr-ai-vad",              editable = true }
+xr-ai-agent        = { path = "../../../agent-sdk",                    editable = true }
+xr-ai-conversation = { path = "../../../agent-sdk/xr-ai-conversation", editable = true }
+xr-ai-models       = { path = "../../../agent-sdk/xr-ai-models",       editable = true }
+xr-ai-pipecat      = { path = "../../../agent-sdk/xr-ai-pipecat",      editable = true }
+xr-ai-logging      = { path = "../../../utils/xr-ai-logging",          editable = true }
+xr-ai-vad          = { path = "../../../utils/xr-ai-vad",              editable = true }
+xr-ai-voicegate    = { path = "../../../utils/xr-ai-voicegate",        editable = true }
 
 [project.scripts]
 xr_render_demo_worker = "xr_render_demo_worker:run"

--- a/agent-samples/xr-render-demo/yaml/voice_gate.yaml
+++ b/agent-samples/xr-render-demo/yaml/voice_gate.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Speech-only opt-in gate (xr-ai-voicegate). The gate sits between STT
+# and the agentic loop; only the speech path is affected — the text
+# data channel is never gated.
+#
+# Default is always-on (empty ``magic_phrases``): every STT transcript
+# becomes a query, matching the pre-gate worker behavior. Populate the
+# list to require a wake word before the agent responds.
+
+# Strict-prefix phrases (case-insensitive, no leading filler words).
+# The matched phrase is stripped before the query reaches the agentic
+# loop. Configure several wordings to support multiple natural
+# greetings, e.g.:
+#   magic_phrases:
+#     - "agent"
+#     - "hey agent"
+magic_phrases:    []
+
+# Follow-up grace window. After a magic-phrase match, the next
+# utterance from the same participant within this many seconds
+# bypasses the gate.
+followup_grace_s: 5.0
+
+# Audible "I heard you" feedback. When true AND ``magic_phrases`` is
+# non-empty, a short two-tone chime plays on the return audio track
+# the moment a phrase is matched. No effect when ``magic_phrases`` is
+# empty (always-on mode has no fresh-match event to ride).
+listening_chime:  false

--- a/agent-samples/xr-render-demo/yaml/xr_render_demo_worker.yaml
+++ b/agent-samples/xr-render-demo/yaml/xr_render_demo_worker.yaml
@@ -30,3 +30,10 @@ vec_mcp_url:    http://localhost:8250
 silence_duration:  0.8
 min_speech:        0.15
 silero_threshold:  0.3
+
+# ── Speech-only opt-in gate (xr-ai-voicegate) ────────────────────────────────
+# Loaded by ``xr-ai-voicegate.load_voice_gate_config``. The gate sits
+# between STT and the agentic loop; only the speech path is affected —
+# the text data channel is never gated. Path is resolved relative to
+# THIS file's directory.
+voice_gate_yaml: voice_gate.yaml


### PR DESCRIPTION
## Summary

Migrates `agent-samples/xr-render-demo` onto the voice-pipeline foundation
(PR #169 — `devdeepr/voice-pipeline-foundation`). Speech ingress now flows
through `xr-ai-voicegate.VoiceGate`; the text data channel is unaffected.

- `RenderSceneProcessor` owns a `VoiceGate` instance wired with
  `wire_voice_gate(...)` — one helper call binding 4 worker-provided
  handlers (`on_query`, `on_stop`, `on_phrase_only`, `on_participant_joined`).
  `on_drop` uses the helper's default DEBUG-level logger.
- `TtsProcessor._synthesize` wraps `tts.synthesize` so every WAV streamed to
  the user is observed by `gate.observe_tts_wav(...)` — the lazy chime build
  picks up the TTS sample rate from this single funnel.
- New `voice_gate.yaml` (default `magic_phrases: []`) preserves the original
  always-on behavior. Operators opt in by populating the list.

## Dependency on PR #169

Builds on PR #169 (`devdeepr/voice-pipeline-foundation`). The foundation
introduces `xr-ai-voicegate`, `xr-ai-conversation`, the codec re-export from
`xr_ai_pipecat.audio`, and the `wire_voice_gate` helper. **Cannot merge
until #169 merges.**

## Honest accounting

- **`processors.py` net change: +119 lines** (1116 → 1235). The earlier
  spec mentioned ~10-13% shrinkage; that figure assumed bundling the
  agentic-loop cleanup that PR #168 carried (drop `_recent_moves`,
  `_VEC_TOOLS`, leaked-tool-call sanitization, `_pre_move_positions`).
  This PR is voicegate-only per scope — net is growth (gate wiring +
  4 handler method bodies + `_EpSink` adapter + `TtsProcessor._synthesize`
  wrapper).
- **No "5-handler collapse" effect on this branch.** This branch never
  carried PR #164's inline 5-handler wiring; it goes straight to the
  collapsed `wire_voice_gate(...)` form.
- **`vec_mcp` preserved everywhere** (config, yaml, agent.py, processors.py
  tool routing). The `vec` removal in PR #168 was a side-effect of its
  broader cleanup and is out of scope here.
- Only semantic shift: `ref_us` (the timestamp the agentic loop uses to
  anchor visual queries) was the STT frame's timestamp; it is now
  `_now_us()` at gate-dispatch time, tens of ms later. No eval fixture
  references `ref_us`.

## Scope discipline

Voicegate-only changes to xr-render-demo. **Untouched**: agentic loop,
scene-state caching, MCP tool routing (incl. vec-mcp), quick-ack,
still-working, validation, leaked-tool-call sanitization, `_recent_moves`
and `_pre_move_positions`, `system.txt`, eval harness, simple-vlm-example,
and foundation packages.

## File-stat

```
DEPENDENCIES.md                                    |   2 +-
agent-samples/xr-render-demo/worker/agent.py       |   9 +-
agent-samples/xr-render-demo/worker/config.py      |  14 ++
agent-samples/xr-render-demo/worker/processors.py  | 149 ++++++++++++++++++---
agent-samples/xr-render-demo/worker/pyproject.toml |  14 +-
agent-samples/xr-render-demo/yaml/voice_gate.yaml  |  30 +++ (new)
agent-samples/xr-render-demo/yaml/xr_render_demo_worker.yaml |   7 +
7 files changed, 203 insertions(+), 22 deletions(-)
```

## Test plan

- [x] `uv sync` clean on `xr-render-demo/worker` (xr-ai-conversation +
      xr-ai-voicegate added)
- [x] `uv lock --check` clean on worker and `tests/`
- [x] Worker import smoke:
      `python -c "from xr_render_demo_worker import main;
                 from processors import RenderSceneProcessor, TtsProcessor,
                                        build_pipeline;
                 from config import load_config"` → OK
- [x] `tests/test_xr_ai_voicegate.py` — 48 passed, 1 skipped
- [x] `tests/test_xr_ai_conversation_loop.py` — 15 passed
- [x] `tests/test_xr_render_demo_wire.py` — 9 passed
- [ ] CI on this branch passes

## Sibling PRs

- Sibling of `devdeepr/simple-vlm-pipeline-migration` (PR-B') for
  simple-vlm-example.
- Coexists with the original PRs #164 / #166 / #167 / #168 — those are
  not touched.

Signed-off-by: Devdeep Ray <devdeepr@nvidia.com>