### PR TITLE
fix(ios): reset isCameraActive when a camera switch fails (#195)

### DIFF
--- a/client-samples/ios-visionos/App/AppModel.swift
+++ b/client-samples/ios-visionos/App/AppModel.swift
@@ -272,6 +272,10 @@ final class AppModel {
             try await session?.startCamera(config: CameraConfig(position: cameraPosition))
         } catch {
             lastError = error.localizedDescription
+            // The backend's startCamera() stops the previous track before
+            // publishing the new one, so on a failed publish nothing is
+            // streaming — reflect that instead of leaving the UI on "Streaming".
+            isCameraActive = false
         }
     }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,16 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-05 — iOS: reset isCameraActive when a camera switch fails
+
+`AppModel.switchCamera(to:)` only ran on an already-active camera and, on a
+failed publish, set `lastError` but left `isCameraActive = true`. Because the
+LiveKit backend's `startCamera()` stops the previous track before publishing
+the new one, a publish failure mid-switch left nothing streaming while the UI
+still showed "Streaming" with a green status and a working Stop button. The
+`catch` now sets `isCameraActive = false`, matching the consistency that
+`startCamera()`/`stopCamera()` already maintain. Fixes #195.
+
 ### 2026-06-05 — piper voice fetch: catch LocalEntryNotFoundError before EntryNotFoundError
 
 Follow-up to #184. That PR added a dedicated `_EXIT_VOICE_UNAVAILABLE = 3`


### PR DESCRIPTION
Fixes #195.

## Problem
On iOS/visionOS, `AppModel.switchCamera(to:)` (`client-samples/ios-visionos/App/AppModel.swift`) is only entered when the camera is already active and calls the backend's `startCamera()`. The LiveKit backend's `startCamera()` first `stopCamera()`s the previous track (unpublish + `localCameraTrack = nil`), then publishes the new one.

If the publish step throws (device busy mid-switch, transient capture error), the old camera is already torn down and the new one is not published — but `switchCamera`'s `catch` only set `lastError` and left `isCameraActive == true`. The UI then shows **"Streaming"** with a green status and a working Stop button, while nothing is published and the preview is blank.

## Fix
Set `isCameraActive = false` in the `catch` (the backend has already stopped the previous camera at that point), matching the state consistency `startCamera()`/`stopCamera()` already maintain.

```swift
} catch {
    lastError = error.localizedDescription
    isCameraActive = false   // backend already stopped the old track; nothing is streaming
}
```

## Notes
- One-line behavioral fix in the catch; no API/dependency changes (`DEPENDENCIES.md` untouched).
- No Swift unit-test harness in CI; verification is on-device — trigger a camera switch that fails mid-publish and confirm the UI drops to "Idle" (not stuck on "Streaming").
- Changelog updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)