### PR TITLE
fix(stt-server): serialize NeMo transcribe() on the shared model (#199)

### DIFF
--- a/ai-services/stt-server/stt_server/__main__.py
+++ b/ai-services/stt-server/stt_server/__main__.py
@@ -100,8 +100,15 @@ class _AsrBackend:
         """Synchronous. Call from a thread pool."""
         self._ensure_loaded()
         import torch
-        with torch.inference_mode():
-            results = self._model.transcribe([audio_path], verbose=False)
+        # NeMo ASR .transcribe() is not re-entrant/thread-safe (shared model
+        # buffers and, on CUDA, shared device state), and the endpoint
+        # dispatches each request to a thread pool — serialize inference on the
+        # shared model, mirroring the magpie TTS backend. _ensure_loaded() runs
+        # BEFORE acquiring the lock because _lock is non-reentrant and
+        # _ensure_loaded() takes it itself (the post-load fast path is lock-free).
+        with self._lock:
+            with torch.inference_mode():
+                results = self._model.transcribe([audio_path], verbose=False)
         # NeMo returns a list of strings (or Hypothesis objects).
         if not results:
             return ""

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,18 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-05 — STT: serialize NeMo transcribe() on the shared model
+
+`_AsrBackend._lock` guarded only model *loading*; the hot path `transcribe()`
+ran `self._model.transcribe(...)` lock-free. The endpoint dispatches each
+`POST /v1/audio/transcriptions` to a thread pool, so concurrent requests
+invoked inference on the same NeMo `ASRModel` simultaneously — which is not
+re-entrant/thread-safe (shared model buffers, shared CUDA device state),
+risking garbled transcriptions or a crash under load. Inference is now wrapped
+in the existing lock, mirroring the magpie TTS backend's stated serialization.
+`_ensure_loaded()` still runs before the lock (it takes the same non-reentrant
+lock for the one-time load). Fixes #199.
+
 ### 2026-06-05 — piper voice fetch: catch LocalEntryNotFoundError before EntryNotFoundError
 
 Follow-up to #184. That PR added a dedicated `_EXIT_VOICE_UNAVAILABLE = 3`


### PR DESCRIPTION
Fixes #199.

## Problem
In `ai-services/stt-server/stt_server/__main__.py`, `_AsrBackend._lock` guards only model **loading** (`_ensure_loaded`). The hot path `transcribe()` called `self._model.transcribe([audio_path])` **lock-free**. The endpoint dispatches each `POST /v1/audio/transcriptions` to the default `ThreadPoolExecutor` via `run_in_executor(None, _run)`, so two concurrent requests invoke `transcribe()` on the same NeMo `ASRModel` simultaneously.

NeMo ASR `.transcribe()` is not re-entrant/thread-safe (shared model buffers and, on CUDA, shared device state). The magpie TTS backend explicitly serializes synthesis for the same reason; STT had the equivalent risk with no guard → garbled transcriptions or a crash under concurrent load.

## Fix
Wrap inference in the existing `self._lock`, mirroring magpie:

```python
self._ensure_loaded()
with self._lock:
    with torch.inference_mode():
        results = self._model.transcribe([audio_path], verbose=False)
```

`_ensure_loaded()` runs **before** acquiring the lock — `_lock` is non-reentrant and `_ensure_loaded()` takes it for the one-time load (post-load fast path is lock-free), so there's no deadlock and concurrent first-calls serialize correctly.

## Notes
- Mirrors the established pattern in `ai-services/tts/magpie/magpie_tts_server/__main__.py` (`synthesize`).
- No API/dependency changes (`DEPENDENCIES.md` untouched).
- Serialization is the correct trade-off here: a single shared model can't run true concurrent inference safely anyway; this removes the corruption/crash risk. Throughput-via-replicas is a separate, larger change.
- Changelog updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)