### PR TITLE
docs(xr-render-demo): add libvulkan-dev prereq and scope npm to the demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ endpoint and no local GPU is required for the agent or hub.
 | NVIDIA driver | 570+ | required for local model inference |
 | Docker | 24+ | required: all vLLM-backed services (LLM, VLM) run in `nvcr.io/nvidia/vllm` containers |
 | NVIDIA Container Toolkit | latest | required: gives Docker access to the GPU.  Without it, `model_servers` fails with `failed to discover GPU vendor from CDI: no known GPU vendor found` |
-| npm | 18+ | only needed to rebuild the web vendor bundle |
 
 `uv` handles all Python dependencies per-sample — no global `pip install`
 or virtual-environment setup needed.  If you do not have it:
@@ -303,12 +302,13 @@ in the background.
 
 #### Step 2 — Start the demo
 
-The CloudXR compositor and LOVR render through Vulkan, so the Vulkan loader and
-headers must be installed on the host before running the demo:
+This demo has two extra host prerequisites beyond the shared
+[Requirements](#requirements):
 
-```bash
-sudo apt install libvulkan-dev
-```
+- **Vulkan loader + headers** — the CloudXR compositor and LOVR render through
+  Vulkan, so install them before running the demo: `sudo apt install libvulkan-dev`
+- **npm 18+** on PATH — the orchestrator builds the web vendor bundle on first
+  run (skipped on subsequent runs).
 
 ```bash
 cd agent-samples/xr-render-demo

--- a/README.md
+++ b/README.md
@@ -303,6 +303,13 @@ in the background.
 
 #### Step 2 — Start the demo
 
+The CloudXR compositor and LOVR render through Vulkan, so the Vulkan loader and
+headers must be installed on the host before running the demo:
+
+```bash
+sudo apt install libvulkan-dev
+```
+
 ```bash
 cd agent-samples/xr-render-demo
 uv sync


### PR DESCRIPTION
## What

Two documentation fixes for the XR render demo quickstart in the main README:

1. **Add the missing `sudo apt install libvulkan-dev` step.** The CloudXR compositor and LOVR render through Vulkan, so the Vulkan loader/headers must be present on the host. Without `libvulkan-dev`, running the demo (`uv run xr_render_demo` / `main.py`) fails, and the step was undocumented.

2. **Move the npm prerequisite into the xr-render-demo section.** npm is only needed by xr-render-demo — its orchestrator (`agent-samples/xr-render-demo/main.py`) is the only sample that builds the web vendor bundle on first run; `simple-vlm-example` and the others don't reference npm. Removed the `npm | 18+` row from the shared **Software** requirements table and listed it as an xr-render-demo host prerequisite alongside `libvulkan-dev`.

## Result

Step 2 of the demo quickstart now opens with both host prerequisites:

- **Vulkan loader + headers** — `sudo apt install libvulkan-dev`
- **npm 18+** on PATH — for the first-run web vendor bundle build

Docs-only — no code, no dependency change, no changelog (not a design decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)