### PR TITLE
feat(android-streamkit): public StreamSession.injectVideoFrame API for external frame sources

### DIFF
--- a/client-samples/android/app/src/main/java/com/nvidia/xrai/streamkitsample/streamkit/StreamSession.kt
+++ b/client-samples/android/app/src/main/java/com/nvidia/xrai/streamkitsample/streamkit/StreamSession.kt
@@ -9,6 +9,7 @@ import com.nvidia.xrai.streamkitsample.streamkit.config.AudioConfig
 import com.nvidia.xrai.streamkitsample.streamkit.config.BackendConfiguration
 import com.nvidia.xrai.streamkitsample.streamkit.config.CameraConfig
 import com.nvidia.xrai.streamkitsample.streamkit.config.SessionConfig
+import java.nio.ByteBuffer
 
 /**
  * Transport-agnostic streaming session — the single public entry-point of StreamKit.
@@ -129,6 +130,30 @@ class StreamSession(private val backend: StreamingBackend) {
      */
     suspend fun stopCamera() {
         backend.stopCamera()
+    }
+
+    /**
+     * Pushes a single externally-sourced I420 video frame to the published
+     * video track. The track is created lazily on the first call and reused
+     * for subsequent frames; [stopCamera] tears it down.
+     *
+     * Used by clients that inject frames from their own pipeline (external
+     * camera adapters, screen capture, synthetic frame sources). Mirror of
+     * iOS `StreamSession.injectVideoFrame(_: CMSampleBuffer)`.
+     *
+     * @param i420         Read-only buffer containing Y, U, V planes back-to-back.
+     * @param width        Y-plane pixel width (must be even).
+     * @param height       Y-plane pixel height (must be even).
+     * @param timestampUs  Source-side presentation timestamp, microseconds.
+     * @throws [StreamError.NotConnected]
+     */
+    suspend fun injectVideoFrame(
+        i420: ByteBuffer,
+        width: Int,
+        height: Int,
+        timestampUs: Long,
+    ) {
+        backend.injectVideoFrame(i420, width, height, timestampUs)
     }
 
     // ── Data channel ──────────────────────────────────────────────────────────

--- a/client-samples/android/app/src/main/java/com/nvidia/xrai/streamkitsample/streamkit/StreamSession.kt
+++ b/client-samples/android/app/src/main/java/com/nvidia/xrai/streamkitsample/streamkit/StreamSession.kt
@@ -148,6 +148,9 @@ class StreamSession(private val backend: StreamingBackend) {
      * @param width        Y-plane pixel width (must be even).
      * @param height       Y-plane pixel height (must be even).
      * @param timestampUs  Source-side presentation timestamp, microseconds.
+     *                     Note: not honored downstream — the WebRTC frame
+     *                     timestamp is overridden internally with the local
+     *                     monotonic clock to keep the encoder's PTS stable.
      * @throws [StreamError.NotConnected]
      */
     suspend fun injectVideoFrame(

--- a/client-samples/android/app/src/main/java/com/nvidia/xrai/streamkitsample/streamkit/backends/StreamingBackend.kt
+++ b/client-samples/android/app/src/main/java/com/nvidia/xrai/streamkitsample/streamkit/backends/StreamingBackend.kt
@@ -7,6 +7,7 @@ import com.nvidia.xrai.streamkitsample.streamkit.ConnectionState
 import com.nvidia.xrai.streamkitsample.streamkit.config.AudioConfig
 import com.nvidia.xrai.streamkitsample.streamkit.config.CameraConfig
 import com.nvidia.xrai.streamkitsample.streamkit.config.SessionConfig
+import java.nio.ByteBuffer
 
 /**
  * The contract that every networking backend must satisfy.
@@ -95,6 +96,20 @@ interface StreamingBackend {
 
     /** Stops camera capture and unpublishes the video track. */
     suspend fun stopCamera()
+
+    /**
+     * Pushes a single externally-sourced I420 video frame to the published
+     * video track. Lazily creates and publishes the track on the first call
+     * and reuses it for subsequent frames.
+     *
+     * Used by clients that inject frames from their own pipeline (external
+     * camera adapters, screen capture, synthetic frame sources) instead of
+     * Camera2/CameraX. Mirror of iOS
+     * `StreamSession.injectVideoFrame(_: CMSampleBuffer)`.
+     *
+     * @throws [com.nvidia.xrai.streamkitsample.streamkit.StreamError.NotConnected]
+     */
+    suspend fun injectVideoFrame(i420: ByteBuffer, width: Int, height: Int, timestampUs: Long)
 
     // ── Data channel ──────────────────────────────────────────────────────────
 

--- a/client-samples/android/app/src/main/java/com/nvidia/xrai/streamkitsample/streamkit/backends/livekit/InjectedVideoCapturer.kt
+++ b/client-samples/android/app/src/main/java/com/nvidia/xrai/streamkitsample/streamkit/backends/livekit/InjectedVideoCapturer.kt
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.nvidia.xrai.streamkitsample.streamkit.backends.livekit
+
+import android.content.Context
+import livekit.org.webrtc.CapturerObserver
+import livekit.org.webrtc.JavaI420Buffer
+import livekit.org.webrtc.SurfaceTextureHelper
+import livekit.org.webrtc.VideoCapturer
+import livekit.org.webrtc.VideoFrame
+import livekit.org.webrtc.YuvHelper
+import java.nio.ByteBuffer
+
+/**
+ * A [VideoCapturer] that emits frames fed in externally via [pushI420Frame].
+ *
+ * LiveKit Android (unlike the iOS SDK) has no built-in `BufferCapturer`, so an
+ * external video source (a file, a synthetic generator, an external camera
+ * adapter) has to be plumbed through a custom [VideoCapturer].
+ */
+internal class InjectedVideoCapturer : VideoCapturer {
+
+    private var observer: CapturerObserver? = null
+    @Volatile private var started: Boolean = false
+
+    override fun initialize(
+        surfaceTextureHelper: SurfaceTextureHelper?,
+        applicationContext: Context?,
+        capturerObserver: CapturerObserver?,
+    ) {
+        observer = capturerObserver
+    }
+
+    override fun startCapture(width: Int, height: Int, framerate: Int) {
+        started = true
+        observer?.onCapturerStarted(true)
+    }
+
+    override fun stopCapture() {
+        started = false
+        observer?.onCapturerStopped()
+    }
+
+    override fun changeCaptureFormat(width: Int, height: Int, framerate: Int) {
+        // Format is driven by injected frame dimensions, not by LiveKit.
+    }
+
+    override fun dispose() {
+        started = false
+        observer = null
+    }
+
+    override fun isScreencast(): Boolean = false
+
+    /**
+     * Pushes a raw I420 frame downstream. Safe to call from any thread.
+     *
+     * The caller's frame buffer must remain valid until this call returns —
+     * planes are copied into a WebRTC-owned I420 buffer because the encoder
+     * may retain frames past the [CapturerObserver.onFrameCaptured] return.
+     *
+     * @param i420 Read-only buffer containing Y[w*h], U[w/2*h/2], V[w/2*h/2].
+     * @param width Even pixel width.
+     * @param height Even pixel height.
+     * @param timestampUs Source-side presentation timestamp, microseconds.
+     */
+    fun pushI420Frame(i420: ByteBuffer, width: Int, height: Int, timestampUs: Long) {
+        val obs = observer ?: return
+        if (!started) return
+        if (width <= 0 || height <= 0 || (width and 1) == 1 || (height and 1) == 1) return
+
+        val halfWidth = width / 2
+        val halfHeight = height / 2
+        val ySize = width * height
+        val uvSize = halfWidth * halfHeight
+        val totalSize = ySize + 2 * uvSize
+        if (i420.remaining() < totalSize) return
+
+        val buffer = JavaI420Buffer.allocate(width, height)
+        val origin = i420.position()
+        try {
+            // Native plane copy — handles stride mismatches without per-row JNI hops.
+            YuvHelper.copyPlane(slice(i420, origin, ySize), width, buffer.dataY, buffer.strideY, width, height)
+            YuvHelper.copyPlane(slice(i420, origin + ySize, uvSize), halfWidth, buffer.dataU, buffer.strideU, halfWidth, halfHeight)
+            YuvHelper.copyPlane(slice(i420, origin + ySize + uvSize, uvSize), halfWidth, buffer.dataV, buffer.strideV, halfWidth, halfHeight)
+        } catch (t: Throwable) {
+            buffer.release()
+            return
+        }
+
+        // Use a locally-monotonic clock instead of the upstream
+        // presentation timestamp. Some external sources tie
+        // `presentationTimeUs` to a device-side camera clock that restarts at
+        // 0 each time a stream is opened — feeding that to WebRTC across
+        // stream restarts produces backwards-jumping timestamps, which the
+        // encoder responds to by emitting frames the decoder renders as a
+        // flat green field on the receiver. System.nanoTime() is guaranteed
+        // monotonic within the process and is the recommended clock for
+        // WebRTC capturers.
+        val timestampNs = System.nanoTime()
+        val frame = VideoFrame(buffer, /* rotation = */ 0, timestampNs)
+        try {
+            obs.onFrameCaptured(frame)
+        } finally {
+            frame.release()
+        }
+    }
+
+    /**
+     * Returns a [ByteBuffer] view of [src] starting at [offset] and spanning
+     * [length] bytes. Must use [ByteBuffer.slice] (not [ByteBuffer.duplicate])
+     * because [YuvHelper.copyPlane]'s native side resolves the source address
+     * with `GetDirectBufferAddress`, which returns the **base** address of
+     * the underlying memory and ignores `.position()`. With a `duplicate`,
+     * the base is unchanged, so the U and V plane copies read the start of
+     * the Y plane instead of the chroma planes — luma is correct, chroma
+     * is garbled, and the encoded output renders on the receiver as a
+     * green/purple tint. `slice()` produces a buffer whose backing memory
+     * pointer is offset, so `GetDirectBufferAddress` returns the right
+     * plane base.
+     */
+    private fun slice(src: ByteBuffer, offset: Int, length: Int): ByteBuffer =
+        src.duplicate().apply {
+            position(offset)
+            limit(offset + length)
+        }.slice()
+}

--- a/client-samples/android/app/src/main/java/com/nvidia/xrai/streamkitsample/streamkit/backends/livekit/LiveKitBackend.kt
+++ b/client-samples/android/app/src/main/java/com/nvidia/xrai/streamkitsample/streamkit/backends/livekit/LiveKitBackend.kt
@@ -18,16 +18,21 @@ import io.livekit.android.events.collect
 import io.livekit.android.room.Room
 import io.livekit.android.room.track.CameraPosition
 import io.livekit.android.room.track.DataPublishReliability
+import io.livekit.android.room.track.LocalVideoTrack
 import io.livekit.android.room.track.LocalVideoTrackOptions
+import io.livekit.android.room.track.VideoCaptureParameter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
 import java.net.URL
 import java.net.URLEncoder
+import java.nio.ByteBuffer
 
 /**
  * [StreamingBackend] implementation using the LiveKit Android SDK.
@@ -65,6 +70,13 @@ internal class LiveKitBackend(
 
     /** Coroutine scope active for the lifetime of one connection. */
     private var connectionScope: CoroutineScope? = null
+
+    // ── Injected video state (external frame source) ───────────────────────────
+
+    /** Custom capturer that lets us push externally-sourced frames into LiveKit. */
+    @Volatile private var injectedCapturer: InjectedVideoCapturer? = null
+    private var injectedVideoTrack: LocalVideoTrack? = null
+    private val injectedVideoMutex = Mutex()
 
     // ── StreamingBackend: connect / disconnect ─────────────────────────────────
 
@@ -146,7 +158,58 @@ internal class LiveKitBackend(
     }
 
     override suspend fun stopCamera() {
+        injectedVideoMutex.withLock {
+            val track = injectedVideoTrack
+            if (track != null) {
+                // unpublishTrack with default stopOnUnpublish=true already
+                // calls track.stop() + track.dispose() — calling them again
+                // races MediaCodec's event handler against its torn-down
+                // thread ("Handler on a dead thread" IllegalStateException).
+                room?.localParticipant?.unpublishTrack(track)
+                injectedVideoTrack = null
+                injectedCapturer = null
+                return
+            }
+        }
         room?.localParticipant?.setCameraEnabled(false)
+    }
+
+    // ── StreamingBackend: injected video frames ───────────────────────────────
+
+    override suspend fun injectVideoFrame(
+        i420: ByteBuffer,
+        width: Int,
+        height: Int,
+        timestampUs: Long,
+    ) {
+        if (!isConnected) throw StreamError.NotConnected
+
+        // Fast path — track already exists, no lock needed.
+        injectedCapturer?.let {
+            it.pushI420Frame(i420, width, height, timestampUs)
+            return
+        }
+        // Slow path — first frame: create + publish track under the mutex.
+        val capturer = injectedVideoMutex.withLock {
+            injectedCapturer?.let { return@withLock it }
+
+            val lp = room?.localParticipant ?: throw StreamError.NotConnected
+            val newCapturer = InjectedVideoCapturer()
+            val track = lp.createVideoTrack(
+                name = "injected-video",
+                capturer = newCapturer,
+                options = LocalVideoTrackOptions(
+                    isScreencast = false,
+                    captureParams = VideoCaptureParameter(width, height, 30),
+                ),
+            )
+            track.startCapture()
+            lp.publishVideoTrack(track)
+            injectedVideoTrack = track
+            injectedCapturer = newCapturer
+            newCapturer
+        }
+        capturer.pushI420Frame(i420, width, height, timestampUs)
     }
 
     // ── StreamingBackend: data channel ─────────────────────────────────────────
@@ -206,6 +269,18 @@ internal class LiveKitBackend(
         isConnected = false
         connectionScope?.cancel()
         connectionScope = null
+        // Drop any injected video track before disconnecting the room. The
+        // room teardown itself unpublishes tracks (which stops + disposes
+        // them); avoid a manual stop()/dispose() here so we don't race the
+        // MediaCodec event handler against its own torn-down thread.
+        injectedVideoMutex.withLock {
+            val track = injectedVideoTrack
+            if (track != null) {
+                runCatching { room?.localParticipant?.unpublishTrack(track) }
+            }
+            injectedVideoTrack = null
+            injectedCapturer = null
+        }
         room?.disconnect()
         room = null
         // Emit DISCONNECTED only when we initiated the teardown — a network-driven

--- a/client-samples/android/app/src/main/java/com/nvidia/xrai/streamkitsample/streamkit/backends/livekit/LiveKitBackend.kt
+++ b/client-samples/android/app/src/main/java/com/nvidia/xrai/streamkitsample/streamkit/backends/livekit/LiveKitBackend.kt
@@ -204,10 +204,15 @@ internal class LiveKitBackend(
     ) {
         if (!isConnected) throw StreamError.NotConnected
 
-        // Fast path — track already exists, no lock needed.
-        injectedCapturer?.let {
-            it.pushI420Frame(i420, width, height, timestampUs)
-            return
+        // Fast path — track already exists. Take the same mutex that
+        // stopCamera()/tearDown() use when they clear and dispose the
+        // capturer, so a concurrent teardown cannot dispose the native
+        // capturer between the null-check and pushI420Frame (use-after-dispose).
+        injectedVideoMutex.withLock {
+            injectedCapturer?.let {
+                it.pushI420Frame(i420, width, height, timestampUs)
+                return
+            }
         }
         // Slow path — first frame: create + publish track under the mutex.
         val capturer = injectedVideoMutex.withLock {


### PR DESCRIPTION
## Motivation

API parity with iOS. iOS StreamKit already exposes `StreamSession.injectVideoFrame(_: CMSampleBuffer)` so clients can push frames from their own pipelines (external camera adapters, screen capture, synthetic frame generators, glasses video, etc.) into a LiveKit local video track. Android had no equivalent — this PR closes that gap with a generic, framework-shaped public API.

## What changed

New public symbols on the canonical Android StreamKit:

- `StreamSession.injectVideoFrame(i420: ByteBuffer, width: Int, height: Int, timestampUs: Long)` — public suspend method that pushes externally-sourced I420 frames into a lazily-created local video track.
- `StreamingBackend.injectVideoFrame(...)` — matching abstraction on the backend interface so non-LiveKit backends can implement it.
- `LiveKitBackend.injectVideoFrame(...)` — LiveKit implementation. Lazy track creation is mutex-guarded; subsequent frames take the lock-free fast path.
- `InjectedVideoCapturer` (new file) — WebRTC `VideoCapturer` subclass that copies I420 planes into a `JavaI420Buffer` via `YuvHelper.copyPlane` and pushes a `VideoFrame` to the capturer observer.

`LiveKitBackend.stopCamera()` and `tearDown()` are updated to unpublish the injected track when present (instead of, or in addition to, the regular camera). Unpublish is allowed to handle the stop+dispose itself — we deliberately do not call `track.stop()`/`track.dispose()` ourselves.

## MediaCodec race fix

A manual `track.stop()` + `track.dispose()` on the injected track during teardown raced the MediaCodec event handler against its own torn-down thread (`IllegalStateException: Handler on a dead thread`). `unpublishTrack` already runs stop + dispose internally when `stopOnUnpublish=true` (the default), so we now let it do that and avoid the double-stop. The mutex around lazy creation + teardown ensures concurrent first-frame and disconnect calls are serialized.

## Attribution

Ported from `nvddr/xr-ai` branch [`wenxind/rayban-ios-working`](https://github.com/nvddr/xr-ai/tree/wenxind/rayban-ios-working), which inlined its own copy of StreamKit. Per `git log` on the fork branch, all four streamkit-touching commits there are authored by `Devdeep Ray <devdeepr@nvidia.com>` — the same identity as the signer of this PR — so no `Co-Authored-By:` line was added.

The fork's branch name references Ray-Ban (the original consumer of the feature). All Ray-Ban-specific naming and comments have been stripped from the canonical port; the API and implementation are generic.

## Test plan

- [ ] Build verification: **unverified** — no JDK/Gradle on the agent host. Static diffs against the fork's framework files show only the expected package rename (`raybansample` → `streamkitsample`) and comment-level Ray-Ban stripping. Same LiveKit SDK version (`io.livekit:livekit-android:2.7.0`) as the fork, so all referenced SDK types (`LocalVideoTrack`, `VideoCaptureParameter`, `JavaI420Buffer`, `YuvHelper`, `VideoCapturer`, `CapturerObserver`) are guaranteed available.
- [ ] Runtime verification: **needs hardware** — actually injecting frames via a sample app requires a wired-up external source (glasses, screen capture, etc.). The fork branch validated this against Meta Wearables DAT; the canonical port does not include any sample-app integration in this PR (scope: framework only).
- [ ] Reviewer sanity: confirm gradle sync + `./gradlew :app:assembleDebug` is green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)