### PR TITLE
feat(nemo): opt-in docker backend for STT + magpie to escape host cuDNN/CUDA

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -105,6 +105,19 @@ xr-ai-vllm  (utils/xr-ai-vllm/)
     container.  Imported by the four vllm wrappers and by the orchestrator
     `--stop` flow.
 
+xr-ai-nemo-runtime  (utils/xr-ai-nemo-runtime/)
+    └── (stdlib only — zero runtime deps)
+    Opt-in NGC NeMo container backend for the two in-process NeMo servers
+    (stt-server, magpie TTS).  When a server's YAML sets `backend: docker` its
+    `run()` delegates here, which `docker run`s an NGC NeMo image, bind-mounts
+    the repo, pip-installs only the light deps the NeMo image lacks
+    (fastapi/uvicorn/hf_transfer/loguru/pyyaml + per-server extras), and runs
+    `python -m <server> --_serve` off PYTHONPATH — never the server's own
+    pyproject, so nemo_toolkit/torch are NOT reinstalled.  Stays stdlib-only so
+    docker mode adds nothing to the wrapper's venv.  Bespoke and separate from
+    `xr-ai-vllm` (different in-container command + packaging).  Imported by
+    stt-server and magpie-tts-server.
+
 xr-ai-vad  (utils/xr-ai-vad/)
     └── numpy >=1.24
     └── silero-vad >=5.1  (pulls torch + onnxruntime transitively)
@@ -252,7 +265,12 @@ stt-server  (ai-services/stt-server/)
     └── uvicorn[standard] >=0.29
     └── python-multipart >=0.0.9
     └── pyyaml >=6.0
+    └── xr-ai-logging       [editable: ../../utils/xr-ai-logging]
+    └── xr-ai-nemo-runtime  [editable: ../../utils/xr-ai-nemo-runtime]
     Model: nvidia/parakeet-tdt-0.6b-v3 (NeMo ASR, in-process)
+    backend: pip|docker — pip path loads NeMo in this venv; docker path runs
+    inside an NGC NeMo image via xr-ai-nemo-runtime (escapes host cuDNN/CUDA
+    mismatches).
 
 magpie-tts-server  (ai-services/tts/magpie/)
     └── nemo_toolkit[tts] >=2.5
@@ -263,7 +281,12 @@ magpie-tts-server  (ai-services/tts/magpie/)
     └── uvicorn[standard] >=0.29
     └── hf-transfer >=0.1.4
     └── pyyaml >=6.0
+    └── xr-ai-logging       [editable: ../../../utils/xr-ai-logging]
+    └── xr-ai-nemo-runtime  [editable: ../../../utils/xr-ai-nemo-runtime]
     Model: nvidia/magpie_tts_multilingual_357m (NeMo TTS, in-process)
+    backend: pip|docker — pip path loads NeMo in this venv; docker path runs
+    inside an NGC NeMo image via xr-ai-nemo-runtime (escapes host cuDNN/CUDA
+    mismatches).
 
 llama-nemotron-llm-server  (ai-services/llm/llama_nemotron/)
     └── vllm >=0.12.0
@@ -453,6 +476,8 @@ updated in the same commit**.
 | `server-runtime/` config fields (`LiveKitConnectorConfig`) | `server-runtime/xr_media_hub.yaml` (reference copy), each sample's `xr_media_hub.yaml`, `AGENTS.md` Config section |
 | `utils/xr-ai-launcher/` `Process` / `run_stack` API | `AGENTS.md` orchestrator boilerplate and process model section |
 | `utils/xr-ai-vllm/` API (`serve`, `stop_persistent_servers`) | All four vllm wrappers (`ai-services/vlm-server/`, `ai-services/llm/llama_nemotron/`, `ai-services/llm/nemotron3_nano/`, `ai-services/llm/nemotron_omni/`), `agent-samples/xr-render-demo/main.py` (`_PERSISTENT_SERVERS`) |
+| `utils/xr-ai-nemo-runtime/` API (`run_nemo_docker`, `DEFAULT_IMAGE`) | `ai-services/stt-server/stt_server/__main__.py`, `ai-services/tts/magpie/magpie_tts_server/__main__.py` |
+| `backend` / `nemo_image` YAML keys (NeMo servers) | `ai-services/stt-server/stt_server.yaml`, `ai-services/tts/magpie/magpie_tts_server.yaml`, the per-profile stt copies in `agent-samples/model-servers/yaml/*/` |
 | `vllm_backend` / `vllm_image` YAML keys | `ai-services/{vlm-server,llm/llama_nemotron,llm/nemotron3_nano,llm/nemotron_omni}/<server>.yaml`, every per-profile copy in `agent-samples/`, `docs/ai-services.md` |
 | Container name used by a vllm wrapper | `_CONTAINER_NAME` in the wrapper's `__main__.py`, `_PERSISTENT_SERVERS` in `agent-samples/xr-render-demo/main.py` |
 | vlm-server model class or supported architectures | `ai-services/vlm-server/vlm_server.yaml` comments |
@@ -476,6 +501,9 @@ updated in the same commit**.
 - `utils/xr-ai-vllm/` — zero runtime dependencies. Stdlib only. Adding deps
   here would defeat docker mode (whose point is to keep heavy vllm-side deps
   out of the wrapper's venv).
+- `utils/xr-ai-nemo-runtime/` — zero runtime dependencies. Stdlib only. Same
+  reasoning as xr-ai-vllm: docker mode exists to keep torch/nemo/cuDNN out of
+  the host venv, so the runner that manages the container must not import them.
 - `agent-sdk/` (`xr-ai-agent`) — only `pyzmq` + `msgpack`. No server-side packages.
 - `agent-sdk/xr-ai-models/` — `xr-ai-logging` + `httpx` + `pyyaml` only. No
   vendor SDKs (no `openai`, no `anthropic`, no `litellm`). All in-tree

--- a/agent-samples/model-servers/yaml/96G_blackwell/stt_server.yaml
+++ b/agent-samples/model-servers/yaml/96G_blackwell/stt_server.yaml
@@ -4,6 +4,9 @@
 # STT server — single Blackwell 96 GB.
 model: nvidia/parakeet-tdt-0.6b-v3
 device: auto
+# "pip" (default, in-venv) or "docker" (NGC NeMo image — escapes host
+# cuDNN/CUDA mismatches). See ai-services/stt-server/stt_server.yaml.
+backend: pip
 port: 8103
 host: "0.0.0.0"
 model_cache: ../../../../models

--- a/agent-samples/model-servers/yaml/dual_48G_ada/stt_server.yaml
+++ b/agent-samples/model-servers/yaml/dual_48G_ada/stt_server.yaml
@@ -16,6 +16,10 @@ device: auto
 # GPU 1 only — GPU 0 is fully allocated to vlm + llm.
 cuda_visible_devices: "1"
 
+# "pip" (default, in-venv) or "docker" (NGC NeMo image — escapes host
+# cuDNN/CUDA mismatches). See ai-services/stt-server/stt_server.yaml.
+backend: pip
+
 port: 8103
 host: "0.0.0.0"
 

--- a/agent-samples/model-servers/yaml/spark/stt_server.yaml
+++ b/agent-samples/model-servers/yaml/spark/stt_server.yaml
@@ -4,6 +4,9 @@
 # STT server — DGX Spark (1× Blackwell, 128 GB).
 model: nvidia/parakeet-tdt-0.6b-v3
 device: auto
+# "pip" (default, in-venv) or "docker" (NGC NeMo image — escapes host
+# cuDNN/CUDA mismatches). See ai-services/stt-server/stt_server.yaml.
+backend: pip
 port: 8103
 host: "0.0.0.0"
 model_cache: ../../../../models

--- a/ai-services/stt-server/pyproject.toml
+++ b/ai-services/stt-server/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "python-multipart>=0.0.9",
     "pyyaml>=6.0",
     "xr-ai-logging",
+    "xr-ai-nemo-runtime",  # stdlib-only opt-in docker backend
 ]
 
 [tool.uv.sources]
@@ -29,8 +30,9 @@ dependencies = [
 # and exposes the same `lightning.pytorch` namespace NeMo uses.  Pull
 # `lightning` straight from the upstream tag — drop this source once
 # PyPI lifts the quarantine.
-lightning     = { git = "https://github.com/Lightning-AI/pytorch-lightning", tag = "2.4.0" }
-xr-ai-logging = { path = "../../utils/xr-ai-logging", editable = true }
+lightning          = { git = "https://github.com/Lightning-AI/pytorch-lightning", tag = "2.4.0" }
+xr-ai-logging      = { path = "../../utils/xr-ai-logging",      editable = true }
+xr-ai-nemo-runtime = { path = "../../utils/xr-ai-nemo-runtime", editable = true }
 
 [project.scripts]
 stt_server = "stt_server.__main__:run"

--- a/ai-services/stt-server/stt_server.yaml
+++ b/ai-services/stt-server/stt_server.yaml
@@ -13,6 +13,17 @@ model: nvidia/parakeet-tdt-0.6b-v3
 # Inference device: "cuda", "cpu", or "auto" (CUDA if available, else CPU).
 device: auto
 
+# Runtime backend: "pip" (default — load NeMo in this venv) or "docker" (run
+# inside an NGC NeMo image). Use "docker" on hosts where the in-venv torch hits
+# a cuDNN/CUDA runtime error (e.g. "cuDNN version incompatibility: compiled
+# against (9,20,0) but found runtime (9,13,1)") — the container's cuDNN/CUDA
+# escape the host's LD_LIBRARY_PATH. Default "pip" = unchanged behavior.
+backend: pip
+
+# NGC NeMo image used when backend: docker. Confirm a tag available to your NGC
+# account (`docker pull <tag>`); the example default may roll over.
+# nemo_image: nvcr.io/nvidia/nemo:25.04
+
 port: 8103
 host: "0.0.0.0"
 

--- a/ai-services/stt-server/stt_server/__main__.py
+++ b/ai-services/stt-server/stt_server/__main__.py
@@ -259,6 +259,33 @@ def _idle_until_stopped(health_url: str) -> None:
             return
 
 
+def _run_docker(cfg: dict, yaml_dir: Path, ns) -> None:
+    """Delegate to the NeMo docker runner (opt-in `backend: docker`)."""
+    from xr_ai_nemo_runtime import DEFAULT_IMAGE, run_nemo_docker
+
+    if not ns.config:
+        sys.exit("[stt_server] backend: docker requires --config (a YAML on a "
+                 "host-visible path the container can mount)")
+
+    model_cache = _resolve_model_cache(cfg, yaml_dir)
+    run_nemo_docker(
+        image=cfg.get("nemo_image", DEFAULT_IMAGE),
+        container_name="xr-ai-nemo-stt-server",
+        log_prefix="stt_server",
+        server_module="stt_server",
+        server_pkg_dir=Path(__file__).resolve().parent.parent,
+        config_path=ns.config.resolve(),
+        model_cache=model_cache,
+        nemo_cache_dir=model_cache / "nemo",
+        host=cfg.get("host", "0.0.0.0"),
+        port=int(cfg.get("port", _DEFAULT_PORT)),
+        hf_token=os.environ.get("HF_TOKEN"),
+        cuda_visible_devices=cfg.get("cuda_visible_devices"),
+        extra_pip=["python-multipart"],
+        ready_file=ns.ready_file,
+    )
+
+
 def run() -> None:
     sys.stdout.reconfigure(line_buffering=True)
     sys.stderr.reconfigure(line_buffering=True)
@@ -281,7 +308,16 @@ def run() -> None:
 
     if ns._serve:
         # Persistent server subprocess — loads model and serves until killed.
+        # Also the in-container entry for the docker backend; it bypasses the
+        # backend dispatch below so the container never re-spawns itself.
         asyncio.run(_run(cfg, yaml_dir, ready_file=None))
+        return
+
+    # Opt-in docker backend: run inside an NGC NeMo image so torch+nemo+cuDNN
+    # come from the container, escaping host cuDNN/LD_LIBRARY_PATH mismatches.
+    # Default `pip` (or unset) keeps the unchanged in-venv path below.
+    if cfg.get("backend", "pip") == "docker":
+        _run_docker(cfg, yaml_dir, ns)
         return
 
     # ── wrapper mode ──────────────────────────────────────────────────────────

--- a/ai-services/tts/magpie/magpie_tts_server.yaml
+++ b/ai-services/tts/magpie/magpie_tts_server.yaml
@@ -13,6 +13,17 @@ model: nvidia/magpie_tts_multilingual_357m
 # Inference device: "cuda", "cpu", or "auto" (CUDA if available, else CPU).
 device: auto
 
+# Runtime backend: "pip" (default — load NeMo in this venv) or "docker" (run
+# inside an NGC NeMo image). Use "docker" on hosts where the in-venv torch hits
+# a cuDNN/CUDA runtime error (e.g. "cuDNN version incompatibility: compiled
+# against (9,20,0) but found runtime (9,13,1)") — the container's cuDNN/CUDA
+# escape the host's LD_LIBRARY_PATH. Default "pip" = unchanged behavior.
+backend: pip
+
+# NGC NeMo image used when backend: docker. Confirm a tag available to your NGC
+# account (`docker pull <tag>`); the example default may roll over.
+# nemo_image: nvcr.io/nvidia/nemo:25.04
+
 port: 8104
 host: "0.0.0.0"
 

--- a/ai-services/tts/magpie/magpie_tts_server/__main__.py
+++ b/ai-services/tts/magpie/magpie_tts_server/__main__.py
@@ -191,6 +191,33 @@ async def _run(cfg: dict, yaml_dir: Path, ready_file: Path | None = None) -> Non
     logger.info("Stopped.")
 
 
+def _run_docker(cfg: dict, yaml_dir: Path, ns) -> None:
+    """Delegate to the NeMo docker runner (opt-in `backend: docker`)."""
+    from xr_ai_nemo_runtime import DEFAULT_IMAGE, run_nemo_docker
+
+    if not ns.config:
+        sys.exit("[magpie_tts_server] backend: docker requires --config (a YAML "
+                 "on a host-visible path the container can mount)")
+
+    model_cache = _resolve_model_cache(cfg, yaml_dir)
+    run_nemo_docker(
+        image=cfg.get("nemo_image", DEFAULT_IMAGE),
+        container_name="xr-ai-nemo-magpie-tts-server",
+        log_prefix="magpie_tts_server",
+        server_module="magpie_tts_server",
+        server_pkg_dir=Path(__file__).resolve().parent.parent,
+        config_path=ns.config.resolve(),
+        model_cache=model_cache,
+        nemo_cache_dir=model_cache / "nemo",
+        host=cfg.get("host", "0.0.0.0"),
+        port=int(cfg.get("port", _DEFAULT_PORT)),
+        hf_token=os.environ.get("HF_TOKEN"),
+        cuda_visible_devices=cfg.get("cuda_visible_devices"),
+        extra_pip=["soundfile", "numpy"],
+        ready_file=ns.ready_file,
+    )
+
+
 def run() -> None:
     sys.stdout.reconfigure(line_buffering=True)
     sys.stderr.reconfigure(line_buffering=True)
@@ -200,6 +227,8 @@ def run() -> None:
     p = argparse.ArgumentParser(add_help=False)
     p.add_argument("--config",     type=Path, default=None)
     p.add_argument("--ready-file", type=Path, default=None)
+    p.add_argument("--_serve",     action="store_true",
+                   help=argparse.SUPPRESS)  # internal: in-container serve mode
     ns, _ = p.parse_known_args()
 
     cfg: dict = {}
@@ -208,6 +237,12 @@ def run() -> None:
         yaml_dir = ns.config.parent.resolve()
         with open(ns.config) as f:
             cfg = yaml.safe_load(f) or {}
+
+    # `--_serve` is the in-container entry for the docker backend; it bypasses
+    # the dispatch below so the container never re-spawns itself.
+    if not ns._serve and cfg.get("backend", "pip") == "docker":
+        _run_docker(cfg, yaml_dir, ns)
+        return
 
     asyncio.run(_run(cfg, yaml_dir, ready_file=ns.ready_file))
 

--- a/ai-services/tts/magpie/pyproject.toml
+++ b/ai-services/tts/magpie/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "hf-transfer>=0.1.4",
     "pyyaml>=6.0",
     "xr-ai-logging",
+    "xr-ai-nemo-runtime",  # stdlib-only opt-in docker backend
 ]
 
 [tool.uv.sources]
@@ -29,8 +30,9 @@ dependencies = [
 # blocking NeMo's [asr]/[tts] extras.  Pull `lightning` straight from the
 # upstream tag (it builds from the same Lightning AI mono-repo as
 # `pytorch-lightning`).  Drop this source once PyPI lifts the quarantine.
-lightning     = { git = "https://github.com/Lightning-AI/pytorch-lightning", tag = "2.4.0" }
-xr-ai-logging = { path = "../../../utils/xr-ai-logging", editable = true }
+lightning          = { git = "https://github.com/Lightning-AI/pytorch-lightning", tag = "2.4.0" }
+xr-ai-logging      = { path = "../../../utils/xr-ai-logging",      editable = true }
+xr-ai-nemo-runtime = { path = "../../../utils/xr-ai-nemo-runtime", editable = true }
 
 [project.scripts]
 magpie_tts_server = "magpie_tts_server.__main__:run"

--- a/docs/ai-services.md
+++ b/docs/ai-services.md
@@ -277,6 +277,49 @@ Existing `~/.docker/config.json` entries take priority and are not overwritten.
 (escalating to `docker kill` after 20 s); for pip mode it falls back to the
 port → PID → SIGTERM/SIGKILL path. Same UX for both.
 
+## Choosing the NeMo runtime (pip vs Docker)
+
+The two **NeMo** servers (`stt_server`, `magpie_tts_server`) load torch+NeMo in
+the wrapper's venv and inherit the host's cuDNN/CUDA via `LD_LIBRARY_PATH`. On
+hosts where that system cuDNN differs from torch's bundled one, the in-venv path
+aborts at torch import (`cuDNN version incompatibility: compiled against
+(9,20,0) but found runtime (9,13,1)`). They accept a `backend:` key to escape
+this by running inside an NGC NeMo container:
+
+| `backend` | Runtime | Default | Use when |
+|---|---|---|---|
+| `pip` | NeMo loaded in the wrapper's venv | yes | Standard development; the host cuDNN/CUDA matches torch's. |
+| `docker` | `docker run nvcr.io/nvidia/nemo:<tag> …` hosting the same FastAPI server | no | The in-venv torch hits a cuDNN/CUDA runtime error; pinning an NGC NeMo release. |
+
+```yaml
+backend: docker
+# nemo_image: nvcr.io/nvidia/nemo:25.04   # confirm a tag available to your NGC account
+```
+
+This is a **bespoke** NeMo path (in `utils/xr-ai-nemo-runtime/`), separate from
+the vLLM one — vLLM's container ships the `vllm serve` binary, whereas the NeMo
+image ships torch+nemo but not our server. So the runner bind-mounts the repo
+read-only, points `PYTHONPATH` at the mounted server package + `xr-ai-logging`,
+pip-installs only the light deps the image lacks (fastapi, uvicorn, hf_transfer,
+loguru, pyyaml, plus `python-multipart` for stt / `soundfile`+`numpy` for
+magpie), and runs `python -m <server> --_serve`. It never installs the server's
+own pyproject (that would drag nemo_toolkit/torch and conflict with the image).
+
+Prerequisites (Docker Engine, NVIDIA Container Toolkit, NGC pull access) are
+identical to the vLLM docker mode above. `--network host --ipc host --gpus …`,
+the same-path `model_cache` bind-mount, `HF_TOKEN` pass-through, and a Ctrl-C
+self-stop all mirror the vLLM runner. `piper` TTS is **not** affected — it is
+ONNX/CPU and never touches torch/cuDNN.
+
+Unlike vLLM, the NeMo container **dies with the stack** — it is not persisted
+across restarts (NeMo reloads in ~20s from cached weights, so persistence isn't
+worth orphaning a container the vLLM-keyed `--stop` reaper can't find). The
+wrapper stops and removes its own container on the shutdown SIGTERM.
+
+> On-device gate: the real NeMo image pull + cuDNN-clean model load can only be
+> verified on a GPU host with docker + NGC access. The hermetic test suite
+> covers argv construction and the pip/docker toggle only.
+
 ## Per-server notes
 
 - **vlm-server** is a thin launcher around `vllm serve` for Cosmos-Reason1-7B

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,55 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-09 — NeMo servers: opt-in `backend: docker` to escape host cuDNN/CUDA
+
+The two in-process NeMo servers (stt-server, magpie TTS) load torch+NeMo in the
+wrapper's venv and inherit the host's cuDNN/CUDA via `LD_LIBRARY_PATH`. On hosts
+whose system cuDNN differs from torch's bundled one this aborts at torch import
+(`cuDNN version incompatibility: compiled against (9,20,0) but found runtime
+(9,13,1)`, observed on an L40S box). The launcher's `LD_LIBRARY_PATH` strip
+(same date, above) handles the common case, but where it can't, the vLLM
+services already escape by running in NGC containers. NeMo now gets the same
+escape hatch.
+
+New stdlib-only package `utils/xr-ai-nemo-runtime/` provides `run_nemo_docker`,
+a bespoke NeMo container runner (deliberately separate from `xr-ai-vllm` — the
+in-container command and packaging differ). Each NeMo server's YAML gains
+`backend: pip|docker`; `run()` delegates to the runner only when `docker`.
+**Default `pip` is exactly today's in-venv behavior — zero change unless opted
+in.** piper TTS is excluded: it is ONNX / CPU (`use_cuda: false`) and never hits
+the torch/cuDNN path.
+
+The key new piece is in-container packaging. The NGC NeMo image ships
+torch+nemo+cuDNN but not our FastAPI server, so the runner bind-mounts the repo
+read-only, points `PYTHONPATH` at the mounted server package + `xr-ai-logging`,
+pip-installs only the light deps the image lacks (fastapi, uvicorn[standard],
+hf_transfer, loguru, pyyaml, plus per-server extras — `python-multipart` for
+stt, `soundfile`/`numpy` for magpie), and runs `python -m <server> --_serve`.
+It never `pip install`s the server's own pyproject, which would drag
+nemo_toolkit/torch and conflict with the image's. `--_serve` short-circuits the
+backend dispatch so the in-container process can't re-read `backend: docker` and
+recursively spawn another container. The host launcher touches the ready-file
+once `/health` returns 200 (the ready-file is not passed into the container,
+sidestepping bind-mount write permissions).
+
+The runner mirrors `xr-ai-vllm`'s container mechanics: `--network host` +
+`--ipc host`, same-path model-cache mount, `HF_TOKEN` pass-through, label-based
+stop/rm, and a SIGINT/SIGTERM handler that stops+removes the container so Ctrl-C
+during a slow NeMo image pull / weight download cleans up (mirroring the same
+self-stop added to `xr_ai_vllm/_docker.run()`).
+
+One deliberate divergence from vLLM: the NeMo container **dies with the stack**,
+it does NOT persist across restarts. vLLM persists to dodge multi-minute model
+reloads; NeMo reloads in ~20s from the HF-cached weights on the mounted volume,
+so persistence isn't worth the failure mode it would create — the
+`model-servers --stop` reaper (`xr_ai_vllm.stop_persistent_servers`) finds
+containers by the `xr-ai-vllm.port=…` label and could not reap an
+`xr-ai-nemo.port=…` container, orphaning it. So the wrapper keeps its
+stop+remove signal handler installed through the idle loop and tears its own
+container down on the shutdown SIGTERM. (`xr_ai_vllm` is intentionally left
+untouched.)
+
 ### 2026-06-09 — Launcher: strip a host cuDNN off LD_LIBRARY_PATH before spawning
 
 Each sub-project's venv ships the exact cuDNN its PyTorch was compiled against

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "xr-ai-vad",
     "xr-ai-voicegate",
     "xr-ai-vllm",
+    "xr-ai-nemo-runtime",
     # MCP servers exercised by subprocess tests (fastmcp pulled in transitively).
     "transcript-mcp-server",
     "vlm-mcp-server",
@@ -46,6 +47,7 @@ xr-ai-logging         = { path = "../utils/xr-ai-logging",              editable
 xr-ai-vad             = { path = "../utils/xr-ai-vad",                  editable = true }
 xr-ai-voicegate       = { path = "../utils/xr-ai-voicegate",            editable = true }
 xr-ai-vllm            = { path = "../utils/xr-ai-vllm",                 editable = true }
+xr-ai-nemo-runtime    = { path = "../utils/xr-ai-nemo-runtime",         editable = true }
 transcript-mcp-server = { path = "../agent-mcp-servers/transcript-mcp", editable = true }
 vlm-mcp-server        = { path = "../agent-mcp-servers/vlm-mcp",        editable = true }
 render-mcp            = { path = "../agent-mcp-servers/render-mcp",     editable = true }

--- a/tests/test_nemo_docker.py
+++ b/tests/test_nemo_docker.py
@@ -1,0 +1,323 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the opt-in NeMo docker backend.
+
+Two layers, both hermetic (no docker/GPU):
+
+* ``xr_ai_nemo_runtime._docker`` pure helpers — the ``docker run`` argv builder
+  and the registry helpers.
+* The backend toggle in each NeMo server's ``run()``: ``backend: pip`` (default
+  / unset) takes the in-venv path; ``backend: docker`` routes to the runner.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+from xr_ai_nemo_runtime import DEFAULT_IMAGE
+from xr_ai_nemo_runtime._docker import (
+    _already_logged_in,
+    _registry_for,
+    build_run_argv,
+    container_exists,
+)
+
+_REPO = Path(__file__).resolve().parents[1]
+
+
+def _base_kwargs(tmp_path: Path) -> dict:
+    return dict(
+        image=DEFAULT_IMAGE,
+        container_name="xr-ai-nemo-stt-server",
+        port=8103,
+        repo_root=_REPO,
+        server_pkg_dir=_REPO / "ai-services" / "stt-server",
+        server_module="stt_server",
+        config_path=_REPO / "ai-services" / "stt-server" / "stt_server.yaml",
+        model_cache=tmp_path / "models",
+        nemo_cache_dir=tmp_path / "models" / "nemo",
+        hf_token="tok123",
+        cuda_visible_devices=None,
+        extra_pip=["python-multipart"],
+        extra_env=None,
+    )
+
+
+class TestBuildRunArgv:
+    def test_docker_run_prefix(self, tmp_path):
+        argv = build_run_argv(**_base_kwargs(tmp_path))
+        assert argv[0] == "docker"
+        assert argv[1] == "run"
+
+    def test_image_present(self, tmp_path):
+        argv = build_run_argv(**_base_kwargs(tmp_path))
+        assert DEFAULT_IMAGE in argv
+
+    def test_container_name(self, tmp_path):
+        argv = build_run_argv(**_base_kwargs(tmp_path))
+        assert argv[argv.index("--name") + 1] == "xr-ai-nemo-stt-server"
+
+    def test_port_label(self, tmp_path):
+        argv = build_run_argv(**_base_kwargs(tmp_path))
+        assert argv[argv.index("--label") + 1] == "xr-ai-nemo.port=8103"
+
+    def test_network_host(self, tmp_path):
+        argv = build_run_argv(**_base_kwargs(tmp_path))
+        assert argv[argv.index("--network") + 1] == "host"
+
+    def test_ipc_host(self, tmp_path):
+        argv = build_run_argv(**_base_kwargs(tmp_path))
+        assert argv[argv.index("--ipc") + 1] == "host"
+
+    def test_gpus_all_when_no_filter(self, tmp_path):
+        argv = build_run_argv(**_base_kwargs(tmp_path))
+        assert argv[argv.index("--gpus") + 1] == "all"
+
+    def test_cuda_visible_devices_applied(self, tmp_path):
+        kwargs = _base_kwargs(tmp_path)
+        kwargs["cuda_visible_devices"] = "1"
+        argv = build_run_argv(**kwargs)
+        assert argv[argv.index("--gpus") + 1] == "device=1"
+
+    def test_hf_transfer_env_on(self, tmp_path):
+        argv = build_run_argv(**_base_kwargs(tmp_path))
+        env_flags = [argv[i + 1] for i, a in enumerate(argv) if a == "-e"]
+        assert "HF_HUB_ENABLE_HF_TRANSFER=1" in env_flags
+
+    def test_hf_token_in_env_when_provided(self, tmp_path):
+        argv = build_run_argv(**_base_kwargs(tmp_path))
+        env_flags = [argv[i + 1] for i, a in enumerate(argv) if a == "-e"]
+        assert any(f.startswith("HF_TOKEN=") for f in env_flags)
+
+    def test_no_hf_token_when_none(self, tmp_path):
+        kwargs = _base_kwargs(tmp_path)
+        kwargs["hf_token"] = None
+        argv = build_run_argv(**kwargs)
+        env_flags = [argv[i + 1] for i, a in enumerate(argv) if a == "-e"]
+        assert not any(f.startswith("HF_TOKEN=") for f in env_flags)
+
+    def test_nemo_cache_dir_in_env(self, tmp_path):
+        argv = build_run_argv(**_base_kwargs(tmp_path))
+        env_flags = [argv[i + 1] for i, a in enumerate(argv) if a == "-e"]
+        assert any(f.startswith("NEMO_CACHE_DIR=") for f in env_flags)
+
+    def test_model_cache_mounted(self, tmp_path):
+        kwargs = _base_kwargs(tmp_path)
+        argv = build_run_argv(**kwargs)
+        cache = str(kwargs["model_cache"])
+        mounts = [argv[i + 1] for i, a in enumerate(argv) if a == "-v"]
+        assert f"{cache}:{cache}" in mounts
+
+    def test_repo_mounted_read_only(self, tmp_path):
+        argv = build_run_argv(**_base_kwargs(tmp_path))
+        mounts = [argv[i + 1] for i, a in enumerate(argv) if a == "-v"]
+        assert f"{_REPO}:{_REPO}:ro" in mounts
+
+    def test_bash_installs_light_deps_not_pyproject(self, tmp_path):
+        # The container has torch+nemo already; we must install only the light
+        # missing deps and never `pip install` our pyproject (which drags
+        # nemo_toolkit/torch and conflicts).
+        argv = build_run_argv(**_base_kwargs(tmp_path))
+        assert argv[-3] == "bash"
+        assert argv[-2] == "-c"
+        bash_cmd = argv[-1]
+        assert bash_cmd.startswith("pip install -q ")
+        assert "fastapi" in bash_cmd
+        assert "uvicorn[standard]" in bash_cmd  # shlex may quote the brackets
+        assert "hf_transfer" in bash_cmd
+        assert "loguru" in bash_cmd
+        assert "pyyaml" in bash_cmd
+        # per-server extra_pip merged in
+        assert "python-multipart" in bash_cmd
+        # never our own package / pyproject
+        assert "nemo_toolkit" not in bash_cmd
+        assert "pip install -e" not in bash_cmd
+        assert "pyproject" not in bash_cmd
+
+    def test_bash_runs_module_with_serve_flag(self, tmp_path):
+        # In-container entry must use --_serve so the server does NOT re-read
+        # `backend: docker` and spawn another container.
+        argv = build_run_argv(**_base_kwargs(tmp_path))
+        bash_cmd = argv[-1]
+        assert "python -m stt_server" in bash_cmd
+        assert "--_serve" in bash_cmd
+        assert "--config" in bash_cmd
+
+    def test_bash_sets_pythonpath_to_mounts(self, tmp_path):
+        # PYTHONPATH points at the mounted server package + xr-ai-logging so
+        # imports resolve from the mount without a pip install.
+        kwargs = _base_kwargs(tmp_path)
+        argv = build_run_argv(**kwargs)
+        bash_cmd = argv[-1]
+        assert "PYTHONPATH=" in bash_cmd
+        assert str(kwargs["server_pkg_dir"]) in bash_cmd
+        assert str(_REPO / "utils" / "xr-ai-logging") in bash_cmd
+
+    def test_magpie_extra_pip_includes_soundfile(self, tmp_path):
+        kwargs = _base_kwargs(tmp_path)
+        kwargs["extra_pip"] = ["soundfile", "numpy"]
+        kwargs["server_module"] = "magpie_tts_server"
+        argv = build_run_argv(**kwargs)
+        bash_cmd = argv[-1]
+        assert "soundfile" in bash_cmd
+        assert "python -m magpie_tts_server" in bash_cmd
+        # magpie does not need python-multipart (no multipart endpoint)
+        assert "python-multipart" not in bash_cmd
+
+
+class TestRegistryHelpers:
+    def test_nvcr_registry(self):
+        assert _registry_for("nvcr.io/nvidia/nemo:25.04") == "nvcr.io"
+
+    def test_unqualified_name_no_registry(self):
+        assert _registry_for("myimage") is None
+
+    def test_tagged_unqualified_name_no_registry(self):
+        assert _registry_for("myimage:latest") is None
+
+    def test_already_logged_in_false_without_config(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "xr_ai_nemo_runtime._docker._DOCKER_CONFIG", tmp_path / "config.json"
+        )
+        assert not _already_logged_in("nvcr.io")
+
+
+class TestContainerHelpers:
+    def test_container_exists_false_when_docker_missing(self):
+        with patch(
+            "xr_ai_nemo_runtime._docker.subprocess.check_output",
+            side_effect=FileNotFoundError,
+        ):
+            assert not container_exists("some-name")
+
+
+# ── backend toggle: server run() routes pip vs docker ────────────────────────
+
+
+def _load_server_main(pkg_dir: Path, module_name: str):
+    """Import a NeMo server's __main__ from its source tree.
+
+    The servers aren't tests deps (that would drag nemo_toolkit), but their
+    top-level imports are light (yaml/loguru/xr_ai_logging only), so the
+    module loads fine once its package dir is on sys.path.
+    """
+    if str(pkg_dir) not in sys.path:
+        sys.path.insert(0, str(pkg_dir))
+    spec = importlib.util.find_spec(f"{module_name}.__main__")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _run_with_argv(mod, argv, monkeypatch):
+    monkeypatch.setattr(sys, "argv", argv)
+    mod.run()
+
+
+class TestSttBackendToggle:
+    def _mod(self):
+        return _load_server_main(_REPO / "ai-services" / "stt-server", "stt_server")
+
+    def test_default_pip_does_not_call_runner(self, tmp_path, monkeypatch):
+        mod = self._mod()
+        cfg = _REPO / "ai-services" / "stt-server" / "stt_server.yaml"
+        called = {"docker": False}
+        monkeypatch.setattr(mod, "_run_docker",
+                            lambda *a, **k: called.__setitem__("docker", True))
+        # Stop the in-venv wrapper path immediately after the toggle decision.
+        sentinel = RuntimeError("pip path reached")
+
+        def _boom(*a, **k):
+            raise sentinel
+        # No server is up: keep the reuse-probe hermetic (no live socket) and
+        # explode on the first in-venv side effect after the toggle decision.
+        monkeypatch.setattr(mod.urllib.request, "urlopen",
+                            lambda *a, **k: (_ for _ in ()).throw(OSError("refused")))
+        monkeypatch.setattr(mod.subprocess, "Popen", _boom)
+        # default config has backend: pip
+        try:
+            _run_with_argv(mod, ["stt_server", "--config", str(cfg)], monkeypatch)
+        except RuntimeError as exc:
+            assert exc is sentinel  # reached the pip path, not docker
+        assert called["docker"] is False
+
+    def test_docker_routes_to_runner(self, tmp_path, monkeypatch):
+        mod = self._mod()
+        cfg = tmp_path / "stt_server.yaml"
+        cfg.write_text("model: nvidia/parakeet-tdt-0.6b-v3\nbackend: docker\nport: 8103\n")
+        seen = {}
+        monkeypatch.setattr(mod, "_run_docker",
+                            lambda c, y, n: seen.update(cfg=c, ns=n))
+        # in-venv path must NOT run
+        monkeypatch.setattr(mod.subprocess, "Popen",
+                            lambda *a, **k: (_ for _ in ()).throw(
+                                AssertionError("pip path invoked under backend: docker")))
+        _run_with_argv(mod, ["stt_server", "--config", str(cfg)], monkeypatch)
+        assert seen["cfg"]["backend"] == "docker"
+
+    def test_serve_flag_bypasses_docker_dispatch(self, tmp_path, monkeypatch):
+        # The in-container entry (--_serve) must never re-route to docker.
+        mod = self._mod()
+        cfg = tmp_path / "stt_server.yaml"
+        cfg.write_text("model: m\nbackend: docker\nport: 8103\n")
+        monkeypatch.setattr(mod, "_run_docker",
+                            lambda *a, **k: (_ for _ in ()).throw(
+                                AssertionError("--_serve re-routed to docker")))
+        # _serve calls asyncio.run(_run(...)); stub _run so we don't load nemo.
+        async def _fake_run(*a, **k):
+            return None
+        monkeypatch.setattr(mod, "_run", _fake_run)
+        _run_with_argv(mod, ["stt_server", "--_serve", "--config", str(cfg)], monkeypatch)
+
+
+class TestMagpieBackendToggle:
+    def _mod(self):
+        return _load_server_main(_REPO / "ai-services" / "tts" / "magpie",
+                                 "magpie_tts_server")
+
+    def test_default_pip_does_not_call_runner(self, tmp_path, monkeypatch):
+        mod = self._mod()
+        cfg = _REPO / "ai-services" / "tts" / "magpie" / "magpie_tts_server.yaml"
+        called = {"docker": False}
+        monkeypatch.setattr(mod, "_run_docker",
+                            lambda *a, **k: called.__setitem__("docker", True))
+        sentinel = RuntimeError("pip path reached")
+
+        async def _fake_run(*a, **k):
+            raise sentinel
+        monkeypatch.setattr(mod, "_run", _fake_run)
+        try:
+            _run_with_argv(mod, ["magpie_tts_server", "--config", str(cfg)], monkeypatch)
+        except RuntimeError as exc:
+            assert exc is sentinel
+        assert called["docker"] is False
+
+    def test_docker_routes_to_runner(self, tmp_path, monkeypatch):
+        mod = self._mod()
+        cfg = tmp_path / "magpie_tts_server.yaml"
+        cfg.write_text("model: nvidia/magpie_tts_multilingual_357m\nbackend: docker\nport: 8104\n")
+        seen = {}
+        monkeypatch.setattr(mod, "_run_docker",
+                            lambda c, y, n: seen.update(cfg=c, ns=n))
+
+        async def _no_pip(*a, **k):
+            raise AssertionError("pip path invoked under backend: docker")
+        monkeypatch.setattr(mod, "_run", _no_pip)
+        _run_with_argv(mod, ["magpie_tts_server", "--config", str(cfg)], monkeypatch)
+        assert seen["cfg"]["backend"] == "docker"
+
+    def test_serve_flag_bypasses_docker_dispatch(self, tmp_path, monkeypatch):
+        mod = self._mod()
+        cfg = tmp_path / "magpie_tts_server.yaml"
+        cfg.write_text("model: m\nbackend: docker\nport: 8104\n")
+        monkeypatch.setattr(mod, "_run_docker",
+                            lambda *a, **k: (_ for _ in ()).throw(
+                                AssertionError("--_serve re-routed to docker")))
+
+        async def _fake_run(*a, **k):
+            return None
+        monkeypatch.setattr(mod, "_run", _fake_run)
+        _run_with_argv(mod, ["magpie_tts_server", "--_serve", "--config", str(cfg)], monkeypatch)

--- a/utils/xr-ai-nemo-runtime/pyproject.toml
+++ b/utils/xr-ai-nemo-runtime/pyproject.toml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "xr-ai-nemo-runtime"
+version = "0.1.0"
+requires-python = ">=3.11,<3.13"
+# Stdlib only — no torch/nemo/fastapi imported here, so the docker path stays
+# light even where the NeMo wrappers' heavy deps are not installed.
+dependencies = []
+
+[tool.hatch.build.targets.wheel]
+packages = ["xr_ai_nemo_runtime"]

--- a/utils/xr-ai-nemo-runtime/xr_ai_nemo_runtime/__init__.py
+++ b/utils/xr-ai-nemo-runtime/xr_ai_nemo_runtime/__init__.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+xr-ai-nemo-runtime — opt-in NGC NeMo container backend for the in-process
+NeMo servers (stt-server, magpie TTS).
+
+The NeMo servers load torch+NeMo in the wrapper's venv and inherit the host's
+cuDNN/CUDA via LD_LIBRARY_PATH, which aborts at torch import on hosts whose
+system cuDNN differs from torch's bundled one. This runs the same FastAPI
+server inside an NGC NeMo image instead, so torch+nemo+cuDNN all come from the
+container and the host's libraries are irrelevant.
+
+Opt in per-server via `backend: docker` in the service YAML (default `pip` =
+today's in-venv behavior, unchanged). This is a BESPOKE NeMo docker path,
+deliberately separate from `xr_ai_vllm` (the vLLM `vllm serve` binary differs
+from our `python -m <server>` entry, and the in-container packaging differs).
+
+Stdlib-only by contract — no torch/nemo/fastapi imported here.
+
+Typical usage from a NeMo server's ``run()``::
+
+    from xr_ai_nemo_runtime import run_nemo_docker, DEFAULT_IMAGE
+
+    run_nemo_docker(
+        image=cfg.get("nemo_image", DEFAULT_IMAGE),
+        container_name="xr-ai-nemo-stt-server",
+        log_prefix="stt_server",
+        server_module="stt_server",
+        server_pkg_dir=Path(__file__).resolve().parent.parent,
+        config_path=ns.config.resolve(),
+        model_cache=model_cache,
+        nemo_cache_dir=model_cache / "nemo",
+        host=host, port=port,
+        hf_token=os.environ.get("HF_TOKEN"),
+        cuda_visible_devices=cfg.get("cuda_visible_devices"),
+        extra_pip=["python-multipart"],
+        ready_file=ns.ready_file,
+    )
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from . import _docker
+
+# Example NGC NeMo image. Override per-server via `nemo_image:` in YAML.
+# NOTE: confirm a tag available to your NGC account — image tags roll over and
+# this default may not be pullable. `docker pull <tag>` before relying on it.
+DEFAULT_IMAGE = "nvcr.io/nvidia/nemo:25.04"
+
+
+def run_nemo_docker(
+    *,
+    image: str = DEFAULT_IMAGE,
+    container_name: str,
+    log_prefix: str,
+    server_module: str,
+    server_pkg_dir: Path,
+    config_path: Path,
+    model_cache: Path,
+    nemo_cache_dir: Path | None = None,
+    host: str,
+    port: int,
+    hf_token: str | None = None,
+    cuda_visible_devices: str | None = None,
+    extra_pip: list[str] | None = None,
+    extra_env: dict[str, str] | None = None,
+    ready_file: Path | None = None,
+) -> None:
+    """Run a NeMo FastAPI server inside an NGC NeMo container.
+
+    *server_module* is the module run via ``python -m <module> --_serve`` in
+    the container (e.g. ``"stt_server"``). The ``--_serve`` flag must
+    short-circuit the server's own backend dispatch so the container does not
+    re-spawn itself.
+
+    *server_pkg_dir* is the directory that CONTAINS the server package (so it
+    goes on PYTHONPATH). It must live under the repo tree that gets
+    bind-mounted; the repo root is derived from it.
+
+    *config_path* must be inside the bind-mounted repo (the server reads it
+    in-container). *model_cache* is mounted read-write so weight downloads
+    persist on the host. *nemo_cache_dir* sets ``NEMO_CACHE_DIR`` in the
+    container (stt sets this today).
+
+    *extra_pip* are the light deps the server needs that the NeMo image lacks
+    beyond the shared base (fastapi/uvicorn/hf_transfer/loguru/pyyaml) — e.g.
+    ``["python-multipart"]`` for stt, ``["soundfile", "numpy"]`` for magpie.
+    Never the server's own pyproject: that drags nemo_toolkit/torch and
+    conflicts with the image's.
+    """
+    repo_root = _find_repo_root(server_pkg_dir)
+    _docker.run(
+        image=image,
+        container_name=container_name,
+        log_prefix=log_prefix,
+        server_module=server_module,
+        repo_root=repo_root,
+        server_pkg_dir=server_pkg_dir,
+        config_path=config_path,
+        model_cache=model_cache,
+        nemo_cache_dir=nemo_cache_dir,
+        host=host,
+        port=port,
+        hf_token=hf_token,
+        cuda_visible_devices=cuda_visible_devices,
+        extra_pip=extra_pip,
+        extra_env=extra_env,
+        ready_file=ready_file,
+    )
+
+
+def _find_repo_root(start: Path) -> Path:
+    """Walk up from *start* to the repo root (the dir holding AGENTS.md).
+
+    The whole repo is bind-mounted so both the server package and
+    ``utils/xr-ai-logging`` are visible in the container. Falls back to the
+    filesystem root's child if no marker is found (mount is still valid; only
+    the xr-ai-logging path would be wrong, which surfaces immediately).
+    """
+    start = start.resolve()
+    for parent in [start, *start.parents]:
+        if (parent / "AGENTS.md").exists():
+            return parent
+    return start.parents[-1]
+
+
+__all__ = ["run_nemo_docker", "DEFAULT_IMAGE", "_docker"]

--- a/utils/xr-ai-nemo-runtime/xr_ai_nemo_runtime/_docker.py
+++ b/utils/xr-ai-nemo-runtime/xr_ai_nemo_runtime/_docker.py
@@ -1,0 +1,521 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+NGC NeMo container backend for the in-process NeMo servers (stt, magpie TTS).
+
+Runs the FastAPI server *inside* an NGC NeMo image so torch + nemo + cuDNN come
+from the container, escaping host cuDNN/LD_LIBRARY_PATH mismatches that abort
+the in-venv path at torch import. The image has torch+nemo+cuDNN but NOT our
+server package, so the run command:
+
+  * bind-mounts the repo read-only and points PYTHONPATH at the mounted server
+    package + xr-ai-logging,
+  * pip-installs only the LIGHT deps the server needs that the NeMo image lacks
+    (fastapi, uvicorn, hf_transfer, + per-server extras) — never the server's
+    own pyproject, which would drag nemo_toolkit/torch and conflict,
+  * runs `python -m <module> --_serve --config <mounted>`.
+
+The container runs foreground with --network host so /health is reachable on
+the host; the wrapper touches the ready-file once /health returns 200.
+
+NGC auth: if the image is from nvcr.io and NGC_API_KEY is set, this runs
+`docker login nvcr.io` once per process. Existing ~/.docker/config.json entries
+take priority and are not overwritten.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import shlex
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from . import _lifecycle
+
+log = logging.getLogger(__name__)
+
+_DOCKER_CONFIG = Path.home() / ".docker" / "config.json"
+_LOGIN_DONE: set[str] = set()
+
+# Where xr-ai-logging lives in the repo, used to build the in-container
+# PYTHONPATH. Relative to the repo root that gets bind-mounted.
+_XR_AI_LOGGING_REL = "utils/xr-ai-logging"
+
+
+# ── docker run argv builder ──────────────────────────────────────────────────
+
+
+def build_run_argv(
+    *,
+    image: str,
+    container_name: str,
+    port: int,
+    repo_root: Path,
+    server_pkg_dir: Path,
+    server_module: str,
+    config_path: Path,
+    model_cache: Path,
+    nemo_cache_dir: Path | None,
+    hf_token: str | None,
+    cuda_visible_devices: str | None,
+    extra_pip: list[str] | None,
+    extra_env: dict[str, str] | None,
+) -> list[str]:
+    """Build the `docker run …` argv that hosts a NeMo FastAPI server.
+
+    Always foreground (no -d). The caller spawns this with
+    start_new_session=True so the container escapes the launcher's process
+    group but remains stoppable by name. With --network host the server's
+    /health is reachable on the host.
+
+    *repo_root* is bind-mounted read-only; *server_pkg_dir* (the directory
+    that CONTAINS the server package) and *_XR_AI_LOGGING_REL* go on
+    PYTHONPATH so the server imports from the mount without a pip install of
+    its own pyproject.
+    """
+    argv: list[str] = ["docker", "run"]
+    argv += ["--name", container_name]
+    # Label lets stop_on_signal / external tooling find this container by port
+    # without knowing the name — implementation detail stays in this module.
+    argv += ["--label", f"xr-ai-nemo.port={port}"]
+    argv += ["--network", "host"]
+    argv += ["--ipc", "host"]
+
+    if cuda_visible_devices:
+        argv += ["--gpus", f"device={cuda_visible_devices}"]
+    else:
+        argv += ["--gpus", "all"]
+
+    env_vars: dict[str, str] = {
+        "HF_HOME": str(model_cache / "huggingface"),
+        "HF_HUB_ENABLE_HF_TRANSFER": "1",
+    }
+    if nemo_cache_dir is not None:
+        env_vars["NEMO_CACHE_DIR"] = str(nemo_cache_dir)
+    if hf_token:
+        env_vars["HF_TOKEN"] = hf_token
+    if extra_env:
+        env_vars.update(extra_env)
+    for key, val in env_vars.items():
+        argv += ["-e", f"{key}={val}"]
+
+    # Repo read-only (source is enough); model cache read-write (weight
+    # downloads land here). Both mounted same-path so the server's
+    # YAML-relative model_cache resolution lands inside the volume.
+    argv += ["-v", f"{repo_root}:{repo_root}:ro"]
+    argv += ["-v", f"{model_cache}:{model_cache}"]
+
+    argv.append(image)
+
+    # PYTHONPATH points at the mounted server package dir + xr-ai-logging so
+    # imports resolve from the mount — no `pip install` of our pyproject.
+    pythonpath = ":".join([str(server_pkg_dir), str(repo_root / _XR_AI_LOGGING_REL)])
+
+    # Light deps the NeMo image lacks. loguru is required by xr-ai-logging,
+    # which we put on PYTHONPATH (not pip-installed), so it must be here.
+    pip_pkgs = ["fastapi", "uvicorn[standard]", "hf_transfer", "loguru", "pyyaml"]
+    if extra_pip:
+        pip_pkgs += extra_pip
+
+    serve_argv = [
+        "python", "-m", server_module,
+        # --_serve short-circuits the server's own backend dispatch so the
+        # in-container process never re-reads `backend: docker` and spawns
+        # another container.
+        "--_serve",
+        "--config", str(config_path),
+    ]
+
+    install_cmds = [
+        f"pip install -q {shlex.join(pip_pkgs)}",
+        f"PYTHONPATH={shlex.quote(pythonpath)} {shlex.join(serve_argv)}",
+    ]
+    argv += ["bash", "-c", " && ".join(install_cmds)]
+    return argv
+
+
+# ── docker container helpers ─────────────────────────────────────────────────
+
+
+def _docker_available() -> bool:
+    try:
+        subprocess.run(
+            ["docker", "version", "--format", "{{.Server.Version}}"],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return True
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return False
+
+
+def container_exists(name: str) -> bool:
+    """True if a container named *name* is currently listed by docker (any state)."""
+    try:
+        out = subprocess.check_output(
+            ["docker", "ps", "-aq", "-f", f"name=^{re.escape(name)}$"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+        return bool(out)
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return False
+
+
+def remove_container(name: str) -> bool:
+    """``docker rm`` *name* if it exists; return True if it was removed."""
+    if not container_exists(name):
+        return False
+    try:
+        subprocess.run(
+            ["docker", "rm", name],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+        return True
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return False
+
+
+def stop_container(name: str, timeout_s: int = 20) -> bool:
+    """Stop container *name* if it exists; return True if one was stopped."""
+    if not container_exists(name):
+        return False
+    try:
+        subprocess.run(
+            ["docker", "stop", "-t", str(timeout_s), name],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+        return True
+    except subprocess.CalledProcessError as exc:
+        log.warning(
+            "docker stop %s failed (rc=%d): %s — escalating to docker kill",
+            name,
+            exc.returncode,
+            (exc.stderr or b"").decode(errors="replace").strip(),
+        )
+        try:
+            subprocess.run(
+                ["docker", "kill", name],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            return True
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            return False
+    except FileNotFoundError:
+        return False
+
+
+# ── NGC auth ────────────────────────────────────────────────────────────────
+
+
+def _registry_for(image: str) -> str | None:
+    """Return the registry host for *image* if fully qualified, else None.
+
+    A registry is only present when the reference contains a `/` AND the first
+    segment looks like a host (a `.` for a hostname or `:` for a port).
+    Without the `/` check a bare tagged image like ``"myimage:latest"`` would
+    be misread as a registry because of the tag's colon.
+    """
+    if "/" not in image:
+        return None
+    head = image.split("/", 1)[0]
+    return head if "." in head or ":" in head else None
+
+
+def _already_logged_in(registry: str) -> bool:
+    """Best-effort: True if ~/.docker/config.json already has creds for *registry*."""
+    try:
+        data = json.loads(_DOCKER_CONFIG.read_text())
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return False
+    return registry in data.get("auths", {})
+
+
+def _maybe_ngc_login(image: str) -> None:
+    """Run `docker login nvcr.io` if the image needs NGC auth and a key exists.
+
+    Skips silently if (a) image is not from nvcr.io, (b) NGC_API_KEY is unset,
+    or (c) docker is already authenticated to that registry.
+    """
+    registry = _registry_for(image)
+    if registry != "nvcr.io":
+        return
+    if registry in _LOGIN_DONE or _already_logged_in(registry):
+        _LOGIN_DONE.add(registry)
+        return
+    token = os.environ.get("NGC_API_KEY", "").strip()
+    if not token:
+        return
+    try:
+        result = subprocess.run(
+            ["docker", "login", registry, "-u", "$oauthtoken", "--password-stdin"],
+            input=token.encode(),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+    except FileNotFoundError:
+        return
+    if result.returncode == 0:
+        _LOGIN_DONE.add(registry)
+        log.debug("docker login %s succeeded via NGC_API_KEY", registry)
+    else:
+        log.warning(
+            "docker login %s failed: %s — pull may fail",
+            registry,
+            (result.stderr or b"").decode(errors="replace").strip(),
+        )
+
+
+# ── log forwarding ──────────────────────────────────────────────────────────
+
+
+def _container_log_path(container_name: str) -> Path:
+    """Sibling log file inside the per-run xr-ai-logging directory.
+
+    Reads ``XR_AI_LOG_NAMESPACE`` / ``XR_AI_LOG_TIMESTAMP`` / ``XR_AI_LOG_ROOT``
+    stamped by ``setup_logging`` so the container log lands next to the
+    wrapper's own log. Falls back to ``XR_AI_LOG_ROOT`` (or ``/tmp``) when the
+    env vars are absent (e.g. running this module outside a stack).
+    """
+    ns = os.environ.get("XR_AI_LOG_NAMESPACE")
+    stamp = os.environ.get("XR_AI_LOG_TIMESTAMP")
+    root = Path(os.environ.get("XR_AI_LOG_ROOT", "/tmp"))
+    log_dir = root / f"log_{ns}_{stamp}" if ns and stamp else root
+    log_dir.mkdir(parents=True, exist_ok=True)
+    return log_dir / f"{container_name}.log"
+
+
+def _start_log_streamer(
+    container_name: str,
+) -> tuple[subprocess.Popen | None, Path | None]:
+    """Stream container stdout/stderr to a sibling file (not the terminal).
+
+    Without this a startup failure inside the container leaves no trace. The
+    streamer writes to a file fd so the launcher's stdout forwarder stays
+    quiet; the user reads the container log on demand via ``tail -f``.
+    """
+    log_path = _container_log_path(container_name)
+    try:
+        out_fd = open(log_path, "ab", buffering=0)
+    except OSError as exc:
+        log.warning("nemo_docker: could not open %s for streaming: %s", log_path, exc)
+        return None, None
+    try:
+        proc = subprocess.Popen(
+            ["docker", "logs", "-f", "-t", container_name],
+            stdout=out_fd,
+            stderr=out_fd,
+        )
+    except FileNotFoundError:
+        out_fd.close()
+        return None, None
+    out_fd.close()  # the child holds its own dup'd fd
+    log.info("container logs → %s", log_path)
+    return proc, log_path
+
+
+def _stop_log_streamer(proc: subprocess.Popen | None) -> None:
+    if proc is None or proc.poll() is not None:
+        return
+    proc.terminate()
+    try:
+        proc.wait(timeout=2)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            pass
+
+
+def _append_post_mortem(container_name: str, log_path: Path | None, n: int = 200) -> None:
+    """Append `docker logs --tail` to the container log as a fallback."""
+    target = log_path or _container_log_path(container_name)
+    try:
+        result = subprocess.run(
+            ["docker", "logs", "--tail", str(n), container_name],
+            capture_output=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return
+    blob = (result.stdout or b"") + (result.stderr or b"")
+    if not blob.strip():
+        return
+    try:
+        with open(target, "ab") as f:
+            f.write(f"\n---- post-mortem `docker logs --tail={n}` ----\n".encode())
+            f.write(blob if blob.endswith(b"\n") else blob + b"\n")
+            f.write(b"---- end post-mortem ----\n")
+    except OSError:
+        return
+
+
+# ── run flow ────────────────────────────────────────────────────────────────
+
+
+def run(
+    *,
+    image: str,
+    container_name: str,
+    log_prefix: str,
+    server_module: str,
+    repo_root: Path,
+    server_pkg_dir: Path,
+    config_path: Path,
+    model_cache: Path,
+    nemo_cache_dir: Path | None,
+    host: str,
+    port: int,
+    hf_token: str | None,
+    cuda_visible_devices: str | None,
+    extra_pip: list[str] | None,
+    extra_env: dict[str, str] | None,
+    ready_file: Path | None,
+) -> None:
+    if not _docker_available():
+        log.error(
+            "nemo_backend: docker requires docker on PATH and a running daemon "
+            "(`docker version` failed). Install Docker Engine and the NVIDIA "
+            "Container Toolkit, then retry — or set `backend: pip` in the YAML."
+        )
+        sys.exit(2)
+
+    health_url = _lifecycle.health_url(host, port)
+
+    # On abort (Ctrl-C during model-servers startup) the launcher SIGTERMs every
+    # wrapper. Without a handler that kills *this* wrapper but leaves the
+    # dockerd-managed container running (still pulling the image / downloading
+    # weights). So the wrapper stops its own container by name on a signal.
+    # On a clean run no signal arrives and these handlers stay dormant.
+    _state: dict[str, object] = {"proc": None, "streamer": None, "handling": False}
+    orig_int = signal.getsignal(signal.SIGINT)
+    orig_term = signal.getsignal(signal.SIGTERM)
+
+    def _on_signal(_sig, _frame):
+        # Guard FIRST: Python does not block re-entry during the handler's own
+        # docker stop, and the user will mash Ctrl-C. A second signal no-ops.
+        if _state["handling"]:
+            return
+        _state["handling"] = True
+        print(
+            f"[{log_prefix}] signal received — stopping container {container_name}…",
+            flush=True,
+        )
+        cp = _state["proc"]
+        if isinstance(cp, subprocess.Popen) and cp.poll() is None:
+            cp.terminate()
+        # Modest timeout so this completes inside the launcher's stop window
+        # before it escalates to SIGKILL. Both helpers work by name.
+        stop_container(container_name, timeout_s=10)
+        remove_container(container_name)
+        sp = _state["streamer"]
+        _stop_log_streamer(sp if isinstance(sp, subprocess.Popen) else None)
+        sys.exit(130)
+
+    signal.signal(signal.SIGINT, _on_signal)
+    signal.signal(signal.SIGTERM, _on_signal)
+
+    # Something is already serving this port (a manually-started container, or
+    # another live wrapper). We don't own it, so don't tear it down on signal —
+    # restore the original handlers and just idle alongside it.
+    if _lifecycle.health_ok(health_url):
+        print(f"[{log_prefix}] NeMo server already on :{port} — reusing", flush=True)
+        if ready_file:
+            ready_file.touch()
+        signal.signal(signal.SIGINT, orig_int)
+        signal.signal(signal.SIGTERM, orig_term)
+        _lifecycle.idle_until_stopped(health_url, log_prefix)
+        return
+
+    # A stale container would make `docker run --name` fail with a name
+    # conflict; clear it so this is a fresh run. stop first so a still-running
+    # but unhealthy leftover (mid-load, or wedged from a prior crash) is also
+    # removable — `docker rm` alone fails on a running container.
+    if container_exists(container_name):
+        stop_container(container_name, timeout_s=10)
+        remove_container(container_name)
+
+    _maybe_ngc_login(image)
+    argv = build_run_argv(
+        image=image,
+        container_name=container_name,
+        port=port,
+        repo_root=repo_root,
+        server_pkg_dir=server_pkg_dir,
+        server_module=server_module,
+        config_path=config_path,
+        model_cache=model_cache,
+        nemo_cache_dir=nemo_cache_dir,
+        hf_token=hf_token,
+        cuda_visible_devices=cuda_visible_devices,
+        extra_pip=extra_pip,
+        extra_env=extra_env,
+    )
+    print(
+        f"[{log_prefix}] Launching NeMo server (docker)  image={image}  "
+        f"container={container_name}  http://{host}:{port}/v1",
+        flush=True,
+    )
+    proc = subprocess.Popen(argv, start_new_session=True)
+    _state["proc"] = proc
+
+    streamer_proc, log_path = _start_log_streamer(container_name)
+    _state["streamer"] = streamer_proc
+    try:
+        _lifecycle.wait_until_healthy(
+            health_url,
+            is_alive=lambda: proc.poll() is None,
+        )
+    except SystemExit:
+        # Two ways here: (a) the container died on its own — the post-mortem is
+        # valuable; (b) our signal handler called sys.exit(130) on abort — it
+        # already stopped+removed the container, so a post-mortem on a removed
+        # container is misleading. Skip it only in the handler case.
+        if _state["handling"]:
+            raise
+        time.sleep(0.5)
+        _append_post_mortem(container_name, log_path)
+        _stop_log_streamer(streamer_proc)
+        if log_path is not None:
+            log.error("NeMo container failed — see %s", log_path)
+        raise
+
+    log.info("Ready  →  http://localhost:%d/v1  (docker: %s)", port, container_name)
+    if ready_file:
+        ready_file.touch()
+
+    # Keep the stop+remove signal handler installed through the idle loop: the
+    # NeMo container is meant to DIE WITH THE STACK (unlike vLLM, which persists
+    # to dodge multi-minute reloads — NeMo reloads in ~20s from the cached
+    # weights on the mounted volume). The launcher's `--stop` path can't reap
+    # this container by label (that path lives in xr_ai_vllm and filters on
+    # xr-ai-vllm.port=…), so the wrapper must clean up its own container on the
+    # shutdown SIGTERM rather than orphan it. _on_signal stops+removes and
+    # sys.exit(130)s; this loop just waits for the container to go away.
+    try:
+        while _lifecycle.health_ok(health_url, timeout=2.0):
+            time.sleep(5.0)
+    finally:
+        # Reached only if the container vanished on its own (the SIGTERM/SIGINT
+        # path exits via the handler). Clean up the now-dead container so a
+        # later run goes through a fresh `docker run`.
+        signal.signal(signal.SIGINT, orig_int)
+        signal.signal(signal.SIGTERM, orig_term)
+        stop_container(container_name, timeout_s=10)
+        remove_container(container_name)
+        _stop_log_streamer(streamer_proc)

--- a/utils/xr-ai-nemo-runtime/xr_ai_nemo_runtime/_lifecycle.py
+++ b/utils/xr-ai-nemo-runtime/xr_ai_nemo_runtime/_lifecycle.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+/health probe + idle loop for the NeMo docker backend.
+
+The NeMo servers expose `/health` via uvicorn; it returns 503 until weights are
+loaded and 200 once ready. The wrapper waits on 200 (model load can take tens
+of seconds), then sits idle until the container goes away or a signal arrives.
+"""
+from __future__ import annotations
+
+import logging
+import signal
+import time
+import urllib.request
+
+log = logging.getLogger(__name__)
+
+
+def health_url(host: str, port: int) -> str:
+    """Build the /health URL.
+
+    The servers bind 0.0.0.0 but the wrapper always probes 127.0.0.1 so it
+    works regardless of which interface the host listens on.
+    """
+    del host  # 127.0.0.1 is always reachable from the wrapper
+    return f"http://127.0.0.1:{port}/health"
+
+
+def health_ok(url: str, timeout: float = 3.0) -> bool:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as r:
+            return r.status == 200
+    except Exception:
+        return False
+
+
+def wait_until_healthy(url: str, *, is_alive, poll_s: float = 2.0) -> None:
+    """Block until *url* responds 200 or *is_alive()* returns False.
+
+    *is_alive* returns True while the container process is still running. If it
+    returns False before /health is up, this raises SystemExit so the wrapper
+    exits the same way the in-venv path would on a failed model load.
+    """
+    while True:
+        if not is_alive():
+            log.error("NeMo container exited before /health became reachable")
+            raise SystemExit(1)
+        if health_ok(url, timeout=2.0):
+            return
+        time.sleep(poll_s)
+
+
+def idle_until_stopped(url: str, log_prefix: str, poll_s: float = 5.0) -> None:
+    """Block until /health stops responding or SIGTERM/SIGINT arrives.
+
+    The container is owned by dockerd, not the wrapper, so the wrapper sits
+    idle here until either the container goes away or the launcher signals us.
+    """
+    stopped = [False]
+    orig_term = signal.getsignal(signal.SIGTERM)
+    orig_int = signal.getsignal(signal.SIGINT)
+
+    def _on_signal(_sig, _frame):
+        stopped[0] = True
+
+    signal.signal(signal.SIGTERM, _on_signal)
+    signal.signal(signal.SIGINT, _on_signal)
+    try:
+        while not stopped[0]:
+            if not health_ok(url, timeout=2.0):
+                print(f"[{log_prefix}] NeMo /health unreachable — exiting", flush=True)
+                return
+            time.sleep(poll_s)
+    finally:
+        signal.signal(signal.SIGTERM, orig_term)
+        signal.signal(signal.SIGINT, orig_int)


### PR DESCRIPTION
## Why

The NeMo GPU services (stt-server, magpie TTS) run in-venv and `import torch`, so they inherit the host's cuDNN/CUDA via `LD_LIBRARY_PATH`. On a host whose system cuDNN differs from torch's bundled one they abort at import:

```
RuntimeError: cuDNN version incompatibility: PyTorch was compiled against (9, 20, 0) but found runtime version (9, 13, 1)
```
(observed on an L40S cloud box). The vLLM services already escape this by running in NGC containers; this gives the NeMo services the same option.

**Relationship to #216:** #216 (already merged) strips a conflicting `libcudnn` dir off `LD_LIBRARY_PATH` in the launcher, which fixes the common in-venv case. This PR is the **complete** isolation: an opt-in container backend immune to *all* host CUDA/cuDNN/NCCL/driver-userspace mismatches, for hosts where the strip isn't enough or where full isolation is wanted. Default stays `pip` — **no behavior change unless opted in.**

## What

- **New stdlib-only package `utils/xr-ai-nemo-runtime/`** — a bespoke NeMo container runner (separate from `xr_ai_vllm`, which is untouched). Builds the `docker run` argv against an NGC NeMo image, waits on `/health`, touches the ready-file, streams container logs, and self-stops+removes its container on SIGINT/SIGTERM (mirrors the #215 vLLM signal handler) so Ctrl-C during a slow pull/download cleans up.
- **Opt-in `backend: pip|docker`** on `stt_server.yaml` / `magpie_tts_server.yaml` (+ the 3 per-profile stt copies). Default `pip` = today's in-venv path, unchanged. `docker` routes to the runner.
- **In-container packaging:** the NeMo image has torch+nemo+cuDNN but not our server, so the run command bind-mounts the repo read-only, puts the server package + `xr-ai-logging` on `PYTHONPATH`, `pip install`s only the light deps the image lacks (`fastapi`, `uvicorn`, `hf_transfer`, `loguru`, `pyyaml`, + per-server extras) — **never** the server's own pyproject (which would drag `nemo_toolkit`/torch and conflict) — then runs `python -m <server> --_serve --config <mounted>`. `--_serve` short-circuits the backend dispatch so the in-container process can't recursively spawn another container.
- **Lifecycle:** NeMo containers **die with the stack** (no cross-restart persistence — NeMo reloads in ~20 s from cached weights). On `--stop` the in-container server is killed and the wrapper's idle loop then stop+removes the (now-dead) container; a stale container from a prior run is cleared before `docker run` so relaunch never hits a name clash. The reaper in `xr_ai_vllm.stop_persistent_servers` filters on `xr-ai-vllm.port=`, so it can't reap these `xr-ai-nemo.port=` containers — hence the self-cleanup.
- piper TTS (CPU/ONNX) is **not** in scope.

## Tests

- `tests/test_nemo_docker.py` — argv-builder (image, name, `xr-ai-nemo.port=` label, `--network`/`--ipc host`, `--gpus`, repo `:ro` + model-cache mounts, HF/NeMo env, light-dep install + `python -m <server> --_serve`, never the pyproject, PYTHONPATH to mounts) + backend toggle for both servers (default-pip skips the runner; `docker` routes to it with the in-venv path NOT invoked; `--_serve` bypasses dispatch).
- `cd tests && uv run pytest test_nemo_docker.py test_vllm_docker.py test_launcher_stack.py -q` → **69 passed** (hermetic; no docker/GPU).
- `DEPENDENCIES.md` updated for the new path package (same commit).

## On-device gate

The real path — NeMo NGC image pull + cuDNN-clean model load + which of the light deps the image already ships + the exact `nvcr.io/nvidia/nemo:<tag>` for your account — can only be confirmed on a GPU host with docker + NGC access. `nemo_image` is a configurable YAML key with an example default (`nvcr.io/nvidia/nemo:25.04`) clearly marked "confirm a tag available to your account". Not asserting it pulls/loads in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)