### PR TITLE
fix(pipecat): downmix multi-channel hub audio before resampling (#193)

### DIFF
--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/transport.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/transport.py
@@ -18,6 +18,7 @@ import time
 
 import numpy as np
 from loguru import logger
+from scipy.signal import resample_poly
 from pipecat.frames.frames import (
     CancelFrame,
     EndFrame,
@@ -71,9 +72,12 @@ def _hub_pcm_to_mono_16k(pcm_int16: bytes, channels: int, sample_rate: int) -> b
         return pcm_int16  # common case — already mono 16 kHz, no work
     audio = np.frombuffer(pcm_int16, dtype=np.int16)
     if channels > 1:
-        audio = audio.reshape(-1, channels).mean(axis=1)
+        # Each interleaved frame is `channels` int16 samples; a complete hub
+        # chunk is always a whole number of frames. Truncate any trailing
+        # partial frame defensively so reshape can't raise on a malformed chunk.
+        usable = (audio.size // channels) * channels
+        audio = audio[:usable].reshape(-1, channels).mean(axis=1)
     if sample_rate != SAMPLE_RATE:
-        from scipy.signal import resample_poly
         audio = resample_poly(audio.astype(np.float64), SAMPLE_RATE, sample_rate)
     return np.clip(np.round(audio), -32768, 32767).astype(np.int16).tobytes()
 

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/transport.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/transport.py
@@ -59,6 +59,25 @@ def _int16_to_float32(data: bytes) -> bytes:
     return (i16.astype(np.float32) / 32767.0).tobytes()
 
 
+def _hub_pcm_to_mono_16k(pcm_int16: bytes, channels: int, sample_rate: int) -> bytes:
+    """Convert hub int16 PCM to mono 16 kHz int16 for the (mono) STT path.
+
+    The hub delivers *interleaved* samples for multi-channel audio (L R L R …).
+    Downmix to mono BEFORE resampling: passing an interleaved buffer straight to
+    ``resample_poly`` treats it as one stream, mixing adjacent L/R samples and
+    destroying channel alignment (#193). STT is mono, so we average channels.
+    """
+    if channels == 1 and sample_rate == SAMPLE_RATE:
+        return pcm_int16  # common case — already mono 16 kHz, no work
+    audio = np.frombuffer(pcm_int16, dtype=np.int16)
+    if channels > 1:
+        audio = audio.reshape(-1, channels).mean(axis=1)
+    if sample_rate != SAMPLE_RATE:
+        from scipy.signal import resample_poly
+        audio = resample_poly(audio.astype(np.float64), SAMPLE_RATE, sample_rate)
+    return np.clip(np.round(audio), -32768, 32767).astype(np.int16).tobytes()
+
+
 # ── Input ─────────────────────────────────────────────────────────────────────
 
 class XRMediaHubInputTransport(BaseInputTransport):
@@ -100,18 +119,13 @@ class XRMediaHubInputTransport(BaseInputTransport):
     async def _on_hub_audio(self, chunk: AudioChunk) -> None:
         if not self._started:
             return
-        pcm_int16 = _float32_to_int16(chunk.data)
-        if chunk.sample_rate != SAMPLE_RATE:
-            from scipy.signal import resample_poly
-            audio_array = np.frombuffer(pcm_int16, dtype=np.int16).astype(np.float64)
-            audio_array = resample_poly(
-                audio_array, SAMPLE_RATE, chunk.sample_rate,
-            ).astype(np.int16)
-            pcm_int16 = audio_array.tobytes()
+        pcm_int16 = _hub_pcm_to_mono_16k(
+            _float32_to_int16(chunk.data), chunk.channels, chunk.sample_rate,
+        )
         frame = InputAudioRawFrame(
             audio=pcm_int16,
             sample_rate=SAMPLE_RATE,
-            num_channels=chunk.channels,
+            num_channels=NUM_CHANNELS,
         )
         # pipecat's ``transport_source`` is the standard "which input
         # track did this come from" hook — set it to the hub-side

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,18 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-05 — pipecat input transport: downmix multi-channel hub audio before resampling
+
+`XRMediaHubInputTransport._on_hub_audio` resampled non-16 kHz hub audio by
+passing the int16 PCM straight to `resample_poly` as a 1-D array. For
+multi-channel chunks the hub delivers *interleaved* samples (L R L R …), so
+the polyphase filter mixed adjacent L/R samples and produced the wrong output
+length — corrupting stereo+ audio before STT (the mono common case was fine,
+hence latent). Extracted `_hub_pcm_to_mono_16k`, which downmixes to mono
+(channel mean) *before* resampling — STT is mono anyway — and the frame is now
+emitted with `num_channels=1`. The mono-16 kHz common case is a byte-identical
+fast path. Regression test: `tests/test_pipecat_audio_resample.py`. Fixes #193.
+
 ### 2026-06-05 — piper voice fetch: catch LocalEntryNotFoundError before EntryNotFoundError
 
 Follow-up to #184. That PR added a dedicated `_EXIT_VOICE_UNAVAILABLE = 3`

--- a/tests/test_pipecat_audio_resample.py
+++ b/tests/test_pipecat_audio_resample.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Regression coverage for #193: hub multi-channel audio must be downmixed to
+mono BEFORE resampling. Resampling an interleaved (L R L R …) buffer as a
+single stream mixes adjacent channels and yields the wrong sample count.
+
+Tests the pure helper ``_hub_pcm_to_mono_16k`` — no pipeline/transport needed.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from xr_ai_pipecat.transport import SAMPLE_RATE, _hub_pcm_to_mono_16k
+
+
+def test_mono_16k_is_byte_identical_passthrough() -> None:
+    pcm = np.array([1, -2, 3, -4, 5], dtype=np.int16).tobytes()
+    assert _hub_pcm_to_mono_16k(pcm, 1, SAMPLE_RATE) == pcm
+
+
+def test_stereo_downmix_averages_channels() -> None:
+    # Interleaved L R: (100,200),(100,200) → mono mean 150,150 (no resample).
+    pcm = np.array([100, 200, 100, 200], dtype=np.int16).tobytes()
+    out = np.frombuffer(_hub_pcm_to_mono_16k(pcm, 2, SAMPLE_RATE), dtype=np.int16)
+    assert out.tolist() == [150, 150]
+
+
+def test_mono_resample_48k_to_16k_length_and_value() -> None:
+    # 480 mono samples @48k → ~160 @16k; a constant signal stays ~constant.
+    src = np.full(480, 500, dtype=np.int16).tobytes()
+    out = np.frombuffer(_hub_pcm_to_mono_16k(src, 1, 48_000), dtype=np.int16)
+    assert 150 <= len(out) <= 170
+    assert abs(int(out[len(out) // 2]) - 500) <= 5
+
+
+def test_stereo_48k_downmixes_to_mono_16k_not_interleaved() -> None:
+    # 480 interleaved STEREO frames @48k. Correct: downmix → 480 mono @48k →
+    # ~160 @16k. The #193 bug resampled the 960-value interleaved buffer as one
+    # stream → ~320 samples (and mislabeled them stereo). The sample COUNT is
+    # the discriminator: ~160 (fixed) vs ~320 (buggy).
+    inter = np.empty(480 * 2, dtype=np.int16)
+    inter[0::2] = 700  # L
+    inter[1::2] = 700  # R
+    out = np.frombuffer(
+        _hub_pcm_to_mono_16k(inter.tobytes(), 2, 48_000), dtype=np.int16,
+    )
+    assert 150 <= len(out) <= 170, f"expected ~160 mono samples, got {len(out)}"
+    assert abs(int(out[len(out) // 2]) - 700) <= 5


### PR DESCRIPTION
Fixes #193.

## Problem
`XRMediaHubInputTransport._on_hub_audio` (`agent-sdk/xr-ai-pipecat/xr_ai_pipecat/transport.py`) resampled non-16 kHz hub audio by converting the int16 PCM to a 1-D array and passing it straight to `resample_poly(..., SAMPLE_RATE, chunk.sample_rate)`. For `chunk.channels > 1` the hub delivers **interleaved** samples (`L R L R …`), but `resample_poly` treats the whole interleaved buffer as one mono stream — the polyphase filter mixes adjacent L/R samples and the output length is no longer a clean multiple of the channel count, destroying channel alignment. The frame was then built with `num_channels=chunk.channels`, so garbage reached STT. The mono case (the common `audio_in_channels=1`) was correct, which is why this was latent.

## Fix
Extract a pure `_hub_pcm_to_mono_16k(pcm, channels, sample_rate)` that **downmixes to mono (channel mean) before resampling** — STT (and VAD) are mono — and emit the frame with `num_channels=1`:

```python
if channels == 1 and sample_rate == SAMPLE_RATE:
    return pcm_int16                      # common case — byte-identical fast path
audio = np.frombuffer(pcm_int16, np.int16)
if channels > 1:
    audio = audio.reshape(-1, channels).mean(axis=1)   # downmix FIRST
if sample_rate != SAMPLE_RATE:
    audio = resample_poly(audio.astype(np.float64), SAMPLE_RATE, sample_rate)
return np.clip(np.round(audio), -32768, 32767).astype(np.int16).tobytes()
```

## Test — `tests/test_pipecat_audio_resample.py`
- mono 16 kHz → byte-identical passthrough
- stereo 16 kHz → averaged mono (`100,200 → 150`)
- mono 48 kHz → ~160 samples @16 kHz, value preserved
- **stereo 48 kHz → ~160 mono samples** (the fix) rather than ~320 (the interleaved-as-mono bug) — the sample count is the discriminator.

Validated locally with numpy+scipy: fixed path = 160 samples, buggy interleaved-as-mono = 320.

## Notes
- No API/dependency changes (`DEPENDENCIES.md` untouched; numpy/scipy already deps of xr-ai-pipecat). Changelog updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)