### PR TITLE
fix(ios): guard switchCamera with startCamera's isCameraStarting re-entrancy flag (#208)

### DIFF
--- a/client-samples/ios-visionos/App/AppModel.swift
+++ b/client-samples/ios-visionos/App/AppModel.swift
@@ -267,7 +267,13 @@ final class AppModel {
 
     func switchCamera(to position: CameraConfig.Position) async {
         cameraPosition = position
-        guard isCameraActive else { return }
+        // Serialize against a concurrent start/switch via the same flag
+        // startCamera() uses. switchCamera re-invokes the backend's
+        // startCamera() (which tears down the active track before publishing
+        // the new one), so an overlapping start must not interleave (#208).
+        guard isCameraActive, !isCameraStarting else { return }
+        isCameraStarting = true
+        defer { isCameraStarting = false }
         do {
             try await session?.startCamera(config: CameraConfig(position: cameraPosition))
         } catch {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,17 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-05 — iOS sample: guard switchCamera against concurrent start/switch
+
+Follow-up to #200. `AppModel.switchCamera(to:)` re-invokes the backend's
+`startCamera()` (which tears down the active track before publishing the new
+one) but, unlike `startCamera()`, took no `isCameraStarting` re-entrancy guard
+— so a switch overlapping a concurrent start could interleave backend calls
+across `await` suspension points on the main actor. Applied the same
+`guard … !isCameraStarting` + `isCameraStarting = true` / `defer` pattern
+`startCamera()` uses, so start and switch are serialized. Sample-only, low
+severity. Fixes #208.
+
 ### 2026-06-05 — Native StreamKit: Android NDK C++20 portability
 
 Native StreamKit no longer depends on C++20 `<format>`. Some Android NDK


### PR DESCRIPTION
Fixes #208. Follow-up to #200 (flagged by @nvddr in that review).

## Problem
`AppModel.switchCamera(to:)` (`client-samples/ios-visionos/App/AppModel.swift`) re-invokes the backend's `startCamera()` — which tears down the active track before publishing the new one — but, unlike `startCamera()`, took no `isCameraStarting` re-entrancy guard. So a switch overlapping a concurrent start/stop could interleave backend calls across `await` suspension points on the `@MainActor` model.

## Fix
Apply the same guard/flag pattern `startCamera()` already uses:

```swift
func switchCamera(to position: CameraConfig.Position) async {
    cameraPosition = position
    guard isCameraActive, !isCameraStarting else { return }
    isCameraStarting = true
    defer { isCameraStarting = false }
    do {
        try await session?.startCamera(config: CameraConfig(position: cameraPosition))
    } catch {
        lastError = error.localizedDescription
        isCameraActive = false   // (#200) backend stopped the old track; nothing is streaming
    }
}
```

Now `startCamera()` (`guard !isCameraStarting`) and `switchCamera` both refuse to start while the other is in flight — start and switch are serialized. The persisted `cameraPosition` is still updated up front (unchanged), and the #200 `catch` state reset is preserved.

## Notes
- Sample-only, low severity (needs a concurrent start/stop racing a switch to trigger; no security/data-integrity impact). Mirrors the established `startCamera()` pattern.
- No automated test — iOS Swift, no Swift test harness in CI; on-device verification is rapidly toggling start / switch. Changelog updated; no dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)