### PR TITLE
feat(streamkit): improve native LiveKit backend compatibility

### DIFF
--- a/client-samples/native/README.md
+++ b/client-samples/native/README.md
@@ -61,6 +61,7 @@ Each test is a standalone executable that asserts and exits non-zero on failure 
 | Data channel `Send` + `_agent.status` interception | ✅ implemented |
 | Video publish via `FrameSink::InjectVideoFrame` | ✅ implemented — first frame creates the track. Real-time callers should use the `std::vector<uint8_t>&&` overload to avoid a 1.4 MB per-frame copy. `CameraConfig::encoding` can set publish-side bitrate, frame-rate, and simulcast options before that first frame. See finding #12 in [issue #134](https://github.com/NVIDIA/xr-ai/issues/134). |
 | Audio publish via `AudioSink::InjectAudioFrame` | ✅ implemented — `StartAudio()` creates the track; host pushes PCM frames |
+| Remote audio access | ⚠️ LiveKit-specific escape hatch — `LiveKitBackend::GetRoom()` exposes the underlying room for receiver-side integrations such as remote audio rendering or AEC reference capture |
 | Platform mic open | ⚠️ no built-in path; host opens its mic and pushes PCM frames via AudioSink |
 | Platform camera open | ⚠️ no built-in path; host opens its camera and pushes frames via FrameSink. `CameraConfig::facing` / `device_id` are inert here — the host chooses the camera |
 | `LiveKitConfig::token_url` HTTP fetch | ⚠️ not implemented; pass `LiveKitConfig::token` inline or override `FetchToken` |

--- a/client-samples/native/README.md
+++ b/client-samples/native/README.md
@@ -59,7 +59,7 @@ Each test is a standalone executable that asserts and exits non-zero on failure 
 |---|---|
 | Connect / Disconnect + state mapping | ✅ implemented |
 | Data channel `Send` + `_agent.status` interception | ✅ implemented |
-| Video publish via `FrameSink::InjectVideoFrame` | ✅ implemented — first frame creates the track. Real-time callers should use the `std::vector<uint8_t>&&` overload to avoid a 1.4 MB per-frame copy. See finding #12 in [issue #134](https://github.com/NVIDIA/xr-ai/issues/134). |
+| Video publish via `FrameSink::InjectVideoFrame` | ✅ implemented — first frame creates the track. Real-time callers should use the `std::vector<uint8_t>&&` overload to avoid a 1.4 MB per-frame copy. `CameraConfig::encoding` can set publish-side bitrate, frame-rate, and simulcast options before that first frame. See finding #12 in [issue #134](https://github.com/NVIDIA/xr-ai/issues/134). |
 | Audio publish via `AudioSink::InjectAudioFrame` | ✅ implemented — `StartAudio()` creates the track; host pushes PCM frames |
 | Platform mic open | ⚠️ no built-in path; host opens its mic and pushes PCM frames via AudioSink |
 | Platform camera open | ⚠️ no built-in path; host opens its camera and pushes frames via FrameSink. `CameraConfig::facing` / `device_id` are inert here — the host chooses the camera |

--- a/client-samples/native/StreamKit/Tests/StreamKitTests/LiveKitBackendTests.cpp
+++ b/client-samples/native/StreamKit/Tests/StreamKitTests/LiveKitBackendTests.cpp
@@ -12,6 +12,7 @@
 
 #include "test_assert.h"
 
+#include "streamkit/Backends/LiveKit/LiveKitBackend.h"
 #include "streamkit/Config/BackendConfiguration.h"
 #include "streamkit/ConnectionState.h"
 #include "streamkit/FrameSink.h"
@@ -33,6 +34,10 @@ int main() {
 
     streamkit::StreamSession session{
         streamkit::BackendConfiguration{lk}};
+    auto* livekit_backend =
+        dynamic_cast<streamkit::LiveKitBackend*>(session.GetBackend());
+    Expect(livekit_backend != nullptr);
+    Expect(!livekit_backend->GetRoom());
 
     std::vector<ConnectionState> states;
     session.on_connection_state_changed = [&states](ConnectionState s) {
@@ -45,11 +50,13 @@ int main() {
     ExpectEq(states.size(), std::size_t{2});
     Expect(states[0] == ConnectionState::kConnecting);
     Expect(states[1] == ConnectionState::kConnected);
+    Expect(!livekit_backend->GetRoom());
 
     // ── Disconnect — exactly one kDisconnected. ──────────────────────────
     session.Disconnect();
     ExpectEq(states.size(), std::size_t{3});
     Expect(states[2] == ConnectionState::kDisconnected);
+    Expect(!livekit_backend->GetRoom());
 
     // ── Reconnect — still no spurious leading kDisconnected. The
     //    TearDown() at the top of Connect sees last_fired_state_ ==

--- a/client-samples/native/StreamKit/Tests/StreamKitTests/StreamSessionTests.cpp
+++ b/client-samples/native/StreamKit/Tests/StreamKitTests/StreamSessionTests.cpp
@@ -39,6 +39,7 @@ struct MockBackend : streamkit::StreamingBackend {
     int stop_audio_calls = 0;
     int start_camera_calls = 0;
     int stop_camera_calls = 0;
+    streamkit::CameraConfig last_camera_config;
     std::vector<std::string> sent_topics;
     std::vector<std::string> sent_payloads;
 
@@ -57,7 +58,10 @@ struct MockBackend : streamkit::StreamingBackend {
     }
     void StartAudio(const streamkit::AudioConfig&) override { ++start_audio_calls; }
     void StopAudio() override { ++stop_audio_calls; }
-    void StartCamera(const streamkit::CameraConfig&) override { ++start_camera_calls; }
+    void StartCamera(const streamkit::CameraConfig& config) override {
+        ++start_camera_calls;
+        last_camera_config = config;
+    }
     void StopCamera() override { ++stop_camera_calls; }
     void Send(std::span<const std::byte> data, bool, std::string_view topic) override {
         sent_topics.emplace_back(topic);
@@ -127,6 +131,21 @@ int main() {
     session.StartCamera();
     ExpectEq(raw->start_audio_calls, 1);
     ExpectEq(raw->start_camera_calls, 1);
+
+    streamkit::CameraConfig encoded_camera;
+    encoded_camera.encoding = streamkit::CameraEncodingConfig{
+        .max_bitrate_bps = 2'500'000,
+        .max_framerate = 21.0,
+        .simulcast = false,
+    };
+    session.StartCamera(encoded_camera);
+    ExpectEq(raw->start_camera_calls, 2);
+    Expect(raw->last_camera_config.encoding.has_value());
+    ExpectEq(raw->last_camera_config.encoding->max_bitrate_bps,
+             std::uint64_t{2'500'000});
+    ExpectEq(raw->last_camera_config.encoding->max_framerate, 21.0);
+    Expect(raw->last_camera_config.encoding->simulcast.has_value());
+    Expect(!*raw->last_camera_config.encoding->simulcast);
 
     // ── Send + data delivery ───────────────────────────────────────────────
     const std::string msg = "hello";

--- a/client-samples/native/StreamKit/include/streamkit/Backends/LiveKit/LiveKitBackend.h
+++ b/client-samples/native/StreamKit/include/streamkit/Backends/LiveKit/LiveKitBackend.h
@@ -117,6 +117,13 @@ public:
                           int samples_per_channel,
                           int64_t timestamp_us) override;
 
+    // ── LiveKit-specific integrations ───────────────────────────────────────
+
+    /// Returns the underlying LiveKit room for advanced receiver-side
+    /// integrations such as remote-audio rendering or AEC reference capture.
+    /// Returns nullptr before Connect(), after Disconnect(), and in stub mode.
+    std::shared_ptr<livekit::Room> GetRoom() const { return room_; }
+
 protected:
     /// Fetches a LiveKit JWT from `config_.token_url`.
     ///

--- a/client-samples/native/StreamKit/include/streamkit/Backends/LiveKit/LiveKitBackend.h
+++ b/client-samples/native/StreamKit/include/streamkit/Backends/LiveKit/LiveKitBackend.h
@@ -158,6 +158,7 @@ private:
 
     LiveKitConfig config_;
     SessionConfig session_config_;
+    CameraConfig camera_config_;
 
     // shared_ptr (not unique_ptr) because the type-erased deleter is
     // captured at construction. That keeps the class destructor valid when

--- a/client-samples/native/StreamKit/include/streamkit/Config/CameraConfig.h
+++ b/client-samples/native/StreamKit/include/streamkit/Config/CameraConfig.h
@@ -3,16 +3,30 @@
 
 #pragma once
 
+#include <cstdint>
 #include <optional>
 #include <string>
 
 namespace streamkit {
 
+/// Optional publish-side encoding controls for externally captured video.
+///
+/// Backends that open their own platform camera may ignore this. The C++
+/// LiveKitBackend consumes it because callers push frames through FrameSink
+/// and need to specify publish options before the first frame creates the
+/// LocalVideoTrack.
+struct CameraEncodingConfig {
+    std::uint64_t max_bitrate_bps = 0;
+    double max_framerate = 0.0;
+    std::optional<bool> simulcast;
+};
+
 /// Configures camera capture passed to StreamSession::StartCamera().
 ///
-/// Resolution and frame-rate are intentionally not exposed: the LiveKit
-/// backend negotiates the best supported format with the hardware
-/// automatically (matching the iOS and Android behaviour).
+/// Capture resolution is intentionally not exposed: backends that open a
+/// camera negotiate the best supported format with the hardware automatically
+/// (matching the iOS and Android behaviour). `encoding` only controls
+/// publish-side media options after capture.
 ///
 /// ## Platform contract for `facing` and `device_id`
 ///
@@ -40,10 +54,13 @@ struct CameraConfig {
     /// When set, this takes precedence over `facing`.
     std::optional<std::string> device_id;
 
+    /// Optional publish-side encoding controls for externally captured video.
+    std::optional<CameraEncodingConfig> encoding;
+
     // ── Presets ────────────────────────────────────────────────────────────
 
     static CameraConfig Default() { return {}; }
-    static CameraConfig Rear()    { return {Facing::kBack, std::nullopt}; }
+    static CameraConfig Rear()    { return {Facing::kBack, std::nullopt, std::nullopt}; }
 };
 
 } // namespace streamkit

--- a/client-samples/native/StreamKit/include/streamkit/Config/SessionConfig.h
+++ b/client-samples/native/StreamKit/include/streamkit/Config/SessionConfig.h
@@ -6,7 +6,6 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
-#include <format>
 #include <string>
 
 namespace streamkit {
@@ -27,9 +26,9 @@ struct SessionConfig {
         static std::atomic_uint64_t sequence{0};
         const auto timestamp =
             std::chrono::steady_clock::now().time_since_epoch().count();
-        return SessionConfig{std::format(
-            "participant-{}-{}", timestamp,
-            sequence.fetch_add(1, std::memory_order_relaxed))};
+        return SessionConfig{
+            "participant-" + std::to_string(timestamp) + "-" +
+            std::to_string(sequence.fetch_add(1, std::memory_order_relaxed))};
     }
 };
 

--- a/client-samples/native/StreamKit/src/Backends/LiveKit/LiveKitBackend.cpp
+++ b/client-samples/native/StreamKit/src/Backends/LiveKit/LiveKitBackend.cpp
@@ -292,8 +292,8 @@ void LiveKitBackend::StartCamera(const CameraConfig& config) {
     // VideoSource ctor requires explicit width/height, so the track cannot
     // be created here. Arm the backend; the first FrameSink::InjectVideoFrame
     // call creates the source and publishes lazily.
-    (void)config;
     StopCamera();
+    camera_config_ = config;
     camera_armed_.store(true);
 }
 
@@ -371,8 +371,23 @@ void LiveKitBackend::InjectVideoFrame(std::vector<std::uint8_t>&& data,
         std::lock_guard<std::mutex> lock(tracks_mutex_);
         if (!video_source_) {
             video_source_ = std::make_shared<livekit::VideoSource>(width, height);
-            video_track_ = room_->localParticipant()->publishVideoTrack(
-                "camera", video_source_, livekit::TrackSource::SOURCE_CAMERA);
+            video_track_ = livekit::LocalVideoTrack::createLocalVideoTrack(
+                "camera", video_source_);
+            livekit::TrackPublishOptions options;
+            options.source = livekit::TrackSource::SOURCE_CAMERA;
+            if (camera_config_.encoding.has_value()) {
+                const auto& encoding = *camera_config_.encoding;
+                if (encoding.max_bitrate_bps > 0 || encoding.max_framerate > 0.0) {
+                    livekit::VideoEncodingOptions video_encoding;
+                    video_encoding.max_bitrate = encoding.max_bitrate_bps;
+                    video_encoding.max_framerate = encoding.max_framerate;
+                    options.video_encoding = video_encoding;
+                }
+                if (encoding.simulcast.has_value()) {
+                    options.simulcast = encoding.simulcast;
+                }
+            }
+            room_->localParticipant()->publishTrack(video_track_, options);
         }
         source = video_source_;
     }

--- a/client-samples/native/StreamKit/src/Backends/LiveKit/LiveKitBackend.cpp
+++ b/client-samples/native/StreamKit/src/Backends/LiveKit/LiveKitBackend.cpp
@@ -21,7 +21,6 @@
 
 #include <cstdint>
 #include <cstring>
-#include <format>
 #include <mutex>
 #include <optional>
 #include <stdexcept>
@@ -69,12 +68,11 @@ ConnectionState MapState(livekit::ConnectionState lk) {
 }
 
 livekit::VideoBufferType MapPixelFormat(PixelFormat fmt) {
-    using enum PixelFormat;
     switch (fmt) {
-        case kI420: return livekit::VideoBufferType::I420;
-        case kNV12: return livekit::VideoBufferType::NV12;
-        case kRGBA: return livekit::VideoBufferType::RGBA;
-        case kBGRA: return livekit::VideoBufferType::BGRA;
+        case PixelFormat::kI420: return livekit::VideoBufferType::I420;
+        case PixelFormat::kNV12: return livekit::VideoBufferType::NV12;
+        case PixelFormat::kRGBA: return livekit::VideoBufferType::RGBA;
+        case PixelFormat::kBGRA: return livekit::VideoBufferType::BGRA;
     }
     return livekit::VideoBufferType::I420;
 }
@@ -86,18 +84,17 @@ livekit::VideoBufferType MapPixelFormat(PixelFormat fmt) {
 std::size_t PackedFrameSize(int width, int height, PixelFormat format) {
     const auto pixels =
         static_cast<std::size_t>(width) * static_cast<std::size_t>(height);
-    using enum PixelFormat;
     switch (format) {
-        case kI420:
-        case kNV12: {
+        case PixelFormat::kI420:
+        case PixelFormat::kNV12: {
             const auto chroma_w =
                 (static_cast<std::size_t>(width)  + 1) / 2;
             const auto chroma_h =
                 (static_cast<std::size_t>(height) + 1) / 2;
             return pixels + 2 * chroma_w * chroma_h;
         }
-        case kRGBA:
-        case kBGRA:
+        case PixelFormat::kRGBA:
+        case PixelFormat::kBGRA:
             return pixels * 4;
     }
     return 0;  // unreachable
@@ -185,7 +182,7 @@ void LiveKitBackend::Connect(const SessionConfig& session_config) {
 
     const std::string scheme = config_.secure ? "wss" : "ws";
     const std::string ws_url =
-        std::format("{}://{}:{}", scheme, config_.host, config_.port);
+        scheme + "://" + config_.host + ":" + std::to_string(config_.port);
 
     std::string token;
     if (config_.token.has_value() && !config_.token->empty()) {
@@ -213,8 +210,7 @@ void LiveKitBackend::Connect(const SessionConfig& session_config) {
         room_.reset();
         delegate_.reset();
         FireStateChanged(ConnectionState::kDisconnected);
-        throw StreamError(std::format(
-            "LiveKit Room::Connect returned false for {}", ws_url));
+        throw StreamError("LiveKit Room::Connect returned false for " + ws_url);
     }
     is_connected_.store(true);
     // The SDK delegate may have already fired kConnected during the
@@ -345,12 +341,12 @@ void LiveKitBackend::InjectVideoFrame(std::vector<std::uint8_t>&& data,
     // their padded HAL or GPU readback buffer?" mistake.
     if (const auto expected = PackedFrameSize(width, height, format);
         data.size() != expected) {
-        throw std::invalid_argument(std::format(
-            "InjectVideoFrame: buffer size {} does not match the packed size "
-            "{} expected for the given dimensions and format. FrameSink "
+        throw std::invalid_argument(
+            "InjectVideoFrame: buffer size " + std::to_string(data.size()) +
+            " does not match the packed size " + std::to_string(expected) +
+            " expected for the given dimensions and format. FrameSink "
             "requires tightly packed input - repack padded buffers before "
-            "calling.",
-            data.size(), expected));
+            "calling.");
     }
 
 #if STREAMKIT_HAVE_LIVEKIT
@@ -422,10 +418,10 @@ void LiveKitBackend::InjectAudioFrame(std::span<const std::int16_t> pcm,
             static_cast<std::size_t>(channels) *
             static_cast<std::size_t>(samples_per_channel);
         pcm.size() != expected) {
-        throw std::invalid_argument(std::format(
-            "InjectAudioFrame: sample count {} does not match channels * "
-            "samples_per_channel = {}",
-            pcm.size(), expected));
+        throw std::invalid_argument(
+            "InjectAudioFrame: sample count " + std::to_string(pcm.size()) +
+            " does not match channels * samples_per_channel = " +
+            std::to_string(expected));
     }
 
 #if STREAMKIT_HAVE_LIVEKIT
@@ -462,8 +458,8 @@ void LiveKitBackend::Send(std::span<const std::byte> data,
         throw NotConnectedError{};
     }
     if (topic == kAgentStatusTopic) {
-        throw std::invalid_argument(std::format(
-            "topic '{}' is reserved for internal SDK use", topic));
+        throw std::invalid_argument(
+            "topic '" + std::string(topic) + "' is reserved for internal SDK use");
     }
 
 #if STREAMKIT_HAVE_LIVEKIT
@@ -554,10 +550,9 @@ std::string LiveKitBackend::FetchToken(
     const std::string& /*identity*/) {
     // No HTTP client shipped — callers must pass an inline JWT via
     // `LiveKitConfig::token` (computed server-side).
-    throw TokenFetchFailedError(std::format(
-        "{} - FetchToken is not implemented in this backend; supply an "
-        "inline token in LiveKitConfig::token",
-        token_url));
+    throw TokenFetchFailedError(
+        token_url + " - FetchToken is not implemented in this backend; supply "
+        "an inline token in LiveKitConfig::token");
 }
 
 } // namespace streamkit

--- a/client-samples/native/StreamKit/src/Backends/LiveKit/LiveKitBackend.cpp
+++ b/client-samples/native/StreamKit/src/Backends/LiveKit/LiveKitBackend.cpp
@@ -414,6 +414,9 @@ void LiveKitBackend::InjectAudioFrame(std::span<const std::int16_t> pcm,
     }
 
 #if STREAMKIT_HAVE_LIVEKIT
+    // AudioSink timestamps are media timestamps; AudioSource::captureFrame's
+    // second parameter is a bounded-wait timeout in milliseconds.
+    (void)timestamp_us;
     livekit::AudioFrame frame(sample_rate, channels, samples_per_channel,
                               pcm.data());
     std::shared_ptr<livekit::AudioSource> source;
@@ -422,7 +425,7 @@ void LiveKitBackend::InjectAudioFrame(std::span<const std::int16_t> pcm,
         source = audio_source_;
     }
     if (source) {
-        source->captureFrame(frame, timestamp_us);
+        source->captureFrame(frame);
     }
 #else
     (void)sample_rate;

--- a/client-samples/native/StreamKit/src/Backends/LiveKit/LiveKitBackend.cpp
+++ b/client-samples/native/StreamKit/src/Backends/LiveKit/LiveKitBackend.cpp
@@ -432,8 +432,9 @@ void LiveKitBackend::InjectAudioFrame(std::span<const std::int16_t> pcm,
     // AudioSink timestamps are media timestamps; AudioSource::captureFrame's
     // second parameter is a bounded-wait timeout in milliseconds.
     (void)timestamp_us;
-    livekit::AudioFrame frame(sample_rate, channels, samples_per_channel,
-                              pcm.data());
+    std::vector<std::int16_t> data(pcm.begin(), pcm.end());
+    livekit::AudioFrame frame(std::move(data), sample_rate, channels,
+                              samples_per_channel);
     std::shared_ptr<livekit::AudioSource> source;
     {
         std::lock_guard<std::mutex> lock(tracks_mutex_);

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,16 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-05 — Native StreamKit: Android NDK C++20 portability
+
+Native StreamKit no longer depends on C++20 `<format>`. Some Android NDK
+libc++ versions used by embedded clients do not ship that header even though
+the project otherwise builds as C++20. The affected identity and error-message
+strings now use `std::to_string` plus string concatenation, preserving behavior
+while keeping the C++ backend portable to those toolchains. The backend also
+uses fully qualified enum labels instead of `using enum`, which older NDK r23
+compilers reject.
+
 ### 2026-06-05 — Native StreamKit: LiveKit room access for receiver-side audio
 
 `LiveKitBackend` now exposes `GetRoom()` for advanced native integrations that

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,16 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-05 — Native StreamKit: LiveKit room access for receiver-side audio
+
+`LiveKitBackend` now exposes `GetRoom()` for advanced native integrations that
+need receiver-side LiveKit APIs, such as rendering remote participant audio
+locally or feeding an acoustic echo canceller with the agent's playback audio.
+This remains intentionally transport-specific: the generic `StreamingBackend`
+surface is unchanged, and callers must opt in by depending on `LiveKitBackend`.
+The accessor returns `nullptr` before connect, after disconnect, and in stub
+mode.
+
 ### 2026-06-05 — Native StreamKit: vector-backed LiveKit AudioFrame construction
 
 `LiveKitBackend::InjectAudioFrame` now constructs `livekit::AudioFrame` through

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,16 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-05 — Native StreamKit: vector-backed LiveKit AudioFrame construction
+
+`LiveKitBackend::InjectAudioFrame` now constructs `livekit::AudioFrame` through
+the vector-data constructor. Some LiveKit C++ SDK builds expose only
+`AudioFrame(std::vector<int16_t>, sample_rate, channels, samples_per_channel)`
+and not the pointer-data constructor. StreamKit still accepts
+`std::span<const int16_t>` at the public `AudioSink` boundary; the conversion is
+contained inside the LiveKit backend so callers and custom backends are
+unaffected.
+
 ### 2026-06-05 — Native StreamKit: publish options for externally captured video
 
 The C++ `LiveKitBackend` publishes camera tracks lazily on the first

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,17 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-05 — Native StreamKit: AudioSink timestamps stay media timestamps
+
+`AudioSink::InjectAudioFrame` carries a capture timestamp in microseconds so
+hosts can pass audio and video frames through the same monotonic-clock model.
+The LiveKit C++ SDK's `AudioSource::captureFrame` API uses its optional second
+argument for a bounded-wait timeout in milliseconds, not for media time. Passing
+StreamKit's `timestamp_us` through that parameter can turn an increasing media
+timestamp into a long capture wait and add audio latency. The C++ LiveKit backend
+now preserves the StreamKit timestamp as API metadata and calls
+`AudioSource::captureFrame(frame)` so the SDK uses its realtime default timeout.
+
 ### 2026-06-05 — Android: synthetic "Virtual Camera" provider over injectVideoFrame
 
 Adds a selectable "Virtual Camera (synthetic)" entry to the Android sample's

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,20 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-05 — Native StreamKit: publish options for externally captured video
+
+The C++ `LiveKitBackend` publishes camera tracks lazily on the first
+`FrameSink::InjectVideoFrame` call because externally captured frames provide
+the stream dimensions. That made callers unable to set LiveKit publish-side
+encoding options before track creation. `CameraConfig` now includes an optional
+`CameraEncodingConfig` with max bitrate, max framerate, and simulcast controls.
+The built-in C++ backend stores the config at `StartCamera()` time and applies
+it when the first frame creates the `LocalVideoTrack`.
+
+Backends that open and manage their own platform camera may ignore
+`CameraConfig::encoding`; it is primarily for C++ hosts that own capture outside
+StreamKit and use `FrameSink` for injection.
+
 ### 2026-06-05 — Native StreamKit: AudioSink timestamps stay media timestamps
 
 `AudioSink::InjectAudioFrame` carries a capture timestamp in microseconds so


### PR DESCRIPTION
## Summary

This PR updates the native C++ StreamKit `LiveKitBackend` for embedded/native hosts that provide their own media capture and build against Android-oriented LiveKit C++ SDK bundles.

Changes:
- keep `AudioSink` capture timestamps separate from the LiveKit SDK's `AudioSource::captureFrame` timeout parameter
- add optional camera publish encoding controls to `CameraConfig` for externally injected video (`max_bitrate_bps`, `max_framerate`, `simulcast`)
- construct `livekit::AudioFrame` through the vector-backed constructor for SDK compatibility
- expose a LiveKit-specific `LiveKitBackend::GetRoom()` accessor for receiver-side integrations such as remote audio rendering and AEC reference capture
- avoid `<format>` and `using enum` in native StreamKit so the C++ backend builds with Android NDK r23-era libc++/clang toolchains

Docs and `docs/changelog.md` are updated in the same change. No `pyproject.toml` changes; `DEPENDENCIES.md` is unaffected.

## Motivation

These changes upstream the small native StreamKit deltas currently needed by the embedded integration. The host owns camera and mic capture, injects frames through StreamKit, and needs explicit publish options, SDK-compatible audio frame construction, remote audio access for AEC, and Android NDK portability.

## Validation

Local StreamKit validation:
- `cmake -S client-samples/native -B /tmp/xr-ai-native-build -DSTREAMKIT_BUILD_TESTS=ON -DSTREAMKIT_BUILD_SAMPLE=OFF`
- `cmake --build /tmp/xr-ai-native-build --parallel`
- `ctest --test-dir /tmp/xr-ai-native-build --output-on-failure`