### PR TITLE
Fix flaky test_piper_tts_smoke (surface server output; skip on voice-unavailable)

### DIFF
--- a/ai-services/tts/piper/piper_tts_server/__main__.py
+++ b/ai-services/tts/piper/piper_tts_server/__main__.py
@@ -41,6 +41,12 @@ from xr_ai_logging import setup_logging
 _DEFAULT_PORT   = 8105
 _HF_REPO        = "rhasspy/piper-voices"
 
+# Exit code for "the voice could not be obtained for environmental reasons"
+# (offline with an empty cache, or a transient HuggingFace download failure),
+# as distinct from a genuine misconfiguration (unknown voice name → exit 1).
+# Callers/tests can treat this as retry-or-skip rather than a hard failure.
+_EXIT_VOICE_UNAVAILABLE = 3
+
 
 def _resolve_model_cache(cfg: dict, yaml_dir: Path) -> Path:
     raw = cfg.get("model_cache", "../models")
@@ -72,9 +78,15 @@ def _hf_path_for_voice(voice: str) -> tuple[str, str]:
 def _ensure_voice(voice: str, cache_dir: Path) -> tuple[Path, Path]:
     """Return (onnx_path, json_path), downloading from HF if necessary.
 
-    Failures are surfaced as a clear single-line error and SystemExit(1) at
+    Failures are surfaced as a clear single-line error and SystemExit at
     startup — without this, a typo in the voice name only manifests as a
     cryptic huggingface_hub stack trace on the first /v1/audio/speech call.
+
+    Exit codes:
+      1  unknown voice name / repo (a misconfiguration — fix the config).
+      3  voice unavailable for environmental reasons: offline with an empty
+         cache, or a transient HF download failure (network / rate-limit).
+         Retryable, not a code bug — see ``_EXIT_VOICE_UNAVAILABLE``.
     """
     from huggingface_hub import hf_hub_download
     from huggingface_hub.errors import (
@@ -105,7 +117,19 @@ def _ensure_voice(voice: str, cache_dir: Path) -> tuple[Path, Path]:
             "or remove the offline restriction.",
             voice, hf_cache,
         )
-        sys.exit(1)
+        sys.exit(_EXIT_VOICE_UNAVAILABLE)
+    except Exception as exc:
+        # Any other huggingface_hub error (HfHubHTTPError, connection reset,
+        # read timeout, 429 rate-limit, …) is a transient download problem,
+        # not a misconfiguration. Surface a clear single line and exit with the
+        # retryable code instead of dumping a raw traceback as exit 1.
+        logger.error(
+            "Could not download voice {!r} from {} ({}: {}). This is usually a "
+            "transient network or HuggingFace availability problem — retry, or "
+            "pre-fetch the voice on a connected host.",
+            voice, _HF_REPO, exc.__class__.__name__, exc,
+        )
+        sys.exit(_EXIT_VOICE_UNAVAILABLE)
     logger.info("Voice files ready")
     return onnx_path, json_path
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,7 +9,26 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
-### 2026-05-28 — xr-render-demo: vec-mcp + redesigned spatial tools + prompt redesign + eval vocab audit
+### 2026-06-04 — piper TTS smoke test: de-flake + dedicated voice-unavailable exit code
+
+`test_piper_tts_smoke` was failing intermittently in CI with an opaque
+"piper_tts_server exited early with code 1" and no further detail. Root
+cause: the server downloads the configured voice from HuggingFace on startup,
+and `_ensure_voice` only caught the "voice name is wrong" errors —
+a transient HF failure (timeout, 429, connection reset) propagated as an
+uncaught traceback and exit 1. The test then reported only the exit code
+because it never read the subprocess's captured output.
+
+Two fixes:
+- **Server**: `_ensure_voice` now catches any other download error and exits
+  with a dedicated `_EXIT_VOICE_UNAVAILABLE = 3` (also used for the offline
+  empty-cache case), distinct from exit 1 (genuine bad voice name / repo).
+  Operators get a clear single line instead of a raw traceback.
+- **Test**: `_wait_for_port` reads and surfaces the server's captured
+  stdout/stderr on early exit. Exit code 3 → `pytest.skip` (environmental,
+  retryable — restores the documented "skip cleanly when the voice can't be
+  obtained" contract); any other code → `pytest.fail` with the captured
+  output so real regressions are diagnosable in the CI log.
 
 The eval score on the agentic-loop suite climbed from 40/66 to 58/66 by
 splitting "vector arithmetic the model is bad at" out of the prompt and

--- a/tests/test_piper_tts.py
+++ b/tests/test_piper_tts.py
@@ -10,8 +10,12 @@ a tiny synthesis request through the OpenAI-compatible
 ``POST /v1/audio/speech`` endpoint.
 
 CPU-only: Piper runs ONNX on CPU at ~100 ms/sentence. No ``gpu`` marker,
-so CI picks this up. Skipped cleanly if the piper venv hasn't been
-``uv sync``'d or if the configured voice weights are not in the HF cache.
+so CI picks this up. Skipped cleanly when the environment can't support it:
+``uv`` is missing, the piper venv hasn't been ``uv sync``'d, or the
+configured voice can't be obtained (offline with an empty cache, or a
+transient HuggingFace download failure — the server signals this with a
+dedicated exit code). Any other early exit fails the test with the server's
+captured output so the cause is visible in CI.
 """
 from __future__ import annotations
 
@@ -36,6 +40,26 @@ _PIPER_PROJECT = _REPO_ROOT / "ai-services" / "tts" / "piper"
 _PIPER_BIN     = _PIPER_PROJECT / ".venv" / "bin" / "piper_tts_server"
 _PIPER_YAML    = _PIPER_PROJECT / "piper_tts_server.yaml"
 _DEFAULT_PORT  = 8105
+
+# Must match _EXIT_VOICE_UNAVAILABLE in piper_tts_server/__main__.py: the
+# server uses this exit code when the voice can't be obtained for
+# environmental reasons (offline empty cache / transient HF download failure),
+# which the smoke test treats as skip rather than fail.
+_EXIT_VOICE_UNAVAILABLE = 3
+
+
+class _ServerExited(Exception):
+    """Raised when piper_tts_server exits before binding its port.
+
+    Carries the process return code and the captured stdout+stderr so callers
+    can decide whether to skip (environmental) or fail (real error) — and so
+    the real cause is visible instead of a bare "exited with code N".
+    """
+
+    def __init__(self, returncode: int, output: str) -> None:
+        self.returncode = returncode
+        self.output = output
+        super().__init__(f"piper_tts_server exited early with code {returncode}")
 
 
 def _pick_port(preferred: int) -> int:
@@ -84,13 +108,18 @@ def _voice_cached(voice: str, hf_cache: Path) -> bool:
 
 
 async def _wait_for_port(port: int, *, proc: subprocess.Popen, timeout: float) -> None:
-    """Poll the bind port until it accepts a TCP connection or proc dies."""
+    """Poll the bind port until it accepts a TCP connection.
+
+    Raises ``_ServerExited`` (with the captured output) if the process dies
+    before binding, or ``TimeoutError`` if the port never opens.
+    """
     deadline = asyncio.get_running_loop().time() + timeout
     while asyncio.get_running_loop().time() < deadline:
         if proc.poll() is not None:
-            raise RuntimeError(
-                f"piper_tts_server exited early with code {proc.returncode}"
-            )
+            # The process is dead, so its pipe won't block — read the captured
+            # stdout+stderr and surface it instead of just the exit code.
+            output = proc.stdout.read().decode("utf-8", "replace") if proc.stdout else ""
+            raise _ServerExited(proc.returncode, output)
         if _port_open(port):
             return
         await asyncio.sleep(0.2)
@@ -157,7 +186,23 @@ async def test_piper_tts_smoke(tmp_path: Path) -> None:
     try:
         # First-run voice download (~50–200 MB) plus ONNX init can take a
         # couple of minutes on a cold cache; reuse is sub-second.
-        await _wait_for_port(port, proc=proc, timeout=300.0)
+        try:
+            await _wait_for_port(port, proc=proc, timeout=300.0)
+        except _ServerExited as exc:
+            tail = exc.output.strip()[-2000:]
+            # A transient HF download failure on a cold cache is environmental,
+            # not a regression — skip rather than fail the suite (matches the
+            # "skipped cleanly if the voice can't be obtained" contract above).
+            if exc.returncode == _EXIT_VOICE_UNAVAILABLE:
+                pytest.skip(
+                    "piper voice could not be obtained (offline cache or "
+                    f"transient HuggingFace download failure):\n{tail}"
+                )
+            # Any other early exit is a real failure — surface the captured
+            # server output so it's diagnosable from the CI log.
+            pytest.fail(
+                f"piper_tts_server exited with code {exc.returncode}:\n{tail}"
+            )
         body = await asyncio.get_running_loop().run_in_executor(
             None, _post_speech, port, voice, "Hello, world.",
         )


### PR DESCRIPTION
## Problem

`test_piper_tts.py::test_piper_tts_smoke` fails intermittently in CI with an opaque:

```
RuntimeError: piper_tts_server exited early with code 1
```

…and no further detail, so the cause was undiagnosable from CI logs. (Seen on PR #181's runs — 3.11 failed, 3.12 passed, on a change that doesn't touch Piper.)

## Root cause

1. `piper_tts_server` downloads the configured voice from HuggingFace on startup (`_ensure_voice` → `hf_hub_download`, before serving).
2. `_ensure_voice` only caught `EntryNotFoundError` / `RepositoryNotFoundError` / `LocalEntryNotFoundError`. A **transient HF failure** (timeout, 429 rate-limit, connection reset) was **uncaught** → traceback → process exits **code 1**.
3. The test's `_wait_for_port` reported only the exit code and **never read the captured stdout/stderr**, hiding the real error.

So a network blip during the cold-cache voice download turned into an opaque hard failure.

## Fix

**Server (`ai-services/tts/piper/piper_tts_server/__main__.py`)**
- `_ensure_voice` now catches any other download error and exits with a dedicated `_EXIT_VOICE_UNAVAILABLE = 3` (also used for the offline empty-cache case), distinct from exit `1` (genuine bad voice name / repo). Operators get a clear single-line message instead of a raw traceback.

**Test (`tests/test_piper_tts.py`)**
- `_wait_for_port` reads and surfaces the server's captured output on early exit (via a small `_ServerExited` carrying `returncode` + `output`).
- Exit code `3` → `pytest.skip` (environmental, retryable — restores the documented "skip cleanly when the voice can't be obtained" contract).
- Any other exit code → `pytest.fail` **with the captured output**, so real regressions are diagnosable in the CI log.

## Notes
- No `pyproject.toml` changes → `DEPENDENCIES.md` unaffected.
- Validated locally: exit-code constant matches across server/test; `_wait_for_port` raises `_ServerExited` with the captured output for both code 3 and code 1.
- Separate from the NIM-backend work (PR #181); this is the flaky-test investigation requested as a standalone change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)