### PR TITLE
fix(hub): release held slots before closing a re-registered ring (#197)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,20 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-05 — Hub: release held slots before closing a re-registered ring
+
+On `CONNECTOR_REGISTER` for a known `connector_id`, `_handle_registration`
+closed and replaced the ring buffer while `_latest_slots` could still hold
+`SlotView`s backed by that ring's mmap. Because a live `SlotView` keeps a
+sliced memoryview exported, `ShmRingBuffer.close()`'s `self._buf.release()`
+raises `BufferError` — leaving the old ring half-closed but still referenced,
+so the next `FRAME_SIGNAL` writes through a released/closing buffer
+(use-after-close). `_handle_registration` now releases the memoryview and slot
+for every `_latest_slots` entry backed by the old ring before closing it,
+matching the teardown order already in `close()`. Triggered by a connector
+crash/reconnect that re-sends its registration while frames are held.
+Regression test: `test_connector_reregistration_releases_held_slots`. Fixes #197.
+
 ### 2026-06-05 — piper voice fetch: catch LocalEntryNotFoundError before EntryNotFoundError
 
 Follow-up to #184. That PR added a dedicated `_EXIT_VOICE_UNAVAILABLE = 3`

--- a/server-runtime/xr_media_hub/ipc/_hub.py
+++ b/server-runtime/xr_media_hub/ipc/_hub.py
@@ -329,7 +329,19 @@ class HubEndpoint:
     def _handle_registration(self, reg: ConnectorRegistration) -> None:
         if reg.connector_id in self._ring_registry:
             logger.warning("Connector {} re-registered — replacing ring buffer", reg.connector_id)
-            self._ring_registry[reg.connector_id].close()
+            old_ring = self._ring_registry[reg.connector_id]
+            # Drop any frames still held in the old ring BEFORE closing it.
+            # A live SlotView keeps a sliced memoryview exported into the ring's
+            # mmap; closing with that outstanding makes ShmRingBuffer.close()'s
+            # self._buf.release() raise BufferError, and leaves _latest_slots
+            # referencing a half-closed ring whose slot the next FRAME_SIGNAL
+            # would write through (#197). Release the memoryview before the slot
+            # and close, matching the teardown order in close().
+            for key in [k for k, (ring, _) in self._latest_slots.items() if ring is old_ring]:
+                _, view = self._latest_slots.pop(key)
+                view.data.release()
+                old_ring.release_slot(view.signal.slot)
+            old_ring.close()
         try:
             self._ring_registry[reg.connector_id] = ShmRingBuffer(
                 name=reg.shm_name, create=False,

--- a/tests/test_participant_events.py
+++ b/tests/test_participant_events.py
@@ -123,3 +123,40 @@ async def test_participant_leave_releases_held_slots(hub, make_connector, settle
 
     # The most recent frame for ("fresh", "cam") should be the one held.
     assert ("fresh", "cam") in hub._latest_slots
+
+
+async def test_connector_reregistration_releases_held_slots(hub, make_connector, settle):
+    """Regression for #197: when a connector re-registers while a frame is
+    still held, the hub must release the slots backed by the old ring BEFORE
+    closing it. Otherwise the still-exported SlotView memoryview makes
+    ``ShmRingBuffer.close()``'s ``_buf.release()`` raise (leaving the ring
+    half-closed) and ``_latest_slots`` keeps pointing at it — a use-after-close
+    on the next frame for that participant."""
+    conn = make_connector()
+    await conn.register()
+    await settle()
+
+    await conn.notify_participant_joined("alice", pts_us=1)
+    await settle()
+    await conn.push_frame(
+        data=_FRAME, width=_W, height=_H, fmt=PixelFormat.I420,
+        pts_us=1, participant_id="alice", track_id="cam",
+    )
+    await settle()
+    assert ("alice", "cam") in hub._latest_slots  # frame held in the ring
+
+    # Re-register the same connector (crash/reconnect while a frame is held).
+    # Pre-fix: the held slot is left dangling and close() raises BufferError
+    # (swallowed by the run loop), so the stale entry survives. Post-fix: the
+    # held slot is released and dropped before the old ring is closed.
+    await conn.register()
+    await settle()
+    assert ("alice", "cam") not in hub._latest_slots
+
+    # And the hub is still healthy — a fresh frame after re-registration lands.
+    await conn.push_frame(
+        data=_FRAME, width=_W, height=_H, fmt=PixelFormat.I420,
+        pts_us=2, participant_id="alice", track_id="cam",
+    )
+    await settle()
+    assert ("alice", "cam") in hub._latest_slots


### PR DESCRIPTION
Fixes #197.

## Problem
In `server-runtime/xr_media_hub/ipc/_hub.py`, on `MsgType.CONNECTOR_REGISTER` for an already-known `connector_id`, `_handle_registration` calls `self._ring_registry[id].close()` and replaces the entry — but `_latest_slots` may still hold `SlotView`s backed by that ring's mmap.

A live `SlotView` keeps a *sliced* memoryview exported into the ring's buffer, so `ShmRingBuffer.close()`'s `self._buf.release()` raises `BufferError` (it's the `release()` on line 169, ahead of the `try/except` that only wraps `_shm.close()`). The old ring is left half-closed but still referenced by `_latest_slots`; the next `FRAME_SIGNAL` for that participant pops the stale entry and `release_slot()`s on that ring → write through a released/closing mmap (undefined behavior / corruption).

**Trigger:** a connector crashes/reconnects and re-sends its registration while frames are still held.

## Fix
Before closing the old ring, release every `_latest_slots` entry backed by it — `view.data.release()` then `release_slot()` then drop the entry — then `close()`. This matches the teardown order already used in `HubEndpoint.close()` (release the exported memoryview *before* closing so the mmap has no exported pointers):

```python
old_ring = self._ring_registry[reg.connector_id]
for key in [k for k, (ring, _) in self._latest_slots.items() if ring is old_ring]:
    _, view = self._latest_slots.pop(key)
    view.data.release()
    old_ring.release_slot(view.signal.slot)
old_ring.close()
```

## Test
`tests/test_participant_events.py::test_connector_reregistration_releases_held_slots` — register, join, push a frame (slot held), re-register the same connector, and assert the held slot was released (no stale `_latest_slots` entry) and that a fresh frame still lands afterward. Mirrors the existing `test_participant_leave_releases_held_slots` (#143).

## Notes
- No API/dependency changes (`DEPENDENCIES.md` untouched). Changelog updated.
- Same single-process, single-loop assumptions as the rest of the hub (no new locking introduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)