### PR TITLE
feat(voice): unified pipecat voice pipeline foundation (no sample migrations)

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -44,21 +44,36 @@ xr-ai-agent  (agent-sdk/)
     └── msgpack >=1.0
 
 xr-ai-pipecat  (agent-sdk/xr-ai-pipecat/)
-    └── xr-ai-agent   [editable: ..]
-    └── xr-ai-logging [editable: ../../utils/xr-ai-logging]
-    └── xr-ai-models  [editable: ../xr-ai-models]
+    └── xr-ai-agent     [editable: ..]
+    └── xr-ai-logging   [editable: ../../utils/xr-ai-logging]
+    └── xr-ai-models    [editable: ../xr-ai-models]
+    └── xr-ai-vad       [editable: ../../utils/xr-ai-vad]
+    └── xr-ai-voicegate [editable: ../../utils/xr-ai-voicegate]
     └── pipecat-ai >=0.0.46
     └── numpy >=1.24
     └── scipy >=1.11
     └── httpx >=0.27
     └── fastmcp >=0.4
-    Optional Pipecat transport bridge: connects ProcessorEndpoint (ZMQ IPC)
-    to a Pipecat frame pipeline. Resamples hub float32 audio → 16 kHz int16
-    for STT; converts TTS int16 PCM back to float32 AudioChunks for return.
-    SttClient / TtsClient are thin wrappers around xr-ai-models'
+    Unified Pipecat voice pipeline. Owns the transport bridge to
+    ProcessorEndpoint (ZMQ IPC) plus the four library FrameProcessors —
+    VadSttProcessor, VoiceGateProcessor, BrainProcessor, StreamingTtsProcessor —
+    composed by ``make_voice_pipeline``. Resamples hub float32 audio →
+    16 kHz int16 for STT, converts TTS int16 PCM back to float32 AudioChunks
+    for return. SttClient / TtsClient are thin wrappers around xr-ai-models'
     OpenAICompatSTT / OpenAICompatTTS — PCM→WAV conversion is handled by
     the SDK. httpx is retained for http_probe() readiness checks.
     Not a dep of xr-ai-agent itself — import only in workers that use Pipecat.
+
+xr-ai-voicegate  (utils/xr-ai-voicegate/)
+    └── numpy >=1.24
+    └── pyyaml >=6.0
+    Pipecat-free speech-input opt-in gate. Owns the magic-phrase + follow-up
+    + STOP ladder, the lazy listening chime synthesized at the TTS sample
+    rate, and the participant-joined greeting hook. Workers feed STT
+    transcripts via ``feed`` and register handlers — either one-at-a-time via
+    ``on_*`` setters or together via ``bind(...)``. Consumed inside
+    xr-ai-pipecat by ``VoiceGateProcessor`` so sample workers don't import it
+    directly when they use the unified pipeline.
 
 xr-ai-models  (agent-sdk/xr-ai-models/)
     └── xr-ai-logging [editable: ../../utils/xr-ai-logging]
@@ -190,6 +205,7 @@ xr-ai-tests  (tests/)
     └── xr-ai-launcher          [editable: ../utils/xr-ai-launcher]
     └── xr-ai-logging           [editable: ../utils/xr-ai-logging]
     └── xr-ai-vad               [editable: ../utils/xr-ai-vad]
+    └── xr-ai-voicegate         [editable: ../utils/xr-ai-voicegate]
     └── xr-ai-vllm              [editable: ../utils/xr-ai-vllm]
     └── transcript-mcp-server   [editable: ../agent-mcp-servers/transcript-mcp]
     └── vlm-mcp-server          [editable: ../agent-mcp-servers/vlm-mcp]

--- a/agent-sdk/xr-ai-pipecat/pyproject.toml
+++ b/agent-sdk/xr-ai-pipecat/pyproject.toml
@@ -13,6 +13,8 @@ dependencies = [
     "xr-ai-agent",
     "xr-ai-logging",
     "xr-ai-models",
+    "xr-ai-vad",
+    "xr-ai-voicegate",
     "pipecat-ai>=0.0.46",
     "numpy>=1.24",
     "scipy>=1.11",
@@ -21,9 +23,11 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-xr-ai-agent   = { path = "..", editable = true }
-xr-ai-logging = { path = "../../utils/xr-ai-logging", editable = true }
-xr-ai-models  = { path = "../xr-ai-models", editable = true }
+xr-ai-agent     = { path = "..", editable = true }
+xr-ai-logging   = { path = "../../utils/xr-ai-logging",   editable = true }
+xr-ai-models    = { path = "../xr-ai-models",             editable = true }
+xr-ai-vad       = { path = "../../utils/xr-ai-vad",       editable = true }
+xr-ai-voicegate = { path = "../../utils/xr-ai-voicegate", editable = true }
 
 [tool.hatch.build.targets.wheel]
 packages = ["xr_ai_pipecat"]

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/__init__.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/__init__.py
@@ -1,6 +1,32 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""xr-ai-pipecat — shared Pipecat transport + audio utilities for xr-ai agents."""
+"""xr-ai-pipecat — unified Pipecat voice pipeline for xr-ai agents.
 
-__all__: list[str] = []
+Top-level entry point is :func:`make_voice_pipeline`. Sample workers
+subclass :class:`BrainProcessor` and hand the instance to the factory;
+everything else (VAD/STT, voice gate, streaming TTS) is provided.
+"""
+from __future__ import annotations
+
+from .frames import GatedQueryFrame, ParticipantJoinedFrame, ParticipantLeftFrame
+from .pipeline import make_voice_pipeline
+from .processors import (
+    BrainProcessor,
+    StreamingTtsProcessor,
+    VadConfig,
+    VadSttProcessor,
+    VoiceGateProcessor,
+)
+
+__all__ = [
+    "BrainProcessor",
+    "GatedQueryFrame",
+    "ParticipantJoinedFrame",
+    "ParticipantLeftFrame",
+    "StreamingTtsProcessor",
+    "VadConfig",
+    "VadSttProcessor",
+    "VoiceGateProcessor",
+    "make_voice_pipeline",
+]

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/__init__.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/__init__.py
@@ -9,7 +9,12 @@ everything else (VAD/STT, voice gate, streaming TTS) is provided.
 """
 from __future__ import annotations
 
-from .frames import GatedQueryFrame, ParticipantJoinedFrame, ParticipantLeftFrame
+from .frames import (
+    BrainResponseEndFrame,
+    GatedQueryFrame,
+    ParticipantJoinedFrame,
+    ParticipantLeftFrame,
+)
 from .pipeline import make_voice_pipeline
 from .processors import (
     BrainProcessor,
@@ -21,6 +26,7 @@ from .processors import (
 
 __all__ = [
     "BrainProcessor",
+    "BrainResponseEndFrame",
     "GatedQueryFrame",
     "ParticipantJoinedFrame",
     "ParticipantLeftFrame",

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/frames.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/frames.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Frame types unique to the xr-ai-pipecat unified voice pipeline.
+
+Everything pipecat already ships (``InputAudioRawFrame``,
+``OutputAudioRawFrame``, ``TranscriptionFrame``, ``UserStartedSpeakingFrame``,
+``UserStoppedSpeakingFrame``, ``InterruptionFrame``, ``TextFrame``) is reused
+directly — only the participant lifecycle and the voicegate-emitted query
+frame live here.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pipecat.frames.frames import DataFrame
+
+
+@dataclass
+class ParticipantJoinedFrame(DataFrame):
+    """A participant joined the conversation.
+
+    Consumed by ``VoiceGateProcessor`` (greeting hook) and
+    ``BrainProcessor`` (per-pid setup). The transport adapter is
+    responsible for emitting one of these per participant.
+    """
+
+    participant_id: str
+
+
+@dataclass
+class ParticipantLeftFrame(DataFrame):
+    """A participant left the conversation.
+
+    Consumed by ``BrainProcessor`` (per-pid teardown).
+    """
+
+    participant_id: str
+
+
+@dataclass
+class GatedQueryFrame(DataFrame):
+    """An STT transcript that has passed the voice gate.
+
+    Emitted by ``VoiceGateProcessor`` for the brain to consume.
+    ``fresh_match`` distinguishes a fresh magic-phrase match (case 2 in
+    the gate's event ladder) from a follow-up-window continuation (case
+    3) so downstream can suppress one-shot side effects on follow-ups.
+    """
+
+    participant_id: str
+    text: str
+    fresh_match: bool
+    pts_us: int

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/frames.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/frames.py
@@ -52,3 +52,24 @@ class GatedQueryFrame(DataFrame):
     text: str
     fresh_match: bool
     pts_us: int
+
+
+@dataclass
+class BrainResponseEndFrame(DataFrame):
+    """A single brain turn finished emitting ``TextFrame``s.
+
+    Emitted by :class:`BrainProcessor` in :meth:`_run_query`'s finally
+    block. Carries ``text`` — the full assembled response — so the
+    downstream :class:`StreamingTtsProcessor` can echo the per-turn
+    response on the data channel exactly once, matching the
+    pre-migration "send full response at end" behavior. ``pid`` is the
+    participant whose turn ended; the data echo addresses the same pid.
+
+    A turn that was cancelled (new query, interruption) still produces
+    one of these on the way out so the consumer never sees an open turn
+    without a corresponding end marker.
+    """
+
+    pid: str
+    text: str
+    pts_us: int

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/pipeline.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/pipeline.py
@@ -35,7 +35,7 @@ def make_voice_pipeline(
     brain: BrainProcessor,
     vad_cfg: VadConfig,
     voice_gate_cfg: VoiceGateConfig,
-    text_topic: str = "agent.response",  # noqa: ARG001 — held for PR-2/3 sample wiring
+    text_topic: str = "agent.response",
 ) -> tuple[Pipeline, PipelineTask]:
     """Assemble the unified voice pipeline.
 
@@ -44,9 +44,19 @@ def make_voice_pipeline(
     :class:`StreamingTtsProcessor` — the TTS processor calls
     ``gate.observe_tts_wav`` so the listening chime gets built at the
     right sample rate.
+
+    ``text_topic`` controls the per-turn data-channel echo emitted by
+    :class:`StreamingTtsProcessor`. Set to ``""`` to opt out — samples
+    whose brain pushes its own response data message (e.g.
+    xr-render-demo) want this off to avoid duplicate sends.
     """
     voice_gate_proc = VoiceGateProcessor(cfg=voice_gate_cfg, tts=tts)
-    streaming_tts   = StreamingTtsProcessor(tts=tts, voice_gate=voice_gate_proc.gate)
+    streaming_tts   = StreamingTtsProcessor(
+        tts        = tts,
+        voice_gate = voice_gate_proc.gate,
+        transport  = transport,
+        text_topic = text_topic,
+    )
     vad_stt         = VadSttProcessor(stt=stt, vad_cfg=vad_cfg)
 
     pipeline = Pipeline([

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/pipeline.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/pipeline.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Factory for the unified voice pipeline.
+
+One call composes:
+
+    input → VadStt → VoiceGate → brain → StreamingTts → output
+
+and returns the assembled :class:`Pipeline` plus a :class:`PipelineTask`
+ready for :meth:`PipelineRunner.run`. Sample workers do not compose the
+pipeline themselves — they subclass :class:`BrainProcessor` and hand it
+to this factory.
+"""
+from __future__ import annotations
+
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.task import PipelineTask
+
+from xr_ai_models import STTService, TTSService
+from xr_ai_voicegate import VoiceGateConfig
+
+from .processors.brain import BrainProcessor
+from .processors.streaming_tts import StreamingTtsProcessor
+from .processors.vad_stt import VadConfig, VadSttProcessor
+from .processors.voice_gate import VoiceGateProcessor
+from .transport import XRMediaHubTransport
+
+
+def make_voice_pipeline(
+    *,
+    transport: XRMediaHubTransport,
+    stt: STTService,
+    tts: TTSService,
+    brain: BrainProcessor,
+    vad_cfg: VadConfig,
+    voice_gate_cfg: VoiceGateConfig,
+    text_topic: str = "agent.response",  # noqa: ARG001 — held for PR-2/3 sample wiring
+) -> tuple[Pipeline, PipelineTask]:
+    """Assemble the unified voice pipeline.
+
+    The factory builds the :class:`VoiceGateProcessor` first because its
+    embedded :class:`xr_ai_voicegate.VoiceGate` is shared with
+    :class:`StreamingTtsProcessor` — the TTS processor calls
+    ``gate.observe_tts_wav`` so the listening chime gets built at the
+    right sample rate.
+    """
+    voice_gate_proc = VoiceGateProcessor(cfg=voice_gate_cfg, tts=tts)
+    streaming_tts   = StreamingTtsProcessor(tts=tts, voice_gate=voice_gate_proc.gate)
+    vad_stt         = VadSttProcessor(stt=stt, vad_cfg=vad_cfg)
+
+    pipeline = Pipeline([
+        transport.input(),
+        vad_stt,
+        voice_gate_proc,
+        brain,
+        streaming_tts,
+        transport.output(),
+    ])
+    task = PipelineTask(pipeline)
+    return pipeline, task

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/pipeline.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/pipeline.py
@@ -7,15 +7,15 @@ One call composes:
 
     input → VadStt → VoiceGate → brain → StreamingTts → output
 
-and returns the assembled :class:`Pipeline` plus a :class:`PipelineTask`
-ready for :meth:`PipelineRunner.run`. Sample workers do not compose the
+and returns the assembled :class:`Pipeline` plus a :class:`PipelineWorker`
+ready for :meth:`WorkerRunner.run`. Sample workers do not compose the
 pipeline themselves — they subclass :class:`BrainProcessor` and hand it
 to this factory.
 """
 from __future__ import annotations
 
 from pipecat.pipeline.pipeline import Pipeline
-from pipecat.pipeline.task import PipelineTask
+from pipecat.pipeline.worker import PipelineWorker
 
 from xr_ai_models import STTService, TTSService
 from xr_ai_voicegate import VoiceGateConfig
@@ -36,7 +36,7 @@ def make_voice_pipeline(
     vad_cfg: VadConfig,
     voice_gate_cfg: VoiceGateConfig,
     text_topic: str = "agent.response",
-) -> tuple[Pipeline, PipelineTask]:
+) -> tuple[Pipeline, PipelineWorker]:
     """Assemble the unified voice pipeline.
 
     The factory builds the :class:`VoiceGateProcessor` first because its
@@ -67,5 +67,5 @@ def make_voice_pipeline(
         streaming_tts,
         transport.output(),
     ])
-    task = PipelineTask(pipeline)
-    return pipeline, task
+    worker = PipelineWorker(pipeline)
+    return pipeline, worker

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/__init__.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/__init__.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Library-owned FrameProcessors that compose the unified voice pipeline."""
+from __future__ import annotations
+
+from .brain import BrainProcessor
+from .streaming_tts import StreamingTtsProcessor
+from .vad_stt import VadConfig, VadSttProcessor
+from .voice_gate import VoiceGateProcessor
+
+__all__ = [
+    "BrainProcessor",
+    "StreamingTtsProcessor",
+    "VadConfig",
+    "VadSttProcessor",
+    "VoiceGateProcessor",
+]

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/brain.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/brain.py
@@ -1,0 +1,171 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""``BrainProcessor`` — base class for sample-specific reasoning.
+
+Sample brains subclass this and implement :meth:`handle_query`. The
+base class owns:
+
+- the per-pid in-flight task,
+- cancellation on ``UserStartedSpeakingFrame`` and ``InterruptionFrame``
+  (the user is talking again — abandon the old response),
+- pushing each yielded token/chunk as a downstream ``TextFrame``,
+- the optional participant join/leave lifecycle hooks.
+
+Sample brains are tiny: write the reasoning loop and (optionally) any
+per-pid setup/teardown.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator, Union
+
+from loguru import logger
+from pipecat.frames.frames import (
+    Frame,
+    InterruptionFrame,
+    TextFrame,
+    UserStartedSpeakingFrame,
+)
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+
+from ..frames import GatedQueryFrame, ParticipantJoinedFrame, ParticipantLeftFrame
+
+
+QueryResult = Union[AsyncIterator[str], str]
+
+
+class BrainProcessor(FrameProcessor):
+    """Subclass and implement :meth:`handle_query`.
+
+    The base class also forwards every non-handled frame, so this
+    processor can sit anywhere in the chain without dropping
+    pipecat-internal traffic.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._inflight: dict[str, asyncio.Task] = {}
+
+    # ── overrides ─────────────────────────────────────────────────────────────
+
+    async def handle_query(
+        self, pid: str, text: str, fresh_match: bool,
+    ) -> QueryResult:
+        """Run the brain's reasoning for a single query.
+
+        Return either a single string (one TextFrame downstream) or an
+        async iterator of strings (one TextFrame per yielded chunk).
+        """
+        raise NotImplementedError
+
+    async def on_user_started_speaking(self, pid: str) -> None:
+        """Override for sample-specific behavior on speech start.
+
+        Fires before the in-flight query (if any) is cancelled — useful
+        for speculative warmup (e.g. camera, image fetch) so the next
+        query starts with a hot cache. Default: no-op.
+        """
+        return
+
+    async def on_participant_joined(self, pid: str) -> None:
+        """Override for per-pid setup. Default: no-op."""
+        return
+
+    async def on_participant_left(self, pid: str) -> None:
+        """Override for per-pid teardown. Default: no-op."""
+        return
+
+    # ── pipecat frame entrypoint ──────────────────────────────────────────────
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
+        # super().process_frame fires base-class interruption + metrics
+        # plumbing for InterruptionFrame; we still cancel our task
+        # ourselves because the base class does not know about it.
+        await super().process_frame(frame, direction)
+
+        if isinstance(frame, UserStartedSpeakingFrame):
+            await self._on_user_started_speaking_locally()
+            await self.push_frame(frame, direction)
+            return
+
+        if isinstance(frame, InterruptionFrame):
+            self._cancel_all_inflight()
+            await self.push_frame(frame, direction)
+            return
+
+        if isinstance(frame, GatedQueryFrame):
+            await self._spawn_query(frame)
+            return
+
+        if isinstance(frame, ParticipantJoinedFrame):
+            await self.on_participant_joined(frame.participant_id)
+            await self.push_frame(frame, direction)
+            return
+
+        if isinstance(frame, ParticipantLeftFrame):
+            await self.on_participant_left(frame.participant_id)
+            self._cancel_pid(frame.participant_id)
+            await self.push_frame(frame, direction)
+            return
+
+        await self.push_frame(frame, direction)
+
+    # ── private ───────────────────────────────────────────────────────────────
+
+    async def _on_user_started_speaking_locally(self) -> None:
+        # The frame itself doesn't carry pid; cancel everything and fan
+        # the hook out across the pids we currently know about. Most
+        # samples are single-speaker today so this collapses to a
+        # single cancel.
+        pids = list(self._inflight)
+        self._cancel_all_inflight()
+        for pid in pids:
+            try:
+                await self.on_user_started_speaking(pid)
+            except Exception:
+                logger.exception("on_user_started_speaking raised pid={!r}", pid)
+
+    async def _spawn_query(self, frame: GatedQueryFrame) -> None:
+        pid = frame.participant_id
+        # A fresh query supersedes any previous in-flight reasoning for
+        # the same pid — happens when the user squeezes in a follow-up
+        # before the last response completes.
+        self._cancel_pid(pid)
+        self._inflight[pid] = asyncio.create_task(
+            self._run_query(frame), name=f"brain-query-{pid}",
+        )
+
+    async def _run_query(self, frame: GatedQueryFrame) -> None:
+        try:
+            result = await self.handle_query(
+                frame.participant_id, frame.text, frame.fresh_match,
+            )
+            if isinstance(result, str):
+                if result:
+                    await self.push_frame(TextFrame(text=result))
+                return
+            async for chunk in result:
+                if not chunk:
+                    continue
+                await self.push_frame(TextFrame(text=chunk))
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("brain handle_query raised pid={!r}", frame.participant_id)
+        finally:
+            # Don't pop if a newer task has taken our slot.
+            current = self._inflight.get(frame.participant_id)
+            if current is asyncio.current_task():
+                self._inflight.pop(frame.participant_id, None)
+
+    def _cancel_pid(self, pid: str) -> None:
+        task = self._inflight.pop(pid, None)
+        if task is not None and not task.done():
+            task.cancel()
+
+    def _cancel_all_inflight(self) -> None:
+        for pid, task in list(self._inflight.items()):
+            if not task.done():
+                task.cancel()
+        self._inflight.clear()

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/brain.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/brain.py
@@ -255,7 +255,7 @@ class BrainProcessor(FrameProcessor):
                 if result:
                     accumulated.append(result)
                     await self._push_text(result, pid=pid)
-                return
+                return  # finally still fires — emits BrainResponseEndFrame
             async for chunk in result:
                 if not chunk:
                     continue

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/brain.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/brain.py
@@ -161,6 +161,9 @@ class BrainProcessor(FrameProcessor):
             return
 
         if isinstance(frame, InterruptionFrame):
+            if self._inflight:
+                for pid in list(self._inflight):
+                    logger.info("brain cancel pid={!r} reason=interruption", pid)
             self._cancel_all_inflight()
             await self.push_frame(frame, direction)
             return
@@ -171,6 +174,7 @@ class BrainProcessor(FrameProcessor):
 
         if isinstance(frame, ParticipantJoinedFrame):
             self._joined.add(frame.participant_id)
+            logger.info("brain participant joined pid={!r}", frame.participant_id)
             # Single-participant default: steer the output transport at
             # the first join so return-audio / return-data routing works
             # without per-sample wiring. Samples that need multi-pid
@@ -184,6 +188,7 @@ class BrainProcessor(FrameProcessor):
         if isinstance(frame, ParticipantLeftFrame):
             self._joined.discard(frame.participant_id)
             self._seen_query.discard(frame.participant_id)
+            logger.info("brain participant left pid={!r}", frame.participant_id)
             if self._transport is not None:
                 self._transport.cleanup_participant(frame.participant_id)
             await self.on_participant_left(frame.participant_id)
@@ -210,6 +215,9 @@ class BrainProcessor(FrameProcessor):
 
     async def _spawn_query(self, frame: GatedQueryFrame) -> None:
         pid = frame.participant_id
+        logger.info(
+            "brain dispatch pid={!r} fresh_match={}", pid, frame.fresh_match,
+        )
         # A fresh query supersedes the previous one for the same pid.
         # Fire the supersede hook on every non-first query for the pid,
         # regardless of whether the prior brain task is still running.
@@ -221,6 +229,7 @@ class BrainProcessor(FrameProcessor):
         # the override lands while the prior task's downstream state is
         # still coherent.
         if pid in self._seen_query:
+            logger.info("brain superseded pid={!r}", pid)
             try:
                 await self.on_query_superseded(pid)
             except Exception:
@@ -264,6 +273,7 @@ class BrainProcessor(FrameProcessor):
             # the response, and a half-assembled data echo would
             # contradict the new turn that's about to render.
             if not cancelled:
+                logger.info("brain query complete pid={!r}", pid)
                 try:
                     await self.push_frame(BrainResponseEndFrame(
                         pid    = pid,

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/brain.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/brain.py
@@ -7,10 +7,19 @@ Sample brains subclass this and implement :meth:`handle_query`. The
 base class owns:
 
 - the per-pid in-flight task,
-- cancellation on ``UserStartedSpeakingFrame`` and ``InterruptionFrame``
-  (the user is talking again — abandon the old response),
+- cancellation on a new ``GatedQueryFrame`` (a fresh user query
+  supersedes any prior in-flight response) and on ``InterruptionFrame``
+  (explicit stop, e.g. from the voice gate),
 - pushing each yielded token/chunk as a downstream ``TextFrame``,
-- the optional participant join/leave lifecycle hooks.
+- the optional participant join/leave / user-started-speaking lifecycle
+  hooks.
+
+``UserStartedSpeakingFrame`` is a hook only — it does NOT cancel
+in-flight work. Cancelling on every speech onset interrupts the agent
+mid-sentence the moment the user starts a follow-up; worse, any AEC
+leak of the agent's own TTS makes the agent cancel itself. The voice
+gate emits ``InterruptionFrame`` explicitly when the user actually
+says "stop"; that is the right cancel signal.
 
 Sample brains are tiny: write the reasoning loop and (optionally) any
 per-pid setup/teardown.
@@ -46,6 +55,10 @@ class BrainProcessor(FrameProcessor):
     def __init__(self) -> None:
         super().__init__()
         self._inflight: dict[str, asyncio.Task] = {}
+        # Joined pids so the user-speech hook can fire on the cold path
+        # (no in-flight task yet) — useful for camera warmup. Cleared on
+        # ``ParticipantLeftFrame``.
+        self._joined: set[str] = set()
 
     # ── overrides ─────────────────────────────────────────────────────────────
 
@@ -62,9 +75,11 @@ class BrainProcessor(FrameProcessor):
     async def on_user_started_speaking(self, pid: str) -> None:
         """Override for sample-specific behavior on speech start.
 
-        Fires before the in-flight query (if any) is cancelled — useful
-        for speculative warmup (e.g. camera, image fetch) so the next
-        query starts with a hot cache. Default: no-op.
+        Useful for speculative warmup (e.g. camera, image fetch) so the
+        next query starts with a hot cache. Does NOT cancel the
+        in-flight query — cancellation happens on the next
+        ``GatedQueryFrame`` or explicit ``InterruptionFrame``. Default:
+        no-op.
         """
         return
 
@@ -85,7 +100,11 @@ class BrainProcessor(FrameProcessor):
         await super().process_frame(frame, direction)
 
         if isinstance(frame, UserStartedSpeakingFrame):
-            await self._on_user_started_speaking_locally()
+            # Hook only — speech onset is NOT a cancel signal. Samples
+            # may override on_user_started_speaking for speculative work
+            # (e.g. camera warmup); cancellation happens on the next
+            # GatedQueryFrame or on an explicit InterruptionFrame.
+            await self._fan_out_user_started_speaking()
             await self.push_frame(frame, direction)
             return
 
@@ -99,11 +118,13 @@ class BrainProcessor(FrameProcessor):
             return
 
         if isinstance(frame, ParticipantJoinedFrame):
+            self._joined.add(frame.participant_id)
             await self.on_participant_joined(frame.participant_id)
             await self.push_frame(frame, direction)
             return
 
         if isinstance(frame, ParticipantLeftFrame):
+            self._joined.discard(frame.participant_id)
             await self.on_participant_left(frame.participant_id)
             self._cancel_pid(frame.participant_id)
             await self.push_frame(frame, direction)
@@ -113,14 +134,14 @@ class BrainProcessor(FrameProcessor):
 
     # ── private ───────────────────────────────────────────────────────────────
 
-    async def _on_user_started_speaking_locally(self) -> None:
-        # The frame itself doesn't carry pid; cancel everything and fan
-        # the hook out across the pids we currently know about. Most
-        # samples are single-speaker today so this collapses to a
-        # single cancel.
-        pids = list(self._inflight)
-        self._cancel_all_inflight()
-        for pid in pids:
+    async def _fan_out_user_started_speaking(self) -> None:
+        # The pipecat ``UserStartedSpeakingFrame`` carries no pid, so we
+        # fan the hook out across every pid the brain currently knows
+        # about. Use the joined set, not the in-flight tasks: the cold
+        # path (first utterance, nothing in flight yet) is exactly where
+        # speculative warmup matters most. Single-speaker samples
+        # collapse to one call.
+        for pid in list(self._joined):
             try:
                 await self.on_user_started_speaking(pid)
             except Exception:

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/brain.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/brain.py
@@ -38,7 +38,12 @@ from pipecat.frames.frames import (
 )
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 
-from ..frames import GatedQueryFrame, ParticipantJoinedFrame, ParticipantLeftFrame
+from ..frames import (
+    BrainResponseEndFrame,
+    GatedQueryFrame,
+    ParticipantJoinedFrame,
+    ParticipantLeftFrame,
+)
 
 if TYPE_CHECKING:
     from ..transport import XRMediaHubTransport
@@ -175,27 +180,64 @@ class BrainProcessor(FrameProcessor):
         )
 
     async def _run_query(self, frame: GatedQueryFrame) -> None:
+        pid = frame.participant_id
+        # Accumulate every token/string we yield so the trailing
+        # ``BrainResponseEndFrame`` carries the full assembled response.
+        # Downstream ``StreamingTtsProcessor`` uses this to send a single
+        # data-channel echo per turn, matching pre-migration behavior.
+        accumulated: list[str] = []
+        cancelled = False
         try:
-            result = await self.handle_query(
-                frame.participant_id, frame.text, frame.fresh_match,
-            )
+            result = await self.handle_query(pid, frame.text, frame.fresh_match)
             if isinstance(result, str):
                 if result:
-                    await self.push_frame(TextFrame(text=result))
+                    accumulated.append(result)
+                    await self._push_text(result, pid=pid)
                 return
             async for chunk in result:
                 if not chunk:
                     continue
-                await self.push_frame(TextFrame(text=chunk))
+                accumulated.append(chunk)
+                await self._push_text(chunk, pid=pid)
         except asyncio.CancelledError:
+            cancelled = True
             raise
         except Exception:
-            logger.exception("brain handle_query raised pid={!r}", frame.participant_id)
+            logger.exception("brain handle_query raised pid={!r}", pid)
         finally:
+            # Emit the end marker only when the turn completed
+            # (success OR caught exception). On asyncio cancellation we
+            # leave the marker out — a cancel means the user superseded
+            # the response, and a half-assembled data echo would
+            # contradict the new turn that's about to render.
+            if not cancelled:
+                try:
+                    await self.push_frame(BrainResponseEndFrame(
+                        pid    = pid,
+                        text   = "".join(accumulated),
+                        pts_us = frame.pts_us,
+                    ))
+                except Exception:
+                    logger.exception("emit BrainResponseEndFrame failed pid={!r}", pid)
+
             # Don't pop if a newer task has taken our slot.
-            current = self._inflight.get(frame.participant_id)
+            current = self._inflight.get(pid)
             if current is asyncio.current_task():
-                self._inflight.pop(frame.participant_id, None)
+                self._inflight.pop(pid, None)
+
+    async def _push_text(self, text: str, *, pid: str) -> None:
+        """Push a ``TextFrame`` tagged with the participant id.
+
+        ``transport_destination`` flows through the pipeline to the
+        ``StreamingTtsProcessor``, which copies it onto the
+        ``OutputAudioRawFrame``s it emits so the output transport knows
+        which participant to address. Without this tag, the empty
+        string ends up on every downstream send and the hub drops the
+        audio.
+        """
+        f = TextFrame(text=text)
+        f.transport_destination = pid
+        await self.push_frame(f)
 
     def _cancel_pid(self, pid: str) -> None:
         task = self._inflight.pop(pid, None)

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/brain.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/brain.py
@@ -27,7 +27,7 @@ per-pid setup/teardown.
 from __future__ import annotations
 
 import asyncio
-from typing import AsyncIterator, Union
+from typing import TYPE_CHECKING, AsyncIterator, Union
 
 from loguru import logger
 from pipecat.frames.frames import (
@@ -39,6 +39,9 @@ from pipecat.frames.frames import (
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 
 from ..frames import GatedQueryFrame, ParticipantJoinedFrame, ParticipantLeftFrame
+
+if TYPE_CHECKING:
+    from ..transport import XRMediaHubTransport
 
 
 QueryResult = Union[AsyncIterator[str], str]
@@ -52,13 +55,19 @@ class BrainProcessor(FrameProcessor):
     pipecat-internal traffic.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *, transport: "XRMediaHubTransport | None" = None) -> None:
         super().__init__()
         self._inflight: dict[str, asyncio.Task] = {}
         # Joined pids so the user-speech hook can fire on the cold path
         # (no in-flight task yet) — useful for camera warmup. Cleared on
         # ``ParticipantLeftFrame``.
         self._joined: set[str] = set()
+        # Optional — when supplied, the output transport is steered at
+        # the first ``ParticipantJoinedFrame`` so the single-participant
+        # return-audio / return-data path "just works" without per-sample
+        # wiring. Samples that handle multi-participant routing manually
+        # leave this unset.
+        self._transport = transport
 
     # ── overrides ─────────────────────────────────────────────────────────────
 
@@ -119,12 +128,20 @@ class BrainProcessor(FrameProcessor):
 
         if isinstance(frame, ParticipantJoinedFrame):
             self._joined.add(frame.participant_id)
+            # Single-participant default: steer the output transport at
+            # the first join so return-audio / return-data routing works
+            # without per-sample wiring. Samples that need multi-pid
+            # routing construct the brain without a transport.
+            if self._transport is not None:
+                self._transport.set_target_participant(frame.participant_id)
             await self.on_participant_joined(frame.participant_id)
             await self.push_frame(frame, direction)
             return
 
         if isinstance(frame, ParticipantLeftFrame):
             self._joined.discard(frame.participant_id)
+            if self._transport is not None:
+                self._transport.cleanup_participant(frame.participant_id)
             await self.on_participant_left(frame.participant_id)
             self._cancel_pid(frame.participant_id)
             await self.push_frame(frame, direction)

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/brain.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/brain.py
@@ -63,6 +63,14 @@ class BrainProcessor(FrameProcessor):
     def __init__(self, *, transport: "XRMediaHubTransport | None" = None) -> None:
         super().__init__()
         self._inflight: dict[str, asyncio.Task] = {}
+        # Pids that have had at least one query — gates the supersede
+        # hook on every non-first query for the pid, regardless of
+        # whether the prior brain task is still running. The brain-task
+        # status is the wrong gate: by the time a follow-up query lands,
+        # the prior brain task may already be done while the downstream
+        # TTS audio is still streaming out. Cleared on
+        # ``ParticipantLeftFrame``.
+        self._seen_query: set[str] = set()
         # Joined pids so the user-speech hook can fire on the cold path
         # (no in-flight task yet) — useful for camera warmup. Cleared on
         # ``ParticipantLeftFrame``.
@@ -98,24 +106,29 @@ class BrainProcessor(FrameProcessor):
         return
 
     async def on_query_superseded(self, pid: str) -> None:
-        """Override to react when a new query supersedes an in-flight one.
+        """Override to react when a new query supersedes the prior one.
 
-        Fires when a new ``GatedQueryFrame`` arrives for ``pid`` while
-        the previous query's task is still in-flight (i.e. the new query
-        supersedes the old). The library still cancels the previous
-        brain task immediately after this hook returns — that is not
-        configurable (you cannot have two queries in flight for the
-        same pid).
+        Fires on every ``GatedQueryFrame`` after the first for ``pid``,
+        regardless of whether the prior brain task is still in-flight.
+        Audio from the prior response may still be playing even if that
+        task already completed — sample brains push ``InterruptionFrame``
+        to drain the TTS sender + flush the hub buffer.
 
-        What IS configurable is what else should happen at supersede
-        time. The most common use is to drain queued downstream audio
-        for the previous response: cancelling the brain task only stops
-        *new* ``TextFrame``s from this processor, while the streaming
-        TTS sender queue, the hub's pacing pipe, and any jitter buffer
-        downstream continue to deliver whatever was already enqueued.
-        Override and push an ``InterruptionFrame`` to flush those
-        layers at the source. Default: no-op — audio continues, the
-        new response queues behind it.
+        The brain-task status is the wrong gate. Cancelling the brain
+        task only stops *new* ``TextFrame``s from this processor; the
+        streaming TTS sender queue, the hub's pacing pipe, and any
+        jitter buffer downstream continue to deliver whatever was
+        already enqueued. If the prior task finished quickly (e.g. a
+        short VLM response that streamed in under a second) the TTS
+        audio for that response can still be mid-flight when the
+        follow-up query arrives. Firing on every non-first query lets
+        the sample decide what to do about prior state (audio drain,
+        accumulated UI, etc.).
+
+        The library still cancels any prior in-flight task immediately
+        after this hook returns — that is not configurable (you cannot
+        have two queries in flight for the same pid). Default: no-op —
+        audio continues, the new response queues behind it.
 
         Exceptions from this hook are logged and swallowed; the
         supersede + spawn of the new query proceeds either way.
@@ -170,6 +183,7 @@ class BrainProcessor(FrameProcessor):
 
         if isinstance(frame, ParticipantLeftFrame):
             self._joined.discard(frame.participant_id)
+            self._seen_query.discard(frame.participant_id)
             if self._transport is not None:
                 self._transport.cleanup_participant(frame.participant_id)
             await self.on_participant_left(frame.participant_id)
@@ -196,19 +210,24 @@ class BrainProcessor(FrameProcessor):
 
     async def _spawn_query(self, frame: GatedQueryFrame) -> None:
         pid = frame.participant_id
-        # A fresh query supersedes any previous in-flight reasoning for
-        # the same pid — happens when the user squeezes in a follow-up
-        # before the last response completes. Fire the supersede hook
-        # *before* cancelling so the override (e.g. push InterruptionFrame
-        # to drain queued TTS audio for the previous response) lands
-        # while the prior task's downstream state is still coherent.
-        existing = self._inflight.get(pid)
-        if existing is not None and not existing.done():
+        # A fresh query supersedes the previous one for the same pid.
+        # Fire the supersede hook on every non-first query for the pid,
+        # regardless of whether the prior brain task is still running.
+        # The brain-task status is the wrong gate: a short prior
+        # response may have finished assembly while its TTS audio is
+        # still streaming out, and the sample needs to decide what to
+        # do about that (e.g. push InterruptionFrame to drain the TTS
+        # sender + flush the hub buffer). Fire *before* cancelling so
+        # the override lands while the prior task's downstream state is
+        # still coherent.
+        if pid in self._seen_query:
             try:
                 await self.on_query_superseded(pid)
             except Exception:
                 logger.exception("on_query_superseded raised pid={!r}", pid)
-            self._cancel_pid(pid)
+        self._seen_query.add(pid)
+        # Library still owns cancelling any task that IS still running.
+        self._cancel_pid(pid)
         self._inflight[pid] = asyncio.create_task(
             self._run_query(frame), name=f"brain-query-{pid}",
         )

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/brain.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/brain.py
@@ -97,6 +97,31 @@ class BrainProcessor(FrameProcessor):
         """
         return
 
+    async def on_query_superseded(self, pid: str) -> None:
+        """Override to react when a new query supersedes an in-flight one.
+
+        Fires when a new ``GatedQueryFrame`` arrives for ``pid`` while
+        the previous query's task is still in-flight (i.e. the new query
+        supersedes the old). The library still cancels the previous
+        brain task immediately after this hook returns — that is not
+        configurable (you cannot have two queries in flight for the
+        same pid).
+
+        What IS configurable is what else should happen at supersede
+        time. The most common use is to drain queued downstream audio
+        for the previous response: cancelling the brain task only stops
+        *new* ``TextFrame``s from this processor, while the streaming
+        TTS sender queue, the hub's pacing pipe, and any jitter buffer
+        downstream continue to deliver whatever was already enqueued.
+        Override and push an ``InterruptionFrame`` to flush those
+        layers at the source. Default: no-op — audio continues, the
+        new response queues behind it.
+
+        Exceptions from this hook are logged and swallowed; the
+        supersede + spawn of the new query proceeds either way.
+        """
+        return
+
     async def on_participant_joined(self, pid: str) -> None:
         """Override for per-pid setup. Default: no-op."""
         return
@@ -173,8 +198,17 @@ class BrainProcessor(FrameProcessor):
         pid = frame.participant_id
         # A fresh query supersedes any previous in-flight reasoning for
         # the same pid — happens when the user squeezes in a follow-up
-        # before the last response completes.
-        self._cancel_pid(pid)
+        # before the last response completes. Fire the supersede hook
+        # *before* cancelling so the override (e.g. push InterruptionFrame
+        # to drain queued TTS audio for the previous response) lands
+        # while the prior task's downstream state is still coherent.
+        existing = self._inflight.get(pid)
+        if existing is not None and not existing.done():
+            try:
+                await self.on_query_superseded(pid)
+            except Exception:
+                logger.exception("on_query_superseded raised pid={!r}", pid)
+            self._cancel_pid(pid)
         self._inflight[pid] = asyncio.create_task(
             self._run_query(frame), name=f"brain-query-{pid}",
         )

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/streaming_tts.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/streaming_tts.py
@@ -159,6 +159,10 @@ class StreamingTtsProcessor(FrameProcessor):
             return
         if not frame.text:
             return
+        logger.info(
+            "data text echo pid={!r} topic={!r} len={}",
+            frame.pid, self._text_topic, len(frame.text),
+        )
         try:
             await self._transport.send_return_data(DataMessage(
                 participant_id = frame.pid,
@@ -201,6 +205,7 @@ class StreamingTtsProcessor(FrameProcessor):
                 await self._dispatch_sentence(sentence, pid=pid)
 
     async def _dispatch_sentence(self, sentence: str, *, pid: str) -> None:
+        logger.info("tts sentence dispatch pid={!r} len={}", pid, len(sentence))
         queue = self._ensure_sender()
         task  = asyncio.create_task(
             self._tts.synthesize(sentence),
@@ -265,6 +270,14 @@ class StreamingTtsProcessor(FrameProcessor):
         the stop is immediate.
         """
         self._pending = ""
+        # Snapshot the target pid + queue length before tearing down so
+        # the user-facing log carries useful breadcrumbs (which
+        # participant was being addressed, how much queued audio is
+        # about to be dropped) without exposing transcript content.
+        target_pid = ""
+        if self._transport is not None:
+            target_pid = self._transport.target_participant
+        queue_len = self._sender_queue.qsize() if self._sender_queue is not None else 0
         if self._sender_task is not None and not self._sender_task.done():
             self._sender_task.cancel()
             try:
@@ -283,6 +296,9 @@ class StreamingTtsProcessor(FrameProcessor):
                     continue
                 task, _ = item
                 task.cancel()
+        logger.info(
+            "tts sender drained pid={!r} queue_len={}", target_pid, queue_len,
+        )
         self._sender_queue = None
         self._sender_task  = None
 
@@ -295,6 +311,7 @@ class StreamingTtsProcessor(FrameProcessor):
         if self._transport is not None:
             pid = self._transport.target_participant
             if pid:
+                logger.info("hub return-audio flushed pid={!r}", pid)
                 try:
                     await self._transport.endpoint.flush_return_audio(pid)
                 except Exception:

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/streaming_tts.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/streaming_tts.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 
 import asyncio
 import re
-import time
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -95,6 +94,10 @@ class StreamingTtsProcessor(FrameProcessor):
         self._pending: str       = ""
         self._sender_task: asyncio.Task | None = None
         self._sender_queue: asyncio.Queue | None = None
+        # Monotonic per-instance counter for unique synth task names — a
+        # wall-clock millisecond stamp collides when two sentences dispatch
+        # within the same millisecond.
+        self._synth_seq: int = 0
 
     # ── pipecat frame entrypoint ──────────────────────────────────────────────
 
@@ -207,9 +210,10 @@ class StreamingTtsProcessor(FrameProcessor):
     async def _dispatch_sentence(self, sentence: str, *, pid: str) -> None:
         logger.info("tts sentence dispatch pid={!r} len={}", pid, len(sentence))
         queue = self._ensure_sender()
+        self._synth_seq += 1
         task  = asyncio.create_task(
             self._tts.synthesize(sentence),
-            name=f"tts-synth-{int(time.time()*1000)}",
+            name=f"tts-synth-{pid}-{self._synth_seq}",
         )
         await queue.put((task, pid))
 

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/streaming_tts.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/streaming_tts.py
@@ -1,0 +1,198 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""``StreamingTtsProcessor`` — sentence-batched parallel TTS.
+
+Consumes ``TextFrame``s (brain output, one per chunk/token) and emits
+``OutputAudioRawFrame``s. Buffers text until a sentence boundary, kicks
+off TTS for each sentence in parallel, then streams the WAVs out in
+order so playback is monotonic.
+
+``InterruptionFrame`` cancels every in-flight synth task and clears the
+output queue so the user does not hear stale audio after asking the
+agent to stop.
+
+Every synthesized WAV is offered to ``VoiceGate.observe_tts_wav`` so
+the gate's listening chime can lazily build at the right sample rate.
+"""
+from __future__ import annotations
+
+import asyncio
+import re
+import time
+
+import numpy as np
+from loguru import logger
+from pipecat.frames.frames import (
+    Frame,
+    InterruptionFrame,
+    OutputAudioRawFrame,
+    TextFrame,
+)
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+
+from xr_ai_models import TTSService
+from xr_ai_voicegate import VoiceGate
+
+from ..audio import wav_to_chunks
+
+
+_SENTENCE_END = re.compile(r"(?<=[.!?])\s+")
+
+
+class StreamingTtsProcessor(FrameProcessor):
+    """Sentence-batched parallel TTS at the tail of the voice pipeline.
+
+    Lifts the parallel-synth-with-ordered-send pattern from
+    :func:`xr_ai_pipecat.audio.stream_sentences_to_audio` and exposes it
+    as a frame processor.
+    """
+
+    def __init__(self, *, tts: TTSService, voice_gate: VoiceGate) -> None:
+        super().__init__()
+        self._tts        = tts
+        self._voice_gate = voice_gate
+        # Pending text we haven't yet split into a sentence — accumulates
+        # across consecutive TextFrames so e.g. token streams from an
+        # LLM coalesce into whole sentences before TTS is invoked.
+        self._pending: str       = ""
+        self._sender_task: asyncio.Task | None = None
+        self._sender_queue: asyncio.Queue | None = None
+
+    # ── pipecat frame entrypoint ──────────────────────────────────────────────
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
+        await super().process_frame(frame, direction)
+
+        if isinstance(frame, InterruptionFrame):
+            await self._drain_on_interrupt()
+            await self.push_frame(frame, direction)
+            return
+
+        if isinstance(frame, TextFrame):
+            await self._handle_text(frame)
+            return
+
+        await self.push_frame(frame, direction)
+
+    # ── private ───────────────────────────────────────────────────────────────
+
+    def _ensure_sender(self) -> asyncio.Queue:
+        """Spin up the ordered-sender task lazily on first sentence."""
+        if self._sender_queue is None or self._sender_task is None or self._sender_task.done():
+            self._sender_queue = asyncio.Queue()
+            self._sender_task  = asyncio.create_task(
+                self._sender_loop(self._sender_queue),
+                name="tts-sender",
+            )
+        return self._sender_queue
+
+    async def _handle_text(self, frame: TextFrame) -> None:
+        if not frame.text:
+            return
+        # A trailing space matters when token-stream text frames arrive
+        # without their own punctuation — preserve whatever the producer
+        # sent verbatim.
+        self._pending += frame.text
+        await self._flush_complete_sentences(pid=frame.transport_destination or "")
+
+    async def _flush_complete_sentences(self, *, pid: str) -> None:
+        """Drain every complete sentence in the pending buffer, leaving
+        any trailing fragment in place until more text arrives. A buffer
+        that already ends in sentence-final punctuation is flushed in
+        one shot — covers the brain-returns-a-complete-string case
+        where no trailing whitespace ever arrives."""
+        while True:
+            m = _SENTENCE_END.search(self._pending)
+            if m is None:
+                break
+            sentence  = self._pending[: m.end()].strip()
+            self._pending = self._pending[m.end() :]
+            if not sentence:
+                continue
+            await self._dispatch_sentence(sentence, pid=pid)
+        # Pending buffer ends in sentence-final punctuation? Flush it
+        # too — the brain is done writing and there's no follow-up
+        # whitespace to fire the boundary regex.
+        if self._pending and self._pending.rstrip().endswith((".", "!", "?")):
+            sentence  = self._pending.strip()
+            self._pending = ""
+            if sentence:
+                await self._dispatch_sentence(sentence, pid=pid)
+
+    async def _dispatch_sentence(self, sentence: str, *, pid: str) -> None:
+        queue = self._ensure_sender()
+        task  = asyncio.create_task(
+            self._tts.synthesize(sentence),
+            name=f"tts-synth-{int(time.time()*1000)}",
+        )
+        await queue.put((task, pid))
+
+    async def _sender_loop(self, queue: asyncio.Queue) -> None:
+        """Awaits each synth task in FIFO order, observes the WAV, and
+        pushes the decoded audio downstream as ``OutputAudioRawFrame``s."""
+        try:
+            while True:
+                item = await queue.get()
+                if item is None:
+                    return
+                task, pid = item
+                try:
+                    wav = await task
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.exception("tts synth failed pid={!r}", pid)
+                    continue
+                if not wav:
+                    continue
+                # Let the gate's lazy chime build pick up the sample rate
+                # from real TTS output exactly once.
+                try:
+                    self._voice_gate.observe_tts_wav(wav)
+                except Exception:
+                    logger.exception("observe_tts_wav raised pid={!r}", pid)
+                await self._push_wav(wav, pid=pid)
+        except asyncio.CancelledError:
+            return
+
+    async def _push_wav(self, wav_bytes: bytes, *, pid: str) -> None:
+        try:
+            chunks = wav_to_chunks(wav_bytes, pid)
+        except Exception:
+            logger.exception("tts WAV decode failed pid={!r}", pid)
+            return
+        for c in chunks:
+            f32 = np.frombuffer(c.data, dtype=np.float32)
+            i16 = np.clip(f32 * 32767.0, -32768, 32767).astype(np.int16).tobytes()
+            out = OutputAudioRawFrame(
+                audio        = i16,
+                sample_rate  = c.sample_rate,
+                num_channels = c.channels,
+            )
+            out.transport_destination = pid
+            await self.push_frame(out)
+
+    async def _drain_on_interrupt(self) -> None:
+        """Cancel everything in flight + flush the pending buffer."""
+        self._pending = ""
+        if self._sender_task is not None and not self._sender_task.done():
+            self._sender_task.cancel()
+            try:
+                await self._sender_task
+            except asyncio.CancelledError:
+                pass
+        # Drop any tasks still parked in the queue so they don't keep
+        # running and emit audio after the interrupt.
+        if self._sender_queue is not None:
+            while not self._sender_queue.empty():
+                try:
+                    item = self._sender_queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    break
+                if item is None:
+                    continue
+                task, _ = item
+                task.cancel()
+        self._sender_queue = None
+        self._sender_task  = None

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/streaming_tts.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/streaming_tts.py
@@ -243,7 +243,16 @@ class StreamingTtsProcessor(FrameProcessor):
             await self.push_frame(out)
 
     async def _drain_on_interrupt(self) -> None:
-        """Cancel everything in flight + flush the pending buffer."""
+        """Cancel everything in flight + flush the pending buffer.
+
+        Cancelling the synth + sender tasks stops *new* audio from being
+        produced, but anything already queued downstream — the hub's
+        pacing pipe and the LiveKit jitter buffer — keeps playing. The
+        user hears the agent finish its current sentence(s) before
+        silence, and STOP feels broken. Flushing the hub's return-audio
+        buffer on the way out drops that pending audio at the source so
+        the stop is immediate.
+        """
         self._pending = ""
         if self._sender_task is not None and not self._sender_task.done():
             self._sender_task.cancel()
@@ -265,3 +274,20 @@ class StreamingTtsProcessor(FrameProcessor):
                 task.cancel()
         self._sender_queue = None
         self._sender_task  = None
+
+        # Flush the hub's return-audio buffer so already-paced audio
+        # stops immediately instead of finishing whatever sentence was
+        # mid-playback. Single-participant samples set
+        # ``target_participant`` on ``ParticipantJoinedFrame``; if the
+        # transport isn't wired or no participant is bound yet, there's
+        # nothing to flush.
+        if self._transport is not None:
+            pid = self._transport.target_participant
+            if pid:
+                try:
+                    await self._transport.endpoint.flush_return_audio(pid)
+                except Exception:
+                    logger.opt(exception=True).debug(
+                        "flush_return_audio failed on interrupt pid={!r}",
+                        pid,
+                    )

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/streaming_tts.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/streaming_tts.py
@@ -51,6 +51,13 @@ if TYPE_CHECKING:
 
 
 _SENTENCE_END = re.compile(r"(?<=[.!?])\s+")
+# Matches a sentence-final char optionally followed by closing punctuation
+# (quote, single quote, paren, bracket) and trailing whitespace. The
+# brain may emit `'... what am I looking at?"'` — the `?` is the
+# sentence end but the buffer's last char is `"`, so an `endswith(.!?)`
+# check would leave the tail in pending and the next turn's text would
+# be concatenated onto it.
+_TRAILING_SENTENCE_END = re.compile(r"""[.!?]["')\]]*\s*$""")
 
 
 class StreamingTtsProcessor(FrameProcessor):
@@ -182,8 +189,12 @@ class StreamingTtsProcessor(FrameProcessor):
             await self._dispatch_sentence(sentence, pid=pid)
         # Pending buffer ends in sentence-final punctuation? Flush it
         # too — the brain is done writing and there's no follow-up
-        # whitespace to fire the boundary regex.
-        if self._pending and self._pending.rstrip().endswith((".", "!", "?")):
+        # whitespace to fire the boundary regex. ``_TRAILING_SENTENCE_END``
+        # tolerates trailing closing quotes/brackets after the sentence
+        # char (e.g. ``... what am I looking at?"``) which a plain
+        # ``endswith((".", "!", "?"))`` would miss, leaving the tail in
+        # pending until it concatenated onto the next turn's reply.
+        if self._pending and _TRAILING_SENTENCE_END.search(self._pending):
             sentence  = self._pending.strip()
             self._pending = ""
             if sentence:

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/streaming_tts.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/streaming_tts.py
@@ -283,6 +283,9 @@ class StreamingTtsProcessor(FrameProcessor):
             try:
                 await self._sender_task
             except asyncio.CancelledError:
+                # Expected: we cancelled this task ourselves; awaiting it
+                # raises CancelledError, which we intentionally swallow so
+                # interrupt drain completes cleanly.
                 pass
         # Drop any tasks still parked in the queue so they don't keep
         # running and emit audio after the interrupt.

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/streaming_tts.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/streaming_tts.py
@@ -14,12 +14,20 @@ agent to stop.
 
 Every synthesized WAV is offered to ``VoiceGate.observe_tts_wav`` so
 the gate's listening chime can lazily build at the right sample rate.
+
+When constructed with a non-empty ``text_topic`` and a ``transport``,
+the processor also echoes each brain turn's full assembled response on
+the data channel under that topic — the moment it sees a
+:class:`BrainResponseEndFrame`. Samples whose brain already pushes its
+own per-turn data echo (e.g. xr-render-demo) pass ``text_topic=""`` to
+opt out of this and avoid duplicate sends.
 """
 from __future__ import annotations
 
 import asyncio
 import re
 import time
+from typing import TYPE_CHECKING
 
 import numpy as np
 from loguru import logger
@@ -31,10 +39,15 @@ from pipecat.frames.frames import (
 )
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 
+from xr_ai_agent import DataMessage
 from xr_ai_models import TTSService
 from xr_ai_voicegate import VoiceGate
 
 from ..audio import wav_to_chunks
+from ..frames import BrainResponseEndFrame
+
+if TYPE_CHECKING:
+    from ..transport import XRMediaHubTransport
 
 
 _SENTENCE_END = re.compile(r"(?<=[.!?])\s+")
@@ -46,12 +59,29 @@ class StreamingTtsProcessor(FrameProcessor):
     Lifts the parallel-synth-with-ordered-send pattern from
     :func:`xr_ai_pipecat.audio.stream_sentences_to_audio` and exposes it
     as a frame processor.
+
+    ``transport`` and ``text_topic`` are optional; when both are
+    supplied (and the topic is non-empty), the processor emits one
+    ``send_return_data`` per :class:`BrainResponseEndFrame` so the
+    client receives the full assembled reply on the data channel.
+    Leaving them out (or passing an empty topic) disables the echo —
+    used by samples whose brain already sends its own per-turn data
+    response.
     """
 
-    def __init__(self, *, tts: TTSService, voice_gate: VoiceGate) -> None:
+    def __init__(
+        self,
+        *,
+        tts: TTSService,
+        voice_gate: VoiceGate,
+        transport: "XRMediaHubTransport | None" = None,
+        text_topic: str = "",
+    ) -> None:
         super().__init__()
         self._tts        = tts
         self._voice_gate = voice_gate
+        self._transport  = transport
+        self._text_topic = text_topic
         # Pending text we haven't yet split into a sentence — accumulates
         # across consecutive TextFrames so e.g. token streams from an
         # LLM coalesce into whole sentences before TTS is invoked.
@@ -66,6 +96,14 @@ class StreamingTtsProcessor(FrameProcessor):
 
         if isinstance(frame, InterruptionFrame):
             await self._drain_on_interrupt()
+            await self.push_frame(frame, direction)
+            return
+
+        if isinstance(frame, BrainResponseEndFrame):
+            await self._handle_response_end(frame)
+            # Forward the marker so any tail processor / sink that
+            # tracks turn boundaries (tests, future debug taps) still
+            # sees it.
             await self.push_frame(frame, direction)
             return
 
@@ -95,6 +133,37 @@ class StreamingTtsProcessor(FrameProcessor):
         # sent verbatim.
         self._pending += frame.text
         await self._flush_complete_sentences(pid=frame.transport_destination or "")
+
+    async def _handle_response_end(self, frame: BrainResponseEndFrame) -> None:
+        """Flush trailing pending text, then send the data echo.
+
+        The brain may finish a turn with text that has no
+        sentence-final punctuation (e.g. an aborted partial answer);
+        the boundary regex would leave that fragment in the buffer
+        forever. End-of-response is the right place to flush it so the
+        user hears the tail of the reply.
+        """
+        if self._pending.strip():
+            sentence = self._pending.strip()
+            self._pending = ""
+            await self._dispatch_sentence(sentence, pid=frame.pid)
+
+        if not self._text_topic or self._transport is None:
+            return
+        if not frame.text:
+            return
+        try:
+            await self._transport.send_return_data(DataMessage(
+                participant_id = frame.pid,
+                topic          = self._text_topic,
+                pts_us         = frame.pts_us,
+                data           = frame.text.encode(),
+            ))
+        except Exception:
+            logger.exception(
+                "send_return_data failed pid={!r} topic={!r}",
+                frame.pid, self._text_topic,
+            )
 
     async def _flush_complete_sentences(self, *, pid: str) -> None:
         """Drain every complete sentence in the pending buffer, leaving

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/vad_stt.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/vad_stt.py
@@ -41,6 +41,8 @@ from xr_ai_models import STTService
 from xr_ai_vad import VadDetector
 from xr_ai_voicegate._phrases import STOP_RE
 
+from ..frames import ParticipantLeftFrame
+
 
 @dataclass(frozen=True)
 class VadConfig:
@@ -107,6 +109,15 @@ class VadSttProcessor(FrameProcessor):
 
         if isinstance(frame, InputAudioRawFrame):
             await self._handle_audio(frame)
+            return
+
+        if isinstance(frame, ParticipantLeftFrame):
+            # Evict all per-pid state for the departing participant so the
+            # detector / buffer / flag dicts don't grow without bound over a
+            # long-lived session of joins and leaves. The frame is still
+            # forwarded downstream so the gate / brain / transport can react.
+            await self._evict_participant(frame.participant_id)
+            await self.push_frame(frame, direction)
             return
 
         await self.push_frame(frame, direction)
@@ -327,6 +338,24 @@ class VadSttProcessor(FrameProcessor):
         tf.transport_source = pid
         await self.push_frame(tf)
         await self.push_frame(UserStoppedSpeakingFrame())
+
+    async def _evict_participant(self, pid: str) -> None:
+        """Drop all per-pid state when a participant leaves.
+
+        ``_detectors`` and the probe-related dicts/sets are keyed by pid and
+        are otherwise only ever added to (on first audio / speech-start), so
+        without an eviction path they grow unbounded across a session's
+        join/leave churn. Cancel any live probe task first so it can't fire
+        against torn-down state, then pop every per-pid entry.
+        """
+        await self._cancel_probe_task(pid)
+        self._detectors.pop(pid, None)
+        self._probe_buffer.pop(pid, None)
+        self._probe_sr.pop(pid, None)
+        self._stop_fired_for_current_utterance.discard(pid)
+        if self._current_pid == pid:
+            self._current_pid = None
+        logger.info("evicted per-participant VAD state pid={!r}", pid)
 
     async def _cancel_probe_task(self, pid: str) -> None:
         """Cancel a pending probe task and await its teardown.

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/vad_stt.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/vad_stt.py
@@ -11,9 +11,18 @@ injected ``STTService`` and pushes a ``TranscriptionFrame`` downstream.
 VAD start/stop edges are forwarded as pipecat's built-in
 ``UserStartedSpeakingFrame`` / ``UserStoppedSpeakingFrame`` so the brain
 can cancel in-flight work on the moment speech starts.
+
+Also runs an early STT *probe* shortly after speech-start so brief
+STOP utterances ("stop", "be quiet") interrupt the agent without
+waiting for VAD's full silence-window finalize. The probe transcribes
+the partial audio buffer; on a STOP-pattern match it pushes an
+``InterruptionFrame`` immediately and lets the gate handle the canned
+ack. Anything else is discarded and normal VAD-finalize handles the
+query.
 """
 from __future__ import annotations
 
+import asyncio
 import time
 from dataclasses import dataclass
 
@@ -21,6 +30,7 @@ from loguru import logger
 from pipecat.frames.frames import (
     Frame,
     InputAudioRawFrame,
+    InterruptionFrame,
     TranscriptionFrame,
     UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
@@ -29,6 +39,7 @@ from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 
 from xr_ai_models import STTService
 from xr_ai_vad import VadDetector
+from xr_ai_voicegate._phrases import STOP_RE
 
 
 @dataclass(frozen=True)
@@ -37,10 +48,18 @@ class VadConfig:
 
     Mirrors the constructor of :class:`xr_ai_vad.VadDetector`. Default
     values match the in-tree samples' current behavior.
+
+    ``stop_probe_after_s`` — seconds after ``on_speech_start`` to run an
+    extra STT pass on the partial audio buffer and check for STOP. This
+    gives the user a fast-path interrupt on brief commands ("stop",
+    "be quiet") that VAD would otherwise hold open for the full
+    ``silence_duration`` window. Set to ``0`` or negative to disable
+    the probe and rely solely on VAD finalize.
     """
-    silence_duration: float = 0.8
-    min_speech:       float = 0.15
-    silero_threshold: float = 0.5
+    silence_duration:   float = 0.8
+    min_speech:         float = 0.15
+    silero_threshold:   float = 0.5
+    stop_probe_after_s: float = 0.4
 
 
 class VadSttProcessor(FrameProcessor):
@@ -66,6 +85,20 @@ class VadSttProcessor(FrameProcessor):
         # can push the matching ``UserStoppedSpeakingFrame`` even though
         # the VAD callback itself is pid-agnostic.
         self._current_pid: str | None = None
+        # Per-pid mutable audio buffer for the early STOP probe — present
+        # only while an utterance is in flight. ``on_speech_start`` opens
+        # the entry; ``on_utterance`` (and the probe itself, after firing)
+        # close it.
+        self._probe_buffer:   dict[str, bytearray] = {}
+        self._probe_sr:       dict[str, int]       = {}
+        # One probe task per pid, so a fresh speech_start can cancel a
+        # lingering task before scheduling the next.
+        self._probe_task:     dict[str, asyncio.Task] = {}
+        # Pids whose probe has already pushed a STOP for the current
+        # utterance — suppresses the duplicate that would fire when VAD
+        # eventually finalizes the same speech run. Cleared on the next
+        # ``on_speech_start`` for the pid.
+        self._stop_fired_for_current_utterance: set[str] = set()
 
     # ── pipecat frame entrypoint ──────────────────────────────────────────────
 
@@ -87,9 +120,44 @@ class VadSttProcessor(FrameProcessor):
 
         async def on_speech_start() -> None:
             self._current_pid = pid
+            # Reset probe state for the new utterance. Any leftover task
+            # from a previous utterance (should be done by now, but
+            # belt-and-suspenders) is cancelled before scheduling a new one.
+            self._stop_fired_for_current_utterance.discard(pid)
+            self._cancel_probe_task(pid)
+            self._probe_buffer[pid] = bytearray()
+            # The first feed after start_fired carries the real sample
+            # rate; default to 0 so a missing entry later means "no audio".
+            self._probe_sr[pid] = 0
+            if self._vad_cfg.stop_probe_after_s > 0:
+                self._probe_task[pid] = asyncio.create_task(
+                    self._run_stop_probe(pid),
+                    name=f"vad-stop-probe-{pid}",
+                )
             await self.push_frame(UserStartedSpeakingFrame())
 
         async def on_utterance(audio_bytes: bytes, sample_rate: int) -> None:
+            # Probe ran-or-not, the utterance has finalized. Close the
+            # probe buffer entry and cancel any pending probe (e.g.
+            # silence_duration < stop_probe_after_s).
+            self._cancel_probe_task(pid)
+            self._probe_buffer.pop(pid, None)
+            self._probe_sr.pop(pid, None)
+
+            # If the probe already pushed STOP for this utterance, the
+            # frames downstream (InterruptionFrame + TranscriptionFrame
+            # to the gate + UserStoppedSpeakingFrame) have already done
+            # their job. Re-firing UserStoppedSpeakingFrame + a fresh
+            # TranscriptionFrame (gate sees STOP again → re-fires the ack
+            # TTS) would double the stop-ack. Suppress.
+            if pid in self._stop_fired_for_current_utterance:
+                self._stop_fired_for_current_utterance.discard(pid)
+                logger.debug(
+                    "VadSttProcessor suppressing duplicate VAD-finalize "
+                    "STOP pid={!r} (probe already fired)", pid,
+                )
+                return
+
             # Order matters: pipecat consumers expect "user stopped speaking"
             # before the transcript so they can finalize turn state.
             await self.push_frame(UserStoppedSpeakingFrame())
@@ -135,7 +203,108 @@ class VadSttProcessor(FrameProcessor):
             )
             return
         det = self._detector_for(pid)
+
         await det.feed(frame.audio, frame.sample_rate)
+
+        # Accumulate audio for the probe only while speech is active —
+        # the dict entry is opened in on_speech_start and closed in
+        # on_utterance (or by the probe itself after firing STOP). Append
+        # AFTER ``feed`` so the chunk that synchronously triggered
+        # on_speech_start lands in the buffer. (In production
+        # on_speech_start runs as a task and may not have created the
+        # entry yet — at most we lose ~20-30ms of audio, which is fine
+        # for STOP detection on the remainder.)
+        buf = self._probe_buffer.get(pid)
+        if buf is not None:
+            buf.extend(frame.audio)
+            self._probe_sr[pid] = frame.sample_rate
+
+    async def _run_stop_probe(self, pid: str) -> None:
+        """Wait ``stop_probe_after_s``, then transcribe whatever's in the
+        per-pid buffer and check it against ``STOP_RE``.
+
+        On match: push ``InterruptionFrame`` immediately, then
+        ``TranscriptionFrame`` (so the gate emits its canned ack), then
+        ``UserStoppedSpeakingFrame``. The duplicate-STOP suppression
+        flag is set so the eventual VAD-finalize for this same utterance
+        doesn't re-fire the ack.
+
+        On a non-STOP transcript, or on STT failure / timeout, the probe
+        is silent — VAD finalize will dispatch normally.
+        """
+        try:
+            await asyncio.sleep(self._vad_cfg.stop_probe_after_s)
+        except asyncio.CancelledError:
+            return
+
+        # Snapshot under the same control flow that owns the buffer dict —
+        # no other coroutine writes to these entries between here and the
+        # cancellation path, so a plain read is safe in the asyncio model.
+        buf = self._probe_buffer.get(pid)
+        sr  = self._probe_sr.get(pid, 0)
+        if not buf or sr <= 0:
+            # Utterance already finalized (and entry cleared) or no audio
+            # ever accumulated — skip silently.
+            return
+        audio_snapshot = bytes(buf)
+
+        try:
+            text = await self._stt.transcribe(audio_snapshot, sample_rate=sr)
+        except asyncio.CancelledError:
+            # Cancelled mid-transcribe — the on_utterance path is taking
+            # over. Don't push anything.
+            return
+        except Exception:
+            logger.exception("stop-probe stt transcribe failed pid={!r}", pid)
+            return
+
+        if not text or not STOP_RE.match(text):
+            return
+
+        # Race guard: if on_utterance already closed the buffer between
+        # the STT await returning and this check, the cancellation simply
+        # hasn't propagated yet. Bow out — the finalize path will handle
+        # the rest.
+        if pid not in self._probe_buffer:
+            return
+
+        logger.info(
+            "VadSttProcessor early-probe STOP match pid={!r} after={:.2f}s",
+            pid, self._vad_cfg.stop_probe_after_s,
+        )
+
+        # Mark before pushing so the suppression flag is set if the VAD
+        # racing-finalize lands while frames are still queueing downstream.
+        self._stop_fired_for_current_utterance.add(pid)
+
+        # Close the probe buffer now — on_utterance will see the empty
+        # entry and skip its own buffering work, but the suppression flag
+        # is what actually gates the duplicate frame emission.
+        self._probe_buffer.pop(pid, None)
+        self._probe_sr.pop(pid, None)
+
+        # Frame order intentionally differs from ``on_utterance``'s
+        # USSF-first convention: the probe is a fast-path interruption,
+        # not a clean end-of-turn. InterruptionFrame goes first so the
+        # brain cancels any in-flight reasoning before the gate sees the
+        # STOP transcript and re-issues its own InterruptionFrame +
+        # canned ack. UserStoppedSpeakingFrame tails as a hint to
+        # downstream turn-state consumers that the partial-audio turn
+        # has ended.
+        await self.push_frame(InterruptionFrame())
+        tf = TranscriptionFrame(
+            text      = text,
+            user_id   = pid,
+            timestamp = _now_iso(),
+        )
+        tf.transport_source = pid
+        await self.push_frame(tf)
+        await self.push_frame(UserStoppedSpeakingFrame())
+
+    def _cancel_probe_task(self, pid: str) -> None:
+        task = self._probe_task.pop(pid, None)
+        if task is not None and not task.done():
+            task.cancel()
 
 
 def _now_iso() -> str:

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/vad_stt.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/vad_stt.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""``VadSttProcessor`` — turns mic audio into transcriptions.
+
+Lives at the head of the voice pipeline. For each
+``InputAudioRawFrame`` it feeds the per-participant ``VadDetector``;
+when the detector emits an utterance the processor sends it through the
+injected ``STTService`` and pushes a ``TranscriptionFrame`` downstream.
+
+VAD start/stop edges are forwarded as pipecat's built-in
+``UserStartedSpeakingFrame`` / ``UserStoppedSpeakingFrame`` so the brain
+can cancel in-flight work on the moment speech starts.
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+from loguru import logger
+from pipecat.frames.frames import (
+    Frame,
+    InputAudioRawFrame,
+    TranscriptionFrame,
+    UserStartedSpeakingFrame,
+    UserStoppedSpeakingFrame,
+)
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+
+from xr_ai_models import STTService
+from xr_ai_vad import VadDetector
+
+
+@dataclass(frozen=True)
+class VadConfig:
+    """Tuning knobs for the Silero-VAD utterance detector.
+
+    Mirrors the constructor of :class:`xr_ai_vad.VadDetector`. Default
+    values match the in-tree samples' current behavior.
+    """
+    silence_duration: float = 0.8
+    min_speech:       float = 0.15
+    silero_threshold: float = 0.5
+
+
+class VadSttProcessor(FrameProcessor):
+    """Consumes ``InputAudioRawFrame``; emits
+    ``UserStartedSpeakingFrame`` / ``UserStoppedSpeakingFrame`` /
+    ``TranscriptionFrame``.
+
+    A single shared ``VadDetector`` is held per-participant. The pid is
+    read from ``frame.transport_source`` (pipecat's standard hook for
+    "which input track did this come from"); an unset transport_source
+    is treated as the single anonymous participant ``""`` — adequate for
+    samples that only ever expect one speaker at a time and matches the
+    transport's current single-target behavior.
+    """
+
+    def __init__(self, *, stt: STTService, vad_cfg: VadConfig) -> None:
+        super().__init__()
+        self._stt        = stt
+        self._vad_cfg    = vad_cfg
+        self._detectors: dict[str, VadDetector] = {}
+        # Track which pid is currently in an utterance so on_utterance
+        # can push the matching ``UserStoppedSpeakingFrame`` even though
+        # the VAD callback itself is pid-agnostic.
+        self._current_pid: str | None = None
+
+    # ── pipecat frame entrypoint ──────────────────────────────────────────────
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
+        await super().process_frame(frame, direction)
+
+        if isinstance(frame, InputAudioRawFrame):
+            await self._handle_audio(frame)
+            return
+
+        await self.push_frame(frame, direction)
+
+    # ── private ───────────────────────────────────────────────────────────────
+
+    def _detector_for(self, pid: str) -> VadDetector:
+        det = self._detectors.get(pid)
+        if det is not None:
+            return det
+
+        async def on_speech_start() -> None:
+            self._current_pid = pid
+            await self.push_frame(UserStartedSpeakingFrame())
+
+        async def on_utterance(audio_bytes: bytes, sample_rate: int) -> None:
+            # Order matters: pipecat consumers expect "user stopped speaking"
+            # before the transcript so they can finalize turn state.
+            await self.push_frame(UserStoppedSpeakingFrame())
+            try:
+                text = await self._stt.transcribe(audio_bytes, sample_rate=sample_rate)
+            except Exception:
+                logger.exception("stt transcribe failed pid={!r}", pid)
+                return
+            if not text:
+                return
+            await self.push_frame(TranscriptionFrame(
+                text      = text,
+                user_id   = pid,
+                timestamp = _now_iso(),
+            ))
+
+        det = VadDetector(
+            on_utterance      = on_utterance,
+            on_speech_start   = on_speech_start,
+            silence_duration  = self._vad_cfg.silence_duration,
+            min_speech        = self._vad_cfg.min_speech,
+            silero_threshold  = self._vad_cfg.silero_threshold,
+        )
+        self._detectors[pid] = det
+        return det
+
+    async def _handle_audio(self, frame: InputAudioRawFrame) -> None:
+        pid = frame.transport_source or ""
+        det = self._detector_for(pid)
+        await det.feed(frame.audio, frame.sample_rate)
+
+
+def _now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime())

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/vad_stt.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/vad_stt.py
@@ -50,10 +50,11 @@ class VadSttProcessor(FrameProcessor):
 
     A single shared ``VadDetector`` is held per-participant. The pid is
     read from ``frame.transport_source`` (pipecat's standard hook for
-    "which input track did this come from"); an unset transport_source
-    is treated as the single anonymous participant ``""`` — adequate for
-    samples that only ever expect one speaker at a time and matches the
-    transport's current single-target behavior.
+    "which input track did this come from"). An unset transport_source
+    means the transport adapter regressed — there is no usable pid to
+    route brain output / return-data / return-audio back to, so the
+    frame is logged and dropped rather than silently dispatched with
+    ``pid=''`` (which the hub drops on the floor anyway).
     """
 
     def __init__(self, *, stt: STTService, vad_cfg: VadConfig) -> None:
@@ -99,11 +100,16 @@ class VadSttProcessor(FrameProcessor):
                 return
             if not text:
                 return
-            await self.push_frame(TranscriptionFrame(
+            tf = TranscriptionFrame(
                 text      = text,
                 user_id   = pid,
                 timestamp = _now_iso(),
-            ))
+            )
+            # Propagate the pid on transport_source too — downstream
+            # processors that key on the pipecat-standard field (rather
+            # than user_id) need the same value.
+            tf.transport_source = pid
+            await self.push_frame(tf)
 
         det = VadDetector(
             on_utterance      = on_utterance,
@@ -116,7 +122,18 @@ class VadSttProcessor(FrameProcessor):
         return det
 
     async def _handle_audio(self, frame: InputAudioRawFrame) -> None:
-        pid = frame.transport_source or ""
+        pid = frame.transport_source
+        if not pid:
+            # The transport adapter is responsible for populating
+            # transport_source with the participant id. If it is missing
+            # there is no usable routing target for any downstream
+            # response — log loudly and drop rather than dispatch with
+            # pid='' (which the hub would drop silently anyway).
+            logger.error(
+                "VadSttProcessor dropped InputAudioRawFrame with no "
+                "transport_source — transport adapter regression?",
+            )
+            return
         det = self._detector_for(pid)
         await det.feed(frame.audio, frame.sample_rate)
 

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/vad_stt.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/vad_stt.py
@@ -121,10 +121,19 @@ class VadSttProcessor(FrameProcessor):
         async def on_speech_start() -> None:
             self._current_pid = pid
             # Reset probe state for the new utterance. Any leftover task
-            # from a previous utterance (should be done by now, but
-            # belt-and-suspenders) is cancelled before scheduling a new one.
+            # from a previous utterance is cancelled AND awaited to
+            # completion before scheduling the next probe — otherwise the
+            # cancelled task may still be mid ``await self.push_frame(...)``
+            # when the new probe task starts, leaving its
+            # ``__process_frame_task_handler`` coroutine in pipecat's
+            # downstream processor in a state where its cancellation
+            # propagates after a fresh one has already been scheduled.
+            # That overlap was the source of intermittent
+            # "coroutine '...__process_frame_task_handler' was never
+            # awaited" RuntimeWarnings observed in production right after
+            # a probe-STOP match.
             self._stop_fired_for_current_utterance.discard(pid)
-            self._cancel_probe_task(pid)
+            await self._cancel_probe_task(pid)
             self._probe_buffer[pid] = bytearray()
             # The first feed after start_fired carries the real sample
             # rate; default to 0 so a missing entry later means "no audio".
@@ -139,8 +148,10 @@ class VadSttProcessor(FrameProcessor):
         async def on_utterance(audio_bytes: bytes, sample_rate: int) -> None:
             # Probe ran-or-not, the utterance has finalized. Close the
             # probe buffer entry and cancel any pending probe (e.g.
-            # silence_duration < stop_probe_after_s).
-            self._cancel_probe_task(pid)
+            # silence_duration < stop_probe_after_s). Await the
+            # cancellation so the probe task is fully torn down — see
+            # the comment in ``on_speech_start`` for why this matters.
+            await self._cancel_probe_task(pid)
             self._probe_buffer.pop(pid, None)
             self._probe_sr.pop(pid, None)
 
@@ -301,10 +312,35 @@ class VadSttProcessor(FrameProcessor):
         await self.push_frame(tf)
         await self.push_frame(UserStoppedSpeakingFrame())
 
-    def _cancel_probe_task(self, pid: str) -> None:
+    async def _cancel_probe_task(self, pid: str) -> None:
+        """Cancel a pending probe task and await its teardown.
+
+        Awaiting is what closes the race that produces intermittent
+        ``coroutine '...__process_frame_task_handler' was never awaited``
+        warnings: a cancelled probe may still be mid
+        ``await self.push_frame(...)`` (frame already queued at the
+        downstream processor's ``__input_queue``) when the next
+        ``on_speech_start`` fires. If we don't wait for that
+        cancellation to land, two probe tasks briefly overlap and
+        downstream cancel-and-recreate-process-task cycles can race
+        against the in-flight push, leaving the freshly-created
+        downstream process-task coroutine un-scheduled.
+
+        Swallow ``CancelledError`` from the task — the cancellation is
+        ours; surfacing it would propagate back into ``on_speech_start``
+        / ``on_utterance`` and abort the rest of those callbacks for no
+        reason.
+        """
         task = self._probe_task.pop(pid, None)
-        if task is not None and not task.done():
-            task.cancel()
+        if task is None or task.done():
+            return
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.exception("stop-probe cancel raised pid={!r}", pid)
 
 
 def _now_iso() -> str:

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/vad_stt.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/vad_stt.py
@@ -354,6 +354,9 @@ class VadSttProcessor(FrameProcessor):
         try:
             await task
         except asyncio.CancelledError:
+            # Expected: we cancelled this probe ourselves; awaiting it
+            # raises CancelledError, which we intentionally swallow so a
+            # fresh probe can't overlap the one being torn down.
             pass
         except Exception:
             logger.exception("stop-probe cancel raised pid={!r}", pid)

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/vad_stt.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/vad_stt.py
@@ -143,6 +143,11 @@ class VadSttProcessor(FrameProcessor):
                     self._run_stop_probe(pid),
                     name=f"vad-stop-probe-{pid}",
                 )
+                logger.info(
+                    "early STOP probe scheduled pid={!r} after={:.2f}s",
+                    pid, self._vad_cfg.stop_probe_after_s,
+                )
+            logger.info("speech start pid={!r}", pid)
             await self.push_frame(UserStartedSpeakingFrame())
 
         async def on_utterance(audio_bytes: bytes, sample_rate: int) -> None:
@@ -155,6 +160,9 @@ class VadSttProcessor(FrameProcessor):
             self._probe_buffer.pop(pid, None)
             self._probe_sr.pop(pid, None)
 
+            dur_s = (len(audio_bytes) // 2) / max(sample_rate, 1)
+            logger.info("utterance finalize pid={!r} dur={:.2f}s", pid, dur_s)
+
             # If the probe already pushed STOP for this utterance, the
             # frames downstream (InterruptionFrame + TranscriptionFrame
             # to the gate + UserStoppedSpeakingFrame) have already done
@@ -163,6 +171,9 @@ class VadSttProcessor(FrameProcessor):
             # TTS) would double the stop-ack. Suppress.
             if pid in self._stop_fired_for_current_utterance:
                 self._stop_fired_for_current_utterance.discard(pid)
+                logger.info(
+                    "suppressed duplicate utterance after probe STOP pid={!r}", pid,
+                )
                 logger.debug(
                     "VadSttProcessor suppressing duplicate VAD-finalize "
                     "STOP pid={!r} (probe already fired)", pid,
@@ -269,7 +280,12 @@ class VadSttProcessor(FrameProcessor):
             logger.exception("stop-probe stt transcribe failed pid={!r}", pid)
             return
 
-        if not text or not STOP_RE.match(text):
+        matched = bool(text and STOP_RE.match(text))
+        logger.info(
+            "early STOP probe fired pid={!r} elapsed={:.2f}s matched={}",
+            pid, self._vad_cfg.stop_probe_after_s, matched,
+        )
+        if not matched:
             return
 
         # Race guard: if on_utterance already closed the buffer between
@@ -279,7 +295,7 @@ class VadSttProcessor(FrameProcessor):
         if pid not in self._probe_buffer:
             return
 
-        logger.info(
+        logger.debug(
             "VadSttProcessor early-probe STOP match pid={!r} after={:.2f}s",
             pid, self._vad_cfg.stop_probe_after_s,
         )

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/voice_gate.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/voice_gate.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""``VoiceGateProcessor`` — wraps :class:`xr_ai_voicegate.VoiceGate` as a
+pipecat ``FrameProcessor``.
+
+Maps gate events to frames:
+
+- ``on_query(pid, text, fresh_match)``    → ``GatedQueryFrame``
+- ``on_stop(pid)``                        → ``InterruptionFrame`` + ``TextFrame("Okay, I will stop.")``
+- ``on_phrase_only(pid)``                 → no frame (internal state only)
+- ``on_participant_joined(pid)``          → ``TextFrame`` with the greeting (only when ``format_phrase_help`` returns text)
+
+The processor also acts as the gate's ``AudioSink`` so the chime and
+stop-ack play out via the same audio path as TTS. The chime fires on
+fresh magic-phrase matches.
+"""
+from __future__ import annotations
+
+import time
+
+import numpy as np
+from loguru import logger
+from pipecat.frames.frames import (
+    Frame,
+    InterruptionFrame,
+    OutputAudioRawFrame,
+    TextFrame,
+    TranscriptionFrame,
+)
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+
+from xr_ai_models import TTSService
+from xr_ai_voicegate import VoiceGate, VoiceGateConfig
+
+from ..audio import wav_to_chunks
+from ..frames import GatedQueryFrame, ParticipantJoinedFrame, ParticipantLeftFrame
+
+
+_STOP_ACK_TEXT = "Okay, I will stop."
+
+
+class VoiceGateProcessor(FrameProcessor):
+    """Adapts ``VoiceGate`` to pipecat frames.
+
+    Owns the gate's handler bindings; emits the right frames downstream
+    when gate events fire. Doubles as the gate's ``AudioSink`` so the
+    chime and ``say_stop_ack`` WAVs travel the same pipeline route as
+    real TTS audio.
+    """
+
+    def __init__(
+        self,
+        *,
+        cfg: VoiceGateConfig,
+        tts: TTSService,
+        gate: VoiceGate | None = None,
+    ) -> None:
+        """Build the gate-backed processor.
+
+        ``cfg`` and ``tts`` are the usual entry path — the gate is built
+        with this processor as its ``AudioSink`` so the chime / stop-ack
+        WAVs route back through the same pipeline.
+
+        ``gate`` is an escape hatch for tests that want to pre-build the
+        gate with a custom sink or TTS double. When supplied, ``cfg`` /
+        ``tts`` are not used to construct a new gate — the caller owns
+        the bindings.
+        """
+        super().__init__()
+        self._gate = gate or VoiceGate(cfg, audio_sink=self, tts=tts)
+        self._gate.bind(
+            on_query              = self._on_gate_query,
+            on_stop               = self._on_gate_stop,
+            on_phrase_only        = self._on_gate_phrase_only,
+            on_participant_joined = self._on_gate_participant_joined,
+        )
+
+    @property
+    def gate(self) -> VoiceGate:
+        """The wrapped gate — exposed so the factory can hand it to
+        :class:`StreamingTtsProcessor` for ``observe_tts_wav`` callbacks."""
+        return self._gate
+
+    # ── AudioSink ─────────────────────────────────────────────────────────────
+
+    async def play_wav(self, pid: str, wav_bytes: bytes) -> None:
+        """``AudioSink`` impl — VoiceGate calls this for chime + stop-ack.
+
+        We decode the WAV into 20 ms chunks and push them as
+        ``OutputAudioRawFrame``s, matching the same int16 PCM path TTS
+        uses. ``transport_destination`` carries the pid so the output
+        transport knows which participant to send the audio back to.
+        """
+        try:
+            chunks = wav_to_chunks(wav_bytes, pid)
+        except Exception:
+            logger.exception("voice-gate audio sink decode failed pid={!r}", pid)
+            return
+        for c in chunks:
+            # AudioChunk holds float32 in `.data`; OutputAudioRawFrame is
+            # int16. Convert here so callers never have to think about
+            # the dtype mismatch.
+            f32 = np.frombuffer(c.data, dtype=np.float32)
+            i16 = np.clip(f32 * 32767.0, -32768, 32767).astype(np.int16).tobytes()
+            out = OutputAudioRawFrame(
+                audio        = i16,
+                sample_rate  = c.sample_rate,
+                num_channels = c.channels,
+            )
+            out.transport_destination = pid
+            await self.push_frame(out)
+
+    # ── pipecat frame entrypoint ──────────────────────────────────────────────
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
+        await super().process_frame(frame, direction)
+
+        if isinstance(frame, TranscriptionFrame):
+            await self._gate.feed(frame.user_id, frame.text)
+            return
+
+        if isinstance(frame, ParticipantJoinedFrame):
+            await self._gate.participant_joined(frame.participant_id)
+            # Pass the frame through so brains/other processors can hook in.
+            await self.push_frame(frame, direction)
+            return
+
+        if isinstance(frame, ParticipantLeftFrame):
+            self._gate.forget(frame.participant_id)
+            await self.push_frame(frame, direction)
+            return
+
+        await self.push_frame(frame, direction)
+
+    # ── gate handlers ─────────────────────────────────────────────────────────
+
+    async def _on_gate_query(self, pid: str, text: str, fresh_match: bool) -> None:
+        if fresh_match:
+            # Fire-and-forget: chime is a UX nicety; failure to play
+            # must not delay the query dispatch downstream.
+            try:
+                await self._gate.play_chime(pid)
+            except Exception:
+                logger.exception("voicegate chime emit failed pid={!r}", pid)
+        await self.push_frame(GatedQueryFrame(
+            participant_id = pid,
+            text           = text,
+            fresh_match    = fresh_match,
+            pts_us         = time.time_ns() // 1_000,
+        ))
+
+    async def _on_gate_stop(self, pid: str) -> None:
+        await self.push_frame(InterruptionFrame())
+        ack = TextFrame(text=_STOP_ACK_TEXT)
+        ack.transport_destination = pid
+        await self.push_frame(ack)
+
+    async def _on_gate_phrase_only(self, pid: str) -> None:
+        # No frame is emitted — the gate's internal followup state is
+        # the only effect. The hook exists so a future debug path can
+        # observe phrase-only matches without changing the contract.
+        return
+
+    async def _on_gate_participant_joined(self, pid: str) -> None:
+        greeting = self._gate.format_phrase_help()
+        if not greeting:
+            # Always-on mode: surfacing a stock greeting "Hi, I'm
+            # listening" would be intrusive on samples that never opted
+            # into a wake word, so stay silent.
+            return
+        frame = TextFrame(text=greeting)
+        frame.transport_destination = pid
+        await self.push_frame(frame)

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/voice_gate.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/voice_gate.py
@@ -139,6 +139,7 @@ class VoiceGateProcessor(FrameProcessor):
         if fresh_match:
             # Fire-and-forget: chime is a UX nicety; failure to play
             # must not delay the query dispatch downstream.
+            logger.info("chime fire pid={!r}", pid)
             try:
                 await self._gate.play_chime(pid)
             except Exception:
@@ -151,6 +152,7 @@ class VoiceGateProcessor(FrameProcessor):
         ))
 
     async def _on_gate_stop(self, pid: str) -> None:
+        logger.info("stop ack emit pid={!r}", pid)
         await self.push_frame(InterruptionFrame())
         ack = TextFrame(text=_STOP_ACK_TEXT)
         ack.transport_destination = pid
@@ -169,6 +171,7 @@ class VoiceGateProcessor(FrameProcessor):
             # listening" would be intrusive on samples that never opted
             # into a wake word, so stay silent.
             return
+        logger.info("greeting emit pid={!r}", pid)
         frame = TextFrame(text=greeting)
         frame.transport_destination = pid
         await self.push_frame(frame)

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/transport.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/transport.py
@@ -96,11 +96,20 @@ class XRMediaHubInputTransport(BaseInputTransport):
                 audio_array, SAMPLE_RATE, chunk.sample_rate,
             ).astype(np.int16)
             pcm_int16 = audio_array.tobytes()
-        await self.push_frame(InputAudioRawFrame(
+        frame = InputAudioRawFrame(
             audio=pcm_int16,
             sample_rate=SAMPLE_RATE,
             num_channels=chunk.channels,
-        ))
+        )
+        # pipecat's ``transport_source`` is the standard "which input
+        # track did this come from" hook — set it to the hub-side
+        # participant id so downstream processors (VadStt, brain, the
+        # output transport's return_data / return_audio routing) can
+        # address the right participant. Without this, every downstream
+        # send falls back to the empty string and the hub drops the
+        # message.
+        frame.transport_source = chunk.participant_id
+        await self.push_frame(frame)
 
 
 # ── Output ────────────────────────────────────────────────────────────────────

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/transport.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/transport.py
@@ -206,8 +206,14 @@ class XRMediaHubOutputTransport(BaseOutputTransport):
         transport layer without forcing every sample to register a
         per-pid pipecat ``MediaSender`` lifecycle.
         """
+        # Route through the default (None) sender, but preserve the pid so
+        # any downstream tap/sink still sees which participant the frame was
+        # addressed to. Leaving it nulled would strip the pid for everyone
+        # observing the frame after us.
+        pid = frame.transport_destination
         frame.transport_destination = None
         await super()._handle_frame(frame)
+        frame.transport_destination = pid
 
     async def write_audio_frame(self, frame: OutputAudioRawFrame) -> bool:
         """Pipecat's audio-out hook — invoked once per chunked output

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/transport.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/transport.py
@@ -21,7 +21,9 @@ from loguru import logger
 from pipecat.frames.frames import (
     CancelFrame,
     EndFrame,
+    Frame,
     InputAudioRawFrame,
+    OutputAudioRawFrame,
     StartFrame,
 )
 from pipecat.transports.base_input import BaseInputTransport
@@ -127,6 +129,15 @@ class XRMediaHubOutputTransport(BaseOutputTransport):
 
     async def start(self, frame: StartFrame):
         await super().start(frame)
+        # Pipecat's BaseOutputTransport leaves the actual "register the
+        # default media sender for destination=None" step to each
+        # transport implementation — every shipped transport calls
+        # set_transport_ready in its start() (see e.g. local/audio.py
+        # and smallwebrtc/transport.py). Skipping it leaves
+        # ``_media_senders`` empty so even a destination=None frame is
+        # dropped at the router; combined with the upstream pid tagging
+        # this was the silent audio-output drop.
+        await self.set_transport_ready(frame)
 
     async def stop(self, frame: EndFrame):
         await super().stop(frame)
@@ -134,21 +145,62 @@ class XRMediaHubOutputTransport(BaseOutputTransport):
     async def cancel(self, frame: CancelFrame):
         await super().cancel(frame)
 
-    async def write_raw_audio_frames(self, frames: bytes) -> None:
+    async def _handle_frame(self, frame: Frame) -> None:
+        """Funnel every output frame through the default media sender.
+
+        Pipecat's ``BaseOutputTransport._handle_frame`` routes a frame to
+        ``_media_senders[frame.transport_destination]`` and drops it
+        (with a warning) when the destination is not registered. Only the
+        default ``None`` sender is registered by ``set_transport_ready``;
+        upstream processors (``VoiceGateProcessor``,
+        ``StreamingTtsProcessor``) tag outbound audio with
+        ``transport_destination = pid`` so the hub knows which
+        participant to send it back to. The two facts together used to
+        drop every TTS / chime frame on the floor.
+
+        Single-participant routing is handled at the hub layer:
+        ``write_audio_frame`` reads ``self._target_participant``
+        (steered by ``BrainProcessor`` on ``ParticipantJoinedFrame``) and
+        addresses the return-audio chunk accordingly. Re-pointing the
+        frame at the default sender preserves the pid information at the
+        transport layer without forcing every sample to register a
+        per-pid pipecat ``MediaSender`` lifecycle.
+        """
+        frame.transport_destination = None
+        await super()._handle_frame(frame)
+
+    async def write_audio_frame(self, frame: OutputAudioRawFrame) -> bool:
+        """Pipecat's audio-out hook — invoked once per chunked output
+        frame after the media sender has resampled and buffered.
+
+        We forward the audio to the hub via ``send_return_audio``,
+        addressing the configured target participant. Returns ``True`` so
+        pipecat keeps pushing the frame downstream (any future tap /
+        sink can still observe the audio); returns ``False`` only when
+        no target participant is set — the hub would drop the message
+        anyway, so we avoid emitting an unaddressable chunk.
+
+        Note: the pipecat upstream method is ``write_audio_frame``
+        (per-frame, returns bool), NOT ``write_raw_audio_frames`` —
+        the previous implementation overrode a phantom name and pipecat
+        never invoked it, which is why every TTS chunk was silently
+        dropped before reaching the hub.
+        """
         if not self._target_participant:
-            return
-        pcm_float32 = _int16_to_float32(frames)
-        num_samples = len(frames) // (2 * NUM_CHANNELS)
+            return False
+        pcm_float32 = _int16_to_float32(frame.audio)
+        num_samples = len(frame.audio) // (2 * frame.num_channels)
         chunk = AudioChunk(
             pts_us=int(time.time() * 1_000_000),
-            sample_rate=self.sample_rate,
-            channels=NUM_CHANNELS,
+            sample_rate=frame.sample_rate,
+            channels=frame.num_channels,
             samples=num_samples,
             data=pcm_float32,
             participant_id=self._target_participant,
             track_id="tts",
         )
         await self._ep.send_return_audio(chunk)
+        return True
 
 
 # ── Transport wrapper ─────────────────────────────────────────────────────────

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/transport.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/transport.py
@@ -252,7 +252,7 @@ class XRMediaHubTransport(BaseTransport):
         self._ep = ProcessorEndpoint(
             sub_addr=_HUB_PUB,
             push_addr=_HUB_PUSH,
-            filter=Subscribe.AUDIO | Subscribe.DATA,
+            filter=Subscribe.AUDIO | Subscribe.DATA | Subscribe.VIDEO,
         )
 
         params = TransportParams(

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/transport.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/transport.py
@@ -30,7 +30,15 @@ from pipecat.transports.base_input import BaseInputTransport
 from pipecat.transports.base_output import BaseOutputTransport
 from pipecat.transports.base_transport import BaseTransport, TransportParams
 
-from xr_ai_agent import AudioChunk, DataMessage, ProcessorEndpoint, Subscribe
+from xr_ai_agent import (
+    AudioChunk,
+    DataMessage,
+    ParticipantEvent,
+    ProcessorEndpoint,
+    Subscribe,
+)
+
+from .frames import ParticipantJoinedFrame, ParticipantLeftFrame
 
 _HUB_PUB  = "ipc:///tmp/xr_hub_pub"
 _HUB_PUSH = "ipc:///tmp/xr_hub_in"
@@ -61,6 +69,7 @@ class XRMediaHubInputTransport(BaseInputTransport):
         self._ep_task: asyncio.Task | None = None
         self._started = False
         self._ep.on_audio(self._on_hub_audio)
+        self._ep.on_participant(self._on_hub_participant)
 
     async def start(self, frame: StartFrame):
         await super().start(frame)
@@ -112,6 +121,31 @@ class XRMediaHubInputTransport(BaseInputTransport):
         # message.
         frame.transport_source = chunk.participant_id
         await self.push_frame(frame)
+
+    async def _on_hub_participant(self, event: ParticipantEvent) -> None:
+        """Translate hub ``ParticipantEvent`` into pipecat lifecycle frames.
+
+        The hub publishes one event per LiveKit join/leave; downstream
+        processors (``VoiceGateProcessor`` greeting hook,
+        ``BrainProcessor.set_target_participant``) consume the resulting
+        ``ParticipantJoinedFrame`` / ``ParticipantLeftFrame``. Without
+        this bridge the gate never greets and the brain never steers the
+        output transport at a participant, so every TTS chunk is dropped
+        by ``XRMediaHubOutputTransport.write_audio_frame``.
+
+        Same ``_started`` guard as ``_on_hub_audio``: a late event after
+        teardown is a no-op rather than racing the pipeline shutdown.
+        """
+        if not self._started:
+            return
+        if event.joined:
+            await self.push_frame(
+                ParticipantJoinedFrame(participant_id=event.participant_id),
+            )
+        else:
+            await self.push_frame(
+                ParticipantLeftFrame(participant_id=event.participant_id),
+            )
 
 
 # ── Output ────────────────────────────────────────────────────────────────────

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/transport.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/transport.py
@@ -157,9 +157,15 @@ class XRMediaHubOutputTransport(BaseOutputTransport):
         super().__init__(params, **kwargs)
         self._ep = ep
         self._target_participant: str = ""
+        # Throttle the "no target participant" warning so a burst of
+        # dropped audio frames produces one log line per burst rather
+        # than one per frame. Reset when a target is set.
+        self._missing_target_warned: bool = False
 
     def set_target_participant(self, pid: str) -> None:
+        logger.info("target participant set pid={!r}", pid)
         self._target_participant = pid
+        self._missing_target_warned = False
 
     async def start(self, frame: StartFrame):
         await super().start(frame)
@@ -221,6 +227,11 @@ class XRMediaHubOutputTransport(BaseOutputTransport):
         dropped before reaching the hub.
         """
         if not self._target_participant:
+            if not self._missing_target_warned:
+                logger.warning(
+                    "no target participant — dropping audio frame",
+                )
+                self._missing_target_warned = True
             return False
         pcm_float32 = _int16_to_float32(frame.audio)
         num_samples = len(frame.audio) // (2 * frame.num_channels)

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "xr-ai-launcher",
     "xr-ai-logging",
     "xr-ai-vad",
+    "xr-ai-voicegate",
     "xr-ai-vllm",
     # MCP servers exercised by subprocess tests (fastmcp pulled in transitively).
     "transcript-mcp-server",
@@ -43,6 +44,7 @@ xr-media-hub          = { path = "../server-runtime",                   editable
 xr-ai-launcher        = { path = "../utils/xr-ai-launcher",             editable = true }
 xr-ai-logging         = { path = "../utils/xr-ai-logging",              editable = true }
 xr-ai-vad             = { path = "../utils/xr-ai-vad",                  editable = true }
+xr-ai-voicegate       = { path = "../utils/xr-ai-voicegate",            editable = true }
 xr-ai-vllm            = { path = "../utils/xr-ai-vllm",                 editable = true }
 transcript-mcp-server = { path = "../agent-mcp-servers/transcript-mcp", editable = true }
 vlm-mcp-server        = { path = "../agent-mcp-servers/vlm-mcp",        editable = true }

--- a/tests/test_xr_ai_pipecat_voice_pipeline.py
+++ b/tests/test_xr_ai_pipecat_voice_pipeline.py
@@ -1,0 +1,680 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the xr-ai-pipecat unified voice pipeline.
+
+Each library FrameProcessor (VadStt, VoiceGate, Brain, StreamingTts) is
+exercised in isolation with mocked dependencies (VAD, STT, TTS, gate).
+The factory is smoke-tested by composing a minimal end-to-end pipeline
+and confirming an audio in / audio out round-trip.
+
+Tests use pipecat's :class:`PipelineWorker` / :class:`WorkerRunner` for
+the full lifecycle (setup → StartFrame → process → EndFrame) and a
+``_CaptureSink`` processor at the tail to collect emitted frames. This
+hits the same code paths the real worker does, so test results reflect
+what a deployed pipeline will see.
+"""
+from __future__ import annotations
+
+import asyncio
+import io
+import wave
+from typing import AsyncIterator, Sequence
+
+import numpy as np
+import pytest
+from pipecat.frames.frames import (
+    EndFrame,
+    Frame,
+    InputAudioRawFrame,
+    InterruptionFrame,
+    OutputAudioRawFrame,
+    TextFrame,
+    TranscriptionFrame,
+    UserStartedSpeakingFrame,
+)
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.worker import PipelineWorker
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+from pipecat.workers.runner import WorkerRunner
+
+from xr_ai_pipecat import (
+    BrainProcessor,
+    GatedQueryFrame,
+    ParticipantJoinedFrame,
+    ParticipantLeftFrame,
+    StreamingTtsProcessor,
+    VadConfig,
+    VadSttProcessor,
+    VoiceGateProcessor,
+)
+from xr_ai_voicegate import VoiceGate, VoiceGateConfig
+
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+
+def _silence_wav(sample_rate: int = 22050, ms: int = 40) -> bytes:
+    n = max(1, int(sample_rate * ms / 1000))
+    pcm = np.zeros(n, dtype=np.int16).tobytes()
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm)
+    return buf.getvalue()
+
+
+class _CaptureSink(FrameProcessor):
+    """Tail processor — collects every downstream frame it sees.
+
+    ``enable_direct_mode`` skips the internal queue/task so frames land
+    in ``self.frames`` synchronously, making assertion order obvious.
+    Frames are forwarded so EndFrame can reach the Pipeline sink and
+    signal the worker to shut down.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(enable_direct_mode=True)
+        self.frames: list[Frame] = []
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
+        await super().process_frame(frame, direction)
+        self.frames.append(frame)
+        await self.push_frame(frame, direction)
+
+
+async def _run_chain(
+    *processors: FrameProcessor,
+    sends: Sequence[Frame],
+    settle_s: float = 0.1,
+    per_send_delay_s: float = 0.0,
+) -> _CaptureSink:
+    """Build a Pipeline(processors), start a PipelineWorker, feed
+    ``sends`` through the worker's downstream queue, then drain with an
+    ``EndFrame``. Returns the capture sink holding every downstream
+    frame seen at the tail. The worker drives StartFrame propagation
+    itself, so no manual setup is needed.
+
+    ``per_send_delay_s`` introduces a sleep between queued frames so
+    earlier ones can start executing before the next arrives — useful
+    for interruption tests that need a previous frame to actually start
+    work before the interrupt lands.
+    """
+    sink = _CaptureSink()
+    pipeline = Pipeline([*processors, sink])
+    worker = PipelineWorker(
+        pipeline,
+        cancel_on_idle_timeout = False,
+        enable_rtvi            = False,
+    )
+    runner = WorkerRunner()
+    await runner.add_workers(worker)
+
+    async def drive() -> None:
+        # The runner's setup happens inside .run(); give it a tick to
+        # push StartFrame through every processor before we feed data.
+        await asyncio.sleep(0.05)
+        for i, f in enumerate(sends):
+            await worker.queue_frame(f)
+            if i < len(sends) - 1 and per_send_delay_s:
+                await asyncio.sleep(per_send_delay_s)
+        await asyncio.sleep(settle_s)
+        await worker.queue_frame(EndFrame())
+
+    await asyncio.gather(runner.run(), drive())
+    return sink
+
+
+class _FakeStt:
+    """STTService double — returns canned text or raises on demand."""
+
+    def __init__(self, text: str = "hello world") -> None:
+        self.text         = text
+        self.calls:        list[tuple[bytes, int]] = []
+        self.raise_on_call = False
+
+    async def transcribe(self, audio: bytes, *, sample_rate: int | None = None, channels: int = 1, timeout: float | None = None) -> str:
+        self.calls.append((audio, sample_rate or 16000))
+        if self.raise_on_call:
+            raise RuntimeError("stt down")
+        return self.text
+
+    async def health(self) -> bool:
+        return True
+
+    async def close(self) -> None:
+        pass
+
+
+class _FakeTts:
+    """TTSService double returning a tiny valid WAV at a fixed rate."""
+
+    def __init__(self, sample_rate: int = 22050) -> None:
+        self.sample_rate    = sample_rate
+        self.calls:         list[str] = []
+        self.raise_on_call  = False
+        self.delay_s:       float = 0.0
+
+    async def synthesize(self, text: str, *, response_format: str = "wav", timeout: float | None = None) -> bytes:
+        self.calls.append(text)
+        if self.delay_s:
+            await asyncio.sleep(self.delay_s)
+        if self.raise_on_call:
+            raise RuntimeError("tts down")
+        return _silence_wav(self.sample_rate)
+
+    async def health(self) -> bool:
+        return True
+
+    async def close(self) -> None:
+        pass
+
+
+class _NullSink:
+    async def play_wav(self, pid: str, wav_bytes: bytes) -> None:
+        return
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# VadSttProcessor
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_vad_stt_emits_transcription_on_utterance(monkeypatch):
+    """When the underlying VadDetector calls back with an utterance,
+    the processor pushes ``UserStoppedSpeakingFrame`` then a
+    ``TranscriptionFrame`` carrying the STT result."""
+    stt = _FakeStt(text="hello agent")
+
+    class _StubVad:
+        def __init__(self, on_utterance, on_speech_start, **_):
+            self._on_utt   = on_utterance
+            self._on_start = on_speech_start
+
+        async def feed(self, pcm_int16: bytes, sample_rate: int) -> None:
+            await self._on_start()
+            await self._on_utt(pcm_int16, sample_rate)
+
+    monkeypatch.setattr("xr_ai_pipecat.processors.vad_stt.VadDetector", _StubVad)
+    proc = VadSttProcessor(stt=stt, vad_cfg=VadConfig())
+    frame = InputAudioRawFrame(audio=b"\x00\x00" * 320, sample_rate=16000, num_channels=1)
+
+    sink = await _run_chain(proc, sends=[frame])
+
+    kinds = [type(f).__name__ for f in sink.frames]
+    assert "UserStartedSpeakingFrame" in kinds
+    assert "UserStoppedSpeakingFrame" in kinds
+    transcripts = [f for f in sink.frames if isinstance(f, TranscriptionFrame)]
+    assert [t.text for t in transcripts] == ["hello agent"]
+    assert stt.calls and stt.calls[0][1] == 16000
+
+
+@pytest.mark.asyncio
+async def test_vad_stt_swallows_empty_transcript(monkeypatch):
+    stt = _FakeStt(text="")
+
+    class _StubVad:
+        def __init__(self, on_utterance, on_speech_start, **_):
+            self._on_utt = on_utterance
+
+        async def feed(self, pcm_int16: bytes, sample_rate: int) -> None:
+            await self._on_utt(pcm_int16, sample_rate)
+
+    monkeypatch.setattr("xr_ai_pipecat.processors.vad_stt.VadDetector", _StubVad)
+    proc = VadSttProcessor(stt=stt, vad_cfg=VadConfig())
+    sink = await _run_chain(
+        proc,
+        sends=[InputAudioRawFrame(audio=b"\x00\x00", sample_rate=16000, num_channels=1)],
+    )
+    assert not any(isinstance(f, TranscriptionFrame) for f in sink.frames)
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# VoiceGateProcessor
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_voice_gate_processor_dispatches_query_frame_on_fresh_match():
+    cfg = VoiceGateConfig(magic_phrases=("agent",))
+    proc = VoiceGateProcessor(cfg=cfg, tts=_FakeTts())
+    sink = await _run_chain(
+        proc,
+        sends=[TranscriptionFrame(text="agent what time is it", user_id="pid-1", timestamp="t")],
+    )
+
+    queries = [f for f in sink.frames if isinstance(f, GatedQueryFrame)]
+    assert len(queries) == 1
+    assert queries[0].text          == "what time is it"
+    assert queries[0].fresh_match   is True
+    assert queries[0].participant_id == "pid-1"
+
+
+@pytest.mark.asyncio
+async def test_voice_gate_processor_stop_emits_interruption_and_ack_text():
+    cfg = VoiceGateConfig(magic_phrases=("agent",))
+    proc = VoiceGateProcessor(cfg=cfg, tts=_FakeTts())
+    sink = await _run_chain(
+        proc,
+        sends=[TranscriptionFrame(text="stop", user_id="pid-1", timestamp="t")],
+    )
+
+    # The order matters: InterruptionFrame must reach downstream before
+    # the ack text so any in-flight reasoning is cancelled BEFORE the
+    # ack itself gets routed back through TTS.
+    indices_interrupt = [i for i, f in enumerate(sink.frames) if isinstance(f, InterruptionFrame)]
+    indices_text      = [i for i, f in enumerate(sink.frames) if isinstance(f, TextFrame)]
+    assert indices_interrupt and indices_text
+    assert indices_interrupt[0] < indices_text[0]
+    ack = next(f for f in sink.frames if isinstance(f, TextFrame))
+    assert ack.text == "Okay, I will stop."
+
+
+@pytest.mark.asyncio
+async def test_voice_gate_processor_greeting_emitted_when_phrases_configured():
+    cfg = VoiceGateConfig(magic_phrases=("agent",))
+    proc = VoiceGateProcessor(cfg=cfg, tts=_FakeTts())
+    sink = await _run_chain(
+        proc,
+        sends=[ParticipantJoinedFrame(participant_id="pid-1")],
+    )
+
+    texts = [f for f in sink.frames if isinstance(f, TextFrame)]
+    assert len(texts) == 1
+    assert texts[0].text.startswith("To talk to me")
+    assert any(isinstance(f, ParticipantJoinedFrame) for f in sink.frames)
+
+
+@pytest.mark.asyncio
+async def test_voice_gate_processor_no_greeting_when_phrases_empty():
+    """Always-on mode: no wake word means no opt-in UX to advertise."""
+    cfg = VoiceGateConfig(magic_phrases=())
+    proc = VoiceGateProcessor(cfg=cfg, tts=_FakeTts())
+    sink = await _run_chain(
+        proc,
+        sends=[ParticipantJoinedFrame(participant_id="pid-1")],
+    )
+    texts = [f for f in sink.frames if isinstance(f, TextFrame)]
+    assert texts == []
+
+
+@pytest.mark.asyncio
+async def test_voice_gate_processor_phrase_only_emits_no_query_frame():
+    cfg = VoiceGateConfig(magic_phrases=("agent",))
+    proc = VoiceGateProcessor(cfg=cfg, tts=_FakeTts())
+    sink = await _run_chain(
+        proc,
+        sends=[TranscriptionFrame(text="agent", user_id="pid-1", timestamp="t")],
+    )
+    assert not any(isinstance(f, GatedQueryFrame) for f in sink.frames)
+
+
+@pytest.mark.asyncio
+async def test_voice_gate_processor_chime_routes_through_pipeline_audio_path():
+    """When a fresh-match query fires AND the chime is enabled AND TTS
+    has been observed, the gate's chime arrives downstream as
+    ``OutputAudioRawFrame``s — not via a sidechannel."""
+    cfg  = VoiceGateConfig(magic_phrases=("agent",), listening_chime=True)
+    proc = VoiceGateProcessor(cfg=cfg, tts=_FakeTts())
+    # Prime the chime by observing a TTS WAV first.
+    proc.gate.observe_tts_wav(_silence_wav(24000))
+
+    sink = await _run_chain(
+        proc,
+        sends=[TranscriptionFrame(text="agent, what time is it", user_id="pid-1", timestamp="t")],
+    )
+    audio_out = [f for f in sink.frames if isinstance(f, OutputAudioRawFrame)]
+    assert audio_out, "chime should have emitted at least one OutputAudioRawFrame"
+    assert all(f.transport_destination == "pid-1" for f in audio_out)
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# BrainProcessor
+# ════════════════════════════════════════════════════════════════════════════
+
+
+class _StringBrain(BrainProcessor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.handle_calls: list[tuple[str, str, bool]] = []
+
+    async def handle_query(self, pid, text, fresh_match):
+        self.handle_calls.append((pid, text, fresh_match))
+        return f"answer: {text}"
+
+
+class _IterBrain(BrainProcessor):
+    def __init__(self, chunks: list[str]) -> None:
+        super().__init__()
+        self._chunks = chunks
+        self.cancelled = False
+
+    async def handle_query(self, pid, text, fresh_match) -> AsyncIterator[str]:
+        async def _gen():
+            try:
+                for c in self._chunks:
+                    yield c
+                    await asyncio.sleep(0.001)
+            except asyncio.CancelledError:
+                self.cancelled = True
+                raise
+        return _gen()
+
+
+class _LifecycleBrain(BrainProcessor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.joined:           list[str] = []
+        self.left:             list[str] = []
+        self.started_speaking: list[str] = []
+
+    async def handle_query(self, pid, text, fresh_match):
+        return ""
+
+    async def on_participant_joined(self, pid: str) -> None:
+        self.joined.append(pid)
+
+    async def on_participant_left(self, pid: str) -> None:
+        self.left.append(pid)
+
+    async def on_user_started_speaking(self, pid: str) -> None:
+        self.started_speaking.append(pid)
+
+
+@pytest.mark.asyncio
+async def test_brain_string_return_pushes_single_text_frame():
+    brain = _StringBrain()
+    sink = await _run_chain(
+        brain,
+        sends=[GatedQueryFrame(participant_id="pid-1", text="hi", fresh_match=True, pts_us=0)],
+    )
+
+    texts = [f for f in sink.frames if isinstance(f, TextFrame)]
+    assert [t.text for t in texts] == ["answer: hi"]
+    assert brain.handle_calls == [("pid-1", "hi", True)]
+
+
+@pytest.mark.asyncio
+async def test_brain_async_iter_return_pushes_text_frame_per_chunk():
+    brain = _IterBrain(chunks=["alpha ", "beta ", "gamma."])
+    sink = await _run_chain(
+        brain,
+        sends=[GatedQueryFrame(participant_id="pid-1", text="hi", fresh_match=True, pts_us=0)],
+        settle_s=0.15,
+    )
+    texts = [f.text for f in sink.frames if isinstance(f, TextFrame)]
+    assert texts == ["alpha ", "beta ", "gamma."]
+
+
+@pytest.mark.asyncio
+async def test_brain_cancels_inflight_on_user_started_speaking():
+    """``UserStartedSpeakingFrame`` is the interrupt point: any
+    in-flight query for that pid must be cancelled before a new turn
+    starts."""
+    brain = _IterBrain(chunks=[f"chunk{i} " for i in range(200)])
+    await _run_chain(
+        brain,
+        sends=[
+            GatedQueryFrame(participant_id="pid-1", text="hi", fresh_match=True, pts_us=0),
+            UserStartedSpeakingFrame(),
+        ],
+        settle_s=0.2,
+        per_send_delay_s=0.05,
+    )
+    assert brain.cancelled is True
+
+
+@pytest.mark.asyncio
+async def test_brain_cancels_inflight_on_interruption_frame():
+    brain = _IterBrain(chunks=[f"chunk{i} " for i in range(200)])
+    await _run_chain(
+        brain,
+        sends=[
+            GatedQueryFrame(participant_id="pid-1", text="hi", fresh_match=True, pts_us=0),
+            InterruptionFrame(),
+        ],
+        settle_s=0.2,
+        per_send_delay_s=0.05,
+    )
+    assert brain.cancelled is True
+
+
+@pytest.mark.asyncio
+async def test_brain_participant_lifecycle_hooks_fire():
+    brain = _LifecycleBrain()
+    sink = await _run_chain(
+        brain,
+        sends=[
+            ParticipantJoinedFrame(participant_id="p1"),
+            ParticipantLeftFrame(participant_id="p1"),
+        ],
+    )
+
+    assert brain.joined == ["p1"]
+    assert brain.left   == ["p1"]
+    kinds = [type(f).__name__ for f in sink.frames]
+    assert "ParticipantJoinedFrame" in kinds
+    assert "ParticipantLeftFrame"   in kinds
+
+
+@pytest.mark.asyncio
+async def test_brain_user_started_speaking_hook_fires():
+    """on_user_started_speaking fires for every pid currently in flight,
+    giving samples a hook to start speculative work (e.g. camera warmup)
+    on the leading edge of the next turn."""
+    # IterBrain has an in-flight task we can probe; intercept its
+    # on_user_started_speaking hook to record what pid was reported.
+    long_brain = _IterBrain(chunks=[f"chunk{i} " for i in range(200)])
+    started_for: list[str] = []
+
+    async def speech_hook(pid: str) -> None:
+        started_for.append(pid)
+
+    long_brain.on_user_started_speaking = speech_hook  # type: ignore[method-assign]
+
+    await _run_chain(
+        long_brain,
+        sends=[
+            GatedQueryFrame(participant_id="pid-1", text="hi", fresh_match=True, pts_us=0),
+            UserStartedSpeakingFrame(),
+        ],
+        settle_s=0.2,
+        per_send_delay_s=0.05,
+    )
+    assert started_for == ["pid-1"]
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# StreamingTtsProcessor
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_streaming_tts_sentence_boundary_triggers_synth():
+    tts  = _FakeTts(sample_rate=22050)
+    gate = VoiceGate(VoiceGateConfig(), audio_sink=_NullSink(), tts=tts)
+    proc = StreamingTtsProcessor(tts=tts, voice_gate=gate)
+
+    sink = await _run_chain(
+        proc,
+        sends=[TextFrame(text="hello"), TextFrame(text=" world. ")],
+    )
+    assert tts.calls == ["hello world."]
+    audio = [f for f in sink.frames if isinstance(f, OutputAudioRawFrame)]
+    assert audio, "synth produced no audio frames downstream"
+
+
+@pytest.mark.asyncio
+async def test_streaming_tts_parallel_synth_keeps_order():
+    """Out-of-order completion of synth tasks must NOT reorder the
+    output audio: the ordered sender awaits in FIFO. ``call_starts``
+    records start order; the sender's FIFO is asserted via
+    ``observe_tts_wav`` observation order, which fires on each completed
+    WAV in the sender loop."""
+    tts = _FakeTts()
+    delays = {"first sentence.": 0.05, "second sentence.": 0.0}
+    call_starts: list[str] = []
+    orig_synth = tts.synthesize
+
+    async def variable_delay_synth(text, **kw):
+        call_starts.append(text)
+        await asyncio.sleep(delays.get(text, 0))
+        return await orig_synth(text, **kw)
+
+    tts.synthesize = variable_delay_synth  # type: ignore[method-assign]
+
+    gate = VoiceGate(VoiceGateConfig(), audio_sink=_NullSink(), tts=tts)
+    observation_order: list[bytes] = []
+    orig_observe = gate.observe_tts_wav
+
+    def spy(wav):
+        observation_order.append(wav)
+        return orig_observe(wav)
+
+    gate.observe_tts_wav = spy  # type: ignore[method-assign]
+
+    proc = StreamingTtsProcessor(tts=tts, voice_gate=gate)
+    sink = await _run_chain(
+        proc,
+        sends=[TextFrame(text="first sentence. second sentence. ")],
+        settle_s=0.2,
+    )
+
+    # Both sentences were dispatched in declared order (first synth
+    # task starts first), even though "second" completes first.
+    assert call_starts == ["first sentence.", "second sentence."]
+    # The sender loop is FIFO: it observes the first WAV before the
+    # second, regardless of completion order.
+    assert len(observation_order) == 2
+    audio = [f for f in sink.frames if isinstance(f, OutputAudioRawFrame)]
+    assert len(audio) >= 2
+
+
+@pytest.mark.asyncio
+async def test_streaming_tts_interruption_cancels_and_clears_pending():
+    tts = _FakeTts()
+    tts.delay_s = 0.2  # so we can interrupt before completion
+    gate = VoiceGate(VoiceGateConfig(), audio_sink=_NullSink(), tts=tts)
+    proc = StreamingTtsProcessor(tts=tts, voice_gate=gate)
+
+    sink = await _run_chain(
+        proc,
+        sends=[
+            TextFrame(text="abandoned sentence one. "),
+            InterruptionFrame(),
+        ],
+        settle_s=0.4,
+        per_send_delay_s=0.05,
+    )
+    audio = [f for f in sink.frames if isinstance(f, OutputAudioRawFrame)]
+    assert audio == []
+    # Pending buffer is cleared so a subsequent partial sentence does
+    # NOT get concatenated to the abandoned fragment.
+    assert proc._pending == ""  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_streaming_tts_observes_each_wav_through_gate():
+    """observe_tts_wav must be invoked once per synthesized WAV so the
+    gate's lazy chime can build at the TTS sample rate."""
+    tts  = _FakeTts(sample_rate=24000)
+    observations: list[bytes] = []
+    gate = VoiceGate(VoiceGateConfig(), audio_sink=_NullSink(), tts=tts)
+    orig_observe = gate.observe_tts_wav
+
+    def spy(wav):
+        observations.append(wav)
+        return orig_observe(wav)
+
+    gate.observe_tts_wav = spy  # type: ignore[method-assign]
+    proc = StreamingTtsProcessor(tts=tts, voice_gate=gate)
+    await _run_chain(proc, sends=[TextFrame(text="hi there. ")])
+    assert len(observations) == 1
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# make_voice_pipeline end-to-end smoke
+# ════════════════════════════════════════════════════════════════════════════
+
+
+class _EchoBrain(BrainProcessor):
+    async def handle_query(self, pid, text, fresh_match) -> str:
+        return f"echo {text}."
+
+
+@pytest.mark.asyncio
+async def test_make_voice_pipeline_audio_in_to_audio_out(monkeypatch):
+    """End-to-end smoke: feed an InputAudioRawFrame at the head, expect
+    OutputAudioRawFrame at the tail.
+
+    Always-on voicegate config means every transcription dispatches as
+    a query; the brain echoes the text; the streaming TTS synthesizes
+    a WAV; the WAV's audio frames are pushed downstream.
+    """
+    from xr_ai_pipecat import make_voice_pipeline
+    from xr_ai_pipecat.transport import XRMediaHubTransport
+
+    stt = _FakeStt(text="hi pipeline")
+    tts = _FakeTts(sample_rate=22050)
+
+    class _StubVad:
+        def __init__(self, on_utterance, on_speech_start, **_):
+            self._on_utt   = on_utterance
+            self._on_start = on_speech_start
+
+        async def feed(self, pcm_int16: bytes, sample_rate: int) -> None:
+            await self._on_start()
+            await self._on_utt(pcm_int16, sample_rate)
+
+    monkeypatch.setattr("xr_ai_pipecat.processors.vad_stt.VadDetector", _StubVad)
+
+    transport = XRMediaHubTransport()
+    try:
+        pipeline, _task = make_voice_pipeline(
+            transport      = transport,
+            stt            = stt,
+            tts            = tts,
+            brain          = _EchoBrain(),
+            vad_cfg        = VadConfig(),
+            voice_gate_cfg = VoiceGateConfig(),
+        )
+        # Confirm the factory composed the expected wiring: Pipeline
+        # body is [transport.input(), vad_stt, voice_gate, brain,
+        # streaming_tts, transport.output()]. Pipeline.processors wraps
+        # that with Source/Sink at indices 0 and 7.
+        kinds = [type(p).__name__ for p in pipeline.processors]
+        assert kinds == [
+            "PipelineSource",
+            "XRMediaHubInputTransport",
+            "VadSttProcessor",
+            "VoiceGateProcessor",
+            "_EchoBrain",
+            "StreamingTtsProcessor",
+            "XRMediaHubOutputTransport",
+            "PipelineSink",
+        ]
+    finally:
+        transport.shutdown()
+
+    # Now spin up a fresh, transport-less pipeline with new processor
+    # instances to exercise an audio → text → audio round-trip. Reusing
+    # the original processors fails because they're already linked into
+    # the factory's pipeline; a fresh chain is simpler than rewiring.
+    voice_gate_cfg = VoiceGateConfig()
+    voice_gate_proc = VoiceGateProcessor(cfg=voice_gate_cfg, tts=tts)
+    streaming_tts   = StreamingTtsProcessor(tts=tts, voice_gate=voice_gate_proc.gate)
+    vad_stt         = VadSttProcessor(stt=stt, vad_cfg=VadConfig())
+    brain           = _EchoBrain()
+
+    sink = await _run_chain(
+        vad_stt, voice_gate_proc, brain, streaming_tts,
+        sends=[InputAudioRawFrame(audio=b"\x00\x00" * 320, sample_rate=16000, num_channels=1)],
+        settle_s=0.6,
+    )
+
+    audio_out = [f for f in sink.frames if isinstance(f, OutputAudioRawFrame)]
+    assert audio_out, "expected at least one OutputAudioRawFrame at the tail"
+    assert tts.calls == ["echo hi pipeline."]

--- a/tests/test_xr_ai_pipecat_voice_pipeline.py
+++ b/tests/test_xr_ai_pipecat_voice_pipeline.py
@@ -1473,3 +1473,31 @@ async def test_make_voice_pipeline_wires_text_topic_through_streaming_tts(monkey
         assert streaming_tts._transport is transport
     finally:
         transport.shutdown()
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# Regression: transport subscribes to VIDEO so brain receives FrameSignals
+# ════════════════════════════════════════════════════════════════════════════
+
+
+def test_xr_media_hub_transport_subscribes_to_video_frames():
+    """The ProcessorEndpoint must subscribe to the video category so
+    that camera FrameSignals reach brain consumers (e.g. VLM workers
+    that bind ``ep.on_frame``). A previous version of the transport
+    filtered out video at the ZMQ subscription layer, causing
+    ``_wait_for_camera_frame`` to time out and the VLM call to block
+    indefinitely after a query."""
+    from xr_ai_agent._processor import Subscribe
+    from xr_ai_pipecat.transport import XRMediaHubTransport
+
+    transport = XRMediaHubTransport()
+    try:
+        assert transport._ep._default_filter & Subscribe.VIDEO, (
+            "transport must subscribe to VIDEO frames so brains receive "
+            "camera FrameSignals"
+        )
+        # Audio and data are also required for the voice pipeline.
+        assert transport._ep._default_filter & Subscribe.AUDIO
+        assert transport._ep._default_filter & Subscribe.DATA
+    finally:
+        transport.shutdown()

--- a/tests/test_xr_ai_pipecat_voice_pipeline.py
+++ b/tests/test_xr_ai_pipecat_voice_pipeline.py
@@ -772,7 +772,7 @@ async def test_brain_cancels_inflight_on_interruption_frame():
 
 
 @pytest.mark.asyncio
-async def test_brain_on_query_superseded_fires_when_new_query_supersedes_inflight():
+async def test_brain_on_query_superseded_fires_on_second_query_while_inflight():
     """When a fresh ``GatedQueryFrame`` arrives while a prior query's
     task is still in-flight, ``on_query_superseded`` must fire so an
     agent can decide what to do with the previous response's queued
@@ -799,6 +799,119 @@ async def test_brain_on_query_superseded_fires_when_new_query_supersedes_infligh
     )
     assert brain.supersede_calls == ["pid-1"]
     assert brain.cancelled is True
+
+
+@pytest.mark.asyncio
+async def test_brain_on_query_superseded_fires_when_prior_task_already_done():
+    """Regression: the supersede hook must fire on every non-first
+    query for a pid, even when the prior brain task has already
+    completed. Real-world case: a short VLM response streams in
+    quickly so the brain task is done, but its TTS audio is still
+    playing out when the user fires a follow-up query. Gating the
+    hook on ``_inflight[pid].done()`` (the old bug) caused the new
+    query to queue behind the prior audio instead of interrupting it.
+
+    Uses ``_StringBrain`` (one-shot string response) plus a generous
+    ``per_send_delay_s`` so the first task finishes before the
+    second query arrives. Asserts that at supersede time the prior
+    task was indeed already done, so the assertion exercises the
+    bug case rather than the in-flight case."""
+    class _SupersedeRecorder(_StringBrain):
+        def __init__(self) -> None:
+            super().__init__()
+            self.supersede_calls: list[str] = []
+            self.prior_task_done_at_supersede: list[bool] = []
+
+        async def on_query_superseded(self, pid: str) -> None:
+            self.supersede_calls.append(pid)
+            existing = self._inflight.get(pid)
+            self.prior_task_done_at_supersede.append(
+                existing is None or existing.done(),
+            )
+
+    brain = _SupersedeRecorder()
+    await _run_chain(
+        brain,
+        sends=[
+            GatedQueryFrame(participant_id="pid-1", text="first",  fresh_match=True, pts_us=0),
+            GatedQueryFrame(participant_id="pid-1", text="second", fresh_match=True, pts_us=1),
+        ],
+        # Long enough that the one-shot ``_StringBrain`` response for
+        # the first query has fully run and emitted its end frame
+        # before the second query is queued.
+        settle_s=0.3,
+        per_send_delay_s=0.2,
+    )
+    assert brain.supersede_calls == ["pid-1"]
+    assert brain.prior_task_done_at_supersede == [True], (
+        "test must exercise the bug case: prior brain task already done "
+        "when supersede fires"
+    )
+    # Both queries ran end-to-end.
+    handled = [t for _pid, t, _fm in brain.handle_calls]
+    assert "first"  in handled
+    assert "second" in handled
+
+
+@pytest.mark.asyncio
+async def test_brain_on_query_superseded_fires_on_every_subsequent_query():
+    """The hook fires once per non-first query — three queries fire
+    it twice, four fire it three times, etc. Uses ``_StringBrain``
+    so each prior task completes before the next query arrives,
+    confirming the gate is per-pid query count, not brain-task state."""
+    class _SupersedeRecorder(_StringBrain):
+        def __init__(self) -> None:
+            super().__init__()
+            self.supersede_calls: list[str] = []
+
+        async def on_query_superseded(self, pid: str) -> None:
+            self.supersede_calls.append(pid)
+
+    brain = _SupersedeRecorder()
+    await _run_chain(
+        brain,
+        sends=[
+            GatedQueryFrame(participant_id="pid-1", text="first",  fresh_match=True, pts_us=0),
+            GatedQueryFrame(participant_id="pid-1", text="second", fresh_match=True, pts_us=1),
+            GatedQueryFrame(participant_id="pid-1", text="third",  fresh_match=True, pts_us=2),
+            GatedQueryFrame(participant_id="pid-1", text="fourth", fresh_match=True, pts_us=3),
+        ],
+        settle_s=0.3,
+        per_send_delay_s=0.1,
+    )
+    # First query: no supersede. Each subsequent query: one supersede.
+    assert brain.supersede_calls == ["pid-1", "pid-1", "pid-1"]
+
+
+@pytest.mark.asyncio
+async def test_brain_on_query_superseded_seen_state_cleared_on_participant_left():
+    """``_seen_query`` is per-pid and must be cleared on
+    ``ParticipantLeftFrame`` so a rejoin's first query is treated
+    as cold (no supersede) rather than as a follow-up. Without
+    this, an override that pushes ``InterruptionFrame`` on
+    supersede would flush unrelated audio on every fresh session."""
+    class _SupersedeRecorder(_StringBrain):
+        def __init__(self) -> None:
+            super().__init__()
+            self.supersede_calls: list[str] = []
+
+        async def on_query_superseded(self, pid: str) -> None:
+            self.supersede_calls.append(pid)
+
+    brain = _SupersedeRecorder()
+    await _run_chain(
+        brain,
+        sends=[
+            GatedQueryFrame(participant_id="pid-1",  text="first",  fresh_match=True, pts_us=0),
+            ParticipantLeftFrame(participant_id="pid-1"),
+            # Same pid rejoins (or different session): the first
+            # query after the left frame must NOT fire the hook.
+            GatedQueryFrame(participant_id="pid-1",  text="second", fresh_match=True, pts_us=1),
+        ],
+        settle_s=0.3,
+        per_send_delay_s=0.1,
+    )
+    assert brain.supersede_calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_xr_ai_pipecat_voice_pipeline.py
+++ b/tests/test_xr_ai_pipecat_voice_pipeline.py
@@ -506,6 +506,55 @@ async def test_brain_cancels_inflight_on_interruption_frame():
 
 
 @pytest.mark.asyncio
+async def test_brain_steers_transport_target_on_participant_joined():
+    """Single-participant routing default: when a brain is constructed
+    with a transport, the first ``ParticipantJoinedFrame`` steers the
+    output transport at that pid so return-audio/return-data go to the
+    right participant without per-sample wiring. The output transport
+    silently drops audio when ``_target_participant`` is empty — this
+    is what previously made the bug "agent thinks but says nothing".
+    """
+    class _FakeTransport:
+        def __init__(self) -> None:
+            self.target_calls:  list[str] = []
+            self.cleanup_calls: list[str] = []
+
+        def set_target_participant(self, pid: str) -> None:
+            self.target_calls.append(pid)
+
+        def cleanup_participant(self, pid: str) -> None:
+            self.cleanup_calls.append(pid)
+
+    transport = _FakeTransport()
+    brain = _StringBrain()
+    brain._transport = transport  # type: ignore[assignment]
+
+    await _run_chain(
+        brain,
+        sends=[
+            ParticipantJoinedFrame(participant_id="web-client"),
+            ParticipantLeftFrame(participant_id="web-client"),
+        ],
+    )
+
+    assert transport.target_calls  == ["web-client"]
+    assert transport.cleanup_calls == ["web-client"]
+
+
+@pytest.mark.asyncio
+async def test_brain_no_transport_steering_when_not_configured():
+    """Multi-pid samples may construct the brain without a transport;
+    join/leave must then be a no-op on the transport side."""
+    brain = _StringBrain()  # default: transport=None
+    await _run_chain(
+        brain,
+        sends=[ParticipantJoinedFrame(participant_id="pid-1")],
+    )
+    # If we got here without an AttributeError, the None-transport path
+    # is exercised. No assertion needed beyond that.
+
+
+@pytest.mark.asyncio
 async def test_brain_participant_lifecycle_hooks_fire():
     brain = _LifecycleBrain()
     sink = await _run_chain(

--- a/tests/test_xr_ai_pipecat_voice_pipeline.py
+++ b/tests/test_xr_ai_pipecat_voice_pipeline.py
@@ -201,6 +201,7 @@ async def test_vad_stt_emits_transcription_on_utterance(monkeypatch):
     monkeypatch.setattr("xr_ai_pipecat.processors.vad_stt.VadDetector", _StubVad)
     proc = VadSttProcessor(stt=stt, vad_cfg=VadConfig())
     frame = InputAudioRawFrame(audio=b"\x00\x00" * 320, sample_rate=16000, num_channels=1)
+    frame.transport_source = "web-client"
 
     sink = await _run_chain(proc, sends=[frame])
 
@@ -209,6 +210,11 @@ async def test_vad_stt_emits_transcription_on_utterance(monkeypatch):
     assert "UserStoppedSpeakingFrame" in kinds
     transcripts = [f for f in sink.frames if isinstance(f, TranscriptionFrame)]
     assert [t.text for t in transcripts] == ["hello agent"]
+    # The pid from transport_source must propagate to TranscriptionFrame
+    # so VoiceGate (which keys off user_id) and any future
+    # transport_source consumer see the real participant.
+    assert transcripts[0].user_id         == "web-client"
+    assert transcripts[0].transport_source == "web-client"
     assert stt.calls and stt.calls[0][1] == 16000
 
 
@@ -225,11 +231,42 @@ async def test_vad_stt_swallows_empty_transcript(monkeypatch):
 
     monkeypatch.setattr("xr_ai_pipecat.processors.vad_stt.VadDetector", _StubVad)
     proc = VadSttProcessor(stt=stt, vad_cfg=VadConfig())
-    sink = await _run_chain(
-        proc,
-        sends=[InputAudioRawFrame(audio=b"\x00\x00", sample_rate=16000, num_channels=1)],
-    )
+    frame = InputAudioRawFrame(audio=b"\x00\x00", sample_rate=16000, num_channels=1)
+    frame.transport_source = "web-client"
+    sink = await _run_chain(proc, sends=[frame])
     assert not any(isinstance(f, TranscriptionFrame) for f in sink.frames)
+
+
+@pytest.mark.asyncio
+async def test_vad_stt_drops_frame_with_missing_transport_source(monkeypatch):
+    """Regression guard: a transport adapter that fails to populate
+    ``transport_source`` used to silently degrade to ``pid=''``, which
+    the hub then dropped on the floor. The processor now drops the
+    frame and logs loudly instead of dispatching with an empty pid."""
+    stt = _FakeStt(text="hello agent")
+
+    fed: list[tuple[bytes, int]] = []
+
+    class _StubVad:
+        def __init__(self, on_utterance, on_speech_start, **_):
+            self._on_utt   = on_utterance
+            self._on_start = on_speech_start
+
+        async def feed(self, pcm_int16: bytes, sample_rate: int) -> None:
+            fed.append((pcm_int16, sample_rate))
+            await self._on_start()
+            await self._on_utt(pcm_int16, sample_rate)
+
+    monkeypatch.setattr("xr_ai_pipecat.processors.vad_stt.VadDetector", _StubVad)
+    proc = VadSttProcessor(stt=stt, vad_cfg=VadConfig())
+
+    # transport_source intentionally left at its default (None).
+    frame = InputAudioRawFrame(audio=b"\x00\x00" * 320, sample_rate=16000, num_channels=1)
+    sink = await _run_chain(proc, sends=[frame])
+
+    assert fed == [], "VAD must not be fed when transport_source is missing"
+    assert not any(isinstance(f, TranscriptionFrame) for f in sink.frames)
+    assert stt.calls == []
 
 
 # ════════════════════════════════════════════════════════════════════════════
@@ -596,6 +633,71 @@ async def test_streaming_tts_observes_each_wav_through_gate():
 
 
 # ════════════════════════════════════════════════════════════════════════════
+# XRMediaHubInputTransport
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_input_transport_populates_transport_source_from_chunk_pid():
+    """The hub-side ``AudioChunk.participant_id`` must flow onto
+    ``InputAudioRawFrame.transport_source`` — without it every
+    downstream return-data / return-audio send routes to ``pid=''`` and
+    the hub drops the message on the floor (production bug fixed in
+    this commit)."""
+    from xr_ai_agent import AudioChunk
+    from xr_ai_pipecat.transport import (
+        SAMPLE_RATE,
+        XRMediaHubInputTransport,
+    )
+    from pipecat.transports.base_transport import TransportParams
+
+    class _StubEndpoint:
+        def __init__(self) -> None:
+            self.audio_cb = None
+
+        def on_audio(self, cb) -> None:
+            self.audio_cb = cb
+
+        def stop(self) -> None:
+            return
+
+    ep = _StubEndpoint()
+    params = TransportParams(
+        audio_in_enabled=True,
+        audio_in_sample_rate=SAMPLE_RATE,
+        audio_in_channels=1,
+    )
+    transport = XRMediaHubInputTransport(ep, params)
+    # Mark started without spinning up the ZMQ run loop; the audio
+    # callback gates on this flag.
+    transport._started = True
+
+    pushed: list[Frame] = []
+
+    async def capture(frame, direction=FrameDirection.DOWNSTREAM):
+        pushed.append(frame)
+
+    transport.push_frame = capture  # type: ignore[method-assign]
+
+    pcm_f32 = np.zeros(320, dtype=np.float32).tobytes()
+    chunk = AudioChunk(
+        pts_us         = 0,
+        sample_rate    = SAMPLE_RATE,
+        channels       = 1,
+        samples        = 320,
+        data           = pcm_f32,
+        participant_id = "web-client",
+        track_id       = "mic",
+    )
+    await ep.audio_cb(chunk)
+
+    assert len(pushed) == 1
+    frame = pushed[0]
+    assert isinstance(frame, InputAudioRawFrame)
+    assert frame.transport_source == "web-client"
+
+
+# ════════════════════════════════════════════════════════════════════════════
 # make_voice_pipeline end-to-end smoke
 # ════════════════════════════════════════════════════════════════════════════
 
@@ -669,9 +771,11 @@ async def test_make_voice_pipeline_audio_in_to_audio_out(monkeypatch):
     vad_stt         = VadSttProcessor(stt=stt, vad_cfg=VadConfig())
     brain           = _EchoBrain()
 
+    in_frame = InputAudioRawFrame(audio=b"\x00\x00" * 320, sample_rate=16000, num_channels=1)
+    in_frame.transport_source = "web-client"
     sink = await _run_chain(
         vad_stt, voice_gate_proc, brain, streaming_tts,
-        sends=[InputAudioRawFrame(audio=b"\x00\x00" * 320, sample_rate=16000, num_channels=1)],
+        sends=[in_frame],
         settle_s=0.6,
     )
 

--- a/tests/test_xr_ai_pipecat_voice_pipeline.py
+++ b/tests/test_xr_ai_pipecat_voice_pipeline.py
@@ -181,6 +181,26 @@ class _NullSink:
         return
 
 
+class _CallbackStubEndpoint:
+    """Endpoint stub that records the audio / participant callbacks the
+    input transport registers in its ``__init__``. ``stop`` is a no-op so
+    tests can flip ``transport._started`` directly without the ZMQ run
+    loop. Shared by the InputTransport audio/participant routing tests."""
+
+    def __init__(self) -> None:
+        self.audio_cb = None
+        self.participant_cb = None
+
+    def on_audio(self, cb) -> None:
+        self.audio_cb = cb
+
+    def on_participant(self, cb) -> None:
+        self.participant_cb = cb
+
+    def stop(self) -> None:
+        return
+
+
 # ════════════════════════════════════════════════════════════════════════════
 # VadSttProcessor
 # ════════════════════════════════════════════════════════════════════════════
@@ -1411,21 +1431,7 @@ async def test_input_transport_populates_transport_source_from_chunk_pid():
     )
     from pipecat.transports.base_transport import TransportParams
 
-    class _StubEndpoint:
-        def __init__(self) -> None:
-            self.audio_cb = None
-            self.participant_cb = None
-
-        def on_audio(self, cb) -> None:
-            self.audio_cb = cb
-
-        def on_participant(self, cb) -> None:
-            self.participant_cb = cb
-
-        def stop(self) -> None:
-            return
-
-    ep = _StubEndpoint()
+    ep = _CallbackStubEndpoint()
     params = TransportParams(
         audio_in_enabled=True,
         audio_in_sample_rate=SAMPLE_RATE,
@@ -1475,21 +1481,7 @@ async def test_input_transport_emits_participant_joined_frame():
     )
     from pipecat.transports.base_transport import TransportParams
 
-    class _StubEndpoint:
-        def __init__(self) -> None:
-            self.audio_cb = None
-            self.participant_cb = None
-
-        def on_audio(self, cb) -> None:
-            self.audio_cb = cb
-
-        def on_participant(self, cb) -> None:
-            self.participant_cb = cb
-
-        def stop(self) -> None:
-            return
-
-    ep = _StubEndpoint()
+    ep = _CallbackStubEndpoint()
     params = TransportParams(
         audio_in_enabled=True,
         audio_in_sample_rate=SAMPLE_RATE,
@@ -1531,21 +1523,7 @@ async def test_input_transport_emits_participant_left_frame():
     )
     from pipecat.transports.base_transport import TransportParams
 
-    class _StubEndpoint:
-        def __init__(self) -> None:
-            self.audio_cb = None
-            self.participant_cb = None
-
-        def on_audio(self, cb) -> None:
-            self.audio_cb = cb
-
-        def on_participant(self, cb) -> None:
-            self.participant_cb = cb
-
-        def stop(self) -> None:
-            return
-
-    ep = _StubEndpoint()
+    ep = _CallbackStubEndpoint()
     params = TransportParams(
         audio_in_enabled=True,
         audio_in_sample_rate=SAMPLE_RATE,
@@ -1583,21 +1561,7 @@ async def test_input_transport_drops_participant_event_before_start():
     )
     from pipecat.transports.base_transport import TransportParams
 
-    class _StubEndpoint:
-        def __init__(self) -> None:
-            self.audio_cb = None
-            self.participant_cb = None
-
-        def on_audio(self, cb) -> None:
-            self.audio_cb = cb
-
-        def on_participant(self, cb) -> None:
-            self.participant_cb = cb
-
-        def stop(self) -> None:
-            return
-
-    ep = _StubEndpoint()
+    ep = _CallbackStubEndpoint()
     params = TransportParams(
         audio_in_enabled=True,
         audio_in_sample_rate=SAMPLE_RATE,
@@ -2001,9 +1965,13 @@ async def test_output_transport_handle_frame_routes_pid_to_default_sender(monkey
     assert seen, "super._handle_frame was not invoked"
     delegated_frame, dest_at_super_entry = seen[0]
     assert delegated_frame is frame
+    # The super-class (default media sender router) must see destination=None
+    # so it accepts the frame...
     assert dest_at_super_entry is None
-    assert frame.transport_destination is None, (
-        "destination must be rewritten to None so the default media sender accepts the frame"
+    # ...but the pid is restored afterward so any downstream tap/sink still
+    # sees which participant the frame was addressed to.
+    assert frame.transport_destination == "web-client", (
+        "destination must be restored after delegating to the default sender"
     )
 
 

--- a/tests/test_xr_ai_pipecat_voice_pipeline.py
+++ b/tests/test_xr_ai_pipecat_voice_pipeline.py
@@ -1373,6 +1373,34 @@ async def test_streaming_tts_flushes_trailing_text_on_response_end():
     assert audio, "expected audio for the flushed trailing fragment"
 
 
+@pytest.mark.asyncio
+async def test_streaming_tts_flushes_sentence_ending_with_closing_quote():
+    """Sentence-final punctuation followed by a closing quote/bracket
+    must still flush the trailing fragment.
+
+    Regression: the voice-gate greeting ends with ``... what am I
+    looking at?"`` — the ``?`` is the sentence end but the buffer's
+    last char is ``"``. A plain ``endswith((".", "!", "?"))`` check
+    misses this; the tail stays in pending and concatenates onto the
+    next turn's response, so the user hears half the greeting up front
+    and the other half glued to their first query reply.
+    """
+    tts  = _FakeTts()
+    gate = VoiceGate(VoiceGateConfig(), audio_sink=_NullSink(), tts=tts)
+    proc = StreamingTtsProcessor(tts=tts, voice_gate=gate)
+
+    await _run_chain(
+        proc,
+        sends=[TextFrame(text='How are you? "I am fine."')],
+        settle_s=0.15,
+    )
+
+    # Both sentences must be dispatched in one turn — no residual
+    # waiting to be glued onto the next reply.
+    assert tts.calls == ['How are you?', '"I am fine."']
+    assert proc._pending == ""  # noqa: SLF001
+
+
 # ════════════════════════════════════════════════════════════════════════════
 # Regression: output transport rewrites destination to default sender (Bug #1)
 # ════════════════════════════════════════════════════════════════════════════

--- a/tests/test_xr_ai_pipecat_voice_pipeline.py
+++ b/tests/test_xr_ai_pipecat_voice_pipeline.py
@@ -772,6 +772,122 @@ async def test_brain_cancels_inflight_on_interruption_frame():
 
 
 @pytest.mark.asyncio
+async def test_brain_on_query_superseded_fires_when_new_query_supersedes_inflight():
+    """When a fresh ``GatedQueryFrame`` arrives while a prior query's
+    task is still in-flight, ``on_query_superseded`` must fire so an
+    agent can decide what to do with the previous response's queued
+    downstream state (e.g. push an InterruptionFrame to drain queued
+    TTS audio). The library default is a no-op; this test only checks
+    the hook is invoked."""
+    class _SupersedeRecorder(_IterBrain):
+        def __init__(self) -> None:
+            super().__init__(chunks=[f"chunk{i} " for i in range(200)])
+            self.supersede_calls: list[str] = []
+
+        async def on_query_superseded(self, pid: str) -> None:
+            self.supersede_calls.append(pid)
+
+    brain = _SupersedeRecorder()
+    await _run_chain(
+        brain,
+        sends=[
+            GatedQueryFrame(participant_id="pid-1", text="first",  fresh_match=True, pts_us=0),
+            GatedQueryFrame(participant_id="pid-1", text="second", fresh_match=True, pts_us=1),
+        ],
+        settle_s=0.2,
+        per_send_delay_s=0.05,
+    )
+    assert brain.supersede_calls == ["pid-1"]
+    assert brain.cancelled is True
+
+
+@pytest.mark.asyncio
+async def test_brain_on_query_superseded_not_called_on_cold_path_first_query():
+    """The cold path — first query, no in-flight task — must NOT call
+    ``on_query_superseded``. There is nothing to supersede, and agents
+    that override to push an InterruptionFrame would otherwise flush
+    unrelated in-flight audio (e.g. a voice-gate chime)."""
+    class _SupersedeRecorder(_StringBrain):
+        def __init__(self) -> None:
+            super().__init__()
+            self.supersede_calls: list[str] = []
+
+        async def on_query_superseded(self, pid: str) -> None:
+            self.supersede_calls.append(pid)
+
+    brain = _SupersedeRecorder()
+    await _run_chain(
+        brain,
+        sends=[GatedQueryFrame(participant_id="pid-1", text="hi", fresh_match=True, pts_us=0)],
+    )
+    assert brain.supersede_calls == []
+
+
+@pytest.mark.asyncio
+async def test_brain_on_query_superseded_can_push_frames_downstream():
+    """The hook is allowed to push frames — this is the whole point of
+    the design (sample-side override pushes ``InterruptionFrame`` to
+    drain queued TTS audio for the previous response). Verify a frame
+    pushed from the hook reaches the downstream sink."""
+    class _InterruptingBrain(_IterBrain):
+        def __init__(self) -> None:
+            super().__init__(chunks=[f"chunk{i} " for i in range(200)])
+
+        async def on_query_superseded(self, pid: str) -> None:
+            await self.push_frame(InterruptionFrame())
+
+    brain = _InterruptingBrain()
+    sink = await _run_chain(
+        brain,
+        sends=[
+            GatedQueryFrame(participant_id="pid-1", text="first",  fresh_match=True, pts_us=0),
+            GatedQueryFrame(participant_id="pid-1", text="second", fresh_match=True, pts_us=1),
+        ],
+        settle_s=0.2,
+        per_send_delay_s=0.05,
+    )
+    assert any(isinstance(f, InterruptionFrame) for f in sink.frames), (
+        "hook must be able to push frames to downstream sink"
+    )
+
+
+@pytest.mark.asyncio
+async def test_brain_on_query_superseded_exception_is_swallowed_and_spawn_proceeds():
+    """A misbehaving override must not break the supersede contract:
+    the previous task is still cancelled and the new query still
+    spawns. The exception is logged at the library boundary."""
+    class _RaisingBrain(_IterBrain):
+        def __init__(self) -> None:
+            super().__init__(chunks=[f"chunk{i} " for i in range(200)])
+            self.handle_calls: list[str] = []
+            self.supersede_calls: list[str] = []
+
+        async def handle_query(self, pid, text, fresh_match):
+            self.handle_calls.append(text)
+            return await super().handle_query(pid, text, fresh_match)
+
+        async def on_query_superseded(self, pid: str) -> None:
+            self.supersede_calls.append(pid)
+            raise RuntimeError("boom")
+
+    brain = _RaisingBrain()
+    await _run_chain(
+        brain,
+        sends=[
+            GatedQueryFrame(participant_id="pid-1", text="first",  fresh_match=True, pts_us=0),
+            GatedQueryFrame(participant_id="pid-1", text="second", fresh_match=True, pts_us=1),
+        ],
+        settle_s=0.2,
+        per_send_delay_s=0.05,
+    )
+    assert brain.supersede_calls == ["pid-1"]
+    # Previous task still cancelled; new query still ran.
+    assert brain.cancelled is True
+    assert "first"  in brain.handle_calls
+    assert "second" in brain.handle_calls
+
+
+@pytest.mark.asyncio
 async def test_brain_steers_transport_target_on_participant_joined():
     """Single-participant routing default: when a brain is constructed
     with a transport, the first ``ParticipantJoinedFrame`` steers the

--- a/tests/test_xr_ai_pipecat_voice_pipeline.py
+++ b/tests/test_xr_ai_pipecat_voice_pipeline.py
@@ -753,9 +753,13 @@ async def test_input_transport_populates_transport_source_from_chunk_pid():
     class _StubEndpoint:
         def __init__(self) -> None:
             self.audio_cb = None
+            self.participant_cb = None
 
         def on_audio(self, cb) -> None:
             self.audio_cb = cb
+
+        def on_participant(self, cb) -> None:
+            self.participant_cb = cb
 
         def stop(self) -> None:
             return
@@ -794,6 +798,165 @@ async def test_input_transport_populates_transport_source_from_chunk_pid():
     frame = pushed[0]
     assert isinstance(frame, InputAudioRawFrame)
     assert frame.transport_source == "web-client"
+
+
+@pytest.mark.asyncio
+async def test_input_transport_emits_participant_joined_frame():
+    """``ParticipantEvent(joined=True)`` from the hub must surface as a
+    ``ParticipantJoinedFrame`` on the pipecat pipeline — otherwise the
+    voice gate never greets and the brain never steers the output
+    transport at a participant, so every TTS chunk gets dropped by
+    ``XRMediaHubOutputTransport.write_audio_frame``."""
+    from xr_ai_agent import ParticipantEvent
+    from xr_ai_pipecat.transport import (
+        SAMPLE_RATE,
+        XRMediaHubInputTransport,
+    )
+    from pipecat.transports.base_transport import TransportParams
+
+    class _StubEndpoint:
+        def __init__(self) -> None:
+            self.audio_cb = None
+            self.participant_cb = None
+
+        def on_audio(self, cb) -> None:
+            self.audio_cb = cb
+
+        def on_participant(self, cb) -> None:
+            self.participant_cb = cb
+
+        def stop(self) -> None:
+            return
+
+    ep = _StubEndpoint()
+    params = TransportParams(
+        audio_in_enabled=True,
+        audio_in_sample_rate=SAMPLE_RATE,
+        audio_in_channels=1,
+    )
+    transport = XRMediaHubInputTransport(ep, params)
+    transport._started = True
+
+    pushed: list[Frame] = []
+
+    async def capture(frame, direction=FrameDirection.DOWNSTREAM):
+        pushed.append(frame)
+
+    transport.push_frame = capture  # type: ignore[method-assign]
+
+    assert ep.participant_cb is not None, (
+        "input transport must bind on_participant in __init__"
+    )
+
+    await ep.participant_cb(
+        ParticipantEvent(participant_id="web-client", joined=True, pts_us=0),
+    )
+
+    assert len(pushed) == 1
+    frame = pushed[0]
+    assert isinstance(frame, ParticipantJoinedFrame)
+    assert frame.participant_id == "web-client"
+
+
+@pytest.mark.asyncio
+async def test_input_transport_emits_participant_left_frame():
+    """``ParticipantEvent(joined=False)`` from the hub must surface as a
+    ``ParticipantLeftFrame`` so ``BrainProcessor`` can run per-pid
+    teardown (cancel in-flight, clear target participant)."""
+    from xr_ai_agent import ParticipantEvent
+    from xr_ai_pipecat.transport import (
+        SAMPLE_RATE,
+        XRMediaHubInputTransport,
+    )
+    from pipecat.transports.base_transport import TransportParams
+
+    class _StubEndpoint:
+        def __init__(self) -> None:
+            self.audio_cb = None
+            self.participant_cb = None
+
+        def on_audio(self, cb) -> None:
+            self.audio_cb = cb
+
+        def on_participant(self, cb) -> None:
+            self.participant_cb = cb
+
+        def stop(self) -> None:
+            return
+
+    ep = _StubEndpoint()
+    params = TransportParams(
+        audio_in_enabled=True,
+        audio_in_sample_rate=SAMPLE_RATE,
+        audio_in_channels=1,
+    )
+    transport = XRMediaHubInputTransport(ep, params)
+    transport._started = True
+
+    pushed: list[Frame] = []
+
+    async def capture(frame, direction=FrameDirection.DOWNSTREAM):
+        pushed.append(frame)
+
+    transport.push_frame = capture  # type: ignore[method-assign]
+
+    await ep.participant_cb(
+        ParticipantEvent(participant_id="web-client", joined=False, pts_us=0),
+    )
+
+    assert len(pushed) == 1
+    frame = pushed[0]
+    assert isinstance(frame, ParticipantLeftFrame)
+    assert frame.participant_id == "web-client"
+
+
+@pytest.mark.asyncio
+async def test_input_transport_drops_participant_event_before_start():
+    """Same ``_started`` guard as ``_on_hub_audio`` — a late event
+    arriving after teardown (or before ``StartFrame``) must be a no-op
+    so the bridge doesn't race the pipeline shutdown."""
+    from xr_ai_agent import ParticipantEvent
+    from xr_ai_pipecat.transport import (
+        SAMPLE_RATE,
+        XRMediaHubInputTransport,
+    )
+    from pipecat.transports.base_transport import TransportParams
+
+    class _StubEndpoint:
+        def __init__(self) -> None:
+            self.audio_cb = None
+            self.participant_cb = None
+
+        def on_audio(self, cb) -> None:
+            self.audio_cb = cb
+
+        def on_participant(self, cb) -> None:
+            self.participant_cb = cb
+
+        def stop(self) -> None:
+            return
+
+    ep = _StubEndpoint()
+    params = TransportParams(
+        audio_in_enabled=True,
+        audio_in_sample_rate=SAMPLE_RATE,
+        audio_in_channels=1,
+    )
+    transport = XRMediaHubInputTransport(ep, params)
+    # Intentionally leave transport._started == False.
+
+    pushed: list[Frame] = []
+
+    async def capture(frame, direction=FrameDirection.DOWNSTREAM):
+        pushed.append(frame)
+
+    transport.push_frame = capture  # type: ignore[method-assign]
+
+    await ep.participant_cb(
+        ParticipantEvent(participant_id="web-client", joined=True, pts_us=0),
+    )
+
+    assert pushed == []
 
 
 # ════════════════════════════════════════════════════════════════════════════

--- a/tests/test_xr_ai_pipecat_voice_pipeline.py
+++ b/tests/test_xr_ai_pipecat_voice_pipeline.py
@@ -713,6 +713,109 @@ async def test_streaming_tts_interruption_cancels_and_clears_pending():
 
 
 @pytest.mark.asyncio
+async def test_streaming_tts_flushes_hub_return_audio_on_interrupt():
+    """STOP must drop audio that's already paced into the hub.
+
+    Cancelling synth + sender tasks only stops *new* audio. The hub's
+    pacing pipe (and LiveKit jitter buffer behind it) keep playing
+    whatever is already queued, so without an explicit flush the user
+    hears the agent finish its current sentence before silence — STOP
+    feels broken. On ``InterruptionFrame`` the processor must call
+    ``transport.endpoint.flush_return_audio(target_participant)`` so the
+    hub drops its pending audio at the source.
+    """
+    class _StubEndpoint:
+        def __init__(self) -> None:
+            self.flush_calls: list[str] = []
+
+        async def flush_return_audio(self, pid: str) -> None:
+            self.flush_calls.append(pid)
+
+    class _StubTransport:
+        def __init__(self, pid: str) -> None:
+            self.endpoint           = _StubEndpoint()
+            self.target_participant = pid
+
+    tts  = _FakeTts()
+    tts.delay_s = 0.2
+    gate = VoiceGate(VoiceGateConfig(), audio_sink=_NullSink(), tts=tts)
+    transport = _StubTransport("web-client")
+    proc = StreamingTtsProcessor(
+        tts=tts, voice_gate=gate, transport=transport,
+    )
+
+    await _run_chain(
+        proc,
+        sends=[
+            TextFrame(text="abandoned sentence one. "),
+            InterruptionFrame(),
+        ],
+        settle_s=0.4,
+        per_send_delay_s=0.05,
+    )
+
+    assert transport.endpoint.flush_calls == ["web-client"]
+
+
+@pytest.mark.asyncio
+async def test_streaming_tts_no_flush_when_transport_unset():
+    """Tests / standalone usage that construct the processor without a
+    transport must still survive ``InterruptionFrame`` — no transport
+    means no flush, not an AttributeError."""
+    tts  = _FakeTts()
+    tts.delay_s = 0.2
+    gate = VoiceGate(VoiceGateConfig(), audio_sink=_NullSink(), tts=tts)
+    proc = StreamingTtsProcessor(tts=tts, voice_gate=gate)  # transport=None
+
+    sink = await _run_chain(
+        proc,
+        sends=[
+            TextFrame(text="abandoned sentence one. "),
+            InterruptionFrame(),
+        ],
+        settle_s=0.3,
+        per_send_delay_s=0.05,
+    )
+    # If we got here without an AttributeError, the None-transport path
+    # is exercised. Pending buffer should still be cleared.
+    assert proc._pending == ""  # noqa: SLF001
+    audio = [f for f in sink.frames if isinstance(f, OutputAudioRawFrame)]
+    assert audio == []
+
+
+@pytest.mark.asyncio
+async def test_streaming_tts_no_flush_when_no_target_participant():
+    """A transport with no target participant bound yet has no pid to
+    flush. The processor must skip the flush rather than calling
+    ``flush_return_audio("")`` which the hub drops on the floor."""
+    class _StubEndpoint:
+        def __init__(self) -> None:
+            self.flush_calls: list[str] = []
+
+        async def flush_return_audio(self, pid: str) -> None:
+            self.flush_calls.append(pid)
+
+    class _StubTransport:
+        def __init__(self) -> None:
+            self.endpoint           = _StubEndpoint()
+            self.target_participant = ""
+
+    tts  = _FakeTts()
+    gate = VoiceGate(VoiceGateConfig(), audio_sink=_NullSink(), tts=tts)
+    transport = _StubTransport()
+    proc = StreamingTtsProcessor(
+        tts=tts, voice_gate=gate, transport=transport,
+    )
+
+    await _run_chain(
+        proc,
+        sends=[InterruptionFrame()],
+        settle_s=0.1,
+    )
+    assert transport.endpoint.flush_calls == []
+
+
+@pytest.mark.asyncio
 async def test_streaming_tts_observes_each_wav_through_gate():
     """observe_tts_wav must be invoked once per synthesized WAV so the
     gate's lazy chime can build at the TTS sample rate."""

--- a/tests/test_xr_ai_pipecat_voice_pipeline.py
+++ b/tests/test_xr_ai_pipecat_voice_pipeline.py
@@ -32,6 +32,7 @@ from pipecat.frames.frames import (
     TextFrame,
     TranscriptionFrame,
     UserStartedSpeakingFrame,
+    UserStoppedSpeakingFrame,
 )
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.worker import PipelineWorker
@@ -268,6 +269,270 @@ async def test_vad_stt_drops_frame_with_missing_transport_source(monkeypatch):
     assert fed == [], "VAD must not be fed when transport_source is missing"
     assert not any(isinstance(f, TranscriptionFrame) for f in sink.frames)
     assert stt.calls == []
+
+
+# ── early STOP probe ────────────────────────────────────────────────────────
+
+
+class _StagedStt:
+    """STTService double that returns canned text from a queue.
+
+    Each call pops from ``texts`` (FIFO); when empty, falls back to
+    ``default``. Lets a single test feed different transcripts to the
+    probe call and the eventual VAD-finalize call.
+    """
+
+    def __init__(self, texts: list[str], default: str = "") -> None:
+        self.texts        = list(texts)
+        self.default      = default
+        self.calls:       list[tuple[bytes, int]] = []
+        self.raise_on_call = False
+
+    async def transcribe(self, audio: bytes, *, sample_rate: int | None = None, channels: int = 1, timeout: float | None = None) -> str:
+        self.calls.append((audio, sample_rate or 16000))
+        if self.raise_on_call:
+            raise RuntimeError("stt down")
+        if self.texts:
+            return self.texts.pop(0)
+        return self.default
+
+    async def health(self) -> bool:
+        return True
+
+    async def close(self) -> None:
+        pass
+
+
+class _StagedVad:
+    """VadDetector double whose ``feed`` only triggers ``on_speech_start``
+    on the first call; the test fires ``on_utterance`` explicitly via
+    ``trigger_utterance`` so the probe / finalize race can be exercised
+    deterministically.
+    """
+
+    instances: list = []
+
+    def __init__(self, on_utterance, on_speech_start, **_):
+        self._on_utt    = on_utterance
+        self._on_start  = on_speech_start
+        self._started   = False
+        self.last_audio: bytes = b""
+        self.last_sr:    int   = 0
+        _StagedVad.instances.append(self)
+
+    async def feed(self, pcm_int16: bytes, sample_rate: int) -> None:
+        # Accumulate the audio the way the real detector buffers an
+        # utterance — keeps a single concatenated snapshot so the test
+        # can assert against the bytes seen by the probe.
+        self.last_audio = self.last_audio + pcm_int16
+        self.last_sr    = sample_rate
+        if not self._started:
+            self._started = True
+            await self._on_start()
+
+    async def trigger_utterance(self) -> None:
+        await self._on_utt(self.last_audio, self.last_sr)
+
+
+@pytest.mark.asyncio
+async def test_vad_stt_stop_probe_schedules_on_speech_start(monkeypatch):
+    """On the first ``on_speech_start`` after silence, the processor
+    schedules a one-shot probe task. Waiting longer than
+    ``stop_probe_after_s`` lets the probe run; the stub STT records the
+    call so the probe firing is observable."""
+    _StagedVad.instances.clear()
+    stt = _StagedStt(texts=["something"])  # not STOP — probe is silent
+    monkeypatch.setattr("xr_ai_pipecat.processors.vad_stt.VadDetector", _StagedVad)
+    proc = VadSttProcessor(stt=stt, vad_cfg=VadConfig(stop_probe_after_s=0.05))
+
+    frame = InputAudioRawFrame(audio=b"\x00\x00" * 320, sample_rate=16000, num_channels=1)
+    frame.transport_source = "web-client"
+    await _run_chain(proc, sends=[frame], settle_s=0.2)
+
+    # Exactly one STT call — the probe's — because on_utterance never fired.
+    assert len(stt.calls) == 1
+    assert stt.calls[0][1] == 16000
+
+
+@pytest.mark.asyncio
+async def test_vad_stt_stop_probe_emits_interruption_on_stop_match(monkeypatch):
+    """When the probe's partial transcript matches ``STOP_RE`` the
+    processor pushes ``InterruptionFrame`` + the matched
+    ``TranscriptionFrame`` + ``UserStoppedSpeakingFrame`` downstream
+    immediately — without waiting for VAD's silence-window finalize."""
+    _StagedVad.instances.clear()
+    stt = _StagedStt(texts=["stop"])
+    monkeypatch.setattr("xr_ai_pipecat.processors.vad_stt.VadDetector", _StagedVad)
+    proc = VadSttProcessor(stt=stt, vad_cfg=VadConfig(stop_probe_after_s=0.05))
+
+    frame = InputAudioRawFrame(audio=b"\x00\x00" * 320, sample_rate=16000, num_channels=1)
+    frame.transport_source = "web-client"
+    sink = await _run_chain(proc, sends=[frame], settle_s=0.2)
+
+    kinds = [type(f).__name__ for f in sink.frames]
+    assert "InterruptionFrame"        in kinds
+    assert "UserStoppedSpeakingFrame" in kinds
+    transcripts = [f for f in sink.frames if isinstance(f, TranscriptionFrame)]
+    assert [t.text for t in transcripts] == ["stop"]
+    # InterruptionFrame must arrive before the TranscriptionFrame so any
+    # in-flight reasoning is cancelled before the gate sees STOP.
+    int_idx = next(i for i, f in enumerate(sink.frames) if isinstance(f, InterruptionFrame))
+    tf_idx  = next(i for i, f in enumerate(sink.frames) if isinstance(f, TranscriptionFrame))
+    assert int_idx < tf_idx
+
+
+@pytest.mark.asyncio
+async def test_vad_stt_stop_probe_silent_on_non_stop_match(monkeypatch):
+    """A non-STOP partial transcript discards the probe result and lets
+    VAD-finalize handle the utterance via the usual path. No
+    ``InterruptionFrame`` is pushed."""
+    _StagedVad.instances.clear()
+    stt = _StagedStt(texts=["hello agent what time is it"])
+    monkeypatch.setattr("xr_ai_pipecat.processors.vad_stt.VadDetector", _StagedVad)
+    proc = VadSttProcessor(stt=stt, vad_cfg=VadConfig(stop_probe_after_s=0.05))
+
+    frame = InputAudioRawFrame(audio=b"\x00\x00" * 320, sample_rate=16000, num_channels=1)
+    frame.transport_source = "web-client"
+    sink = await _run_chain(proc, sends=[frame], settle_s=0.2)
+
+    assert not any(isinstance(f, InterruptionFrame) for f in sink.frames)
+    assert not any(isinstance(f, TranscriptionFrame) for f in sink.frames)
+
+
+@pytest.mark.asyncio
+async def test_vad_stt_stop_probe_cancelled_when_vad_finalizes_first(monkeypatch):
+    """If VAD finalizes the utterance before the probe timer fires, the
+    pending probe task is cancelled — STT is called exactly once (by
+    the on_utterance path) and no probe-side STT call lands."""
+    _StagedVad.instances.clear()
+    stt = _StagedStt(texts=["hello agent"])
+    monkeypatch.setattr("xr_ai_pipecat.processors.vad_stt.VadDetector", _StagedVad)
+    proc = VadSttProcessor(stt=stt, vad_cfg=VadConfig(stop_probe_after_s=1.0))
+
+    frame = InputAudioRawFrame(audio=b"\x00\x00" * 320, sample_rate=16000, num_channels=1)
+    frame.transport_source = "web-client"
+
+    # Drive the first frame so on_speech_start fires and the probe task
+    # is scheduled; then trigger on_utterance manually well before the
+    # 1-second probe timer expires.
+    sink = _CaptureSink()
+    pipeline = Pipeline([proc, sink])
+    worker = PipelineWorker(pipeline, cancel_on_idle_timeout=False, enable_rtvi=False)
+    runner = WorkerRunner()
+    await runner.add_workers(worker)
+
+    async def drive() -> None:
+        await asyncio.sleep(0.05)
+        await worker.queue_frame(frame)
+        await asyncio.sleep(0.05)
+        assert _StagedVad.instances, "VAD stub was not instantiated"
+        await _StagedVad.instances[-1].trigger_utterance()
+        await asyncio.sleep(0.1)
+        await worker.queue_frame(EndFrame())
+
+    await asyncio.gather(runner.run(), drive())
+
+    # Only the on_utterance STT call — no probe call.
+    assert len(stt.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_vad_stt_stop_probe_suppresses_duplicate_vad_finalize(monkeypatch):
+    """After the probe fires STOP, the eventual VAD-finalize for the
+    same utterance must NOT re-emit ``UserStoppedSpeakingFrame`` + a
+    second ``TranscriptionFrame`` — otherwise the gate would re-fire
+    its canned "Okay, I will stop." ack TTS."""
+    _StagedVad.instances.clear()
+    # Probe call returns "stop"; the eventual on_utterance call (if
+    # the suppression failed) would return "stop now" — we must not see
+    # that downstream.
+    stt = _StagedStt(texts=["stop", "stop now"])
+    monkeypatch.setattr("xr_ai_pipecat.processors.vad_stt.VadDetector", _StagedVad)
+    proc = VadSttProcessor(stt=stt, vad_cfg=VadConfig(stop_probe_after_s=0.05))
+
+    frame = InputAudioRawFrame(audio=b"\x00\x00" * 320, sample_rate=16000, num_channels=1)
+    frame.transport_source = "web-client"
+
+    sink = _CaptureSink()
+    pipeline = Pipeline([proc, sink])
+    worker = PipelineWorker(pipeline, cancel_on_idle_timeout=False, enable_rtvi=False)
+    runner = WorkerRunner()
+    await runner.add_workers(worker)
+
+    async def drive() -> None:
+        await asyncio.sleep(0.05)
+        await worker.queue_frame(frame)
+        # Wait for the probe to fire (>= stop_probe_after_s).
+        await asyncio.sleep(0.2)
+        # VAD now finalizes after silence — would normally push a fresh
+        # UserStoppedSpeakingFrame + TranscriptionFrame.
+        assert _StagedVad.instances
+        await _StagedVad.instances[-1].trigger_utterance()
+        await asyncio.sleep(0.1)
+        await worker.queue_frame(EndFrame())
+
+    await asyncio.gather(runner.run(), drive())
+
+    transcripts = [f for f in sink.frames if isinstance(f, TranscriptionFrame)]
+    assert [t.text for t in transcripts] == ["stop"], (
+        "duplicate transcription from VAD-finalize must be suppressed "
+        "after the probe already fired STOP"
+    )
+    # The probe's stop-emit ends with UserStoppedSpeakingFrame; VAD's
+    # finalize would re-push one. With suppression we should see exactly
+    # one of each.
+    stops = [f for f in sink.frames if isinstance(f, UserStoppedSpeakingFrame)]
+    assert len(stops) == 1
+    # Only the probe-side STT call should have happened — the on_utterance
+    # path bailed before its own STT call.
+    assert len(stt.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_vad_stt_stop_probe_disabled_when_setting_zero(monkeypatch):
+    """``stop_probe_after_s = 0`` opts out of the probe entirely — no
+    background task is scheduled and the only STT call comes from
+    on_utterance, matching the pre-probe behavior."""
+    _StagedVad.instances.clear()
+    stt = _StagedStt(texts=["stop"])
+    monkeypatch.setattr("xr_ai_pipecat.processors.vad_stt.VadDetector", _StagedVad)
+    proc = VadSttProcessor(stt=stt, vad_cfg=VadConfig(stop_probe_after_s=0.0))
+
+    frame = InputAudioRawFrame(audio=b"\x00\x00" * 320, sample_rate=16000, num_channels=1)
+    frame.transport_source = "web-client"
+
+    sink = _CaptureSink()
+    pipeline = Pipeline([proc, sink])
+    worker = PipelineWorker(pipeline, cancel_on_idle_timeout=False, enable_rtvi=False)
+    runner = WorkerRunner()
+    await runner.add_workers(worker)
+
+    async def drive() -> None:
+        await asyncio.sleep(0.05)
+        await worker.queue_frame(frame)
+        # Give the world long enough for any (incorrectly-scheduled) probe
+        # to fire; with the probe disabled, nothing happens here.
+        await asyncio.sleep(0.2)
+        assert _StagedVad.instances
+        await _StagedVad.instances[-1].trigger_utterance()
+        await asyncio.sleep(0.05)
+        await worker.queue_frame(EndFrame())
+
+    await asyncio.gather(runner.run(), drive())
+
+    # Exactly one STT call — the on_utterance one. No probe ran.
+    assert len(stt.calls) == 1
+    transcripts = [f for f in sink.frames if isinstance(f, TranscriptionFrame)]
+    assert [t.text for t in transcripts] == ["stop"]
+    # The discriminating signal: with the probe disabled, the
+    # InterruptionFrame the probe normally pushes on STOP-match must NOT
+    # appear. (Without this assertion, the call-count check above would
+    # pass even if the probe ran — its STT call and the on_utterance one
+    # would either way total exactly one because the suppression flag
+    # would gate out the duplicate.)
+    assert not any(isinstance(f, InterruptionFrame) for f in sink.frames), (
+        "probe must not push InterruptionFrame when stop_probe_after_s=0"
+    )
 
 
 # ════════════════════════════════════════════════════════════════════════════

--- a/tests/test_xr_ai_pipecat_voice_pipeline.py
+++ b/tests/test_xr_ai_pipecat_voice_pipeline.py
@@ -447,16 +447,42 @@ async def test_brain_async_iter_return_pushes_text_frame_per_chunk():
 
 
 @pytest.mark.asyncio
-async def test_brain_cancels_inflight_on_user_started_speaking():
-    """``UserStartedSpeakingFrame`` is the interrupt point: any
-    in-flight query for that pid must be cancelled before a new turn
-    starts."""
-    brain = _IterBrain(chunks=[f"chunk{i} " for i in range(200)])
-    await _run_chain(
+async def test_brain_does_not_cancel_on_user_started_speaking():
+    """Regression guard: ``UserStartedSpeakingFrame`` is a hook, not a
+    cancel signal. Cancelling on speech onset breaks two things:
+
+    * any AEC leak of the agent's own TTS becomes self-cancel,
+    * a quick follow-up utterance aborts the prior response BEFORE the
+      voice gate even decides whether the new utterance was a query.
+
+    The brain must keep streaming TextFrames; cancellation happens on
+    the next GatedQueryFrame or on an explicit InterruptionFrame."""
+    brain = _IterBrain(chunks=[f"chunk{i} " for i in range(5)])
+    sink = await _run_chain(
         brain,
         sends=[
             GatedQueryFrame(participant_id="pid-1", text="hi", fresh_match=True, pts_us=0),
             UserStartedSpeakingFrame(),
+        ],
+        settle_s=0.3,
+        per_send_delay_s=0.05,
+    )
+    assert brain.cancelled is False
+    texts = [f.text for f in sink.frames if isinstance(f, TextFrame)]
+    assert texts == [f"chunk{i} " for i in range(5)]
+
+
+@pytest.mark.asyncio
+async def test_brain_cancels_inflight_on_new_query_for_same_pid():
+    """A fresh GatedQueryFrame supersedes any in-flight reasoning for
+    the same pid — this is the contract that makes rapid follow-ups
+    work without the user having to wait for the previous answer."""
+    brain = _IterBrain(chunks=[f"chunk{i} " for i in range(200)])
+    await _run_chain(
+        brain,
+        sends=[
+            GatedQueryFrame(participant_id="pid-1", text="hi",   fresh_match=True, pts_us=0),
+            GatedQueryFrame(participant_id="pid-1", text="hi 2", fresh_match=True, pts_us=1),
         ],
         settle_s=0.2,
         per_send_delay_s=0.05,
@@ -498,30 +524,53 @@ async def test_brain_participant_lifecycle_hooks_fire():
 
 
 @pytest.mark.asyncio
-async def test_brain_user_started_speaking_hook_fires():
-    """on_user_started_speaking fires for every pid currently in flight,
-    giving samples a hook to start speculative work (e.g. camera warmup)
-    on the leading edge of the next turn."""
-    # IterBrain has an in-flight task we can probe; intercept its
-    # on_user_started_speaking hook to record what pid was reported.
-    long_brain = _IterBrain(chunks=[f"chunk{i} " for i in range(200)])
+async def test_brain_user_started_speaking_hook_fires_for_joined_pids():
+    """on_user_started_speaking fires for every joined pid (NOT just the
+    in-flight ones), so the cold path — first utterance, nothing in
+    flight yet — still gets the speculative-warmup hook. Tracking
+    in-flight tasks here would mean the very first turn never sees
+    camera warmup, which is precisely the case it was designed for."""
+    brain = _IterBrain(chunks=[])
     started_for: list[str] = []
 
     async def speech_hook(pid: str) -> None:
         started_for.append(pid)
 
-    long_brain.on_user_started_speaking = speech_hook  # type: ignore[method-assign]
+    brain.on_user_started_speaking = speech_hook  # type: ignore[method-assign]
 
     await _run_chain(
-        long_brain,
+        brain,
         sends=[
-            GatedQueryFrame(participant_id="pid-1", text="hi", fresh_match=True, pts_us=0),
+            ParticipantJoinedFrame(participant_id="pid-1"),
             UserStartedSpeakingFrame(),
         ],
-        settle_s=0.2,
+        settle_s=0.1,
         per_send_delay_s=0.05,
     )
     assert started_for == ["pid-1"]
+
+
+@pytest.mark.asyncio
+async def test_brain_user_started_speaking_hook_skipped_after_leave():
+    brain = _IterBrain(chunks=[])
+    started_for: list[str] = []
+
+    async def speech_hook(pid: str) -> None:
+        started_for.append(pid)
+
+    brain.on_user_started_speaking = speech_hook  # type: ignore[method-assign]
+
+    await _run_chain(
+        brain,
+        sends=[
+            ParticipantJoinedFrame(participant_id="pid-1"),
+            ParticipantLeftFrame(participant_id="pid-1"),
+            UserStartedSpeakingFrame(),
+        ],
+        settle_s=0.1,
+        per_send_delay_s=0.05,
+    )
+    assert started_for == []
 
 
 # ════════════════════════════════════════════════════════════════════════════

--- a/tests/test_xr_ai_pipecat_voice_pipeline.py
+++ b/tests/test_xr_ai_pipecat_voice_pipeline.py
@@ -17,8 +17,10 @@ what a deployed pipeline will see.
 from __future__ import annotations
 
 import asyncio
+import gc
 import io
 import wave
+import warnings
 from typing import AsyncIterator, Sequence
 
 import numpy as np
@@ -532,6 +534,68 @@ async def test_vad_stt_stop_probe_disabled_when_setting_zero(monkeypatch):
     # would gate out the duplicate.)
     assert not any(isinstance(f, InterruptionFrame) for f in sink.frames), (
         "probe must not push InterruptionFrame when stop_probe_after_s=0"
+    )
+
+
+@pytest.mark.asyncio
+async def test_vad_stt_stop_probe_no_unawaited_coroutine_under_finalize_race(monkeypatch):
+    """Regression guard: the probe-STOP-then-VAD-finalize sequence must
+    not produce any "coroutine was never awaited" RuntimeWarnings.
+
+    Production saw an intermittent
+    ``coroutine 'FrameProcessor.__process_frame_task_handler' was never
+    awaited`` right after a probe-STOP match. The fix awaits the
+    cancelled probe task to completion before scheduling the next one
+    (and before ``on_utterance`` clears its bookkeeping) so a cancelled
+    probe never overlaps a fresh one. Capture all RuntimeWarnings
+    raised during the sequence, then force GC so the unawaited-coroutine
+    finalizer fires before the assertion runs.
+    """
+    _StagedVad.instances.clear()
+    # Probe sees STOP; finalize would see "stop now" if suppression failed.
+    stt = _StagedStt(texts=["stop", "stop now"])
+    monkeypatch.setattr("xr_ai_pipecat.processors.vad_stt.VadDetector", _StagedVad)
+    proc = VadSttProcessor(stt=stt, vad_cfg=VadConfig(stop_probe_after_s=0.05))
+
+    frame = InputAudioRawFrame(audio=b"\x00\x00" * 320, sample_rate=16000, num_channels=1)
+    frame.transport_source = "web-client"
+
+    sink = _CaptureSink()
+    pipeline = Pipeline([proc, sink])
+    worker = PipelineWorker(pipeline, cancel_on_idle_timeout=False, enable_rtvi=False)
+    runner = WorkerRunner()
+    await runner.add_workers(worker)
+
+    async def drive() -> None:
+        await asyncio.sleep(0.05)
+        await worker.queue_frame(frame)
+        # Let the probe fire its STOP.
+        await asyncio.sleep(0.15)
+        # VAD finalize races 0.1s after the probe — matches the
+        # production timing reported in the original incident.
+        assert _StagedVad.instances
+        await _StagedVad.instances[-1].trigger_utterance()
+        await asyncio.sleep(0.1)
+        await worker.queue_frame(EndFrame())
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        await asyncio.gather(runner.run(), drive())
+        # Coroutine-never-awaited surfaces from the GC finalizer, not from
+        # a raise — force a collection cycle so the warning lands inside
+        # the catch_warnings block.
+        for _ in range(3):
+            gc.collect()
+            await asyncio.sleep(0)
+
+    unawaited = [
+        w for w in caught
+        if issubclass(w.category, RuntimeWarning)
+        and "never awaited" in str(w.message)
+    ]
+    assert not unawaited, (
+        "probe → finalize sequence leaked unawaited coroutines: "
+        + ", ".join(str(w.message) for w in unawaited)
     )
 
 

--- a/tests/test_xr_ai_pipecat_voice_pipeline.py
+++ b/tests/test_xr_ai_pipecat_voice_pipeline.py
@@ -40,6 +40,7 @@ from pipecat.workers.runner import WorkerRunner
 
 from xr_ai_pipecat import (
     BrainProcessor,
+    BrainResponseEndFrame,
     GatedQueryFrame,
     ParticipantJoinedFrame,
     ParticipantLeftFrame,
@@ -880,3 +881,432 @@ async def test_make_voice_pipeline_audio_in_to_audio_out(monkeypatch):
     audio_out = [f for f in sink.frames if isinstance(f, OutputAudioRawFrame)]
     assert audio_out, "expected at least one OutputAudioRawFrame at the tail"
     assert tts.calls == ["echo hi pipeline."]
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# Regression: brain tags TextFrames with pid (Bug #2)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_brain_tags_text_frame_with_pid_for_string_return():
+    """The brain MUST set ``transport_destination`` on every TextFrame.
+
+    Downstream ``StreamingTtsProcessor`` reads
+    ``frame.transport_destination or ""`` and copies it onto the
+    resulting ``OutputAudioRawFrame``. Without the pid tag the empty
+    string flows through and the hub drops every audio chunk on the
+    floor — the "agent thinks but says nothing" failure mode.
+    """
+    brain = _StringBrain()
+    sink = await _run_chain(
+        brain,
+        sends=[GatedQueryFrame(participant_id="web-client", text="hi", fresh_match=True, pts_us=0)],
+    )
+
+    texts = [f for f in sink.frames if isinstance(f, TextFrame)]
+    assert texts, "brain produced no TextFrame"
+    assert all(t.transport_destination == "web-client" for t in texts)
+
+
+@pytest.mark.asyncio
+async def test_brain_tags_text_frame_with_pid_for_async_iter_return():
+    brain = _IterBrain(chunks=["alpha ", "beta."])
+    sink = await _run_chain(
+        brain,
+        sends=[GatedQueryFrame(participant_id="web-client", text="hi", fresh_match=True, pts_us=0)],
+        settle_s=0.15,
+    )
+    texts = [f for f in sink.frames if isinstance(f, TextFrame)]
+    assert len(texts) == 2
+    assert all(t.transport_destination == "web-client" for t in texts)
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# Regression: brain emits BrainResponseEndFrame at end of turn (Bug #4)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_brain_emits_response_end_after_string_turn():
+    """One ``BrainResponseEndFrame`` per completed turn carries the full
+    assembled text and pid — the downstream data-channel echo keys off
+    this marker."""
+    brain = _StringBrain()
+    sink = await _run_chain(
+        brain,
+        sends=[GatedQueryFrame(participant_id="pid-1", text="hi", fresh_match=True, pts_us=42)],
+    )
+    ends = [f for f in sink.frames if isinstance(f, BrainResponseEndFrame)]
+    assert len(ends) == 1
+    assert ends[0].pid    == "pid-1"
+    assert ends[0].text   == "answer: hi"
+    assert ends[0].pts_us == 42
+
+
+@pytest.mark.asyncio
+async def test_brain_emits_response_end_after_streamed_turn():
+    brain = _IterBrain(chunks=["one ", "two ", "three."])
+    sink = await _run_chain(
+        brain,
+        sends=[GatedQueryFrame(participant_id="pid-1", text="q", fresh_match=True, pts_us=7)],
+        settle_s=0.2,
+    )
+    ends = [f for f in sink.frames if isinstance(f, BrainResponseEndFrame)]
+    assert len(ends) == 1
+    assert ends[0].text == "one two three."
+    assert ends[0].pid  == "pid-1"
+
+
+@pytest.mark.asyncio
+async def test_brain_does_not_emit_response_end_on_cancel():
+    """Cancellation (new query or InterruptionFrame) supersedes the
+    in-flight turn — the data-channel echo would surface a partial
+    answer that contradicts the new turn, so the brain skips the end
+    marker. The second turn still emits its own end marker normally."""
+    brain = _IterBrain(chunks=[f"chunk{i} " for i in range(200)])
+    sink = await _run_chain(
+        brain,
+        sends=[
+            GatedQueryFrame(participant_id="pid-1", text="first",  fresh_match=True, pts_us=0),
+            GatedQueryFrame(participant_id="pid-1", text="second", fresh_match=True, pts_us=1),
+        ],
+        settle_s=0.4,
+        per_send_delay_s=0.05,
+    )
+    ends = [f for f in sink.frames if isinstance(f, BrainResponseEndFrame)]
+    # Only the second turn's end marker survives — the first was cancelled.
+    assert len(ends) == 1
+    assert ends[0].pts_us == 1
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# Regression: handle_query async-def-returning-async-iterator shape works (Bug #3)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+class _StreamMethodBrain(BrainProcessor):
+    """Locks in the simple-vlm / xr-render-demo handle_query shape:
+
+        async def handle_query(...) -> AsyncIterator[str]:
+            return self._stream(...)
+
+    where ``_stream`` is itself an async-generator function. ``await``-
+    ing handle_query resolves to the async-generator object the base
+    brain then iterates with ``async for`` — the shape is valid Python
+    and must remain supported, since both samples use it.
+    """
+
+    def __init__(self, chunks: list[str]) -> None:
+        super().__init__()
+        self._chunks = chunks
+
+    async def handle_query(self, pid, text, fresh_match) -> AsyncIterator[str]:
+        return self._stream(pid, text)
+
+    async def _stream(self, pid: str, text: str) -> AsyncIterator[str]:
+        for c in self._chunks:
+            yield c
+            await asyncio.sleep(0.001)
+
+
+@pytest.mark.asyncio
+async def test_brain_supports_handle_query_returning_async_generator_method():
+    brain = _StreamMethodBrain(chunks=["foo ", "bar."])
+    sink = await _run_chain(
+        brain,
+        sends=[GatedQueryFrame(participant_id="pid-1", text="hi", fresh_match=True, pts_us=0)],
+        settle_s=0.15,
+    )
+    texts = [f.text for f in sink.frames if isinstance(f, TextFrame)]
+    assert texts == ["foo ", "bar."]
+    ends = [f for f in sink.frames if isinstance(f, BrainResponseEndFrame)]
+    assert len(ends) == 1
+    assert ends[0].text == "foo bar."
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# Regression: StreamingTts data-channel echo (Bug #4)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+class _RecordingTransport:
+    """Transport double — captures every ``send_return_data`` call."""
+
+    def __init__(self) -> None:
+        self.sends: list = []
+
+    async def send_return_data(self, msg) -> None:
+        self.sends.append(msg)
+
+
+@pytest.mark.asyncio
+async def test_streaming_tts_echoes_data_when_topic_set():
+    tts  = _FakeTts()
+    gate = VoiceGate(VoiceGateConfig(), audio_sink=_NullSink(), tts=tts)
+    transport = _RecordingTransport()
+    proc = StreamingTtsProcessor(
+        tts=tts, voice_gate=gate,
+        transport=transport, text_topic="vlm.response",
+    )
+
+    await _run_chain(
+        proc,
+        sends=[
+            BrainResponseEndFrame(pid="web-client", text="hello there", pts_us=99),
+        ],
+    )
+
+    assert len(transport.sends) == 1
+    msg = transport.sends[0]
+    assert msg.participant_id == "web-client"
+    assert msg.topic          == "vlm.response"
+    assert msg.data           == b"hello there"
+    assert msg.pts_us         == 99
+
+
+@pytest.mark.asyncio
+async def test_streaming_tts_skips_echo_when_topic_empty():
+    """Samples whose brain pushes its own per-turn data echo (e.g.
+    xr-render-demo) pass ``text_topic=""`` to opt out of the
+    pipeline-level send and avoid duplicates."""
+    tts  = _FakeTts()
+    gate = VoiceGate(VoiceGateConfig(), audio_sink=_NullSink(), tts=tts)
+    transport = _RecordingTransport()
+    proc = StreamingTtsProcessor(
+        tts=tts, voice_gate=gate,
+        transport=transport, text_topic="",
+    )
+    await _run_chain(
+        proc,
+        sends=[BrainResponseEndFrame(pid="pid-1", text="hi", pts_us=0)],
+    )
+    assert transport.sends == []
+
+
+@pytest.mark.asyncio
+async def test_streaming_tts_flushes_trailing_text_on_response_end():
+    """The brain may finish a turn with text that has no sentence-final
+    punctuation (e.g. partial answer). End-of-response is the last
+    chance to flush the buffer; otherwise the tail of the reply is
+    silently dropped."""
+    tts  = _FakeTts()
+    gate = VoiceGate(VoiceGateConfig(), audio_sink=_NullSink(), tts=tts)
+    proc = StreamingTtsProcessor(tts=tts, voice_gate=gate)
+
+    sink = await _run_chain(
+        proc,
+        sends=[
+            TextFrame(text="trailing fragment with no period"),
+            BrainResponseEndFrame(pid="pid-1", text="trailing fragment with no period", pts_us=0),
+        ],
+        settle_s=0.15,
+    )
+    assert tts.calls == ["trailing fragment with no period"]
+    audio = [f for f in sink.frames if isinstance(f, OutputAudioRawFrame)]
+    assert audio, "expected audio for the flushed trailing fragment"
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# Regression: output transport rewrites destination to default sender (Bug #1)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_output_transport_handle_frame_routes_pid_to_default_sender(monkeypatch):
+    """Pipecat's ``BaseOutputTransport._handle_frame`` drops frames whose
+    ``transport_destination`` is not a registered key in
+    ``_media_senders``. By default only ``None`` is registered, so a
+    frame tagged with a pid (the way the brain / TTS / chime tag every
+    outbound frame) would be silently dropped — the audio bug. The
+    override rewrites the destination to ``None`` before delegating to
+    the base class so the default sender picks it up; the hub layer
+    routes by ``_target_participant``.
+    """
+    from xr_ai_pipecat.transport import XRMediaHubOutputTransport
+    from pipecat.transports.base_output import BaseOutputTransport
+    from pipecat.transports.base_transport import TransportParams
+
+    class _StubEndpoint:
+        async def send_return_audio(self, *_a, **_kw) -> None:
+            return
+
+    transport = XRMediaHubOutputTransport(_StubEndpoint(), TransportParams())
+
+    # Capture what the super-class sees so the assertion focuses on the
+    # destination rewrite without needing the full media-sender lifecycle.
+    seen: list = []
+
+    async def fake_super_handle(self, frame):
+        seen.append((frame, frame.transport_destination))
+
+    monkeypatch.setattr(BaseOutputTransport, "_handle_frame", fake_super_handle)
+
+    frame = OutputAudioRawFrame(audio=b"\x00\x00", sample_rate=16000, num_channels=1)
+    frame.transport_destination = "web-client"
+    await transport._handle_frame(frame)
+
+    assert seen, "super._handle_frame was not invoked"
+    delegated_frame, dest_at_super_entry = seen[0]
+    assert delegated_frame is frame
+    assert dest_at_super_entry is None
+    assert frame.transport_destination is None, (
+        "destination must be rewritten to None so the default media sender accepts the frame"
+    )
+
+
+@pytest.mark.asyncio
+async def test_output_transport_writes_audio_to_target_participant():
+    """End-to-end inside the output transport: ``write_audio_frame``
+    (the pipecat hook the media sender invokes per chunked output frame)
+    must produce one ``send_return_audio`` whose ``participant_id``
+    matches the configured target.
+
+    The previous implementation overrode the non-existent
+    ``write_raw_audio_frames`` instead — pipecat never invoked it, so
+    every TTS chunk was dropped before reaching the hub. This is the
+    regression that locks the right hook in."""
+    from xr_ai_agent import AudioChunk
+    from xr_ai_pipecat.transport import (
+        TTS_NATIVE_SAMPLE_RATE,
+        XRMediaHubOutputTransport,
+    )
+    from pipecat.transports.base_transport import TransportParams
+
+    captured: list[AudioChunk] = []
+
+    class _StubEndpoint:
+        async def send_return_audio(self, chunk: AudioChunk) -> None:
+            captured.append(chunk)
+
+    params = TransportParams(
+        audio_out_enabled=True,
+        audio_out_sample_rate=TTS_NATIVE_SAMPLE_RATE,
+        audio_out_channels=1,
+    )
+    transport = XRMediaHubOutputTransport(_StubEndpoint(), params)
+    transport.set_target_participant("web-client")
+
+    pcm = b"\x00\x00" * 320  # 320 int16 samples = 20 ms @ 16 kHz
+    frame = OutputAudioRawFrame(audio=pcm, sample_rate=TTS_NATIVE_SAMPLE_RATE, num_channels=1)
+    ok = await transport.write_audio_frame(frame)
+
+    assert ok is True
+    assert len(captured) == 1
+    assert captured[0].participant_id == "web-client"
+    assert captured[0].track_id       == "tts"
+    assert captured[0].sample_rate    == TTS_NATIVE_SAMPLE_RATE
+
+
+@pytest.mark.asyncio
+async def test_output_transport_write_audio_frame_returns_false_without_target():
+    """No target participant configured — drop the frame at the hub
+    boundary instead of emitting an unaddressable AudioChunk. Returning
+    False also tells pipecat to skip the downstream push so a tail tap
+    doesn't see a half-routed frame."""
+    from xr_ai_pipecat.transport import XRMediaHubOutputTransport
+    from pipecat.transports.base_transport import TransportParams
+
+    captured: list = []
+
+    class _StubEndpoint:
+        async def send_return_audio(self, chunk) -> None:
+            captured.append(chunk)
+
+    transport = XRMediaHubOutputTransport(_StubEndpoint(), TransportParams())
+    frame = OutputAudioRawFrame(audio=b"\x00\x00", sample_rate=22050, num_channels=1)
+    ok = await transport.write_audio_frame(frame)
+    assert ok is False
+    assert captured == []
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# E2E smoke: GatedQueryFrame → full pipeline → OutputAudioRawFrame reaches transport
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_gated_query_drives_audio_through_full_pipeline_to_transport():
+    """The end-to-end "agent says something" path:
+
+    GatedQueryFrame → brain (TextFrame tagged with pid) → StreamingTts
+    (OutputAudioRawFrame tagged with pid) → output transport
+    (write_raw_audio_frames invoked → send_return_audio).
+
+    This is the path that was previously silently dropping every audio
+    frame at the output transport's media-sender router. The assertion
+    is on ``send_return_audio`` reaching the hub, not just on audio
+    frames appearing at the tail — that's the bug we shipped the fix
+    for.
+    """
+    from xr_ai_agent import AudioChunk
+    from xr_ai_pipecat.transport import (
+        TTS_NATIVE_SAMPLE_RATE,
+        XRMediaHubOutputTransport,
+    )
+    from pipecat.transports.base_transport import TransportParams
+
+    captured: list[AudioChunk] = []
+
+    class _StubEndpoint:
+        async def send_return_audio(self, chunk: AudioChunk) -> None:
+            captured.append(chunk)
+
+    params = TransportParams(
+        audio_out_enabled=True,
+        audio_out_sample_rate=TTS_NATIVE_SAMPLE_RATE,
+        audio_out_channels=1,
+    )
+    output = XRMediaHubOutputTransport(_StubEndpoint(), params)
+    output.set_target_participant("web-client")
+
+    tts  = _FakeTts(sample_rate=TTS_NATIVE_SAMPLE_RATE)
+    gate = VoiceGate(VoiceGateConfig(), audio_sink=_NullSink(), tts=tts)
+    brain = _StringBrain()
+    streaming_tts = StreamingTtsProcessor(tts=tts, voice_gate=gate)
+
+    await _run_chain(
+        brain, streaming_tts, output,
+        sends=[GatedQueryFrame(
+            participant_id="web-client", text="echo this", fresh_match=True, pts_us=0,
+        )],
+        settle_s=0.4,
+    )
+
+    assert captured, "no audio reached the hub via send_return_audio"
+    assert all(c.participant_id == "web-client" for c in captured)
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# Regression: factory wires text_topic through to StreamingTts (Bug #4)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_make_voice_pipeline_wires_text_topic_through_streaming_tts(monkeypatch):
+    """The factory's ``text_topic`` argument must reach the streaming
+    TTS processor's data-echo path. Previously the parameter was
+    explicitly unused (``# noqa: ARG001``) and the echo silently never
+    fired."""
+    from xr_ai_pipecat import make_voice_pipeline
+    from xr_ai_pipecat.transport import XRMediaHubTransport
+
+    transport = XRMediaHubTransport()
+    try:
+        pipeline, _task = make_voice_pipeline(
+            transport      = transport,
+            stt            = _FakeStt(),
+            tts            = _FakeTts(),
+            brain          = _StringBrain(),
+            vad_cfg        = VadConfig(),
+            voice_gate_cfg = VoiceGateConfig(),
+            text_topic     = "vlm.response",
+        )
+        # The streaming-tts processor lives at index 5 in the wrapped
+        # pipeline (source, input, vad_stt, voice_gate, brain, tts, output, sink).
+        streaming_tts = pipeline.processors[5]
+        assert isinstance(streaming_tts, StreamingTtsProcessor)
+        assert streaming_tts._text_topic == "vlm.response"
+        assert streaming_tts._transport is transport
+    finally:
+        transport.shutdown()

--- a/tests/test_xr_ai_voicegate.py
+++ b/tests/test_xr_ai_voicegate.py
@@ -1,0 +1,856 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the xr-ai-voicegate package.
+
+Covers the phrase matcher, STOP regex, lazy chime synthesis, the per-pid
+event ladder in ``VoiceGate.feed`` (STOP / fresh-match / followup /
+phrase-only / drop), and the listening-chime + stop-ack side effects.
+
+Everything is local: a no-op ``AudioSink`` and an in-memory ``TTSLike``
+stub that returns a minimal WAV blob synthesized via the same primitive
+the chime uses. No GPU, no network, no model loads.
+"""
+from __future__ import annotations
+
+import io
+import pathlib
+import wave
+
+import numpy as np
+import pytest
+
+from xr_ai_voicegate import VoiceGate, VoiceGateConfig, load_voice_gate_config
+from xr_ai_voicegate._chime import build_chime_wav, read_wav_sample_rate
+from xr_ai_voicegate._phrases import STOP_RE, build_magic_pattern, strip_magic
+
+
+# ── test doubles ────────────────────────────────────────────────────────────
+
+
+def _silence_wav(sample_rate: int, ms: int = 10) -> bytes:
+    """Return a tiny but well-formed WAV blob at ``sample_rate`` Hz so the
+    chime's ``read_wav_sample_rate`` has something to parse."""
+    n = max(1, int(sample_rate * ms / 1000))
+    pcm = np.zeros(n, dtype=np.int16).tobytes()
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm)
+    return buf.getvalue()
+
+
+class _FakeAudioSink:
+    """No-op audio sink that records every (pid, wav_bytes) it receives."""
+
+    def __init__(self) -> None:
+        self.plays: list[tuple[str, bytes]] = []
+
+    async def play_wav(self, pid: str, wav_bytes: bytes) -> None:
+        self.plays.append((pid, wav_bytes))
+
+
+class _FakeTTS:
+    """TTS double returning a tiny but valid WAV at a configurable rate."""
+
+    def __init__(self, sample_rate: int = 22050) -> None:
+        self.sample_rate     = sample_rate
+        self.synth_calls:    list[str] = []
+        self.raise_on_synth: bool      = False
+
+    async def synthesize(self, text: str) -> bytes:
+        self.synth_calls.append(text)
+        if self.raise_on_synth:
+            raise RuntimeError("tts down")
+        return _silence_wav(self.sample_rate)
+
+
+def _gate(
+    *,
+    phrases:          tuple[str, ...] = (),
+    followup_grace_s: float           = 5.0,
+    listening_chime:  bool            = False,
+    tts_rate:         int             = 22050,
+) -> tuple[VoiceGate, _FakeAudioSink, _FakeTTS]:
+    cfg  = VoiceGateConfig(
+        magic_phrases    = phrases,
+        followup_grace_s = followup_grace_s,
+        listening_chime  = listening_chime,
+    )
+    sink = _FakeAudioSink()
+    tts  = _FakeTTS(sample_rate=tts_rate)
+    return VoiceGate(cfg, audio_sink=sink, tts=tts), sink, tts
+
+
+def _recording_handlers(gate: VoiceGate) -> list[tuple]:
+    """Wire all five handler slots to a single events list and return it.
+
+    ``on_query`` exposes the post-chime-fix signature ``(pid, text, fresh_match)``
+    so tests can assert that case 2 (fresh magic-phrase match) and case 3
+    (follow-up window continuation) are distinguishable."""
+    events: list[tuple] = []
+
+    async def on_query(pid: str, text: str, fresh_match: bool) -> None:
+        events.append(("query", pid, text, fresh_match))
+
+    async def on_stop(pid: str) -> None:
+        events.append(("stop", pid))
+
+    async def on_phrase_only(pid: str) -> None:
+        events.append(("phrase_only", pid))
+
+    async def on_drop(pid: str, text: str) -> None:
+        events.append(("drop", pid, text))
+
+    async def on_join(pid: str) -> None:
+        events.append(("join", pid))
+
+    gate.on_query(on_query)
+    gate.on_stop(on_stop)
+    gate.on_phrase_only(on_phrase_only)
+    gate.on_drop(on_drop)
+    gate.on_participant_joined(on_join)
+    return events
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 1. Phrase matcher (`_phrases.py`)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+def test_phrase_strict_prefix_strip_returns_query_tail():
+    """Case 1: 'agent, what am I looking at?' strips to the query tail."""
+    pat = build_magic_pattern(["agent"])
+    assert strip_magic(pat, "agent, what am I looking at?") == "what am I looking at?"
+
+
+def test_phrase_multi_phrase_both_forms_match():
+    """Case 2: with ['agent', 'hey agent'] both prefixes match and strip."""
+    pat = build_magic_pattern(["agent", "hey agent"])
+    assert strip_magic(pat, "agent, hi")     == "hi"
+    assert strip_magic(pat, "hey agent, hi") == "hi"
+
+
+def test_phrase_case_insensitive_match():
+    """Case 3: STT may upper-case the first letter — must still match."""
+    pat = build_magic_pattern(["hey agent"])
+    assert strip_magic(pat, "Hey Agent, what's up?") == "what's up?"
+
+
+def test_phrase_tolerates_internal_and_trailing_punctuation():
+    """Case 4: 'Hey, agent.' has a comma between words and a period at the
+    end. The matcher must still treat it as the configured 'hey agent'
+    prefix and strip it cleanly."""
+    pat = build_magic_pattern(["hey agent"])
+    stripped = strip_magic(pat, "Hey, agent.")
+    # The configured "hey agent" is matched even with STT punctuation
+    # spliced in; nothing follows so the tail is empty.
+    assert stripped == ""
+
+
+def test_phrase_mid_sentence_does_not_match():
+    """Case 5: strict-prefix only — 'the agent told me ...' must not strip."""
+    pat = build_magic_pattern(["agent"])
+    assert strip_magic(pat, "the agent told me to wait") is None
+
+
+def test_phrase_no_filler_allowance_before_phrase():
+    """Case 6: even one filler word before the phrase ('hello agent') is
+    rejected. Strict prefix means literally first token after whitespace."""
+    pat = build_magic_pattern(["agent"])
+    assert strip_magic(pat, "hello agent") is None
+
+
+def test_phrase_empty_list_yields_none_pattern_and_passthrough_strip():
+    """Case 7: no phrases → ``build_magic_pattern`` returns None; with the
+    None pattern ``strip_magic`` is the identity on the input text."""
+    assert build_magic_pattern([]) is None
+    assert strip_magic(None, "anything goes here") == "anything goes here"
+
+
+def test_phrase_only_utterance_strips_to_empty_string():
+    """Case 8: 'agent' on its own — match succeeds, payload is empty
+    string (NOT None, which means 'no match')."""
+    pat = build_magic_pattern(["agent"])
+    assert strip_magic(pat, "agent") == ""
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 2. STOP regex (`_phrases.STOP_RE`)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.parametrize("text", [
+    "stop",
+    "Stop.",
+    "be quiet",
+    "shut up",
+    "stop talking",
+])
+def test_stop_regex_canonical_forms_match(text: str):
+    """Case 9: all the canonical interruption phrases match."""
+    assert STOP_RE.match(text) is not None
+
+
+def test_stop_regex_suffix_with_too_much_filler_does_not_match():
+    """Case 10 (locked to actual behavior): 'the agent told me to stop'
+    has 4 filler words before 'stop'; the regex allows {0,2} filler
+    words, so this does NOT match.
+
+    The original brief speculated this would match as a "suffix STOP" —
+    the impl says no. We lock the impl's behavior in as the contract."""
+    assert STOP_RE.match("the agent told me to stop") is None
+
+
+def test_stop_regex_mid_sentence_real_question_does_not_match():
+    """Case 11: 'what should we stop doing about climate change' is a
+    genuine question that mentions 'stop' mid-sentence; must not trigger."""
+    assert STOP_RE.match("what should we stop doing about climate change") is None
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 3. Chime synthesis (`_chime.py`)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+def test_chime_24khz_header_shape_and_duration():
+    """Case 12: 24 kHz chime is a parseable mono int16 WAV ~250 ms long."""
+    wav = build_chime_wav(24_000)
+    with wave.open(io.BytesIO(wav), "rb") as wf:
+        assert wf.getframerate()  == 24_000
+        assert wf.getnchannels()  == 1
+        assert wf.getsampwidth()  == 2          # int16 → 2 bytes/sample
+        # 250 ms ± one frame (the chime uses int(sr * 0.25) samples).
+        assert wf.getnframes() == int(24_000 * 0.25)
+
+
+def test_chime_16khz_header_shape_and_duration():
+    """Case 13: same contract at 16 kHz."""
+    wav = build_chime_wav(16_000)
+    with wave.open(io.BytesIO(wav), "rb") as wf:
+        assert wf.getframerate()  == 16_000
+        assert wf.getnchannels()  == 1
+        assert wf.getsampwidth()  == 2
+        assert wf.getnframes() == int(16_000 * 0.25)
+
+
+@pytest.mark.parametrize("sample_rate", [16_000, 24_000])
+def test_chime_read_wav_sample_rate_round_trip(sample_rate: int):
+    """Case 14: ``read_wav_sample_rate`` recovers the rate the chime was
+    built at — round-trip guard for the WAV header parsing path that
+    ``observe_tts_wav`` relies on."""
+    wav = build_chime_wav(sample_rate)
+    assert read_wav_sample_rate(wav) == sample_rate
+
+
+def test_chime_clamp_accepts_upper_bound_192khz():
+    """Case 14 (b): 192 kHz is at the documented upper bound and must
+    still build — the clamp is inclusive on both ends so legitimate
+    high-rate TTS outputs are not rejected."""
+    wav = build_chime_wav(192_000)
+    assert read_wav_sample_rate(wav) == 192_000
+
+
+def test_chime_clamp_rejects_just_above_upper_bound():
+    """Case 14 (c): one Hz past the upper bound raises ValueError. Guards
+    against a hostile or corrupted WAV header that declares a multi-GHz
+    rate from driving a multi-GB ``np.linspace`` allocation."""
+    with pytest.raises(ValueError):
+        build_chime_wav(192_001)
+
+
+@pytest.mark.asyncio
+async def test_observe_tts_wav_with_out_of_range_rate_disables_chime_without_crash():
+    """Case 14 (d): a malicious or corrupted TTS WAV declaring an
+    absurdly high sample rate (here 1 GHz, the kind of value an attacker
+    might splice into a uint32 header) must not crash the gate. The
+    chime caller swallows the ValueError, logs "sample rate out of
+    range", and disables the chime so subsequent ``play_chime`` calls
+    are no-ops.
+
+    1 GHz is comfortably above the 192 kHz clamp but stays under the
+    uint32-byterate limit Python's ``wave`` module enforces on the WAV
+    header, so the malformed blob is round-trip parseable and the
+    failure happens inside ``build_chime_wav`` exactly where the clamp
+    is meant to fire."""
+    gate, sink, _ = _gate(phrases=("agent",), listening_chime=True)
+
+    # _silence_wav uses int16 PCM so the 1-frame buffer is 2 bytes
+    # regardless of the (fictitious) sample rate stored in the header.
+    bad_wav = _silence_wav(1_000_000_000, ms=0)
+
+    gate.observe_tts_wav(bad_wav)        # must not raise
+    await gate.play_chime("p1")          # must not crash, must not emit
+
+    assert gate._chime_wav is None
+    assert gate._chime_enabled is False
+    assert sink.plays == []
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 4. Event ladder (`gate.feed`)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_feed_no_phrases_passes_every_utterance_through_to_on_query():
+    """Case 15: with ``magic_phrases=()`` the gate is in always-on mode —
+    every non-STOP utterance dispatches to ``on_query`` with
+    ``fresh_match=True``. Matches the original simple-vlm-example
+    behavior the gate was extracted from, and what ``VoiceGateConfig``'s
+    docstring promises ("empty tuple disables the gate so every STT
+    transcript is dispatched")."""
+    gate, _, _ = _gate(phrases=())
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "what am I looking at")
+    await gate.feed("p1", "tell me about this")
+
+    assert events == [
+        ("query", "p1", "what am I looking at", True),
+        ("query", "p1", "tell me about this", True),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_feed_no_phrases_stop_still_routes_to_on_stop():
+    """Case 15 (b): even in always-on mode, the STOP regex must still
+    fire ``on_stop`` so an interrupt works without a wake word."""
+    gate, _, _ = _gate(phrases=())
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "stop")
+
+    assert events == [("stop", "p1")]
+
+
+@pytest.mark.asyncio
+async def test_feed_raw_stop_fires_on_stop():
+    """Case 16: with phrases configured, the raw word 'stop' bypasses the
+    magic-phrase requirement and fires on_stop."""
+    gate, _, _ = _gate(phrases=("agent",))
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "stop")
+
+    assert events == [("stop", "p1")]
+
+
+@pytest.mark.asyncio
+async def test_feed_magic_phrase_with_query_fires_on_query_with_fresh_match_true():
+    """Case 17: 'agent, what is this?' → on_query(pid, 'what is this?', fresh_match=True).
+
+    ``fresh_match=True`` is the signal consumers use to drive one-shot
+    side effects like the listening chime that should fire on case 2 but
+    not on case 3 (the followup-window continuation)."""
+    gate, _, _ = _gate(phrases=("agent",))
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "agent, what is this?")
+
+    assert events == [("query", "p1", "what is this?", True)]
+
+
+@pytest.mark.asyncio
+async def test_feed_no_phrase_and_no_followup_fires_on_drop():
+    """Case 18: with phrases configured but no magic phrase in the
+    transcript and no open followup window, the gate drops the utterance."""
+    gate, _, _ = _gate(phrases=("agent",))
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "what am I looking at")
+
+    assert events == [("drop", "p1", "what am I looking at")]
+
+
+@pytest.mark.asyncio
+async def test_feed_phrase_only_opens_followup_window_and_dispatches_with_fresh_match_false():
+    """Case 19: bare 'agent' fires on_phrase_only; the next utterance
+    within the followup grace fires on_query with the raw text AND
+    ``fresh_match=False`` so consumers can suppress the chime on the
+    continuation (the chime already played when phrase-only opened the
+    window — repeating it on the dispatch would be a double chime)."""
+    gate, _, _ = _gate(phrases=("agent",), followup_grace_s=5.0)
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "agent")
+    await gate.feed("p1", "what am I looking at")
+
+    assert events == [
+        ("phrase_only", "p1"),
+        ("query", "p1", "what am I looking at", False),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_feed_followup_window_closes_after_one_dispatch():
+    """Case 20: each dispatch (fresh-match or followup-accepted) closes
+    the window; subsequent utterances must reintroduce a magic phrase."""
+    gate, _, _ = _gate(phrases=("agent",), followup_grace_s=5.0)
+    events = _recording_handlers(gate)
+
+    # Followup path: opens window, then next utterance consumes it.
+    await gate.feed("p1", "agent")
+    await gate.feed("p1", "what am I looking at")
+    # Window is now closed — this third utterance must drop.
+    await gate.feed("p1", "and another question")
+
+    assert events == [
+        ("phrase_only", "p1"),
+        ("query", "p1", "what am I looking at", False),
+        ("drop", "p1", "and another question"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_feed_fresh_match_with_payload_closes_window_too():
+    """Case 20 (b): a fresh-match dispatch ALSO closes the window so
+    ambient speech after the answer doesn't ride a stale followup."""
+    gate, _, _ = _gate(phrases=("agent",), followup_grace_s=5.0)
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "agent, what is this")
+    await gate.feed("p1", "and another question")
+
+    assert events == [
+        ("query", "p1", "what is this", True),
+        ("drop", "p1", "and another question"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_feed_followup_window_expires_after_grace(monkeypatch):
+    """Case 21: once ``followup_grace_s`` seconds elapse, the window is
+    closed; the next utterance drops instead of dispatching."""
+    gate, _, _ = _gate(phrases=("agent",), followup_grace_s=2.0)
+    events = _recording_handlers(gate)
+
+    # Drive ``time.monotonic`` by hand so the test is deterministic and
+    # doesn't sleep. Patch the symbol on the ``gate`` module — that's
+    # where the lookup happens.
+    from xr_ai_voicegate import gate as gate_module
+
+    fake_now = [1000.0]
+    monkeypatch.setattr(gate_module.time, "monotonic", lambda: fake_now[0])
+
+    await gate.feed("p1", "agent")          # opens window until t=1002
+    fake_now[0] = 1002.5                    # 0.5s past the grace deadline
+    await gate.feed("p1", "what is this")   # window expired → must drop
+
+    assert events == [
+        ("phrase_only", "p1"),
+        ("drop", "p1", "what is this"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_feed_stop_wins_over_open_followup_window():
+    """Case 22: 'stop' inside an open followup window must NOT be treated
+    as a followup query — STOP_RE check sits above the followup branch."""
+    gate, _, _ = _gate(phrases=("agent",), followup_grace_s=5.0)
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "agent")  # opens window
+    await gate.feed("p1", "stop")   # must fire on_stop, NOT on_query
+
+    assert events == [
+        ("phrase_only", "p1"),
+        ("stop", "p1"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_feed_stop_matched_on_magic_stripped_tail():
+    """Case 23: 'hey agent stop' — the gate strips the magic prefix to
+    'stop' and the STOP regex matches the tail. on_stop fires."""
+    gate, _, _ = _gate(phrases=("hey agent",))
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "hey agent stop")
+
+    assert events == [("stop", "p1")]
+
+
+@pytest.mark.asyncio
+async def test_feed_fresh_match_flag_distinguishes_case_2_from_case_3():
+    """Regression guard for the chime fix at 665faaf — case 2 (fresh
+    magic-phrase + payload) must dispatch with ``fresh_match=True`` and
+    case 3 (followup window continuation) must dispatch with
+    ``fresh_match=False``. The original extraction collapsed both onto
+    a single ``on_query(pid, text)`` signature so the consumer chimed
+    twice per question; the flag is the contract that keeps the
+    listening-chime side effect one-shot."""
+    gate, _, _ = _gate(phrases=("agent",), followup_grace_s=5.0)
+    events = _recording_handlers(gate)
+
+    # Case 2: phrase + payload in the same utterance.
+    await gate.feed("p1", "agent, what is this")
+    # Case 3: phrase-only opens window, next utterance is the continuation.
+    await gate.feed("p2", "agent")
+    await gate.feed("p2", "what is this")
+
+    assert events == [
+        ("query",       "p1", "what is this", True),
+        ("phrase_only", "p2"),
+        ("query",       "p2", "what is this", False),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_feed_forget_clears_followup_window_for_pid():
+    """Case 24: forget(pid) drops the open followup; the next utterance
+    from that pid must be re-gated."""
+    gate, _, _ = _gate(phrases=("agent",), followup_grace_s=5.0)
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "agent")
+    gate.forget("p1")
+    await gate.feed("p1", "what is this")
+
+    assert events == [
+        ("phrase_only", "p1"),
+        ("drop", "p1", "what is this"),
+    ]
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 5. Chime lifecycle
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_play_chime_before_tts_observed_is_noop_not_crash():
+    """Case 25: chime is built lazily after the first TTS WAV is observed.
+    Calling play_chime before that point logs and returns — does not
+    crash and does not push anything onto the audio sink."""
+    gate, sink, _ = _gate(phrases=("agent",), listening_chime=True)
+
+    await gate.play_chime("p1")
+
+    assert sink.plays == []
+
+
+@pytest.mark.asyncio
+async def test_play_chime_after_observe_tts_wav_emits_built_chime():
+    """Case 26: once a TTS WAV is observed, the chime is built at that
+    sample rate and subsequent play_chime calls push the WAV bytes to
+    the audio sink at the matching rate."""
+    gate, sink, _ = _gate(phrases=("agent",), listening_chime=True)
+
+    gate.observe_tts_wav(_silence_wav(22_050))
+    await gate.play_chime("p1")
+
+    assert len(sink.plays) == 1
+    pid, wav = sink.plays[0]
+    assert pid == "p1"
+    assert read_wav_sample_rate(wav) == 22_050
+
+
+@pytest.mark.asyncio
+async def test_play_chime_disabled_when_listening_chime_false():
+    """Case 27: listening_chime=False disables the chime even after a TTS
+    WAV is observed."""
+    gate, sink, _ = _gate(phrases=("agent",), listening_chime=False)
+
+    gate.observe_tts_wav(_silence_wav(22_050))
+    await gate.play_chime("p1")
+
+    assert sink.plays == []
+
+
+@pytest.mark.asyncio
+async def test_play_chime_disabled_when_no_magic_phrases_configured():
+    """Case 27 (b): even with listening_chime=True, an empty phrase list
+    disables the chime — the chime is meant to ride a fresh-match event,
+    and there are no fresh-matches without phrases."""
+    gate, sink, _ = _gate(phrases=(), listening_chime=True)
+
+    gate.observe_tts_wav(_silence_wav(22_050))
+    await gate.play_chime("p1")
+
+    assert sink.plays == []
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 6. Greeting + stop ack
+# ════════════════════════════════════════════════════════════════════════════
+
+
+def test_format_phrase_help_returns_none_with_no_phrases():
+    """Case 28: no phrases → no help string (caller picks generic greeting)."""
+    gate, _, _ = _gate(phrases=())
+    assert gate.format_phrase_help() is None
+
+
+def test_format_phrase_help_one_phrase():
+    """Case 29: single-phrase form."""
+    gate, _, _ = _gate(phrases=("agent",))
+    assert gate.format_phrase_help() == (
+        'To talk to me, start your question with "agent". '
+        'For example, "agent, what am I looking at?"'
+    )
+
+
+def test_format_phrase_help_two_phrases():
+    """Case 30: two-phrase form uses 'or', not a comma."""
+    gate, _, _ = _gate(phrases=("agent", "hey agent"))
+    assert gate.format_phrase_help() == (
+        'To talk to me, start your question with "agent" or "hey agent". '
+        'For example, "agent, what am I looking at?"'
+    )
+
+
+def test_format_phrase_help_three_phrases():
+    """Case 31: three-or-more form uses commas with a final ', or'."""
+    gate, _, _ = _gate(phrases=("a", "b", "c"))
+    assert gate.format_phrase_help() == (
+        'To talk to me, start your question with "a", "b", or "c". '
+        'For example, "a, what am I looking at?"'
+    )
+
+
+@pytest.mark.asyncio
+async def test_say_stop_ack_synthesizes_observes_and_plays():
+    """Case 32: say_stop_ack runs the full three-step flow —
+    tts.synthesize → observe_tts_wav (so the chime can build) → audio_sink.play_wav."""
+    gate, sink, tts = _gate(phrases=("agent",), listening_chime=True, tts_rate=22_050)
+
+    await gate.say_stop_ack("p1")
+
+    # 1. TTS was called with the canned ack text.
+    assert tts.synth_calls == ["Okay, I will stop."]
+    # 2. The same WAV the TTS returned was pushed to the audio sink.
+    assert len(sink.plays) == 1
+    ack_pid, ack_wav = sink.plays[0]
+    assert ack_pid == "p1"
+    assert read_wav_sample_rate(ack_wav) == 22_050
+    # 3. observe_tts_wav was called as part of the flow — confirm by
+    #    playing the chime now and asserting it lands at the right rate.
+    await gate.play_chime("p1")
+    assert len(sink.plays) == 2
+    _, chime_wav = sink.plays[1]
+    assert read_wav_sample_rate(chime_wav) == 22_050
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 7. Handler exception swallowing
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_handler_exceptions_are_swallowed_and_gate_keeps_working():
+    """Case 33: when on_query raises, the gate logs and continues —
+    subsequent feed() calls still dispatch normally."""
+    gate, _, _ = _gate(phrases=("agent",))
+
+    calls: list[str] = []
+
+    async def flaky_on_query(pid: str, text: str, fresh_match: bool) -> None:
+        calls.append(text)
+        if text == "boom":
+            raise RuntimeError("handler exploded")
+
+    gate.on_query(flaky_on_query)
+
+    # First call raises inside the handler — must not propagate.
+    await gate.feed("p1", "agent, boom")
+    # Second call still works — gate state is intact.
+    await gate.feed("p1", "agent, second time")
+
+    assert calls == ["boom", "second time"]
+
+
+@pytest.mark.asyncio
+async def test_bind_registers_every_handler_in_one_call():
+    """``bind`` is the single-call equivalent of the per-handler setters —
+    when all five slots are supplied, the event ladder fires through them
+    exactly as if each had been wired with the matching ``on_*`` setter."""
+    gate, _, _ = _gate(phrases=("agent",), followup_grace_s=1.0)
+    events: list[tuple] = []
+
+    async def on_q(pid: str, text: str, fresh_match: bool) -> None:
+        events.append(("query", pid, text, fresh_match))
+
+    async def on_s(pid: str) -> None:
+        events.append(("stop", pid))
+
+    async def on_phrase_only(pid: str) -> None:
+        events.append(("phrase_only", pid))
+
+    async def on_drop(pid: str, text: str) -> None:
+        events.append(("drop", pid, text))
+
+    async def on_joined(pid: str) -> None:
+        events.append(("joined", pid))
+
+    gate.bind(
+        on_query              = on_q,
+        on_stop               = on_s,
+        on_phrase_only        = on_phrase_only,
+        on_drop               = on_drop,
+        on_participant_joined = on_joined,
+    )
+
+    await gate.participant_joined("p1")
+    await gate.feed("p1", "agent")                  # phrase only
+    await gate.feed("p1", "what time is it")        # followup
+    await gate.feed("p1", "agent, what is this")    # fresh match
+    await gate.feed("p1", "stop")                   # stop
+    await gate.feed("p1", "noise without phrase")   # drop
+
+    assert events == [
+        ("joined",       "p1"),
+        ("phrase_only",  "p1"),
+        ("query",        "p1", "what time is it",  False),
+        ("query",        "p1", "what is this",     True),
+        ("stop",         "p1"),
+        ("drop",         "p1", "noise without phrase"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_bind_optional_handlers_default_to_noop():
+    """Only the required ``on_query`` + ``on_stop`` need to be passed to
+    ``bind``; the omitted slots stay None and the gate degrades to "no
+    handler for that event" rather than raising."""
+    gate, _, _ = _gate(phrases=("agent",))
+    events: list[tuple] = []
+
+    async def on_q(pid: str, text: str, fresh_match: bool) -> None:
+        events.append(("query", pid, text, fresh_match))
+
+    async def on_s(pid: str) -> None:
+        events.append(("stop", pid))
+
+    gate.bind(on_query=on_q, on_stop=on_s)
+
+    # Each of these would normally hit an optional handler — without
+    # binding one, the gate must still process the feed cleanly. The
+    # phrase-only opens the followup window so the next utterance gets
+    # routed to on_query with fresh_match=False rather than to on_drop.
+    await gate.participant_joined("p2")
+    await gate.feed("p2", "agent")                  # phrase_only — no handler
+    gate.forget("p2")                                # close the followup window
+    await gate.feed("p2", "noise without phrase")   # drop — no handler
+    await gate.feed("p2", "agent, real query")      # query — fires
+
+    assert events == [("query", "p2", "real query", True)]
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# 8. YAML loader (`load_voice_gate_config`)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+def test_load_voice_gate_config_full_file(tmp_path: pathlib.Path):
+    """Case 34: a populated file parses into a VoiceGateConfig with every
+    field set as written."""
+    p = tmp_path / "voice_gate.yaml"
+    p.write_text(
+        "magic_phrases:\n"
+        '  - "agent"\n'
+        '  - "hey agent"\n'
+        "listening_chime:  true\n"
+        "followup_grace_s: 7.5\n"
+    )
+    cfg = load_voice_gate_config(p)
+    assert cfg == VoiceGateConfig(
+        magic_phrases    = ("agent", "hey agent"),
+        followup_grace_s = 7.5,
+        listening_chime  = True,
+    )
+
+
+def test_load_voice_gate_config_missing_file_returns_defaults(tmp_path: pathlib.Path):
+    """Case 35: a path that does not exist degrades to the dataclass
+    defaults (always-on, no chime, 5 s follow-up grace) — same behavior
+    the inline-block parser had for an absent block."""
+    assert load_voice_gate_config(tmp_path / "nope.yaml") == VoiceGateConfig()
+
+
+def test_load_voice_gate_config_empty_file_returns_defaults(tmp_path: pathlib.Path):
+    """Case 36: an empty file (``yaml.safe_load`` → None) degrades to
+    defaults, matching the ``raw or {}`` normalization."""
+    p = tmp_path / "empty.yaml"
+    p.write_text("")
+    assert load_voice_gate_config(p) == VoiceGateConfig()
+
+
+def test_load_voice_gate_config_bare_string_phrase_normalizes(tmp_path: pathlib.Path):
+    """Case 37: ``magic_phrases: agent`` (bare string, not a list) is
+    normalized to a single-element tuple, matching the inline parser."""
+    p = tmp_path / "voice_gate.yaml"
+    p.write_text("magic_phrases: agent\n")
+    cfg = load_voice_gate_config(p)
+    assert cfg.magic_phrases == ("agent",)
+
+
+def test_load_voice_gate_config_null_phrases_normalizes_to_empty(tmp_path: pathlib.Path):
+    """Case 38: ``magic_phrases: null`` (or omitted) is normalized to an
+    empty tuple — the gate's always-on mode."""
+    p = tmp_path / "voice_gate.yaml"
+    p.write_text("magic_phrases: null\nfollowup_grace_s: 3.0\n")
+    cfg = load_voice_gate_config(p)
+    assert cfg.magic_phrases == ()
+    assert cfg.followup_grace_s == 3.0
+
+
+def test_load_voice_gate_config_strips_whitespace_and_drops_empty(tmp_path: pathlib.Path):
+    """Case 39: phrase entries are stripped, and empty entries (after
+    strip) are dropped — same normalization the inline parser ran."""
+    p = tmp_path / "voice_gate.yaml"
+    p.write_text(
+        "magic_phrases:\n"
+        '  - "  agent  "\n'
+        '  - ""\n'
+        '  - "hey agent"\n'
+    )
+    cfg = load_voice_gate_config(p)
+    assert cfg.magic_phrases == ("agent", "hey agent")
+
+
+def test_load_voice_gate_config_rejects_non_mapping_top_level(tmp_path: pathlib.Path):
+    """Case 40: a top-level list (or any non-mapping) raises ValueError —
+    catches typo'd files that would otherwise silently degrade."""
+    p = tmp_path / "voice_gate.yaml"
+    p.write_text("- agent\n- hey agent\n")
+    with pytest.raises(ValueError):
+        load_voice_gate_config(p)
+
+
+# ── Round-trip checks against the in-tree sample voice_gate.yaml files ──────
+#
+# Skipped when the tests are run from an environment where the agent-samples
+# tree isn't reachable on disk (e.g. a published wheel install). When reachable,
+# these guard against accidental drift between the loader's accepted schema
+# and the YAML the samples actually ship.
+
+
+def _repo_root() -> pathlib.Path:
+    return pathlib.Path(__file__).resolve().parents[1]
+
+
+def test_load_voice_gate_config_simple_vlm_sample_round_trip():
+    """Case 41: the simple-vlm-example sample ships with the wake-word
+    config — confirm the file parses and exposes the documented phrases."""
+    p = _repo_root() / "agent-samples" / "simple-vlm-example" / "yaml" / "voice_gate.yaml"
+    if not p.exists():
+        pytest.skip(f"sample voice_gate.yaml not reachable at {p}")
+    cfg = load_voice_gate_config(p)
+    assert cfg.magic_phrases    == ("agent", "hey agent")
+    assert cfg.listening_chime  is False
+    assert cfg.followup_grace_s == 5.0
+
+
+def test_load_voice_gate_config_xr_render_demo_sample_round_trip():
+    """Case 42: the xr-render-demo sample ships with the empty-list
+    default (always-on) — confirm the file parses to defaults."""
+    p = _repo_root() / "agent-samples" / "xr-render-demo" / "yaml" / "voice_gate.yaml"
+    if not p.exists():
+        pytest.skip(f"sample voice_gate.yaml not reachable at {p}")
+    cfg = load_voice_gate_config(p)
+    assert cfg.magic_phrases    == ()
+    assert cfg.listening_chime  is False
+    assert cfg.followup_grace_s == 5.0

--- a/tests/test_xr_ai_voicegate.py
+++ b/tests/test_xr_ai_voicegate.py
@@ -765,8 +765,10 @@ def test_load_voice_gate_config_full_file(tmp_path: pathlib.Path):
 
 def test_load_voice_gate_config_missing_file_returns_defaults(tmp_path: pathlib.Path):
     """Case 35: a path that does not exist degrades to the dataclass
-    defaults (always-on, no chime, 5 s follow-up grace) — same behavior
-    the inline-block parser had for an absent block."""
+    defaults (always-on, chime opt-out only, 5 s follow-up grace) —
+    same behavior the inline-block parser had for an absent block.
+    The dataclass default for ``listening_chime`` is True, but always-on
+    mode (empty ``magic_phrases``) inhibits the chime regardless."""
     assert load_voice_gate_config(tmp_path / "nope.yaml") == VoiceGateConfig()
 
 

--- a/utils/xr-ai-voicegate/pyproject.toml
+++ b/utils/xr-ai-voicegate/pyproject.toml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "xr-ai-voicegate"
+version = "0.1.0"
+requires-python = ">=3.11,<3.13"
+# Speech-only opt-in gate shared by agent workers that ingest microphone
+# audio.  Owns the magic-phrase + follow-up + STOP ladder, the lazy
+# listening chime, and the participant-joined greeting hook so each
+# worker only wires handlers and feeds STT transcripts.  numpy is used
+# for the chime tone synthesis; pyyaml parses the standalone
+# voice_gate.yaml file referenced from each worker YAML.
+dependencies = [
+    "numpy>=1.24",
+    "pyyaml>=6.0",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["xr_ai_voicegate"]

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/__init__.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public surface of the xr-ai-voicegate package."""
+from __future__ import annotations
+
+from .config import AudioSink, TTSLike, VoiceGateConfig, load_voice_gate_config
+from .gate import VoiceGate
+
+__all__ = [
+    "AudioSink",
+    "TTSLike",
+    "VoiceGate",
+    "VoiceGateConfig",
+    "load_voice_gate_config",
+]

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/_chime.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/_chime.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Listening-chime synthesis and WAV header parsing for the voice gate."""
+from __future__ import annotations
+
+import io
+import wave
+
+import numpy as np
+
+
+def build_chime_wav(sample_rate: int) -> bytes:
+    """Synthesize the listening-chime as a self-contained WAV blob.
+
+    Two-tone perfect-fifth ding (880 + 1320 Hz) with exponential decay,
+    ~250 ms total, mono int16 PCM. ``sample_rate`` MUST match the rate
+    of the return audio track the consumer plays into (e.g. TTS sample
+    rate) so the underlying transport doesn't reject frames at a
+    different rate.
+
+    Clamped to a sane audio range. A WAV header is uint32 and a hostile
+    or corrupted blob can claim a multi-GHz rate, which would drive
+    ``np.linspace`` into a multi-GB allocation. Reject outside [8 kHz,
+    192 kHz] — the chime caller (``observe_tts_wav``) treats ValueError
+    as "disable the chime", so the worst case is no chime.
+    """
+    if not 8000 <= sample_rate <= 192000:
+        raise ValueError(f"unsupported chime sample rate: {sample_rate}")
+    dur  = 0.25
+    t    = np.linspace(0.0, dur, int(sample_rate * dur), endpoint=False, dtype=np.float32)
+    tone = 0.55 * np.sin(2 * np.pi * 880.0 * t) + 0.30 * np.sin(2 * np.pi * 1320.0 * t)
+    env  = np.exp(-t * 8.0).astype(np.float32)
+    pcm  = (tone * env * 0.5 * 32767.0).clip(-32768, 32767).astype(np.int16)
+
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm.tobytes())
+    return buf.getvalue()
+
+
+def read_wav_sample_rate(wav_bytes: bytes) -> int:
+    """Pull the sample rate from a WAV blob without decoding the audio."""
+    with wave.open(io.BytesIO(wav_bytes), "rb") as wf:
+        return wf.getframerate()

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/_phrases.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/_phrases.py
@@ -12,7 +12,7 @@ from typing import Sequence
 # user can interrupt a response mid-flight without having to start with
 # the configured phrase.
 STOP_RE: re.Pattern = re.compile(
-    r'^\s*(?:\S+\s+){0,2}'               # up to 2 optional filler words
+    r'^\s*(?:\S+\s+){0,2}'               # 0–2 filler words before stop ("uh, stop"); 3+ = ordinary speech
     r'(?:stop(?:\s+\w+){0,2}|be\s+quiet|quiet|shut\s+up)'
     r'\s*[.!?]?\s*$',
     re.IGNORECASE,

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/_phrases.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/_phrases.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Magic-phrase and STOP pattern matching for the voice gate."""
+from __future__ import annotations
+
+import re
+from typing import Sequence
+
+
+# Transcripts matching this pattern bypass the magic-phrase gate so the
+# user can interrupt a response mid-flight without having to start with
+# the configured phrase.
+STOP_RE: re.Pattern = re.compile(
+    r'^\s*(?:\S+\s+){0,2}'               # up to 2 optional filler words
+    r'(?:stop(?:\s+\w+){0,2}|be\s+quiet|quiet|shut\s+up)'
+    r'\s*[.!?]?\s*$',
+    re.IGNORECASE,
+)
+
+
+def build_magic_pattern(phrases: Sequence[str]) -> re.Pattern | None:
+    """Compile one strict-prefix regex covering every configured phrase.
+
+    Longest-first ordering picks the most specific match when one phrase
+    is a prefix of another (e.g. "agent" vs "agent buddy"). Inside each
+    phrase, the literal space between words is treated as "whitespace OR
+    punctuation" so STT transcripts like "Hey, agent." still match the
+    configured "hey agent". Returns ``None`` when ``phrases`` is empty
+    so the gate degrades to always-on.
+    """
+    cleaned = tuple(p.strip().lower() for p in phrases if p and p.strip())
+    if not cleaned:
+        return None
+    sep = r'[\s,.:;!?-]+'
+    alts = "|".join(
+        sep.join(re.escape(w) for w in p.split())
+        for p in sorted(cleaned, key=len, reverse=True)
+    )
+    return re.compile(rf'^\s*(?:{alts})\b[\s,.:;!?-]*', re.IGNORECASE)
+
+
+def strip_magic(pattern: re.Pattern | None, text: str) -> str | None:
+    """Return the transcript with the matched phrase stripped, or ``None``
+    when no phrase is the strict prefix. With ``pattern is None`` the gate
+    is disabled and ``text`` is returned unchanged."""
+    if pattern is None:
+        return text
+    m = pattern.match(text)
+    return None if m is None else text[m.end():]

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/config.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/config.py
@@ -24,11 +24,14 @@ class VoiceGateConfig:
     ``listening_chime``  — when true AND ``magic_phrases`` is non-empty,
                            a short two-tone chime plays on the consumer's
                            audio sink whenever the worker invokes
-                           ``VoiceGate.play_chime``.
+                           ``VoiceGate.play_chime``. Defaults to ``True``
+                           because the chime is an audible "I heard you"
+                           cue that most consumers want by default;
+                           opt out explicitly with ``listening_chime: false``.
     """
     magic_phrases:    tuple[str, ...] = ()
     followup_grace_s: float           = 5.0
-    listening_chime:  bool            = False
+    listening_chime:  bool            = True
 
 
 def load_voice_gate_config(path: pathlib.Path) -> VoiceGateConfig:
@@ -54,7 +57,7 @@ def load_voice_gate_config(path: pathlib.Path) -> VoiceGateConfig:
     return VoiceGateConfig(
         magic_phrases    = phrases,
         followup_grace_s = float(raw.get("followup_grace_s", 5.0)),
-        listening_chime  = bool(raw.get("listening_chime", False)),
+        listening_chime  = bool(raw.get("listening_chime", True)),
     )
 
 

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/config.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/config.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration dataclass, YAML loader, and consumer-facing Protocols
+for the voice gate."""
+from __future__ import annotations
+
+import pathlib
+from dataclasses import dataclass
+from typing import Protocol
+
+import yaml
+
+
+@dataclass(frozen=True)
+class VoiceGateConfig:
+    """Voice-gate behaviour knobs.
+
+    ``magic_phrases``    — strict-prefix opt-in words; empty tuple disables
+                           the gate so every STT transcript is dispatched.
+    ``followup_grace_s`` — seconds after a phrase match during which the
+                           next utterance from the same participant
+                           bypasses the gate.
+    ``listening_chime``  — when true AND ``magic_phrases`` is non-empty,
+                           a short two-tone chime plays on the consumer's
+                           audio sink whenever the worker invokes
+                           ``VoiceGate.play_chime``.
+    """
+    magic_phrases:    tuple[str, ...] = ()
+    followup_grace_s: float           = 5.0
+    listening_chime:  bool            = False
+
+
+def load_voice_gate_config(path: pathlib.Path) -> VoiceGateConfig:
+    """Load + parse a voice_gate YAML file into a :class:`VoiceGateConfig`.
+
+    Schema: a top-level mapping with keys ``magic_phrases`` (list[str] or
+    bare str), ``listening_chime`` (bool), ``followup_grace_s`` (float).
+    Missing file or empty file → returns the dataclass defaults (gate
+    disabled / always-on). ``magic_phrases: null`` and trailing whitespace
+    in phrases are normalized the same way the inline-block parser did.
+    """
+    if not path.exists():
+        return VoiceGateConfig()
+    raw = yaml.safe_load(path.read_text()) or {}
+    if not isinstance(raw, dict):
+        raise ValueError(f"{path}: top-level must be a mapping")
+
+    phrases_raw = raw.get("magic_phrases") or []
+    if isinstance(phrases_raw, str):
+        phrases_raw = [phrases_raw]
+    phrases = tuple(p for p in (s.strip() for s in phrases_raw) if p)
+
+    return VoiceGateConfig(
+        magic_phrases    = phrases,
+        followup_grace_s = float(raw.get("followup_grace_s", 5.0)),
+        listening_chime  = bool(raw.get("listening_chime", False)),
+    )
+
+
+class AudioSink(Protocol):
+    """Consumer-supplied return-audio writer."""
+
+    async def play_wav(self, pid: str, wav_bytes: bytes) -> None: ...
+
+
+class TTSLike(Protocol):
+    """Duck-typed text-to-speech client used for ``say_stop_ack``."""
+
+    async def synthesize(self, text: str) -> bytes: ...

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/gate.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/gate.py
@@ -147,10 +147,20 @@ class VoiceGate:
         # other utterance is a fresh query.
         if self._magic_re is None:
             if STOP_RE.match(text):
+                logger.info(
+                    "gate decision pid=%r kind=STOP fresh_match=False "
+                    "followup_window_open=False",
+                    pid,
+                )
                 logger.info("stop bypass pid=%r (text suppressed)", pid)
                 logger.debug("stop bypass pid=%r %r", pid, text[:80])
                 await self._invoke(self._on_stop_h, "on_stop", pid)
                 return
+            logger.info(
+                "gate decision pid=%r kind=DISPATCH fresh_match=True "
+                "followup_window_open=False",
+                pid,
+            )
             logger.info("audio query pid=%r (text suppressed)", pid)
             logger.debug("audio query pid=%r %r", pid, text[:80])
             await self._invoke(self._on_query_h, "on_query", pid, text, True)
@@ -166,6 +176,11 @@ class VoiceGate:
         #    ("stop") AND on the magic-phrase-stripped tail ("hey agent,
         #    stop") so the fast path triggers either way.
         if STOP_RE.match(stop_candidate):
+            logger.info(
+                "gate decision pid=%r kind=STOP fresh_match=%s "
+                "followup_window_open=%s",
+                pid, matched_magic, in_followup,
+            )
             logger.info("stop bypass pid=%r (text suppressed)", pid)
             logger.debug("stop bypass pid=%r %r", pid, stop_candidate[:80])
             self._followup_until.pop(pid, None)
@@ -178,6 +193,11 @@ class VoiceGate:
                 # 2. Fresh magic-phrase match with a payload — dispatch
                 #    immediately and close the window so ambient speech
                 #    after the answer must re-introduce a phrase.
+                logger.info(
+                    "gate decision pid=%r kind=DISPATCH fresh_match=True "
+                    "followup_window_open=%s",
+                    pid, in_followup,
+                )
                 self._followup_until.pop(pid, None)
                 logger.info("audio query pid=%r (text suppressed)", pid)
                 logger.debug("audio query pid=%r %r", pid, query[:80])
@@ -185,6 +205,11 @@ class VoiceGate:
                 return
             # 4. Magic phrase with no follow-up payload — open the window
             #    so the user's next utterance counts as the actual query.
+            logger.info(
+                "gate decision pid=%r kind=PHRASE_ONLY fresh_match=True "
+                "followup_window_open=%s",
+                pid, in_followup,
+            )
             self._followup_until[pid] = now_mono + self._cfg.followup_grace_s
             logger.info(
                 "magic phrase only pid=%r — awaiting followup (%.1fs)",
@@ -198,6 +223,11 @@ class VoiceGate:
             #    window. Refreshing it on accept happens implicitly: the
             #    consumer can decide to re-open by calling back via a
             #    fresh magic-phrase match.
+            logger.info(
+                "gate decision pid=%r kind=DISPATCH fresh_match=False "
+                "followup_window_open=True",
+                pid,
+            )
             self._followup_until.pop(pid, None)
             logger.info("followup query pid=%r (text suppressed)", pid)
             logger.debug("followup query pid=%r %r", pid, text[:80])
@@ -205,6 +235,11 @@ class VoiceGate:
             return
 
         # 5. Default drop — log and close the window defensively.
+        logger.info(
+            "gate decision pid=%r kind=DROP fresh_match=False "
+            "followup_window_open=%s",
+            pid, in_followup,
+        )
         logger.info("drop pid=%r (text suppressed)", pid)
         logger.debug("drop pid=%r %r", pid, text[:80])
         self._followup_until.pop(pid, None)

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/gate.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/gate.py
@@ -1,0 +1,295 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Speech-only opt-in gate shared by agent workers.
+
+Owns the magic-phrase + follow-up + STOP ladder, the lazy listening
+chime, and the participant-joined greeting hook. Workers feed STT
+transcripts via ``feed`` and register handlers for the events the gate
+emits (query, stop, phrase-only, drop, participant-joined).
+
+The gate does NOT serialize calls per-pid. Consumers are expected to
+gate concurrency themselves (e.g. a per-pid ``transcribing`` flag while
+STT is in flight) so two utterances from the same participant don't
+race through ``feed`` at the same time.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from typing import Awaitable, Callable
+
+from ._chime import build_chime_wav, read_wav_sample_rate
+from ._phrases import STOP_RE, build_magic_pattern, strip_magic
+from .config import AudioSink, TTSLike, VoiceGateConfig
+
+
+logger = logging.getLogger("xr_ai_voicegate")
+
+
+QueryHandler             = Callable[[str, str, bool], Awaitable[None]]   # (pid, query, fresh_match)
+StopHandler              = Callable[[str], Awaitable[None]]
+PhraseOnlyHandler        = Callable[[str], Awaitable[None]]
+DropHandler              = Callable[[str, str], Awaitable[None]]
+ParticipantJoinedHandler = Callable[[str], Awaitable[None]]
+
+
+class VoiceGate:
+    """Speech-input gating state machine.
+
+    Event ladder in ``feed`` — exactly one event fires per call, in this
+    deterministic priority order:
+
+    1. STOP detected on raw text OR on the magic-phrase-stripped tail
+       → ``on_stop(pid)``; closes the follow-up window.
+    2. Magic phrase matched AND query non-empty
+       → ``on_query(pid, query, fresh_match=True)``; closes the follow-up
+       window.
+    3. Follow-up window still open (and not STOP)
+       → ``on_query(pid, raw_text, fresh_match=False)``; closes the
+       follow-up window. ``fresh_match`` distinguishes this continuation
+       from case 2 so consumers can suppress one-shot side effects
+       (e.g. the listening chime) on the follow-up dispatch.
+    4. Magic phrase matched AND query empty
+       → ``on_phrase_only(pid)``; opens the follow-up window.
+    5. Otherwise → ``on_drop(pid, raw_text)``; closes the window
+       defensively.
+
+    When ``magic_phrases`` is empty the gate is in always-on mode: STOP
+    still wins (interrupts must work without a phrase) and every other
+    utterance dispatches straight to ``on_query`` with
+    ``fresh_match=True``. The follow-up / phrase-only / drop branches
+    are inert in this mode — they only make sense once a phrase exists
+    to gate against.
+
+    Handler exceptions are logged and swallowed so one bad handler does
+    not kill the gate.
+    """
+
+    def __init__(
+        self,
+        cfg: VoiceGateConfig,
+        *,
+        audio_sink: AudioSink,
+        tts: TTSLike,
+    ) -> None:
+        self._cfg          = cfg
+        self._audio_sink   = audio_sink
+        self._tts          = tts
+        self._magic_re     = build_magic_pattern(cfg.magic_phrases)
+        # Without a phrase the chime would have no fresh-match event to
+        # ride; mirror the original simple-vlm-example wiring rather than
+        # firing on every utterance.
+        self._chime_enabled: bool = bool(cfg.listening_chime) and self._magic_re is not None
+        self._chime_wav: bytes | None = None
+        self._followup_until: dict[str, float] = {}
+
+        self._on_query_h:               QueryHandler | None             = None
+        self._on_stop_h:                StopHandler | None              = None
+        self._on_phrase_only_h:         PhraseOnlyHandler | None        = None
+        self._on_drop_h:                DropHandler | None              = None
+        self._on_participant_joined_h:  ParticipantJoinedHandler | None = None
+
+    # ── handler registration ──────────────────────────────────────────────────
+
+    def on_query(self, h: QueryHandler) -> None:
+        self._on_query_h = h
+
+    def on_stop(self, h: StopHandler) -> None:
+        self._on_stop_h = h
+
+    def on_phrase_only(self, h: PhraseOnlyHandler) -> None:
+        self._on_phrase_only_h = h
+
+    def on_drop(self, h: DropHandler) -> None:
+        self._on_drop_h = h
+
+    def on_participant_joined(self, h: ParticipantJoinedHandler) -> None:
+        self._on_participant_joined_h = h
+
+    def bind(
+        self,
+        *,
+        on_query: QueryHandler,
+        on_stop: StopHandler,
+        on_phrase_only: PhraseOnlyHandler | None = None,
+        on_drop: DropHandler | None = None,
+        on_participant_joined: ParticipantJoinedHandler | None = None,
+    ) -> None:
+        """Register every handler in one call.
+
+        Equivalent to calling the individual ``on_*`` setters; offered as a
+        single bind point for external consumers that have all handlers in
+        hand. ``on_query`` and ``on_stop`` are required because the gate is
+        useless without them; the others are optional and default to no-op
+        when unset.
+        """
+        self._on_query_h              = on_query
+        self._on_stop_h               = on_stop
+        self._on_phrase_only_h        = on_phrase_only
+        self._on_drop_h               = on_drop
+        self._on_participant_joined_h = on_participant_joined
+
+    # ── per-participant lifecycle ─────────────────────────────────────────────
+
+    async def participant_joined(self, pid: str) -> None:
+        await self._invoke(self._on_participant_joined_h, "on_participant_joined", pid)
+
+    def forget(self, pid: str) -> None:
+        self._followup_until.pop(pid, None)
+
+    # ── event ladder ──────────────────────────────────────────────────────────
+
+    async def feed(self, pid: str, text: str) -> None:
+        # Always-on mode: no phrases configured, so the magic-phrase /
+        # follow-up / phrase-only / drop branches don't apply. STOP still
+        # wins (interrupts must work even without a phrase), and every
+        # other utterance is a fresh query.
+        if self._magic_re is None:
+            if STOP_RE.match(text):
+                logger.info("stop bypass pid=%r (text suppressed)", pid)
+                logger.debug("stop bypass pid=%r %r", pid, text[:80])
+                await self._invoke(self._on_stop_h, "on_stop", pid)
+                return
+            logger.info("audio query pid=%r (text suppressed)", pid)
+            logger.debug("audio query pid=%r %r", pid, text[:80])
+            await self._invoke(self._on_query_h, "on_query", pid, text, True)
+            return
+
+        now_mono       = time.monotonic()
+        in_followup    = self._followup_until.get(pid, 0.0) > now_mono
+        stripped       = strip_magic(self._magic_re, text)
+        matched_magic  = stripped is not None
+        stop_candidate = stripped if (matched_magic and stripped) else text
+
+        # 1. STOP — always wins. Matched on both the raw transcript
+        #    ("stop") AND on the magic-phrase-stripped tail ("hey agent,
+        #    stop") so the fast path triggers either way.
+        if STOP_RE.match(stop_candidate):
+            logger.info("stop bypass pid=%r (text suppressed)", pid)
+            logger.debug("stop bypass pid=%r %r", pid, stop_candidate[:80])
+            self._followup_until.pop(pid, None)
+            await self._invoke(self._on_stop_h, "on_stop", pid)
+            return
+
+        if matched_magic:
+            query = stripped or ""
+            if query:
+                # 2. Fresh magic-phrase match with a payload — dispatch
+                #    immediately and close the window so ambient speech
+                #    after the answer must re-introduce a phrase.
+                self._followup_until.pop(pid, None)
+                logger.info("audio query pid=%r (text suppressed)", pid)
+                logger.debug("audio query pid=%r %r", pid, query[:80])
+                await self._invoke(self._on_query_h, "on_query", pid, query, True)
+                return
+            # 4. Magic phrase with no follow-up payload — open the window
+            #    so the user's next utterance counts as the actual query.
+            self._followup_until[pid] = now_mono + self._cfg.followup_grace_s
+            logger.info(
+                "magic phrase only pid=%r — awaiting followup (%.1fs)",
+                pid, self._cfg.followup_grace_s,
+            )
+            await self._invoke(self._on_phrase_only_h, "on_phrase_only", pid)
+            return
+
+        if in_followup:
+            # 3. Followup continuation — dispatch raw text and close the
+            #    window. Refreshing it on accept happens implicitly: the
+            #    consumer can decide to re-open by calling back via a
+            #    fresh magic-phrase match.
+            self._followup_until.pop(pid, None)
+            logger.info("followup query pid=%r (text suppressed)", pid)
+            logger.debug("followup query pid=%r %r", pid, text[:80])
+            await self._invoke(self._on_query_h, "on_query", pid, text, False)
+            return
+
+        # 5. Default drop — log and close the window defensively.
+        logger.info("drop pid=%r (text suppressed)", pid)
+        logger.debug("drop pid=%r %r", pid, text[:80])
+        self._followup_until.pop(pid, None)
+        await self._invoke(self._on_drop_h, "on_drop", pid, text)
+
+    # ── worker-callable side effects ──────────────────────────────────────────
+
+    async def play_chime(self, pid: str) -> None:
+        """Emit the listening chime on the consumer's audio sink.
+
+        No-op when the chime is disabled or has not been built yet (the
+        chime is lazily synthesized to match the TTS sample rate the
+        first time ``observe_tts_wav`` is called).
+        """
+        if not self._chime_enabled:
+            return
+        if self._chime_wav is None:
+            logger.debug("play_chime no-op pid=%r — chime not yet built", pid)
+            return
+        try:
+            await self._audio_sink.play_wav(pid, self._chime_wav)
+        except Exception:
+            logger.exception("chime send error pid=%r", pid)
+
+    def format_phrase_help(self) -> str | None:
+        """Return a sentence fragment telling the user how to address the
+        agent given the configured phrases. ``None`` when no phrases are
+        configured (the caller picks a generic greeting). The wording
+        carries over from the original ``_greet`` implementation."""
+        phrases = list(self._cfg.magic_phrases)
+        if not phrases:
+            return None
+        if len(phrases) == 1:
+            phrase_list = f'"{phrases[0]}"'
+        elif len(phrases) == 2:
+            phrase_list = f'"{phrases[0]}" or "{phrases[1]}"'
+        else:
+            phrase_list = (
+                ", ".join(f'"{p}"' for p in phrases[:-1])
+                + f', or "{phrases[-1]}"'
+            )
+        return (
+            f'To talk to me, start your question with {phrase_list}. '
+            f'For example, "{phrases[0]}, what am I looking at?"'
+        )
+
+    async def say_stop_ack(self, pid: str) -> None:
+        """Synthesize a short canned stop acknowledgement and play it on
+        the consumer's audio sink. Also observes the WAV so the lazy
+        chime build can pick up the sample rate from this path."""
+        try:
+            wav = await self._tts.synthesize("Okay, I will stop.")
+        except Exception:
+            logger.exception("stop-ack tts error pid=%r", pid)
+            return
+        self.observe_tts_wav(wav)
+        try:
+            await self._audio_sink.play_wav(pid, wav)
+        except Exception:
+            logger.exception("stop-ack audio error pid=%r", pid)
+
+    def observe_tts_wav(self, wav_bytes: bytes) -> None:
+        """Build the chime at the TTS sample rate the first time a real
+        TTS WAV passes through. No-op once built or when chime is
+        disabled. A malformed WAV header disables the chime so the
+        consumer doesn't keep paying for failed builds."""
+        if self._chime_wav is not None or not self._chime_enabled:
+            return
+        try:
+            sr = read_wav_sample_rate(wav_bytes)
+            self._chime_wav = build_chime_wav(sr)
+            logger.info("listening chime ready (sr=%d Hz)", sr)
+        except ValueError:
+            logger.exception("listening chime disabled (sample rate out of range)")
+            self._chime_enabled = False
+        except Exception:
+            logger.exception("listening chime disabled (bad TTS wav header)")
+            self._chime_enabled = False
+
+    # ── handler dispatch ──────────────────────────────────────────────────────
+
+    async def _invoke(self, handler, name: str, *args) -> None:
+        if handler is None:
+            return
+        try:
+            await handler(*args)
+        except Exception:
+            logger.exception("voicegate handler %s raised", name)

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/gate.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/gate.py
@@ -141,6 +141,13 @@ class VoiceGate:
     # ── event ladder ──────────────────────────────────────────────────────────
 
     async def feed(self, pid: str, text: str) -> None:
+        """Run one transcript through the event ladder; fires exactly one event.
+
+        Not re-entrant per-pid: the follow-up window (``_followup_until``) is
+        read-then-mutated without locking, so two concurrent ``feed`` calls
+        for the same pid can race the window state. Consumers must serialize
+        calls per participant (e.g. a per-pid ``transcribing`` flag).
+        """
         # Always-on mode: no phrases configured, so the magic-phrase /
         # follow-up / phrase-only / drop branches don't apply. STOP still
         # wins (interrupts must work even without a phrase), and every
@@ -152,7 +159,6 @@ class VoiceGate:
                     "followup_window_open=False",
                     pid,
                 )
-                logger.info("stop bypass pid=%r (text suppressed)", pid)
                 logger.debug("stop bypass pid=%r %r", pid, text[:80])
                 await self._invoke(self._on_stop_h, "on_stop", pid)
                 return
@@ -161,7 +167,6 @@ class VoiceGate:
                 "followup_window_open=False",
                 pid,
             )
-            logger.info("audio query pid=%r (text suppressed)", pid)
             logger.debug("audio query pid=%r %r", pid, text[:80])
             await self._invoke(self._on_query_h, "on_query", pid, text, True)
             return
@@ -181,7 +186,6 @@ class VoiceGate:
                 "followup_window_open=%s",
                 pid, matched_magic, in_followup,
             )
-            logger.info("stop bypass pid=%r (text suppressed)", pid)
             logger.debug("stop bypass pid=%r %r", pid, stop_candidate[:80])
             self._followup_until.pop(pid, None)
             await self._invoke(self._on_stop_h, "on_stop", pid)
@@ -199,7 +203,6 @@ class VoiceGate:
                     pid, in_followup,
                 )
                 self._followup_until.pop(pid, None)
-                logger.info("audio query pid=%r (text suppressed)", pid)
                 logger.debug("audio query pid=%r %r", pid, query[:80])
                 await self._invoke(self._on_query_h, "on_query", pid, query, True)
                 return
@@ -229,7 +232,6 @@ class VoiceGate:
                 pid,
             )
             self._followup_until.pop(pid, None)
-            logger.info("followup query pid=%r (text suppressed)", pid)
             logger.debug("followup query pid=%r %r", pid, text[:80])
             await self._invoke(self._on_query_h, "on_query", pid, text, False)
             return
@@ -240,7 +242,6 @@ class VoiceGate:
             "followup_window_open=%s",
             pid, in_followup,
         )
-        logger.info("drop pid=%r (text suppressed)", pid)
         logger.debug("drop pid=%r %r", pid, text[:80])
         self._followup_until.pop(pid, None)
         await self._invoke(self._on_drop_h, "on_drop", pid, text)


### PR DESCRIPTION
## Summary

ONE shared pipecat pipeline that every xr-ai sample worker can drive. Sample workers subclass ``BrainProcessor`` and implement ``handle_query``; the factory composes the four library processors — VAD/STT, voice gate, brain, streaming TTS — into a single pipecat ``Pipeline``. This PR is the foundation only: ``agent-samples/simple-vlm-example`` and ``agent-samples/xr-render-demo`` are NOT touched. PR-2 and PR-3 will migrate those samples on top of this branch.

## What this PR adds

**``utils/xr-ai-voicegate/``** — new pipecat-free utility package
- ``VoiceGate`` (state machine) + ``VoiceGateConfig`` + ``load_voice_gate_config``
- Strict-prefix multi-phrase matcher with punctuation tolerance
- Follow-up grace window that closes on dispatch; STOP wins over follow-up
- Lazy listening chime built at TTS sample rate via ``observe_tts_wav``
- ``format_phrase_help`` for the greeting, ``say_stop_ack`` for the stop acknowledgment
- Security clamp on chime sample rate to [8000, 192000] Hz
- ``bind(*, on_query, on_stop, on_phrase_only=None, on_drop=None, on_participant_joined=None)`` — single bind point on the gate (replaces the discarded ``wire_voice_gate`` free function)

**``agent-sdk/xr-ai-pipecat/``** — expanded into the unified pipeline
- ``frames.py``: ``ParticipantJoinedFrame``, ``ParticipantLeftFrame``, ``GatedQueryFrame``. Everything else (``InputAudioRawFrame``, ``OutputAudioRawFrame``, ``TranscriptionFrame``, ``UserStartedSpeakingFrame``, ``UserStoppedSpeakingFrame``, ``InterruptionFrame``, ``TextFrame``) reuses pipecat built-ins.
- ``processors/vad_stt.py``: ``VadSttProcessor`` (per-pid ``xr_ai_vad.VadDetector`` lifecycle, ``VadConfig`` dataclass, STT via injected ``STTService``).
- ``processors/voice_gate.py``: ``VoiceGateProcessor`` (wraps ``VoiceGate``; doubles as ``AudioSink`` so the chime and stop-ack travel the same audio path as TTS; greets only when phrases are configured — always-on samples stay silent on join).
- ``processors/streaming_tts.py``: ``StreamingTtsProcessor`` (sentence-batched parallel synth lifted from the existing ``stream_sentences_to_audio``; ``InterruptionFrame`` cancels in-flight tasks and clears pending; calls ``voice_gate.observe_tts_wav`` once per WAV).
- ``processors/brain.py``: ``BrainProcessor`` base — sample brains implement ``handle_query`` returning a string OR async iterator. Optional hooks: ``on_user_started_speaking``, ``on_participant_joined``, ``on_participant_left``.
- ``pipeline.py``: ``make_voice_pipeline`` factory — composes ``input → VadStt → VoiceGate → brain → StreamingTts → output`` and returns ``(Pipeline, PipelineTask)``.

**``DEPENDENCIES.md`` + ``tests/pyproject.toml``** updated for the new package and the new ``xr-ai-pipecat`` deps.

## Behavioral defaults locked

- ``xr-render-demo`` will ship with ``magic_phrases: []`` (always-on) — PR-3's job to set that.
- ``BrainProcessor`` interrupts on ``UserStartedSpeakingFrame`` (earlier than the old on-transcript interrupt — minor behavior change for simple-vlm).
- ``StreamingTtsProcessor`` does parallel sentence-batched synth from day one.

## Notes for reviewers

- **InterruptionFrame propagation** (the spec asked to confirm): ``InterruptionFrame`` is a ``SystemFrame``, so pipecat routes it via ``__input_frame_task_handler`` — bypassing the per-frame process queue that gets cancelled on interruption. Base ``_start_interruption()`` cancels and recreates the process task; our ``BrainProcessor`` keeps its in-flight ``_run_query`` task in a separate ``self._inflight`` map, so our explicit ``_cancel_all_inflight()`` is what actually stops the streaming response. Verified in ``test_brain_cancels_inflight_on_interruption_frame``.
- **StreamingTts sentence-flush divergence from ``stream_sentences_to_audio``**: the original function got the whole text up front and split on sentence boundaries. The processor receives a stream of ``TextFrame``s with no "end of text" marker, so a brain that returns a single complete string (``"echo hi."`` with no trailing whitespace) would never trip the regex ``(?<=[.!?])\s+``. The processor flushes a pending tail that already ends in ``.``/``!``/``?``. Reviewers comparing against ``audio.py`` should expect this adaptation.
- **``PipelineTask`` / ``PipelineRunner`` are deprecated aliases** in pipecat 1.3.0 (the modern names are ``PipelineWorker`` / ``WorkerRunner``). I used the spec's names; they still work and emit ``DeprecationWarning`` at construction. Flagging so engineering-lead can decide whether PR-2/3 should switch to the modern names — out of scope here.

## Supersedes / relationship

- Supersedes the seven closed PRs: #164, #166, #167, #168, #169, #170, #171.
- Depends on no other PRs.
- Sample migrations land as PR-2 (simple-vlm-example) and PR-3 (xr-render-demo) on top of this branch.

## Test plan

- [x] ``python -c "from xr_ai_pipecat import make_voice_pipeline, VadConfig, BrainProcessor"`` succeeds
- [x] ``python -c "from xr_ai_voicegate import VoiceGate, VoiceGateConfig, load_voice_gate_config"`` succeeds
- [x] All voicegate unit tests pass on Python 3.11 + 3.12 (54 tests, 2 sample-yaml tests skipped — those YAMLs land in PR-2/3)
- [x] New pipecat-voice tests pass on Python 3.11 + 3.12 (19 tests)
- [x] Full repo unit suite still passes — no regressions
- [ ] CI green on this branch