### PR TITLE
build(deps): bump pyzmq lower bound to >=27.0

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -40,7 +40,7 @@ CI matrices:
 
 ```
 xr-ai-agent  (agent-sdk/)
-    └── pyzmq >=26.0
+    └── pyzmq >=27.0
     └── msgpack >=1.0
 
 xr-ai-pipecat  (agent-sdk/xr-ai-pipecat/)
@@ -118,7 +118,7 @@ xr-ai-vad  (utils/xr-ai-vad/)
 
 xr-media-hub  (server-runtime/)
     └── xr-ai-agent  [editable: ../agent-sdk]
-    └── pyzmq >=26.0
+    └── pyzmq >=27.0
     └── livekit >=0.17
     └── livekit-api >=0.7
     └── fastapi >=0.111
@@ -169,7 +169,7 @@ cloudxr-runtime  (cloudxr-runtime/)
 
 render-mcp-server  (agent-mcp-servers/render-mcp/)
     └── xr-ai-launcher  [editable: ../../utils/xr-ai-launcher] (ManagedProcess + load_cloudxr_env)
-    └── pyzmq >=26.0       (PUSH socket → LOVR; libzmq.so reused by LOVR FFI)
+    └── pyzmq >=27.0       (PUSH socket → LOVR; libzmq.so reused by LOVR FFI)
     └── msgpack >=1.0      (wire format for LOVR ops)
     └── pyyaml >=6.0
     └── fastapi >=0.111

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -21,7 +21,7 @@ For the per-package dependency mapping, see [`DEPENDENCIES.md`](DEPENDENCIES.md)
 | Package        | Version  | License       | Upstream |
 |---             |---       |---            |---|
 | `msgpack`      | 1.0.0    | Apache-2.0    | https://github.com/msgpack/msgpack-python |
-| `pyzmq`        | 26.0.0   | BSD-3-Clause  | https://github.com/zeromq/pyzmq |
+| `pyzmq`        | 27.0.0   | BSD-3-Clause  | https://github.com/zeromq/pyzmq |
 | `uvicorn`      | 0.29.0   | BSD-3-Clause  | https://github.com/encode/uvicorn |
 | `fastapi`      | 0.111.0  | MIT           | https://github.com/fastapi/fastapi |
 | `httpx`        | 0.27.0   | BSD-3-Clause  | https://github.com/encode/httpx |

--- a/agent-mcp-servers/render-mcp/pyproject.toml
+++ b/agent-mcp-servers/render-mcp/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "uvicorn[standard]>=0.29",
     "fastmcp>=0.4",
     # render-mcp → LOVR uses ZMQ PUSH/PULL with msgpack-encoded {op, ...} frames.
-    "pyzmq>=26",
+    "pyzmq>=27.0",
     "msgpack>=1.0",
 ]
 

--- a/agent-sdk/pyproject.toml
+++ b/agent-sdk/pyproject.toml
@@ -10,7 +10,7 @@ name = "xr-ai-agent"
 version = "0.1.0"
 requires-python = ">=3.11,<3.13"
 dependencies = [
-    "pyzmq>=26.0",
+    "pyzmq>=27.0",
     "msgpack>=1.0",
 ]
 

--- a/server-runtime/pyproject.toml
+++ b/server-runtime/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     # Shared loguru setup (setup_logging + stdlib InterceptHandler)
     "xr-ai-logging",
     # IPC layer — server side uses ZMQ directly (connector + hub)
-    "pyzmq>=26.0",
+    "pyzmq>=27.0",
     # LiveKit transport
     "livekit>=0.17",
     "livekit-api>=0.7",

--- a/server-runtime/requirements.txt
+++ b/server-runtime/requirements.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # IPC layer
-pyzmq>=26.0
+pyzmq>=27.0
 msgpack>=1.0
 
 # LiveKit transport


### PR DESCRIPTION
Fixes #36

Raises the `pyzmq` floor from `>=26.0` (and the inconsistent `>=26` in render-mcp) to `>=27.0` across the repo.

## Why this is safe
pyzmq **27.0 and 27.1 introduce no breaking API changes** for the long-stable APIs this codebase uses: SUB/PUSH/PULL sockets, `setsockopt` (SUBSCRIBE/UNSUBSCRIBE/SNDHWM/LINGER/NOBLOCK), `send`/`recv`, `zmq.Again`, and `zmq.ZMQError`. The repo targets Python 3.11/3.12, which pyzmq 27 fully supports.

## Files changed
- `agent-sdk/pyproject.toml` — `"pyzmq>=26.0"` → `"pyzmq>=27.0"`
- `server-runtime/pyproject.toml` — `"pyzmq>=26.0"` → `"pyzmq>=27.0"`
- `server-runtime/requirements.txt` — `pyzmq>=26.0` → `pyzmq>=27.0`
- `agent-mcp-servers/render-mcp/pyproject.toml` — `"pyzmq>=26"` → `"pyzmq>=27.0"` (also normalizes the inconsistent format)
- `DEPENDENCIES.md` — updated the pyzmq floor for `xr-ai-agent`, `xr-media-hub`, and `render-mcp-server` (same commit, per repo convention)

## Lockfiles
The affected `uv.lock` files (`server-runtime/`, `tests/`, `agent-samples/simple-vlm-example/worker/`) already resolve pyzmq to 27.1.0 and pass `uv lock --check` with the new `>=27.0` specifier, so no lockfile changes were required.

## Caveat
Prebuilt manylinux wheels for pyzmq 27 require **glibc >= 2.28**. Any deploy environment on older glibc will build pyzmq from source instead of using a wheel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)