### PR TITLE
fix(piper-tts): valid empty WAV on empty/whitespace input (#194)

### DIFF
--- a/ai-services/tts/piper/piper_tts_server/__main__.py
+++ b/ai-services/tts/piper/piper_tts_server/__main__.py
@@ -180,7 +180,17 @@ class _PiperBackend:
         self._ensure_loaded()
         buf = io.BytesIO()
         with wave.open(buf, "wb") as wf:
-            self._voice.synthesize_wav(text, wf)
+            if text.strip():
+                self._voice.synthesize_wav(text, wf)
+            else:
+                # Empty/whitespace input yields no synthesized chunks, and
+                # Piper's synthesize_wav sets the WAV format params only on the
+                # first chunk — so they'd never be set and wave.close() would
+                # raise "# channels not specified" (→ unhandled HTTP 500, #194).
+                # Emit a valid, empty (silent) WAV instead, matching magpie.
+                wf.setnchannels(1)
+                wf.setsampwidth(2)
+                wf.setframerate(self.sample_rate)
         return buf.getvalue()
 
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,19 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-05 — Piper TTS: valid empty WAV on empty/whitespace input
+
+`_PiperBackend.synthesize` returned an HTTP 500 for empty/whitespace input.
+Piper's `synthesize_wav` sets the WAV format params only on the first
+synthesized chunk; empty input produces no chunks, so the params were never
+set and `wave.close()` raised `wave.Error: # channels not specified`, which
+propagated out of the `/v1/audio/speech` handler unhandled. `synthesize` now
+short-circuits empty/whitespace input to a valid, empty (silent) WAV — header
+params set, zero audio frames — matching the magpie backend (whose `sf.write`
+already emits a valid header for empty audio). The non-empty path is
+unchanged. Regression covered by the piper smoke test (`test_piper_tts_smoke`
+now also POSTs whitespace input and asserts a 200 + WAV header). Fixes #194.
+
 ### 2026-06-05 — piper voice fetch: catch LocalEntryNotFoundError before EntryNotFoundError
 
 Follow-up to #184. That PR added a dedicated `_EXIT_VOICE_UNAVAILABLE = 3`

--- a/tests/test_piper_tts.py
+++ b/tests/test_piper_tts.py
@@ -208,6 +208,12 @@ async def test_piper_tts_smoke(tmp_path: Path) -> None:
         body = await asyncio.get_running_loop().run_in_executor(
             None, _post_speech, port, voice, "Hello, world.",
         )
+        # Regression #194: whitespace-only input must return a valid (empty)
+        # WAV, not an HTTP 500 (wave.Error: # channels not specified).
+        # _post_speech asserts status 200, so a 500 here fails the test.
+        empty_body = await asyncio.get_running_loop().run_in_executor(
+            None, _post_speech, port, voice, "   ",
+        )
     finally:
         if proc.poll() is None:
             proc.send_signal(signal.SIGTERM)
@@ -219,3 +225,7 @@ async def test_piper_tts_smoke(tmp_path: Path) -> None:
 
     assert body, "empty response body"
     assert body[:4] == b"RIFF", f"expected WAV RIFF header, got {body[:8]!r}"
+    # Whitespace-only input → a valid WAV header (zero audio frames), not a 500.
+    assert empty_body[:4] == b"RIFF", (
+        f"expected WAV for whitespace input, got {empty_body[:8]!r}"
+    )


### PR DESCRIPTION
Fixes #194.

## Problem
`_PiperBackend.synthesize` (`ai-services/tts/piper/piper_tts_server/__main__.py`, reached via `/v1/audio/speech`) returned an unhandled **HTTP 500** on empty/whitespace input. Piper's `synthesize_wav` sets the WAV format params (`setnchannels`/`setsampwidth`/`setframerate`) only inside its per-chunk loop, on the first chunk. For empty input there are no chunks, so the params are never set and `wave.close()` raises `wave.Error: # channels not specified` — which propagates out of `run_in_executor` into the async handler with no try/except → 500.

(Magpie doesn't share this: `sf.write` emits a valid header even for empty audio.)

## Fix
Short-circuit empty/whitespace input to a valid, empty (silent) WAV — set the header params and write no frames — matching magpie's behavior. The non-empty path is byte-for-byte unchanged:

```python
with wave.open(buf, "wb") as wf:
    if text.strip():
        self._voice.synthesize_wav(text, wf)
    else:
        wf.setnchannels(1)
        wf.setsampwidth(2)
        wf.setframerate(self.sample_rate)
```

I chose "return a valid empty WAV" over "400 on empty input" because the sample TTS pipelines batch synthesis per sentence and can occasionally emit whitespace; a graceful empty WAV avoids turning that into client-visible errors, and matches the magpie contract.

## Test
`tests/test_piper_tts.py::test_piper_tts_smoke` now also POSTs whitespace-only input and asserts a `200` + `RIFF` WAV header (`_post_speech` asserts status 200, so a 500 fails the test). Runs end-to-end against the real server, under the same voice-availability gating as the rest of the smoke test.

## Notes
- No API/dependency changes (`DEPENDENCIES.md` untouched). Changelog updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)