### PR TITLE
fix(launcher): strip host cuDNN off LD_LIBRARY_PATH so venv-bundled cuDNN wins

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,22 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-09 — Launcher: strip a host cuDNN off LD_LIBRARY_PATH before spawning
+
+Each sub-project's venv ships the exact cuDNN its PyTorch was compiled against
+(via the `nvidia-cudnn-cu12` wheel). On hosts that export an `LD_LIBRARY_PATH`
+pointing at a *different* system cuDNN (common on cloud GPU images), the dynamic
+loader found the system copy first and GPU services aborted at torch import with
+`RuntimeError: cuDNN version incompatibility: PyTorch was compiled against
+(9, 20, 0) but found runtime version (9, 13, 1)`. The launcher's `_spawn` now
+sanitizes the child `LD_LIBRARY_PATH`, dropping only the directories that
+actually contain a `libcudnn.so*` so the venv-bundled cuDNN wins while every
+unrelated entry (CUDA toolkit, driver, app libs) stays put. Done once at the
+single point where the child env is built (alongside the existing `VIRTUAL_ENV`
+strip), so it covers every launched service; a one-time WARNING records what was
+removed. Chosen over editing each service or documenting a manual `unset` so the
+stack works out-of-the-box on misconfigured hosts.
+
 ### 2026-06-09 — Voice pipeline: idle-timeout auto-cancel off by default, opt-in via YAML
 
 pipecat's `PipelineWorker` defaults to `cancel_on_idle_timeout=True` at

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -83,6 +83,35 @@ sudo apt install nvidia-cuda-toolkit
 
 This applies to the `xr-render-demo/yaml/96G_blackwell/` profile.
 
+### GPU service aborts with `cuDNN version incompatibility`
+
+**Symptom:** a GPU service (commonly the NeMo STT server) crashes at torch
+import with:
+
+```
+RuntimeError: cuDNN version incompatibility: PyTorch was compiled against
+(9, 20, 0) but found runtime version (9, 13, 1). ... Looks like your
+LD_LIBRARY_PATH contains incompatible version of cudnn.
+```
+
+**Cause:** the host exports an `LD_LIBRARY_PATH` that points at a system cuDNN
+(common on cloud GPU images). It shadows the cuDNN bundled in the service's
+venv — the exact version that venv's PyTorch was compiled against — so torch
+loads the wrong runtime and aborts.
+
+**Fix:** the launcher handles this automatically — `model_servers` /
+`xr_render_demo` strip any `libcudnn`-bearing directory from each child's
+`LD_LIBRARY_PATH` before spawning (logged once as a WARNING), so the
+venv-bundled cuDNN is used. If you hit this running a service **directly**
+(outside the launcher), clear the conflicting path yourself first:
+
+```bash
+# Inspect what's on the path
+echo "$LD_LIBRARY_PATH"
+# Run the service without the host cuDNN shadowing the venv copy
+env -u LD_LIBRARY_PATH uv run <command>
+```
+
 ### `vllm_backend: docker` — image pull fails with "unauthorized" / "denied"
 
 **Symptom:** the wrapper logs `[<service>] Launching vLLM (docker)` and then

--- a/tests/test_launcher_stack.py
+++ b/tests/test_launcher_stack.py
@@ -4,9 +4,11 @@
 """Unit tests for xr_ai_launcher._stack data structures and pure helpers."""
 from __future__ import annotations
 
+import os
+
 import pytest
 
-from xr_ai_launcher._stack import Parallel, Process
+from xr_ai_launcher._stack import Parallel, Process, _strip_conflicting_cudnn
 
 
 class TestProcessDataclass:
@@ -65,3 +67,55 @@ class TestParallelDataclass:
         group = Parallel([])
         with pytest.raises((AttributeError, TypeError)):
             group.processes = ()  # type: ignore[misc]
+
+
+class TestStripConflictingCudnn:
+    """LD_LIBRARY_PATH sanitization so a host cuDNN can't shadow the venv one."""
+
+    def _make_cudnn_dir(self, tmp_path, name):
+        d = tmp_path / name
+        d.mkdir()
+        (d / "libcudnn.so.9").touch()
+        return str(d)
+
+    def test_none_and_empty_pass_through(self):
+        assert _strip_conflicting_cudnn(None) == (None, [])
+        assert _strip_conflicting_cudnn("") == ("", [])
+
+    def test_no_cudnn_dirs_unchanged(self, tmp_path):
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        value = os.pathsep.join([str(plain), "/usr/lib"])
+        assert _strip_conflicting_cudnn(value) == (value, [])
+
+    def test_drops_only_the_cudnn_dir(self, tmp_path):
+        cudnn = self._make_cudnn_dir(tmp_path, "cudnn")
+        keep = tmp_path / "keep"
+        keep.mkdir()
+        value = os.pathsep.join([cudnn, str(keep)])
+        cleaned, dropped = _strip_conflicting_cudnn(value)
+        assert cleaned == str(keep)
+        assert dropped == [cudnn]
+
+    def test_returns_none_when_only_cudnn_dir(self, tmp_path):
+        cudnn = self._make_cudnn_dir(tmp_path, "cudnn")
+        cleaned, dropped = _strip_conflicting_cudnn(cudnn)
+        assert cleaned is None
+        assert dropped == [cudnn]
+
+    def test_preserves_empty_cwd_entry(self, tmp_path):
+        cudnn = self._make_cudnn_dir(tmp_path, "cudnn")
+        # Leading "" => current-directory entry; must survive untouched.
+        value = os.pathsep.join(["", cudnn, "/usr/lib"])
+        cleaned, dropped = _strip_conflicting_cudnn(value)
+        assert cleaned == os.pathsep.join(["", "/usr/lib"])
+        assert dropped == [cudnn]
+
+    def test_matches_versioned_soname(self, tmp_path):
+        # glob libcudnn.so* must catch libcudnn.so.9.13.1 etc.
+        d = tmp_path / "lib"
+        d.mkdir()
+        (d / "libcudnn.so.9.13.1").touch()
+        cleaned, dropped = _strip_conflicting_cudnn(str(d))
+        assert cleaned is None
+        assert dropped == [str(d)]

--- a/utils/xr-ai-launcher/xr_ai_launcher/_stack.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/_stack.py
@@ -33,6 +33,7 @@ the IPC socket connects, after the HTTP server starts listening, etc.
 """
 from __future__ import annotations
 
+import glob
 import logging
 import os
 import re
@@ -151,6 +152,48 @@ def _forward(stream, prefix: str, *, quiet_native: bool = False) -> None:
             print(formatted, flush=True)
 
 
+# Dedup key for the LD_LIBRARY_PATH cuDNN warning — the dropped dirs are the
+# same for every spawned process, so warn once per unique set rather than once
+# per process.
+_warned_cudnn_ld: set[str] = set()
+
+
+def _strip_conflicting_cudnn(ld_library_path: str | None) -> tuple[str | None, list[str]]:
+    """Drop ``LD_LIBRARY_PATH`` entries that ship their own ``libcudnn``.
+
+    Each sub-project's venv installs (via the ``nvidia-cudnn-cu12`` wheel that
+    PyTorch pulls in) the exact cuDNN that its PyTorch was compiled against.
+    When the host exports an ``LD_LIBRARY_PATH`` pointing at a *different*
+    system cuDNN, the dynamic loader finds the system copy first and PyTorch
+    aborts at import with, e.g.::
+
+        RuntimeError: cuDNN version incompatibility: PyTorch was compiled
+        against (9, 20, 0) but found runtime version (9, 13, 1) ...
+
+    Removing only the directories that actually contain a ``libcudnn.so*``
+    lets the venv-bundled cuDNN win while leaving every unrelated entry (CUDA
+    toolkit, driver libs, application libraries) on the path untouched.
+
+    Returns the cleaned value (``None`` when nothing remains, so the caller
+    drops the variable entirely) and the list of removed directories.
+    """
+    if not ld_library_path:
+        return ld_library_path, []
+
+    kept: list[str] = []
+    dropped: list[str] = []
+    for entry in ld_library_path.split(os.pathsep):
+        # An empty entry means "current directory" — never a cuDNN dir; keep it.
+        if entry and glob.glob(os.path.join(entry, "libcudnn.so*")):
+            dropped.append(entry)
+        else:
+            kept.append(entry)
+
+    if not dropped:
+        return ld_library_path, []
+    return (os.pathsep.join(kept) if kept else None), dropped
+
+
 def _spawn(proc: Process, base: Path, ready_file: Path) -> subprocess.Popen:
     project = (base / proc.project).resolve()
 
@@ -167,6 +210,25 @@ def _spawn(proc: Process, base: Path, ready_file: Path) -> subprocess.Popen:
     env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
     if proc.gpu is not None:
         env["CUDA_VISIBLE_DEVICES"] = proc.gpu
+
+    # Keep a host system cuDNN on LD_LIBRARY_PATH from shadowing the
+    # venv-bundled cuDNN each project's PyTorch was compiled against — without
+    # this, GPU services (e.g. the NeMo STT server) abort at torch import with
+    # a "cuDNN version incompatibility" RuntimeError.
+    cleaned, dropped = _strip_conflicting_cudnn(env.get("LD_LIBRARY_PATH"))
+    if dropped:
+        if cleaned is None:
+            env.pop("LD_LIBRARY_PATH", None)
+        else:
+            env["LD_LIBRARY_PATH"] = cleaned
+        key = os.pathsep.join(dropped)
+        if key not in _warned_cudnn_ld:
+            _warned_cudnn_ld.add(key)
+            log.warning(
+                "Removed cuDNN dir(s) from LD_LIBRARY_PATH so the venv-bundled "
+                "cuDNN (which PyTorch was compiled against) is used instead: %s",
+                key,
+            )
 
     # start_new_session=True puts uv + its children (e.g. xr_media_hub) in a
     # new process group.  _shutdown then kills the whole group so grandchild


### PR DESCRIPTION
## Problem

Running `agent-samples/model-servers` (`uv run main.py`) on a cloud GPU host, the STT server crashed at PyTorch import:

```
RuntimeError: cuDNN version incompatibility: PyTorch was compiled against (9, 20, 0)
but found runtime version (9, 13, 1). ... Looks like your LD_LIBRARY_PATH contains
incompatible version of cudnn.
```

**Root cause:** each sub-project's venv ships the exact cuDNN its PyTorch was compiled against (via the `nvidia-cudnn-cu12` wheel). The host's `LD_LIBRARY_PATH` pointed at a *different* system cuDNN (9.13.1) that the dynamic loader found first — shadowing the venv-bundled 9.20.0 — so torch aborted.

The launcher previously forwarded the parent environment to every child untouched (it only stripped `VIRTUAL_ENV`); `LD_LIBRARY_PATH` was never sanitized anywhere in the repo.

## Fix

`xr_ai_launcher/_stack.py` — `_spawn` now sanitizes each child's `LD_LIBRARY_PATH` at the single point where the child env is built (right beside the existing `VIRTUAL_ENV` strip and `CUDA_VISIBLE_DEVICES` handling):

- New pure helper `_strip_conflicting_cudnn()` drops **only** the directories that actually contain a `libcudnn.so*`. With the system cuDNN dir gone from `LD_LIBRARY_PATH`, torch's bundled cuDNN (reached via its `RUNPATH`) wins, while every unrelated entry (CUDA toolkit, driver libs, app libraries) stays on the path. Standard ldconfig dirs still resolve their other libraries normally.
- Applies to **all** launched services in one spot, and propagates into the STT server's internal `--_serve` re-spawn via normal env inheritance.
- Logs a one-time `WARNING` naming exactly which dirs were removed.

## Tests / docs

- `tests/test_launcher_stack.py` — added `TestStripConflictingCudnn` covering: None/empty pass-through, no-cuDNN-unchanged, drop-only-the-cuDNN-dir, return-None-when-only-cuDNN, preserve the empty (cwd) entry, and versioned soname matching (`libcudnn.so.9.13.1`).
- `docs/troubleshooting.md` — new "GPU service aborts with `cuDNN version incompatibility`" entry (notes it's now auto-handled, plus the `env -u LD_LIBRARY_PATH` workaround for running a service directly outside the launcher).
- `docs/changelog.md` — decision entry.

No `pyproject.toml` changes (`glob` is stdlib), so no `DEPENDENCIES.md` update. Launcher stays stdlib-only per AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)