### PR TITLE
fix(streamkit): fix TOCTOU null-deref race in LiveKitBackend.send()

### DIFF
--- a/client-samples/web/StreamKit/Backends/LiveKit/LiveKitBackend.js
+++ b/client-samples/web/StreamKit/Backends/LiveKit/LiveKitBackend.js
@@ -373,7 +373,10 @@ export class LiveKitBackend {
    * @throws {StreamError} `notConnected` if not connected.
    */
   async send(data, { reliable = true, topic } = {}) {
-    if (!this.#room || this.#room.state !== 'connected') {
+    // Snapshot the room so a concurrent #tearDown() nulling this.#room across
+    // the await below can't turn the publishData() deref into a null crash.
+    const room = this.#room;
+    if (!room || room.state !== 'connected') {
       throw StreamError.notConnected();
     }
 
@@ -402,7 +405,7 @@ export class LiveKitBackend {
     if (this.#config.hubIdentity) {
       opts.destinationIdentities = [this.#config.hubIdentity];
     }
-    await this.#room.localParticipant.publishData(bytes, opts);
+    await room.localParticipant.publishData(bytes, opts);
   }
 
   // ── Private helpers ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## The bug

`LiveKitBackend.send()` read `this.#room` twice: once in its guard
(`if (\!this.#room || this.#room.state \!== 'connected')`) and again at the
`await this.#room.localParticipant.publishData(...)` call.

Because `await` yields the event loop, a concurrent `#tearDown()` can null
`this.#room` between the guard and the dereference, turning the
`publishData()` access into a null-deref crash (TOCTOU race).

## The fix

Snapshot `this.#room` into a local `const room` at the top of `send()` and
use that local everywhere — the guard and the `await`. This is the exact same
snapshot pattern commit `4fedfe0` applied to `stopAudio` / `stopCamera` in
this same file. Change is 4 lines.

Fixes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)