### PR TITLE
fix(launcher): clean teardown on Ctrl-C during model-servers startup

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,39 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-09 — Ctrl-C during startup tears down everything, incl. persist + docker containers
+
+Pressing Ctrl-C while `model-servers` was launching (slow image pull / weight
+download) left half-started vLLM docker containers running: the user could not
+simply abort and retry (e.g. after forgetting `HF_TOKEN`). Two coupled causes,
+two coupled fixes.
+
+`run_stack` (`utils/xr-ai-launcher/_stack.py`) treated every interruption like a
+clean exit: its `finally` always ran `_shutdown(launched, _no_kill)`, and
+model-servers' processes are all `launch_mode="persist"`, so `_no_kill`
+contained all of them — abort skipped every one ("keeping alive"). Now it tracks
+an `aborted` flag (set in the `except (SystemExit, KeyboardInterrupt)` handler,
+and in a generic `except Exception` that re-raises to preserve the traceback)
+and calls `_shutdown(launched, no_kill=set() if aborted else _no_kill)`. So a
+clean ready-exit (including `exit_after_ready`'s early `return`) keeps persist
+alive as before, while an abort kills EVERYTHING — sending SIGTERM to each
+wrapper's process group — and then `sys.exit(130)`.
+
+That SIGTERM alone still didn't stop the dockerd-managed container: the docker
+wrapper (`utils/xr-ai-vllm/_docker.py` `run`) spawns `docker run` with
+`start_new_session=True` (its own session) and installed no signal handler, so
+killing the wrapper orphaned the container. The `--stop` path
+(`stop_persistent_servers`) was no help — it gates on `/health` 200 and skips
+anything not healthy, so it can never reach a mid-download container. That
+health-gate is precisely why a wrapper-signal approach was chosen instead: `run`
+now installs SIGINT/SIGTERM handlers up front that idempotently (guard flag)
+terminate the in-flight `docker` client, `stop_container(name, timeout_s=10)` +
+`remove_container(name)` (both by name, health-independent, inside the launcher's
+20s SIGKILL window), stop the log streamer, and `sys.exit(130)`. Handlers are
+restored once the container reaches ready, so steady-state/`--stop` behavior is
+unchanged. The same wrapper backs simple-vlm-example's vlm-server, so its
+identical lingering-container bug is fixed for free.
+
 ### 2026-06-05 — TokenServer: fail startup loudly on bind error; keep shutdown graceful
 
 `TokenServer` ran `self._server.serve()` directly as its task. uvicorn calls

--- a/tests/test_launcher_stack.py
+++ b/tests/test_launcher_stack.py
@@ -7,12 +7,11 @@ from __future__ import annotations
 import pytest
 
 import xr_ai_launcher._stack as _stack
-from xr_ai_launcher._stack import Parallel, Process, run_stack
 
 
 class TestProcessDataclass:
     def test_defaults(self):
-        p = Process("hub", "../../server-runtime", "xr_media_hub")
+        p = _stack.Process("hub", "../../server-runtime", "xr_media_hub")
         assert p.name == "hub"
         assert p.project == "../../server-runtime"
         assert p.command == "xr_media_hub"
@@ -22,7 +21,7 @@ class TestProcessDataclass:
         assert p.port is None
 
     def test_all_fields(self):
-        p = Process(
+        p = _stack.Process(
             "vlm", "../../ai-services/vlm-server", "vlm_server",
             config="yaml/vlm.yaml",
             gpu="0",
@@ -35,35 +34,35 @@ class TestProcessDataclass:
         assert p.port == 8100
 
     def test_frozen_immutability(self):
-        p = Process("hub", "../../server-runtime", "xr_media_hub")
+        p = _stack.Process("hub", "../../server-runtime", "xr_media_hub")
         with pytest.raises((AttributeError, TypeError)):
             p.name = "other"  # type: ignore[misc]
 
     def test_reuse_launch_mode(self):
-        p = Process("stt", "../../ai-services/stt-server", "stt_server",
+        p = _stack.Process("stt", "../../ai-services/stt-server", "stt_server",
                     launch_mode="reuse")
         assert p.launch_mode == "reuse"
 
 
 class TestParallelDataclass:
     def test_stores_processes_as_tuple(self):
-        p1 = Process("stt", "../../ai-services/stt-server", "stt_server")
-        p2 = Process("tts", "../../ai-services/tts/piper", "piper_tts_server")
-        group = Parallel([p1, p2])
+        p1 = _stack.Process("stt", "../../ai-services/stt-server", "stt_server")
+        p2 = _stack.Process("tts", "../../ai-services/tts/piper", "piper_tts_server")
+        group = _stack.Parallel([p1, p2])
         assert isinstance(group.processes, tuple)
         assert group.processes == (p1, p2)
 
     def test_accepts_single_process(self):
-        p = Process("stt", "../../ai-services/stt-server", "stt_server")
-        group = Parallel([p])
+        p = _stack.Process("stt", "../../ai-services/stt-server", "stt_server")
+        group = _stack.Parallel([p])
         assert len(group.processes) == 1
 
     def test_empty_parallel_ok(self):
-        group = Parallel([])
+        group = _stack.Parallel([])
         assert group.processes == ()
 
     def test_frozen_immutability(self):
-        group = Parallel([])
+        group = _stack.Parallel([])
         with pytest.raises((AttributeError, TypeError)):
             group.processes = ()  # type: ignore[misc]
 
@@ -113,11 +112,11 @@ class TestRunStackShutdownContract:
 
         monkeypatch.setattr(_stack, "_wait_ready", _boom)
 
-        processes = [Process("vlm", "../../vlm", "vlm_server",
+        processes = [_stack.Process("vlm", "../../vlm", "vlm_server",
                              launch_mode="persist", port=8100)]
 
         with pytest.raises(SystemExit) as excinfo:
-            run_stack(processes, tmp_path)
+            _stack.run_stack(processes, tmp_path)
 
         assert excinfo.value.code == 130
         # Despite a persist process, abort must tear down EVERYTHING.
@@ -130,11 +129,11 @@ class TestRunStackShutdownContract:
         # Ready file appears immediately; no interruption.
         monkeypatch.setattr(_stack, "_wait_ready", lambda name, rf, proc: None)
 
-        processes = [Process("vlm", "../../vlm", "vlm_server",
+        processes = [_stack.Process("vlm", "../../vlm", "vlm_server",
                              launch_mode="persist", port=8100)]
 
         # exit_after_ready returns normally (no SystemExit) after readiness.
-        run_stack(processes, tmp_path, exit_after_ready=True)
+        _stack.run_stack(processes, tmp_path, exit_after_ready=True)
 
         # Clean exit preserves the persist set so the container outlives us.
         assert stub_stack["no_kill"] == {"vlm"}

--- a/tests/test_launcher_stack.py
+++ b/tests/test_launcher_stack.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 
 import pytest
 
-from xr_ai_launcher._stack import Parallel, Process
+import xr_ai_launcher._stack as _stack
+from xr_ai_launcher._stack import Parallel, Process, run_stack
 
 
 class TestProcessDataclass:
@@ -65,3 +66,75 @@ class TestParallelDataclass:
         group = Parallel([])
         with pytest.raises((AttributeError, TypeError)):
             group.processes = ()  # type: ignore[misc]
+
+
+class _FakePopen:
+    """Minimal Popen stand-in: alive (poll()->None), spawned without subprocess."""
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def poll(self):
+        return None
+
+
+class TestRunStackShutdownContract:
+    """run_stack abort vs clean-exit shutdown semantics.
+
+    Hermetic: no real subprocess, no docker, no credential I/O. We monkeypatch
+    _spawn, _wait_ready*, _shutdown, and load_credentials so only the
+    abort/clean-exit branch logic is exercised.
+    """
+
+    @pytest.fixture()
+    def stub_stack(self, monkeypatch, tmp_path):
+        # load_credentials reads real ~/.config/~/.cache — neutralize it.
+        monkeypatch.setattr(_stack, "load_credentials", lambda: None)
+        monkeypatch.setattr(
+            _stack, "_spawn",
+            lambda proc, base, ready_file: _FakePopen(proc.name),
+        )
+        monkeypatch.setattr(_stack, "_print_ready_banner", lambda names: None)
+
+        calls: dict[str, object] = {}
+
+        def _spy_shutdown(procs, no_kill=None):
+            calls["procs"] = procs
+            calls["no_kill"] = no_kill
+
+        monkeypatch.setattr(_stack, "_shutdown", _spy_shutdown)
+        return calls
+
+    def test_abort_during_startup_kills_everything_including_persist(
+        self, stub_stack, tmp_path, monkeypatch,
+    ):
+        # Simulate Ctrl-C while waiting for the (persist) server to come up.
+        def _boom(name, ready_file, proc):
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(_stack, "_wait_ready", _boom)
+
+        processes = [Process("vlm", "../../vlm", "vlm_server",
+                             launch_mode="persist", port=8100)]
+
+        with pytest.raises(SystemExit) as excinfo:
+            run_stack(processes, tmp_path)
+
+        assert excinfo.value.code == 130
+        # Despite a persist process, abort must tear down EVERYTHING.
+        assert stub_stack["no_kill"] == set()
+        assert "vlm" in stub_stack["procs"]
+
+    def test_clean_exit_after_ready_keeps_persist_alive(
+        self, stub_stack, tmp_path, monkeypatch,
+    ):
+        # Ready file appears immediately; no interruption.
+        monkeypatch.setattr(_stack, "_wait_ready", lambda name, rf, proc: None)
+
+        processes = [Process("vlm", "../../vlm", "vlm_server",
+                             launch_mode="persist", port=8100)]
+
+        # exit_after_ready returns normally (no SystemExit) after readiness.
+        run_stack(processes, tmp_path, exit_after_ready=True)
+
+        # Clean exit preserves the persist set so the container outlives us.
+        assert stub_stack["no_kill"] == {"vlm"}

--- a/utils/xr-ai-launcher/xr_ai_launcher/_stack.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/_stack.py
@@ -393,6 +393,13 @@ def run_stack(
 
     launched: dict[str, subprocess.Popen] = {}
 
+    # Tracks whether startup got interrupted before/at the "All processes ready"
+    # milestone. On abort we must tear down EVERYTHING — including persist
+    # processes — so each wrapper's process group gets SIGTERM and (for the
+    # vLLM docker wrapper) its self-stop signal handler kills the half-started
+    # container. Keeping persist alive is correct only on a clean ready-exit.
+    aborted = False
+
     with tempfile.TemporaryDirectory(prefix="xr-ai-") as _tmpdir:
         tmpdir = Path(_tmpdir)
         try:
@@ -423,6 +430,31 @@ def run_stack(
             _monitor(launched)
 
         except (SystemExit, KeyboardInterrupt):
-            pass
+            # Ctrl-C (or a _wait_ready SystemExit) during startup: abort and
+            # tear everything down. Swallow it here as before so orchestrators
+            # don't each need their own handler; the non-zero exit happens
+            # below, after the finally has run shutdown.
+            aborted = True
+            print(
+                "\nAborting — stopping launched processes and containers…",
+                flush=True,
+            )
+        except Exception:
+            # A spawn/wait failure before ready is also an abort: kill
+            # everything, but re-raise so the real traceback isn't lost (only
+            # the KI/SystemExit path is the user-driven Ctrl-C case).
+            aborted = True
+            print(
+                "\nAborting — stopping launched processes and containers…",
+                flush=True,
+            )
+            raise
         finally:
-            _shutdown(launched, _no_kill)
+            # Clean exit (including exit_after_ready's early return, which runs
+            # this finally with aborted=False) keeps persist/reuse alive. Abort
+            # passes no_kill=set() so persist processes are killed too.
+            _shutdown(launched, no_kill=(set() if aborted else _no_kill))
+
+    if aborted:
+        # Tempdir is now cleaned up; exit non-zero so callers/CI see the abort.
+        sys.exit(130)

--- a/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
@@ -22,6 +22,7 @@ import logging
 import os
 import re
 import shlex
+import signal
 import subprocess
 import sys
 import time
@@ -391,6 +392,43 @@ def run(
 
     health_url = _lifecycle.health_url(host, port)
 
+    # On abort (Ctrl-C during model-servers startup) the launcher passes
+    # no_kill=set() and SIGTERMs every wrapper's process group. Without a
+    # handler, SIGTERM kills *this* wrapper but leaves the dockerd-managed
+    # container running (still pulling the image / downloading weights). The
+    # --stop path can't clean that up either: it gates on /health 200 and a
+    # mid-download container is never healthy. So the wrapper stops its own
+    # container by name (works regardless of health) when it receives a signal.
+    # On a clean run no signal arrives and these handlers stay dormant.
+    _state: dict[str, object] = {"proc": None, "streamer": None, "handling": False}
+    orig_int  = signal.getsignal(signal.SIGINT)
+    orig_term = signal.getsignal(signal.SIGTERM)
+
+    def _on_signal(_sig, _frame):
+        # Guard FIRST: Python does not block re-entry during the handler's own
+        # docker stop, and the user will mash Ctrl-C. A second signal no-ops.
+        if _state["handling"]:
+            return
+        _state["handling"] = True
+        print(
+            f"[{log_prefix}] signal received — stopping container {container_name}…",
+            flush=True,
+        )
+        cp = _state["proc"]
+        if isinstance(cp, subprocess.Popen) and cp.poll() is None:
+            cp.terminate()
+        # Modest timeout so this completes inside the launcher's _STOP_TIMEOUT
+        # (20s) window before it escalates to SIGKILL. Both helpers work by
+        # name and are idempotent regardless of container health.
+        stop_container(container_name, timeout_s=10)
+        remove_container(container_name)
+        sp = _state["streamer"]
+        _stop_log_streamer(sp if isinstance(sp, subprocess.Popen) else None)
+        sys.exit(130)
+
+    signal.signal(signal.SIGINT,  _on_signal)
+    signal.signal(signal.SIGTERM, _on_signal)
+
     # Reuse a container that survived a wrapper restart (weight persistence).
     if _lifecycle.health_ok(health_url):
         print(
@@ -399,6 +437,8 @@ def run(
         )
         if ready_file:
             ready_file.touch()
+        signal.signal(signal.SIGINT,  orig_int)
+        signal.signal(signal.SIGTERM, orig_term)
         _lifecycle.idle_until_stopped(health_url, log_prefix)
         return
 
@@ -413,6 +453,7 @@ def run(
             ["docker", "start", "-a", container_name],
             start_new_session=True,
         )
+        _state["proc"] = proc
     else:
         _maybe_ngc_login(image)
         argv = build_run_argv(
@@ -432,14 +473,24 @@ def run(
             flush=True,
         )
         proc = subprocess.Popen(argv, start_new_session=True)
+        _state["proc"] = proc
 
     streamer_proc, log_path = _start_log_streamer(container_name)
+    _state["streamer"] = streamer_proc
     try:
         _lifecycle.wait_until_healthy(
             health_url,
             is_alive=lambda: proc.poll() is None,
         )
     except SystemExit:
+        # Two ways to land here: (a) wait_until_healthy raised SystemExit(1)
+        # because the container died on its own — the post-mortem log is
+        # valuable; (b) our signal handler called sys.exit(130) on abort — it
+        # already stopped+removed the container, so a "container failed"
+        # post-mortem on a now-removed container is misleading and wasteful.
+        # Skip the post-mortem only in the handler case.
+        if _state["handling"]:
+            raise
         time.sleep(0.5)
         _append_post_mortem(container_name, log_path)
         _stop_log_streamer(streamer_proc)
@@ -450,6 +501,13 @@ def run(
     log.info("Ready  →  http://localhost:%d/v1  (docker: %s)", port, container_name)
     if ready_file:
         ready_file.touch()
+
+    # Past readiness the abort-cleanup handler is no longer needed: a persist
+    # container that reached ready is meant to outlive the launcher, and the
+    # --stop path (health-gated) can now reach it. Restore the original
+    # handlers so steady-state signal behavior is unchanged.
+    signal.signal(signal.SIGINT,  orig_int)
+    signal.signal(signal.SIGTERM, orig_term)
 
     try:
         _lifecycle.idle_until_stopped(health_url, log_prefix)


### PR DESCRIPTION
## Problem

When `model-servers` is launching and it's slow (pulling the vLLM image / downloading weights), Ctrl-C does **not** cleanly tear down what was launched — half-started vLLM **docker containers linger** (still downloading). A user who, say, forgot `HF_TOKEN` can't simply abort + retry; the containers stay around.

## Root cause

Two compounding issues:

1. **Launcher keeps persist processes alive on abort.** `model-servers` runs every service as `launch_mode="persist"`, so `run_stack`'s `_no_kill` set contains all of them. On Ctrl-C during startup, `finally: _shutdown(launched, _no_kill)` **skips every persist process** — correct on a clean ready-exit, wrong on an abort.
2. **The docker container outlives a killed wrapper.** The `docker run` client is spawned `start_new_session=True` and the container is dockerd-managed, so killing the wrapper's process group never stops the container. The wrapper installed **no signal handler**. And `stop_persistent_servers` (the `--stop` path) **gates on `/health` 200**, so it can't stop a mid-download container — it's never healthy yet.

## Fix (two coordinated changes)

**A. Launcher (`_stack.py`):** `run_stack` tracks an `aborted` flag. On `KeyboardInterrupt`/`SystemExit` (and a generic pre-ready `Exception`, which re-raises to preserve the traceback) it tears down **everything** — `_shutdown(launched, no_kill=set())` — so each wrapper's process group gets SIGTERM. A clean exit (incl. `exit_after_ready`'s early return) still keeps persist alive. Prints an abort line and exits `130`.

**B. Docker wrapper (`xr_ai_vllm/_docker.py`):** `run()` installs idempotent SIGINT/SIGTERM handlers up front that terminate the in-flight docker client, then `stop_container(name, timeout_s=10)` + `remove_container(name)` — by **name**, so it works regardless of container health (the mid-download case) and completes within the launcher's 20 s SIGKILL window. Handlers are restored after readiness (and on the reuse path) so steady-state / `--stop` behavior is unchanged. This is sample-agnostic, so it also fixes the identical lingering-container bug in **simple-vlm-example**'s docker vlm-server.

Together: Ctrl-C mid-startup now SIGTERMs every wrapper (incl. persist), and each wrapper stops + removes its own container — even mid-pull/mid-download.

## Tests

- `tests/test_launcher_stack.py` — `TestRunStackShutdownContract`: hermetic (no real subprocess/docker/creds) — abort raises `SystemExit(130)` and `_shutdown` is called with `no_kill=set()` despite a persist process; clean `exit_after_ready` preserves the persist `no_kill` set.
- `cd tests && uv run pytest test_launcher_stack.py test_vllm_docker.py test_vllm_lifecycle.py test_launcher_credentials.py -q` → **60 passed**.

## Notes / on-device gate

- The end-to-end "Ctrl-C mid-pull actually removes the container" path needs a real GPU/docker host and is **not** exercised in CI — worth a manual smoke test (launch model-servers with `HF_TOKEN` unset, Ctrl-C during download, confirm `docker ps -a` is clean). The unit test covers the launcher branch; the wrapper handler's non-docker logic (guard flag, holder wiring, handler restore) is correct by inspection.
- No `pyproject.toml` change → `DEPENDENCIES.md` untouched.
- Related (not fixed here): `stop_persistent_servers`'s `/health` gate means `--stop` also can't stop a mid-download container — out of scope for this Ctrl-C fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)