### PR TITLE
fix(magpie-tts): honor the launcher --ready-file contract (#191)

### DIFF
--- a/ai-services/tts/magpie/magpie_tts_server/__main__.py
+++ b/ai-services/tts/magpie/magpie_tts_server/__main__.py
@@ -157,7 +157,7 @@ def _build_app(cfg: dict, model_cache: Path):
     return app, backend
 
 
-async def _run(cfg: dict, yaml_dir: Path) -> None:
+async def _run(cfg: dict, yaml_dir: Path, ready_file: Path | None = None) -> None:
     import uvicorn
 
     if not cfg.get("model"):
@@ -182,6 +182,11 @@ async def _run(cfg: dict, yaml_dir: Path) -> None:
     server = uvicorn.Server(config)
 
     logger.info("Ready  →  http://localhost:{}/v1", port)
+    # Signal readiness to the launcher AFTER the model is loaded (above) so
+    # _wait_ready unblocks. Without this the launcher blocks forever — the
+    # process stays alive serving, so it never appears via proc.poll() either.
+    if ready_file:
+        ready_file.touch()
     await server.serve()
     logger.info("Stopped.")
 
@@ -193,7 +198,8 @@ def run() -> None:
     setup_logging("tts-magpie")
 
     p = argparse.ArgumentParser(add_help=False)
-    p.add_argument("--config", type=Path, default=None)
+    p.add_argument("--config",     type=Path, default=None)
+    p.add_argument("--ready-file", type=Path, default=None)
     ns, _ = p.parse_known_args()
 
     cfg: dict = {}
@@ -203,7 +209,7 @@ def run() -> None:
         with open(ns.config) as f:
             cfg = yaml.safe_load(f) or {}
 
-    asyncio.run(_run(cfg, yaml_dir))
+    asyncio.run(_run(cfg, yaml_dir, ready_file=ns.ready_file))
 
 
 if __name__ == "__main__":

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,18 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-05 — Magpie TTS: honor the launcher's --ready-file contract
+
+The launcher injects `--ready-file <path>` into every spawned process and
+blocks in `_wait_ready` (no timeout) until that file appears or the process
+exits. Piper and STT touch it after their model loads; Magpie didn't — `run()`
+only registered `--config`, so `--ready-file` landed in the ignored unknowns
+and `_run` never created the file. Magpie then stays alive serving, so
+`proc.poll()` stays `None` too — the launcher deadlocked at startup on the
+Magpie TTS service. Mirrored piper/stt: register `--ready-file`, thread it
+into `_run`, and `ready_file.touch()` after `_ensure_loaded()` completes
+(before `server.serve()`). Fixes #191.
+
 ### 2026-06-05 — piper voice fetch: catch LocalEntryNotFoundError before EntryNotFoundError
 
 Follow-up to #184. That PR added a dedicated `_EXIT_VOICE_UNAVAILABLE = 3`


### PR DESCRIPTION
Fixes #191.

## Problem
The launcher (`utils/xr-ai-launcher/xr_ai_launcher/_stack.py`) injects `--ready-file <path>` into **every** spawned process and then blocks in `_wait_ready` — with **no timeout** — until that file appears or the process exits. Piper and STT register `--ready-file` and `touch()` it after their model loads. Magpie's `run()` only registered `--config`, so `--ready-file <path>` fell into `parse_known_args`'s ignored unknowns and `_run` never created the file. Magpie then stays alive serving (`await server.serve()`), so `proc.poll()` stays `None` too → **startup deadlocks** on the Magpie TTS service.

## Fix
Mirror the piper/stt pattern:
- register `p.add_argument("--ready-file", type=Path, default=None)`
- thread `ready_file=ns.ready_file` into `_run`
- `if ready_file: ready_file.touch()` after `backend._ensure_loaded()` completes, before `server.serve()`

```python
logger.info("Ready  →  http://localhost:{}/v1", port)
if ready_file:
    ready_file.touch()
await server.serve()
```

## Notes
- 3-line change mirroring the proven piper/stt readiness handling; no API/dependency changes (`DEPENDENCIES.md` untouched). Changelog updated.
- No automated test: there is no Magpie smoke test (it's a heavy GPU/NeMo service, unlike the CPU Piper one), so exercising readiness would require the Magpie venv + model + GPU in CI. The fix is a direct mirror of the already-tested piper/stt path; on-stack verification is launching a sample that uses Magpie TTS and confirming the stack no longer hangs at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)