### PR TITLE
Prevent mic startup timeout for AVP

### DIFF
--- a/client-samples/ios-visionos/App/AppModel.swift
+++ b/client-samples/ios-visionos/App/AppModel.swift
@@ -148,6 +148,7 @@ final class AppModel {
             self.connectionState = state
             if state == .disconnected {
                 self.isAudioActive = false
+                self.isAudioStarting = false
                 self.isCameraActive = false
                 self.agentStatus = nil
                 self.agentResponse = nil
@@ -199,6 +200,7 @@ final class AppModel {
         agentStatus = nil
         agentResponse = nil
         isAudioActive = false
+        isAudioStarting = false
         isCameraActive = false
     }
 

--- a/client-samples/ios-visionos/App/AppModel.swift
+++ b/client-samples/ios-visionos/App/AppModel.swift
@@ -108,6 +108,7 @@ final class AppModel {
     /// Mirrors the web client's Agent panel; nil shows the "Waiting for agent..." placeholder.
     var agentResponse: String?
     var isAudioActive = false
+    private(set) var isAudioStarting = false
     var isCameraActive = false
     private var isCameraStarting = false
     var isConnecting = false
@@ -204,11 +205,19 @@ final class AppModel {
     // MARK: - Audio
 
     func startAudio() async {
+        guard !isAudioStarting, !isAudioActive else { return }
+        isAudioStarting = true
+        defer { isAudioStarting = false }
+
         do {
             try await session?.startAudio(config: AudioConfig(mode: audioMode))
             isAudioActive = true
         } catch {
-            lastError = error.localizedDescription
+            #if DEBUG
+            let ns = error as NSError
+            print("startAudio failed: \(type(of: error)) \(ns.domain) #\(ns.code) — \(error)")
+            #endif
+            lastError = "Microphone couldn’t start — please try again."
         }
     }
 

--- a/client-samples/ios-visionos/App/ContentView.swift
+++ b/client-samples/ios-visionos/App/ContentView.swift
@@ -175,7 +175,7 @@ struct ContentView: View {
             Text("Software (AEC on)").tag(AudioConfig.MicrophoneMode.softwareProcessing)
             Text("Raw (no DSP)").tag(AudioConfig.MicrophoneMode.raw)
         }
-        .disabled(!isConnected || model.isAudioActive)
+        .disabled(!isConnected || model.isAudioActive || model.isAudioStarting)
 
         LabeledContent("Microphone") {
             HStack {
@@ -191,7 +191,7 @@ struct ContentView: View {
                         Task { await model.startAudio() }
                     }
                     .buttonStyle(.bordered)
-                    .disabled(!isConnected)
+                    .disabled(!isConnected || model.isAudioStarting)
                 }
             }
         }
@@ -199,6 +199,7 @@ struct ContentView: View {
 
     private var micStatusLabel: String {
         if model.isAudioActive { return "Live" }
+        if model.isAudioStarting { return "Starting…" }
         return model.connectionState == .connected ? "Idle" : "Not connected"
     }
 

--- a/client-samples/ios-visionos/README.md
+++ b/client-samples/ios-visionos/README.md
@@ -263,6 +263,27 @@ now forwards `Authorization` (and every other end-to-end header) on both
 the `/rtc/validate` HTTP shim and the `/rtc[/<version>]` WebSocket. No
 client-side action needed.
 
+### Microphone fails to start with a "Timed out" error
+
+If tapping **Start** under Microphone occasionally fails — the SDK throws
+`io.livekit.swift-sdk Code=101 "Timed out"` after ~5s — the LiveKit recording
+engine didn't start, so the publish's frame watcher never saw a buffer. The
+CoreAudio `-50` and `FigAudioSession err=-19224` lines that show up around the
+same time are benign; they appear on successful starts too.
+
+**Fix:** `LiveKitBackend.startAudio` pre-warms the recording engine
+(`AudioManager.shared.setRecordingAlwaysPreparedMode(true)`) before publishing,
+so a frame is available immediately and the publish completes. No client action
+needed — it's built in.
+
+### Orange mic indicator stays lit after stopping audio
+
+Prepared mode keeps the engine input hot for fast re-enable, which the OS reads
+as the mic still being in use. `LiveKitBackend.stopAudio` now drops prepared
+mode and disables engine *input* while leaving *output* up (so the agent can
+still be heard); the dot clears while you stay connected, and is fully released
+on disconnect.
+
 ---
 
 ## Quick-start usage

--- a/client-samples/ios-visionos/StreamKit/Sources/StreamKit/Backends/LiveKit/LiveKitBackend.swift
+++ b/client-samples/ios-visionos/StreamKit/Sources/StreamKit/Backends/LiveKit/LiveKitBackend.swift
@@ -146,8 +146,20 @@ public final class LiveKitBackend: NSObject, StreamingBackend, FrameInjectable, 
         // frame watcher never sees a buffer and times out. Reset availability
         // first because stopAudio pins input down, and prepared mode can't
         // start a disabled engine.
-        try? AudioManager.shared.setEngineAvailability(.default)
-        try? await AudioManager.shared.setRecordingAlwaysPreparedMode(true)
+        do {
+            try AudioManager.shared.setEngineAvailability(.default)
+        } catch {
+            #if DEBUG
+            print("startAudio: setEngineAvailability(.default) failed: \(error)")
+            #endif
+        }
+        do {
+            try await AudioManager.shared.setRecordingAlwaysPreparedMode(true)
+        } catch {
+            #if DEBUG
+            print("startAudio: setRecordingAlwaysPreparedMode(true) failed: \(error)")
+            #endif
+        }
 
         do {
             let captureOptions = AudioCaptureOptions(from: config)

--- a/client-samples/ios-visionos/StreamKit/Sources/StreamKit/Backends/LiveKit/LiveKitBackend.swift
+++ b/client-samples/ios-visionos/StreamKit/Sources/StreamKit/Backends/LiveKit/LiveKitBackend.swift
@@ -144,8 +144,8 @@ public final class LiveKitBackend: NSObject, StreamingBackend, FrameInjectable, 
 
         // Pre-warm the recording engine before publishing, or the publish's
         // frame watcher never sees a buffer and times out. Reset availability
-        // first — stopAudio pins input down, and prepared mode can't start a
-        // disabled engine.
+        // first because stopAudio pins input down, and prepared mode can't
+        // start a disabled engine.
         try? AudioManager.shared.setEngineAvailability(.default)
         try? await AudioManager.shared.setRecordingAlwaysPreparedMode(true)
 

--- a/client-samples/ios-visionos/StreamKit/Sources/StreamKit/Backends/LiveKit/LiveKitBackend.swift
+++ b/client-samples/ios-visionos/StreamKit/Sources/StreamKit/Backends/LiveKit/LiveKitBackend.swift
@@ -142,16 +142,38 @@ public final class LiveKitBackend: NSObject, StreamingBackend, FrameInjectable, 
             throw StreamError.notConnected
         }
 
-        let captureOptions = AudioCaptureOptions(from: config)
-        try await room.localParticipant.setMicrophone(
-            enabled: true,
-            captureOptions: captureOptions
-        )
+        // Pre-warm the recording engine before publishing, or the publish's
+        // frame watcher never sees a buffer and times out. Reset availability
+        // first — stopAudio pins input down, and prepared mode can't start a
+        // disabled engine.
+        try? AudioManager.shared.setEngineAvailability(.default)
+        try? await AudioManager.shared.setRecordingAlwaysPreparedMode(true)
+
+        do {
+            let captureOptions = AudioCaptureOptions(from: config)
+            try await room.localParticipant.setMicrophone(
+                enabled: true,
+                captureOptions: captureOptions
+            )
+        } catch {
+            // A failed publish must not leave the engine hot, or the mic
+            // indicator stays lit with no way to clear it but disconnecting.
+            await releaseRecordingEngine()
+            throw error
+        }
     }
 
     public func stopAudio() async throws {
         guard let room else { return }
-        try await room.localParticipant.setMicrophone(enabled: false)
+        let micError: Error?
+        do {
+            try await room.localParticipant.setMicrophone(enabled: false)
+            micError = nil
+        } catch {
+            micError = error
+        }
+        await releaseRecordingEngine()
+        if let micError { throw micError }
     }
 
     // MARK: - StreamingBackend: camera
@@ -283,6 +305,16 @@ public final class LiveKitBackend: NSObject, StreamingBackend, FrameInjectable, 
     }
 
     // MARK: - Private helpers
+
+    /// Roll the recording engine back to its idle state: drop prepared mode and
+    /// take the mic input side down so the OS mic indicator clears, leaving output
+    /// up for agent playback.
+    private func releaseRecordingEngine() async {
+        try? await AudioManager.shared.setRecordingAlwaysPreparedMode(false)
+        try? AudioManager.shared.setEngineAvailability(
+            AudioEngineAvailability(isInputAvailable: false, isOutputAvailable: true)
+        )
+    }
 
     private func tearDown() async {
         #if targetEnvironment(simulator)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,35 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-11 — iOS/visionOS: pre-warm the LiveKit recording engine on mic start
+
+`LiveKitBackend.startAudio` now calls
+`AudioManager.shared.setRecordingAlwaysPreparedMode(true)` (after resetting
+`setEngineAvailability(.default)`) *before* `setMicrophone(enabled: true)`.
+
+The symptom was an intermittent mic-publish timeout
+(`io.livekit.swift-sdk Code=101 "Timed out"`) on Apple Vision Pro: the publish
+arms an `AsyncCompleter` that waits ~5s for the first captured audio frame, but
+the `AVAudioEngine` recording path sometimes never started, so no frame ever
+arrived and the publish failed. Pre-warming the recording path makes a frame
+available immediately, so the completer resolves and the publish succeeds.
+
+Because prepared mode keeps the engine input hot for fast re-enable, the OS mic
+indicator (orange dot) stayed lit after the user stopped audio. So `stopAudio`
+now drops prepared mode and pins
+`setEngineAvailability(isInputAvailable: false, isOutputAvailable: true)` —
+input goes down so the dot clears, output stays up for agent playback. (The
+disconnect path already clears the dot on its own — `room.disconnect()` releases
+the engine — verified on device by disabling a defensive `tearDown` reset and
+confirming the dot still cleared, so no extra teardown handling was needed.)
+A failed start also rolls the recording engine back (drop prepared mode, pin
+input down) so the mic indicator doesn't linger after a failed start, and
+`stopAudio` runs that same rollback even if the unpublish throws.
+App-side, `AppModel.startAudio` gained an
+`isAudioStarting` re-entrancy guard (surfaced as a "Starting…" state and a
+locked mic-mode picker in `ContentView`) and reports an honest failure message
+instead of silently leaving the UI in a half-started state.
+
 ### 2026-06-09 — render-mcp: scene resync survives a LOVR respawn (blocking send, not NOBLOCK)
 
 After a LOVR (re)start, `render-mcp` re-pushed every stored primitive via
@@ -294,7 +323,6 @@ params set, zero audio frames — matching the magpie backend (whose `sf.write`
 already emits a valid header for empty audio). The non-empty path is
 unchanged. Regression covered by the piper smoke test (`test_piper_tts_smoke`
 now also POSTs whitespace input and asserts a 200 + WAV header). Fixes #194.
-
 ### 2026-06-05 — piper voice fetch: catch LocalEntryNotFoundError before EntryNotFoundError
 
 Follow-up to #184. That PR added a dedicated `_EXIT_VOICE_UNAVAILABLE = 3`


### PR DESCRIPTION
Improves reliability of starting the microphone on the Apple Vision Pro client.