### PR TITLE
[codex] Refresh XR-AI docs wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,15 @@
 
 # xr-ai
 
-Agentic AI for XR — a sample blueprint for multi-modal, real-time conversational AI
-within the CloudXR ecosystem.
+Agentic AI for XR — an open-source foundation for multi-modal, real-time
+conversational AI within the CloudXR ecosystem.
 
-## Early Access Notice
+## Public Beta Notice
 
-This project is currently in early access and is under active development.
-Features, APIs, documentation, and behavior may change without notice.
-Expect bugs, incomplete functionality, and breaking changes as the project
-evolves. Use at your own discretion, and please report issues or feedback
-to help improve the project.
+This project is publicly available in beta and is under active development.
+Features, APIs, documentation, and behavior may change as the project evolves.
+Expect bugs, incomplete functionality, and breaking changes. Use at your own
+discretion, and please report issues or feedback to help improve the project.
 
 ## What is XR-AI?
 
@@ -24,7 +23,7 @@ XR-AI is a developer stack for building powerful XR and AI systems across device
 
 With XR-AI, developers can build agents that see and hear what the user experiences, reason over live physical context, call external tools through MCP, and respond with audio or data in the same XR session. The stack provides an end-to-end foundation for multimodal spatial computing applications: real-time media routing, participant-aware response handling, agent interfaces, AI service integration, remote rendering, and sample applications that show the pieces working together.
 
-The value is speed without lock-in. XR-AI is designed to work quickly with NVIDIA open models for vision, language, speech, and speech synthesis, while still giving developers the flexibility to bring their own models, services, tools, and application logic. Because it is built around NVIDIA GPU infrastructure, the same architecture can be deployed where the workload needs to run: cloud, data center, workstation, or edge.
+The value is speed without lock-in. XR-AI is designed to work quickly with NVIDIA open models for vision, language, and speech, plus swappable speech synthesis services, while still giving developers the flexibility to bring their own models, services, tools, and application logic. Because it is built around NVIDIA GPU infrastructure, the same architecture can be deployed where the workload needs to run: cloud, data center, workstation, or edge.
 
 XR-AI also gives developers a practical path across product categories. Teams can start with AI glasses-style experiences that use live camera, audio, and agent responses, then extend the same framework to richer AR glasses or XR headset experiences that use CloudXR remote rendering. This lets developers build for today's lightweight AI devices while keeping a clear path to immersive, GPU-rendered spatial applications.
 
@@ -107,7 +106,7 @@ frames are dropped if it is closed.
 
 | Layer | Directory | Description |
 |---|---|---|
-| Clients | `client-samples/` | Android, iOS/visionOS, Web clients |
+| Clients | `client-samples/` | Android, iOS/visionOS, Web, and native StreamKit clients |
 | Server runtime | `server-runtime/` | XR-Media-Hub + LiveKit internal transport |
 | Launcher | `utils/xr-ai-launcher/` | stdlib-only process manager used by samples |
 | Logging | `utils/xr-ai-logging/` | shared loguru sink + stdlib bridge for every process |

--- a/docs/ai-services.md
+++ b/docs/ai-services.md
@@ -11,9 +11,11 @@ orchestrator pattern that wires servers into a sample, see
 
 Multiple reusable HTTP servers are available as launchable peers of
 `server-runtime/`. All expose an OpenAI-compatible REST API so agent workers
-can call them with any OpenAI SDK client or plain `httpx` / `requests`. Three
-LLM backends ship side-by-side under `ai-services/llm/` — pick one per sample
-based on the tool-calling / reasoning / hardware trade-offs documented below.
+can call them with any OpenAI SDK client or plain `httpx` / `requests`.
+Reference services cover vision-language reasoning, speech recognition,
+text-to-speech, and large language models. Three LLM backends ship
+side-by-side under `ai-services/llm/` — pick one per sample based on the
+tool-calling / reasoning / hardware trade-offs documented below.
 
 | Server | Command | Port | Model | Backend |
 |---|---|---|---|---|
@@ -53,10 +55,11 @@ PROCESSES = [
 ]
 ```
 
-The agent samples in this repo (`simple-vlm-example`) default to Piper
-TTS — it runs on CPU with ~100 ms/sentence latency and avoids the NeMo
-dep tree. Magpie is still a supported option (better voice quality,
-multilingual) when GPU is available; swap the `Process` row and YAML.
+The agent samples in this repo (`simple-vlm-example` and `xr-render-demo`)
+default to Piper TTS — it runs on CPU with ~100 ms/sentence latency and avoids
+the NeMo dep tree. Magpie is still a supported NVIDIA TTS option with better
+voice quality and multilingual support when GPU is available; swap the
+`Process` row and YAML.
 
 **2 — Copy the reference YAML to your sample's `yaml/` directory:**
 


### PR DESCRIPTION
## Summary
- refresh README overview and availability wording
- clarify client coverage in the architecture table
- make AI-service wording more explicit for VLM, STT, TTS, and LLM services
- note Piper as the default sample TTS path and Magpie as the NVIDIA TTS option

## Validation
- git diff --check -- README.md docs/ai-services.md