### PR TITLE
feat(pipecat): make idle-timeout auto-cancel opt-in (disabled by default)

### DIFF
--- a/agent-samples/simple-vlm-example/worker/simple_vlm_example_worker.py
+++ b/agent-samples/simple-vlm-example/worker/simple_vlm_example_worker.py
@@ -120,6 +120,11 @@ async def main(
         ),
         voice_gate_cfg = voice_gate_cfg,
         text_topic     = "vlm.response",
+        # Idle-timeout auto-cancel. Disabled by default (0 / unset → None) so a
+        # quiet session stays connected; set a positive seconds value in the
+        # worker YAML to opt in. See xr_ai_pipecat.make_voice_pipeline.
+        idle_timeout_secs = (float(cfg["idle_timeout_secs"])
+                             if cfg.get("idle_timeout_secs") else None),
     )
 
     loop = asyncio.get_running_loop()

--- a/agent-samples/simple-vlm-example/yaml/simple_vlm_example_worker.yaml
+++ b/agent-samples/simple-vlm-example/yaml/simple_vlm_example_worker.yaml
@@ -60,3 +60,11 @@ camera_grace_s:       5.0   # keep camera on this long after a query (avoids res
 silero_threshold:  0.5    # Silero speech-probability gate (0..1); lower = more sensitive
 silence_duration:  0.4    # seconds of silence that ends an utterance
 min_speech:        0.1    # minimum seconds of speech before STT is called
+
+# ── Idle timeout ──────────────────────────────────────────────────────────
+# Auto-cancel the voice pipeline after this many seconds with no user/bot
+# speech. DISABLED by default (0 = off) — a quiet session stays connected
+# indefinitely, which is what XR sessions usually want. Set a positive value
+# (e.g. 300 for 5 min) to opt in; the worker then tears the pipeline down
+# after that long idle. Threaded to xr_ai_pipecat.make_voice_pipeline.
+idle_timeout_secs: 0

--- a/agent-samples/xr-render-demo/worker/config.py
+++ b/agent-samples/xr-render-demo/worker/config.py
@@ -31,6 +31,10 @@ class WorkerConfig:
     min_speech:        float
     silero_threshold:  float   # Silero speech probability gate (0..1)
 
+    # Idle-timeout auto-cancel (seconds). None = disabled (default): a quiet
+    # session is never cancelled for inactivity. A positive value opts in.
+    idle_timeout_secs: float | None
+
 
 def load_config(path: pathlib.Path | None) -> WorkerConfig:
     data: dict = {}
@@ -68,6 +72,9 @@ def load_config(path: pathlib.Path | None) -> WorkerConfig:
         silence_duration  = float(data.get("silence_duration",  0.8)),
         min_speech        = float(data.get("min_speech",        0.15)),
         silero_threshold  = float(data.get("silero_threshold",  0.5)),
+        # 0 / unset → disabled (None); a positive value opts into idle cancel.
+        idle_timeout_secs = (float(data["idle_timeout_secs"])
+                             if data.get("idle_timeout_secs") else None),
     )
 
 

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker.py
@@ -177,6 +177,8 @@ async def main(
             # ``RenderDemoBrain._run_turn``); opting out of the
             # pipeline-level echo here avoids a duplicate send.
             text_topic="",
+            # Idle-timeout auto-cancel — disabled unless set in the worker YAML.
+            idle_timeout_secs=cfg.idle_timeout_secs,
         )
 
         loop = asyncio.get_running_loop()

--- a/agent-samples/xr-render-demo/yaml/xr_render_demo_worker.yaml
+++ b/agent-samples/xr-render-demo/yaml/xr_render_demo_worker.yaml
@@ -45,3 +45,11 @@ vec_mcp_url:    http://localhost:8250
 silence_duration:  0.8
 min_speech:        0.15
 silero_threshold:  0.3
+
+# ── Idle timeout ──────────────────────────────────────────────────────────
+# Auto-cancel the voice pipeline after this many seconds with no user/bot
+# speech. DISABLED by default (0 = off) — a quiet session stays connected
+# indefinitely, which is what XR sessions usually want. Set a positive value
+# (e.g. 300 for 5 min) to opt in; the worker then tears the pipeline down
+# after that long idle. Threaded to xr_ai_pipecat.make_voice_pipeline.
+idle_timeout_secs: 0

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/pipeline.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/pipeline.py
@@ -36,6 +36,7 @@ def make_voice_pipeline(
     vad_cfg: VadConfig,
     voice_gate_cfg: VoiceGateConfig,
     text_topic: str = "agent.response",
+    idle_timeout_secs: float | None = None,
 ) -> tuple[Pipeline, PipelineWorker]:
     """Assemble the unified voice pipeline.
 
@@ -49,6 +50,16 @@ def make_voice_pipeline(
     :class:`StreamingTtsProcessor`. Set to ``""`` to opt out — samples
     whose brain pushes its own response data message (e.g.
     xr-render-demo) want this off to avoid duplicate sends.
+
+    ``idle_timeout_secs`` controls pipecat's idle-timeout auto-cancel.
+    **Disabled by default** (``None``): the pipeline is *never* cancelled for
+    inactivity, so a quiet session stays connected indefinitely — important
+    for XR sessions where the user may simply not be speaking. Set a positive
+    number of seconds to opt in: the worker then cancels the pipeline (and its
+    runner) after that long with no user/bot speech. We pass this explicitly
+    rather than inheriting pipecat's default, which is ``cancel_on_idle_timeout
+    =True`` at ``IDLE_TIMEOUT_SECS`` — i.e. on by default upstream, which would
+    silently drop idle sessions.
     """
     voice_gate_proc = VoiceGateProcessor(cfg=voice_gate_cfg, tts=tts)
     streaming_tts   = StreamingTtsProcessor(
@@ -67,5 +78,20 @@ def make_voice_pipeline(
         streaming_tts,
         transport.output(),
     ])
-    worker = PipelineWorker(pipeline)
+    if idle_timeout_secs is None:
+        # Disabled: never cancel the pipeline for inactivity. Override
+        # pipecat's on-by-default idle cancel (and the runner cancel) so a
+        # quiet XR session is not silently dropped.
+        worker = PipelineWorker(
+            pipeline,
+            idle_timeout_secs=None,
+            cancel_on_idle_timeout=False,
+            cancel_runner_on_idle_timeout=False,
+        )
+    else:
+        worker = PipelineWorker(
+            pipeline,
+            idle_timeout_secs=idle_timeout_secs,
+            cancel_on_idle_timeout=True,
+        )
     return pipeline, worker

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,26 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-09 — Voice pipeline: idle-timeout auto-cancel off by default, opt-in via YAML
+
+pipecat's `PipelineWorker` defaults to `cancel_on_idle_timeout=True` at
+`IDLE_TIMEOUT_SECS`, so an idle voice pipeline is silently cancelled after a
+few minutes of no user/bot speech. `make_voice_pipeline` constructed
+`PipelineWorker(pipeline)` with no override, so we inherited that — a quiet XR
+session (user simply not talking) would drop on its own, which is the wrong
+default for this product.
+
+`make_voice_pipeline` now takes `idle_timeout_secs: float | None = None` and is
+**disabled by default**: when `None` it passes `cancel_on_idle_timeout=False`
+and `cancel_runner_on_idle_timeout=False` so the pipeline is never cancelled
+for inactivity. The mechanism is preserved, not deleted — a positive value
+opts back in (worker then cancels after that many idle seconds). Surfaced in
+each sample's worker YAML as `idle_timeout_secs: 0` (0/unset → disabled) with a
+comment, threaded through `simple_vlm_example_worker` and the xr-render-demo
+`WorkerConfig`. Documented in `make_voice_pipeline`'s docstring and
+`docs/troubleshooting.md`. Tests cover the default-off and opt-in paths at both
+the factory and the xr-render config loader.
+
 ### 2026-06-05 — TokenServer: fail startup loudly on bind error; keep shutdown graceful
 
 `TokenServer` ran `self._server.serve()` directly as its task. uvicorn calls

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -190,6 +190,20 @@ back to OpenH264 (which is royalty-bearing). See
 
 ## Runtime / connection issues
 
+### Voice session drops / agent goes silent after a few minutes idle
+
+**Cause:** an idle-timeout that auto-cancels the voice pipeline after a stretch
+with no user/bot speech.
+
+**Status:** disabled by default. `make_voice_pipeline` passes
+`cancel_on_idle_timeout=False` (overriding pipecat's on-by-default
+`IDLE_TIMEOUT_SECS`), so a quiet session stays connected indefinitely.
+
+**If you want it:** set `idle_timeout_secs: <seconds>` (e.g. `300` for 5 min)
+in the sample's worker YAML (`simple_vlm_example_worker.yaml` /
+`xr_render_demo_worker.yaml`); `0` or unset keeps it disabled. The knob is
+threaded to `xr_ai_pipecat.make_voice_pipeline`, where it's documented.
+
 ### Browser client connects but no audio / no video
 
 **Most common cause:** firewall blocking WebRTC media on UDP 7882 (LiveKit).

--- a/tests/test_xr_ai_pipecat_voice_pipeline.py
+++ b/tests/test_xr_ai_pipecat_voice_pipeline.py
@@ -1672,6 +1672,56 @@ async def test_make_voice_pipeline_audio_in_to_audio_out(monkeypatch):
 
 
 # ════════════════════════════════════════════════════════════════════════════
+# make_voice_pipeline idle-timeout knob
+# ════════════════════════════════════════════════════════════════════════════
+
+
+def test_make_voice_pipeline_idle_timeout_disabled_by_default():
+    """Default: idle-timeout auto-cancel is OFF (pipecat's on-by-default is
+    overridden), so a quiet session is never dropped for inactivity."""
+    from xr_ai_pipecat import make_voice_pipeline
+    from xr_ai_pipecat.transport import XRMediaHubTransport
+
+    transport = XRMediaHubTransport()
+    try:
+        _, worker = make_voice_pipeline(
+            transport      = transport,
+            stt            = _FakeStt(),
+            tts            = _FakeTts(),
+            brain          = _EchoBrain(),
+            vad_cfg        = VadConfig(),
+            voice_gate_cfg = VoiceGateConfig(),
+        )
+        assert worker._cancel_on_idle_timeout is False
+        assert worker._cancel_runner_on_idle_timeout is False
+        assert worker._idle_timeout_secs is None
+    finally:
+        transport.shutdown()
+
+
+def test_make_voice_pipeline_idle_timeout_opt_in():
+    """A positive idle_timeout_secs opts into pipecat's idle auto-cancel."""
+    from xr_ai_pipecat import make_voice_pipeline
+    from xr_ai_pipecat.transport import XRMediaHubTransport
+
+    transport = XRMediaHubTransport()
+    try:
+        _, worker = make_voice_pipeline(
+            transport      = transport,
+            stt            = _FakeStt(),
+            tts            = _FakeTts(),
+            brain          = _EchoBrain(),
+            vad_cfg        = VadConfig(),
+            voice_gate_cfg = VoiceGateConfig(),
+            idle_timeout_secs = 300.0,
+        )
+        assert worker._cancel_on_idle_timeout is True
+        assert worker._idle_timeout_secs == 300.0
+    finally:
+        transport.shutdown()
+
+
+# ════════════════════════════════════════════════════════════════════════════
 # Regression: brain tags TextFrames with pid (Bug #2)
 # ════════════════════════════════════════════════════════════════════════════
 

--- a/tests/test_xr_render_demo_wire.py
+++ b/tests/test_xr_render_demo_wire.py
@@ -82,6 +82,29 @@ def test_models_yaml_loads() -> None:
     assert agent_llm_spec.reasoning_field == "reasoning"
 
 
+def test_worker_config_idle_timeout_disabled_by_default() -> None:
+    """The shipped worker YAML ships idle_timeout_secs: 0, which the loader
+    maps to None (disabled) so a quiet session is never auto-cancelled."""
+    from config import load_config
+
+    worker_yaml = (
+        Path(__file__).resolve().parent.parent
+        / "agent-samples" / "xr-render-demo" / "yaml" / "xr_render_demo_worker.yaml"
+    )
+    cfg = load_config(worker_yaml)
+    assert cfg.idle_timeout_secs is None
+
+
+def test_worker_config_idle_timeout_opt_in(tmp_path) -> None:
+    """A positive idle_timeout_secs in the YAML is parsed to a float."""
+    from config import load_config
+
+    y = tmp_path / "w.yaml"
+    y.write_text("idle_timeout_secs: 300\n")
+    cfg = load_config(y)
+    assert cfg.idle_timeout_secs == 300.0
+
+
 # ── quick-ack wire golden ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Problem

pipecat's `PipelineWorker` defaults to `cancel_on_idle_timeout=True` at `IDLE_TIMEOUT_SECS`, so an idle voice pipeline is **silently cancelled** after a few minutes with no user/bot speech. `make_voice_pipeline` constructed `PipelineWorker(pipeline)` with no override, so we inherited that default — a quiet XR session (user simply not talking) would drop on its own. That's the wrong default for this product, and it's the kind of implicit behavior that comes back to bite.

## Change

Keep the mechanism, flip the default to **off**, make it an explicit YAML knob.

- **`make_voice_pipeline(..., idle_timeout_secs: float | None = None)`** — disabled by default: when `None` it passes `cancel_on_idle_timeout=False` **and** `cancel_runner_on_idle_timeout=False`, so the pipeline is never cancelled for inactivity. A positive value opts in (worker cancels after that many idle seconds). Documented in the docstring, including *why* we override pipecat's default.
- **Surfaced in each sample's worker YAML** as `idle_timeout_secs: 0` with a comment (`0`/unset → disabled; set seconds to enable). Threaded through `simple_vlm_example_worker` (dict config) and the xr-render-demo `WorkerConfig` (typed dataclass + loader).
- **Docs:** `docs/troubleshooting.md` gets a "voice session drops after a few minutes idle" entry mapping the symptom to the knob; changelog records the decision.

## Behavior

- Default (shipped YAML `idle_timeout_secs: 0`): sessions stay connected indefinitely — no more silent idle drops.
- Opt-in: set `idle_timeout_secs: 300` (etc.) in the worker YAML to restore an idle auto-cancel.

## Tests

- `test_xr_ai_pipecat_voice_pipeline.py`: factory default disables idle cancel (`_cancel_on_idle_timeout is False`, `_idle_timeout_secs is None`); a positive value enables it.
- `test_xr_render_demo_wire.py`: shipped worker YAML loads as disabled (`None`); a positive YAML value parses to a float.
- Full affected suites green (134 passed).

## Notes

- No `pyproject.toml` change → `DEPENDENCIES.md` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)