### PR TITLE
fix(streamkit): resolve remaining Sonar findings in LiveKitBackend

### DIFF
--- a/client-samples/native/StreamKit/src/Backends/LiveKit/LiveKitBackend.cpp
+++ b/client-samples/native/StreamKit/src/Backends/LiveKit/LiveKitBackend.cpp
@@ -86,17 +86,18 @@ livekit::VideoBufferType MapPixelFormat(PixelFormat fmt) {
 std::size_t PackedFrameSize(int width, int height, PixelFormat format) {
     const auto pixels =
         static_cast<std::size_t>(width) * static_cast<std::size_t>(height);
+    using enum PixelFormat;
     switch (format) {
-        case PixelFormat::kI420:
-        case PixelFormat::kNV12: {
+        case kI420:
+        case kNV12: {
             const auto chroma_w =
                 (static_cast<std::size_t>(width)  + 1) / 2;
             const auto chroma_h =
                 (static_cast<std::size_t>(height) + 1) / 2;
             return pixels + 2 * chroma_w * chroma_h;
         }
-        case PixelFormat::kRGBA:
-        case PixelFormat::kBGRA:
+        case kRGBA:
+        case kBGRA:
             return pixels * 4;
     }
     return 0;  // unreachable
@@ -165,6 +166,8 @@ LiveKitBackend::~LiveKitBackend() noexcept {
     try {
         TearDown();
     } catch (...) {
+        // Swallowed: a destructor must not propagate, and a failed teardown
+        // here has no recoverable action.
     }
 }
 


### PR DESCRIPTION
## What

Resolves the two remaining Sonar findings in `LiveKitBackend.cpp` that survived the earlier sweep (`86d1760`, already on `main`):

1. **Empty `catch (...)` in `~LiveKitBackend`** (`bug`/`code-smell`: handle the exception or document the empty block) — added a comment explaining the deliberate swallow. A destructor must not propagate, and a failed teardown during destruction has no recoverable action.
2. **`PackedFrameSize` enum verbosity** — added `using enum PixelFormat;` and dropped the `PixelFormat::` qualifiers on the switch cases, matching `MapPixelFormat` directly above it.

Verified with `g++ -std=c++20 -fsyntax-only` in stub mode (no LiveKit SDK).

## Findings intentionally *not* addressed (with reasons)

- **`StreamSession.h` — "Don't mix public and private data members."** The public `std::function` hooks (`on_connection_state_changed`, `on_data_received`, `on_agent_status`) are the documented, assign-directly public API (`session.on_data_received = ...`) and mirror the Swift/Kotlin/JS `StreamSession`. The private members (`backend_`, `connection_state_`) are internal state. Satisfying the rule would mean either exposing internals or wrapping the callbacks in setters, both of which degrade the API. Deliberate design — left as-is.
- **`test_assert.h` — "Use `std::print` instead of `fprintf`" (×2).** `std::print` is **C++23**; this project targets **C++20** (`target_compile_features(streamkit PUBLIC cxx_std_20)`), and the tests inherit that standard. The finding is not actionable without a standard bump, which carries real toolchain-support risk (`<print>` availability across libstdc++/libc++). The `fprintf`-to-`stderr` in this zero-dependency test harness is correct and intentional. Happy to revisit if we decide to move StreamKit to C++23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)