### PR TITLE
feat(launcher): stop prompting for HF_TOKEN; warn + document instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,11 @@ GPU profiles are auto-detected (`dual_48G_ada` / `spark` / `96G_blackwell`).
 On first run each model downloads from HuggingFace (~50 GB total; can take
 tens of minutes).  On subsequent runs the containers restart in under a minute.
 
+The default models are public, so no HuggingFace token is required.  Set
+`HF_TOKEN` to lift download rate limits / speed, or to use a gated model — see
+[`docs/credentials.md`](docs/credentials.md).  The launcher won't prompt; it
+prints a one-line notice and continues if the token is unset.
+
 To stop all model servers when done:
 
 ```bash
@@ -181,7 +186,9 @@ uv run simple_vlm_example
 ```
 
 On the very first run weights download from HuggingFace (~23 GB; can take
-several minutes).
+several minutes).  The default model is public — no HuggingFace token needed;
+set `HF_TOKEN` only to lift rate limits / speed or for a gated model (see
+[`docs/credentials.md`](docs/credentials.md)).
 
 **With model-servers pre-running** — if VLM (port 8100) and STT (port 8103)
 are already up from `model-servers`, the demo detects them at startup and

--- a/agent-samples/model-servers/main.py
+++ b/agent-samples/model-servers/main.py
@@ -24,7 +24,7 @@ import argparse
 import os
 from pathlib import Path
 
-from xr_ai_launcher import Process, detect_gpu_config, run_stack
+from xr_ai_launcher import Process, detect_gpu_config, run_stack, warn_if_missing
 from xr_ai_logging import setup_logging
 from xr_ai_vllm import stop_persistent_servers
 
@@ -77,6 +77,10 @@ def run() -> None:
         _stop_models()
         return
 
+    # HF_TOKEN is optional for the default (public) models — it only raises HF
+    # rate limits / download speed and is required only for gated models.
+    # Warn instead of prompting; see docs/credentials.md.
+    warn_if_missing("HF_TOKEN")
     run_stack(_build_processes(), _BASE, exit_after_ready=True)
 
 

--- a/agent-samples/simple-vlm-example/main.py
+++ b/agent-samples/simple-vlm-example/main.py
@@ -29,7 +29,7 @@ How to run (from agent-samples/simple-vlm-example/):
 import re
 from pathlib import Path
 
-from xr_ai_launcher import Process, ensure_credentials, run_stack
+from xr_ai_launcher import Process, ensure_credentials, run_stack, warn_if_missing
 from xr_ai_logging import setup_logging
 
 _BASE = Path(__file__).resolve().parent
@@ -77,7 +77,10 @@ def _build_processes(backend: str) -> list[Process]:
 def run() -> None:
     setup_logging("orchestrator", namespace="simple-vlm-example")
     backend = _model_backend()
-    ensure_credentials("HF_TOKEN")
+    # HF_TOKEN is optional for the default (public) model — it only raises HF
+    # rate limits / download speed and is required only for gated models.
+    # Warn instead of prompting; see docs/credentials.md.
+    warn_if_missing("HF_TOKEN")
     if backend == "nim":
         ensure_credentials("NGC_API_KEY")
     run_stack(_build_processes(backend), _BASE)

--- a/ai-services/vlm-server/vlm_server.yaml
+++ b/ai-services/vlm-server/vlm_server.yaml
@@ -9,6 +9,9 @@ model: nvidia/Cosmos-Reason1-7B
 
 host: "0.0.0.0"
 port: 8100
+# Optional. Leave "" to inherit HF_TOKEN from the environment (the launcher
+# injects it from env / huggingface-cli / saved creds). Only needed for gated
+# models or to lift HF download rate limits / speed. See docs/credentials.md.
 hf_token: ""
 
 # Shared weight cache — resolves relative to this YAML.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,30 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-09 — Credentials: stop prompting for HF_TOKEN; document it instead
+
+`simple-vlm-example` was the only sample that called
+`ensure_credentials("HF_TOKEN")`, which blocks first-run startup on an
+interactive `getpass` prompt. The model servers (the heavier, more
+download-intensive path) never prompted — they rely on `run_stack`'s automatic
+`load_credentials()` (env / `huggingface-cli login` / saved creds). That
+asymmetry was confusing, and the prompt isn't warranted: the samples' default
+models are **public** (`nvidia/Cosmos-Reason1-7B` is not gated), so `HF_TOKEN`
+only raises HuggingFace rate limits / download speed and is strictly required
+only for gated models.
+
+Replaced the interactive prompt with a non-blocking path: new
+`warn_if_missing(*names)` launcher helper loads any saved/env/CLI token, and if
+the token is still absent prints one actionable line (pointing at
+`docs/credentials.md`) and continues — it never prompts. `simple-vlm-example`
+and `model-servers` now call `warn_if_missing("HF_TOKEN")`. `ensure_credentials`
+is unchanged and still used for `NGC_API_KEY`, where the prompt is intentional —
+the NIM backend is opt-in and cannot function without the key.
+`docs/credentials.md` rewritten to document HF_TOKEN as auto-picked-up +
+optional (required-vs-optional spelled out) with the three ways to provide it,
+plus pointers from the README quickstart and the `vlm_server.yaml` `hf_token`
+field.
+
 ### 2026-06-05 — TokenServer: fail startup loudly on bind error; keep shutdown graceful
 
 `TokenServer` ran `self._server.serve()` directly as its task. uvicorn calls

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -12,42 +12,75 @@ Tokens are cached in `~/.config/xr-ai/credentials.json` — outside any repo,
 no `.gitignore` entry required. Values already in `os.environ` always take
 priority (useful in CI or when you want to override the cache).
 
-`HF_TOKEN` is additionally written to `~/.cache/huggingface/token`, the same
-file used by `huggingface-cli login`. This means:
-- Child processes find it without relying on env-var inheritance.
-- If you've already run `huggingface-cli login`, no prompt appears.
+`run_stack` always calls `load_credentials()` before spawning child processes,
+so any token saved in the credentials file, exported in the environment, or
+stored by `huggingface-cli login` is injected into **every** subprocess in the
+stack automatically — no per-sample wiring needed.
 
-## Prompting for a token
+## HuggingFace token (`HF_TOKEN`)
 
-Call `ensure_credentials` **before** `run_stack(...)` in any orchestrator
-that needs a token:
+**Optional.** The samples' default models are **public**, so they download
+without a token. Set `HF_TOKEN` when you want:
 
-```python
-from xr_ai_launcher import ensure_credentials, run_stack
+- **Gated models** — any model whose HuggingFace page requires accepting a
+  license / requesting access. These *require* a token (and license
+  acceptance on your account) or the download fails.
+- **Higher rate limits and faster downloads** — unauthenticated Hub requests
+  are rate-limited and slower; an authenticated token lifts both.
 
-def run() -> None:
-    ensure_credentials("HF_TOKEN")          # prompts once, saves for future runs
-    run_stack(PROCESSES, _BASE)
+The samples **do not prompt** for it. If `HF_TOKEN` is not set, the
+orchestrator prints a one-line notice and continues (public models still
+download). Provide it any one of these ways — all are picked up automatically:
+
+```bash
+# 1. Environment variable (highest priority; good for CI / one-off overrides)
+export HF_TOKEN=hf_xxx
+
+# 2. huggingface-cli login (writes ~/.cache/huggingface/token)
+huggingface-cli login
+
+# 3. Save it once for all samples (written to ~/.config/xr-ai/credentials.json
+#    and ~/.cache/huggingface/token)
+python3 -c "from xr_ai_launcher import ensure_credentials; ensure_credentials('HF_TOKEN')"
 ```
 
-Supported tokens: `HF_TOKEN`, `NGC_API_KEY`. The user is shown a prompt
-(password-style, no echo) that explains what the token is for and the
-consequence of skipping it, alongside a link to generate one. Pressing
-Enter without typing skips the token (left unset, not saved).
+Get a token at <https://huggingface.co/settings/tokens>. `HF_TOKEN` is also
+written to `~/.cache/huggingface/token` — the standard location
+`huggingface_hub` checks — so child processes (e.g. `vlm-server`) find it even
+when env-var inheritance is incomplete, and an existing `huggingface-cli login`
+is reused without any further setup.
 
-`NGC_API_KEY` authenticates both `nvcr.io` image pulls and **hosted NVIDIA
-NIM** inference endpoints — a `models.yaml` entry with
-`api_key_env: NGC_API_KEY` sends it as the `Authorization: Bearer` token (see
-[`docs/ai-services.md`](ai-services.md#hosting-models-on-nvidia-nim)). Because
-`run_stack` injects saved credentials into every subprocess, no per-sample
-wiring is needed once the key is saved.
+## NGC API key (`NGC_API_KEY`)
 
-## Automatic injection
+**Required only for the NIM model backend and `nvcr.io` image pulls.** It
+authenticates both `nvcr.io` container pulls and **hosted NVIDIA NIM**
+inference endpoints — a `models.yaml` entry with `api_key_env: NGC_API_KEY`
+sends it as the `Authorization: Bearer` token (see
+[`docs/ai-services.md`](ai-services.md#hosting-models-on-nvidia-nim)).
 
-`run_stack` always calls `load_credentials()` internally before spawning child
-processes, so any token already saved in the credentials file is available to
-every subprocess in the stack — even orchestrators that never call
-`ensure_credentials` directly.
+Samples that select the NIM backend call `ensure_credentials("NGC_API_KEY")`,
+which **prompts once** (password-style, no echo) if the key isn't already
+available and saves it for future runs — NIM cannot function without it, so the
+prompt is intentional. Get a key at <https://ngc.nvidia.com/setup/api-key>, or
+set it ahead of time:
+
+```bash
+export NGC_API_KEY=nvapi-xxx
+```
+
+## How a token is resolved
+
+`load_credentials()` (always) and `ensure_credentials()` (NGC only) resolve in
+this priority order, highest first:
+
+1. Already set in `os.environ`
+2. Saved in `~/.config/xr-ai/credentials.json`
+3. Stored in `~/.cache/huggingface/token` (`HF_TOKEN` only)
+4. *(interactive paths only)* prompted, then saved to both locations
+
+`warn_if_missing(...)` runs steps 1–3 and, if the token is still absent, prints
+an actionable notice and continues **without prompting** — this is how
+`HF_TOKEN` is handled in the samples.
 
 ## Managing saved tokens
 
@@ -55,7 +88,7 @@ every subprocess in the stack — even orchestrators that never call
 # View saved tokens
 cat ~/.config/xr-ai/credentials.json
 
-# Remove a token (re-run will prompt again)
+# Remove a token
 python3 -c "
 import json, pathlib
 p = pathlib.Path.home() / '.config/xr-ai/credentials.json'

--- a/tests/test_launcher_credentials.py
+++ b/tests/test_launcher_credentials.py
@@ -140,3 +140,31 @@ class TestEnsureCredentials:
         saved = json.loads(creds_file.read_text())
         assert saved["HF_TOKEN"] == "new_tok"
         assert hf_file.read_text().strip() == "new_tok"
+
+
+class TestWarnIfMissing:
+    """warn_if_missing surfaces a missing token but NEVER prompts."""
+
+    def test_missing_token_does_not_prompt(self, fake_creds_dir, monkeypatch):
+        # If getpass were called this would raise; warn_if_missing must not call it.
+        with patch("getpass.getpass", side_effect=AssertionError("must not prompt")):
+            _creds.warn_if_missing("HF_TOKEN")
+        assert not os.environ.get("HF_TOKEN")  # still unset, nothing saved
+
+    def test_missing_token_not_saved(self, fake_creds_dir, monkeypatch):
+        _creds.warn_if_missing("HF_TOKEN")
+        creds_file, _ = fake_creds_dir
+        assert not creds_file.exists()
+
+    def test_present_token_is_loaded_from_saved(self, fake_creds_dir, monkeypatch):
+        creds_file, _ = fake_creds_dir
+        creds_file.write_text(json.dumps({"HF_TOKEN": "saved_tok"}))
+        with patch("getpass.getpass", side_effect=AssertionError("must not prompt")):
+            _creds.warn_if_missing("HF_TOKEN")
+        assert os.environ.get("HF_TOKEN") == "saved_tok"
+
+    def test_env_token_short_circuits(self, fake_creds_dir, monkeypatch):
+        monkeypatch.setenv("HF_TOKEN", "env_tok")
+        with patch("getpass.getpass", side_effect=AssertionError("must not prompt")):
+            _creds.warn_if_missing("HF_TOKEN")
+        assert os.environ.get("HF_TOKEN") == "env_tok"

--- a/utils/xr-ai-launcher/xr_ai_launcher/__init__.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/__init__.py
@@ -27,14 +27,14 @@ Typical usage::
 """
 
 from ._cloudxr_env import XR_RUNTIME_VAR, load_cloudxr_env
-from ._credentials import ensure_credentials, load_credentials
+from ._credentials import ensure_credentials, load_credentials, warn_if_missing
 from ._gpu import detect_gpu_config
 from ._processes import ManagedProcess
 from ._stack import Parallel, Process, run_stack
 
 __all__ = [
     "XR_RUNTIME_VAR", "load_cloudxr_env",
-    "ensure_credentials", "load_credentials",
+    "ensure_credentials", "load_credentials", "warn_if_missing",
     "detect_gpu_config",
     "ManagedProcess",
     "Parallel", "Process", "run_stack",

--- a/utils/xr-ai-launcher/xr_ai_launcher/_credentials.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/_credentials.py
@@ -100,6 +100,33 @@ def load_credentials() -> None:
             os.environ["HF_TOKEN"] = hf
 
 
+def warn_if_missing(*names: str) -> None:
+    """
+    Non-interactively surface missing optional tokens — NEVER prompts.
+
+    Loads saved / `huggingface-cli login` / env tokens, then prints one
+    actionable line per still-missing token (pointing at docs/credentials.md)
+    so a missing token is visible early without blocking startup on an
+    interactive prompt. Use this in orchestrators that pull HuggingFace / NGC
+    artifacts instead of ``ensure_credentials`` when the token is optional
+    (e.g. the default models are public — a token only raises rate limits and
+    download speed, and is required only for gated models).
+    """
+    load_credentials()
+    for name in names:
+        if os.environ.get(name):
+            continue
+        label, url, why = _KNOWN.get(name, (name, "", ""))
+        print(f"\n[credentials] {label} not set — continuing without it.", file=sys.stderr)
+        if why:
+            print(f"  {why}", file=sys.stderr)
+        if url:
+            how = ("`export HF_TOKEN=...` or `huggingface-cli login`"
+                   if name == "HF_TOKEN" else f"`export {name}=...`")
+            print(f"  To enable it: get one at {url}, then {how}.", file=sys.stderr)
+        print("  See docs/credentials.md.", file=sys.stderr)
+
+
 def ensure_credentials(*names: str) -> None:
     """
     Ensure each named token is available in os.environ.


### PR DESCRIPTION
## Problem

`simple-vlm-example` was the **only** sample that called `ensure_credentials("HF_TOKEN")`, which blocks first-run startup on an interactive `getpass` prompt. The **model servers** — the heavier, more download-intensive path — never prompted; they rely on `run_stack`'s automatic `load_credentials()` (env / `huggingface-cli login` / saved creds). That asymmetry is confusing, and the prompt isn't warranted:

- The samples' default models are **public** — `nvidia/Cosmos-Reason1-7B` reports `gated: false` on the Hub.
- `HF_TOKEN` only raises HuggingFace **rate limits / download speed**, and is strictly **required only for gated models**.

So a blocking prompt on every fresh setup is the wrong default for an optional token.

## Approach

Document it; don't prompt for it.

- **New `warn_if_missing(*names)` launcher helper** — loads any saved/env/`huggingface-cli` token (`load_credentials()`), and if the token is still absent prints **one actionable line** (pointing at `docs/credentials.md`) and continues. It **never prompts**.
- `simple-vlm-example` and `model-servers` now call `warn_if_missing("HF_TOKEN")` — consistent across both, non-blocking.
- `ensure_credentials` is **unchanged** and still used for `NGC_API_KEY`, where the prompt is intentional (the NIM backend is opt-in and cannot function without the key). This PR deliberately does **not** change NGC behavior.
- **`docs/credentials.md` rewritten** to document `HF_TOKEN` as auto-picked-up + optional, spelling out required-vs-optional and the three ways to provide it (env / `huggingface-cli login` / save-once). Pointers added from the README quickstart (model-servers + simple-vlm) and the `vlm_server.yaml` `hf_token` field.

## Behavior change

- Configured users (env / `huggingface-cli login` / saved creds): **no change** — the token still flows through `load_credentials()` to every subprocess.
- Tokenless users: instead of a blocking prompt, they get a one-line notice and startup continues; public models download fine. A gated model would still fail to download — now with a doc pointer rather than after a prompt.

## Tests

`tests/test_launcher_credentials.py`: added `TestWarnIfMissing` — asserts `warn_if_missing` never calls `getpass`, doesn't persist anything when the token is absent, and still resolves a saved/env token. Full credentials suite passes (21).

## Notes

- No `pyproject.toml` change → `DEPENDENCIES.md` untouched.
- No new README files; central `docs/credentials.md` is the source of truth with light pointers from existing surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)