### PR TITLE
fix(render-mcp): block scene resync until LOVR connects (fixes #198)

### DIFF
--- a/agent-mcp-servers/render-mcp/render_mcp/__main__.py
+++ b/agent-mcp-servers/render-mcp/render_mcp/__main__.py
@@ -235,11 +235,20 @@ class SceneDispatcher:
 
             self._watch_task = asyncio.create_task(_watch(), name="lovr-watch")
 
-            self._lovr_started = True
             logger.info("render-mcp: LOVR spawned (xr.start handled)")
-            # Resync current scene state into LOVR's ZMQ receive buffer so any
-            # previously-added primitives survive a LOVR restart.
+            # Restore the scene BEFORE advertising started. While resync's first
+            # (blocking) send is parked waiting for LOVR's PULL to attach,
+            # ``_lovr_started`` stays False so concurrent live ``forward()`` ops
+            # keep fast-dropping as "not_started" instead of queueing behind the
+            # parked send on the shared PUSH socket (PR #219 review nit). It also
+            # makes the flag mean what it says: LOVR connected AND scene restored.
             await self._resync_scene()
+            # Only advertise started if LOVR is still alive — it may have exited
+            # during the resync wait, in which case ``_watch`` has already run to
+            # completion (its post-wait body has no awaits) and cleared the flag,
+            # so we must not re-set it True.
+            if self._watch_task is not None and not self._watch_task.done():
+                self._lovr_started = True
             return {"status": "started"}
 
     async def _resync_scene(self) -> None:

--- a/agent-mcp-servers/render-mcp/render_mcp/__main__.py
+++ b/agent-mcp-servers/render-mcp/render_mcp/__main__.py
@@ -46,6 +46,11 @@ from xr_ai_logging import setup_logging
 
 _DEFAULT_YAML = Path(__file__).resolve().parent.parent / "render_mcp.yaml"
 
+# Max seconds the post-spawn scene resync waits for LOVR to connect its PULL
+# socket. LOVR normally attaches within a second or two of spawn; the bound
+# stops a LOVR that never connects from wedging the spawn path indefinitely.
+_RESYNC_TIMEOUT_S = 10.0
+
 
 # ── Config ─────────────────────────────────────────────────────────────────────
 
@@ -238,20 +243,55 @@ class SceneDispatcher:
             return {"status": "started"}
 
     async def _resync_scene(self) -> None:
-        """Push scene.add for every known primitive into LOVR's ZMQ buffer.
-        Called after LOVR (re)starts so primitives added in a previous session
-        are visible immediately when LOVR connects."""
-        for obj_id, obj in list(self._objects.items()):
+        """Re-push scene.add for every known primitive after a LOVR (re)start.
+
+        LOVR has just been spawned and has NOT yet connected its PULL socket.
+        A PUSH socket with zero connected peers does NOT buffer up to SNDHWM —
+        it returns ``EAGAIN`` immediately under ``NOBLOCK`` — so routing the
+        resync through the live ``forward()`` path silently dropped the entire
+        restore (issue #198). Send these as *blocking* sends instead, so each
+        one queues the moment LOVR attaches, bounded by an overall deadline so
+        a LOVR that never connects can't wedge the spawn (we hold the spawn
+        lock here)."""
+        objs = list(self._objects.items())
+        if not objs:
+            return
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + _RESYNC_TIMEOUT_S
+        sent = 0
+        for obj_id, obj in objs:
             pos = obj["position"]
             col = obj["color"]
-            await self.forward("scene.add", {
-                "id":       obj_id,
-                "type":     obj["type"],
-                "position": [pos["x"], pos["y"], pos["z"]],
-                "color":    [col["r"], col["g"], col["b"]],
-                "size":    obj["size"],
-            })
+            payload = msgpack.packb(
+                {"op": "scene.add", "value": {
+                    "id":       obj_id,
+                    "type":     obj["type"],
+                    "position": [pos["x"], pos["y"], pos["z"]],
+                    "color":    [col["r"], col["g"], col["b"]],
+                    "size":     obj["size"],
+                }},
+                use_bin_type=True,
+            )
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                break
+            try:
+                # Blocking send (no NOBLOCK): the first one waits until LOVR's
+                # PULL connects; the rest queue (up to SNDHWM) and return fast.
+                await asyncio.wait_for(self._push.send(payload), timeout=remaining)
+            except asyncio.TimeoutError:
+                break
+            sent += 1
             logger.debug("render-mcp: resync  id={}", obj_id)
+
+        if sent == len(objs):
+            if sent:
+                logger.info("render-mcp: scene resync sent {} primitive(s) to LOVR", sent)
+        else:
+            logger.warning(
+                "render-mcp: scene resync incomplete ({}/{} primitives) — LOVR did "
+                "not connect within {:.0f}s", sent, len(objs), _RESYNC_TIMEOUT_S,
+            )
 
     # ── scene state ───────────────────────────────────────────────────────────
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,18 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-09 — render-mcp: scene resync survives a LOVR respawn (blocking send, not NOBLOCK)
+
+After a LOVR (re)start, `render-mcp` re-pushed every stored primitive via
+`_resync_scene` → `forward()`, which sends with `zmq.NOBLOCK`. But LOVR has not
+yet connected its PULL socket at that instant, and a PUSH with zero peers does
+not buffer up to `SNDHWM` — it returns `EAGAIN` immediately under `NOBLOCK` — so
+the entire resync was silently dropped and the scene came back empty after a
+crash/respawn even though `_objects` still held everything. `_resync_scene` now
+sends the restore as *blocking* sends (the first waits for LOVR's PULL to
+attach, the rest queue up to `SNDHWM`), bounded by `_RESYNC_TIMEOUT_S` so a LOVR
+that never connects can't wedge the spawn path. Fixes #198.
+
 ### 2026-06-09 — Ctrl-C during startup tears down everything, incl. persist + docker containers
 
 Pressing Ctrl-C while `model-servers` was launching (slow image pull / weight

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,7 +19,10 @@ the entire resync was silently dropped and the scene came back empty after a
 crash/respawn even though `_objects` still held everything. `_resync_scene` now
 sends the restore as *blocking* sends (the first waits for LOVR's PULL to
 attach, the rest queue up to `SNDHWM`), bounded by `_RESYNC_TIMEOUT_S` so a LOVR
-that never connects can't wedge the spawn path. Fixes #198.
+that never connects can't wedge the spawn path. `_lovr_started` is now flipped
+True only *after* resync completes (and only if LOVR is still alive), so live
+`forward()` ops fast-drop as `not_started` during the resync window instead of
+contending on the shared PUSH socket behind the parked send. Fixes #198.
 
 ### 2026-06-09 — Ctrl-C during startup tears down everything, incl. persist + docker containers
 

--- a/tests/test_local_render_mcp.py
+++ b/tests/test_local_render_mcp.py
@@ -426,6 +426,62 @@ async def test_resync_delivers_after_late_peer_connect(tmp_path: Path):
 
 
 @_asyncio
+async def test_live_forward_fast_drops_during_resync_window(tmp_path: Path, monkeypatch):
+    """PR #219 review nit: while the post-spawn resync is parked waiting for
+    LOVR to connect, ``_lovr_started`` stays False, so a concurrent live
+    ``forward()`` fast-drops as ``not_started`` instead of contending on the
+    shared PUSH socket behind the parked (blocking) resync send. The flag flips
+    to True only once resync completes (LOVR connected and scene restored).
+    """
+    sock_path = _unique_ipc(tmp_path)
+    lovr_bin  = tmp_path / "lovr.sh"
+    lovr_bin.write_text("#!/bin/sh\nsleep 999\n")
+    lovr_bin.chmod(0o755)
+    xr_app_dir = tmp_path / "xr_app"
+    xr_app_dir.mkdir()
+    cfg = Config(
+        lovr_bin=lovr_bin, xr_app_dir=xr_app_dir, scene_socket=sock_path,
+        cloudxr_env_file=None, host="127.0.0.1", port=0,
+    )
+    monkeypatch.setattr(render_main, "ManagedProcess",
+                        lambda *a, **kw: _FakeManagedProcessCtx())
+
+    stack = contextlib.AsyncExitStack()
+    await stack.__aenter__()
+    pull = None
+    try:
+        disp = SceneDispatcher(cfg, stack)
+        disp.add("sphere", {"x": 0, "y": 0, "z": 0}, {"r": 1, "g": 0, "b": 0}, 0.1)
+
+        # start_lovr_once parks inside _resync_scene (blocking send, no peer).
+        start_task = asyncio.create_task(disp.start_lovr_once())
+        await asyncio.sleep(0.1)
+        assert not start_task.done()         # parked waiting for LOVR
+        assert disp._lovr_started is False   # not advertised during resync
+
+        # A live op in this window must fast-drop, not queue behind the parked
+        # send. (Before the fix, _lovr_started was True here and forward() would
+        # attempt the contended NOBLOCK send.)
+        res = await disp.forward("scene.update", {"id": "sphere-0", "x": 1})
+        assert res == {"ok": False, "reason": "not_started"}
+
+        # LOVR connects → resync drains → start_lovr_once finishes.
+        ctx = zmq.asyncio.Context.instance()
+        pull = ctx.socket(zmq.PULL)
+        pull.setsockopt(zmq.LINGER, 0)
+        pull.connect(sock_path)
+        _ = await _recv_op(pull, timeout=2.0)            # the resync scene.add
+        result = await asyncio.wait_for(start_task, timeout=2.0)
+        assert result == {"status": "started"}
+        assert disp._lovr_started is True
+    finally:
+        if pull is not None:
+            pull.close(linger=0)
+        disp.close()
+        await stack.__aexit__(None, None, None)
+
+
+@_asyncio
 async def test_resync_is_bounded_when_lovr_never_connects(tmp_path: Path, monkeypatch):
     """A LOVR that never connects must not wedge the spawn — resync returns
     after the deadline instead of blocking forever."""

--- a/tests/test_local_render_mcp.py
+++ b/tests/test_local_render_mcp.py
@@ -372,3 +372,81 @@ async def test_close_cancels_lovr_watch_task(tmp_path: Path, monkeypatch):
         assert disp._watch_task.done()
     finally:
         await stack.__aexit__(None, None, None)
+
+
+# ── Issue #198: scene resync survives a late LOVR connect ─────────────────────
+
+
+@_asyncio
+async def test_resync_delivers_after_late_peer_connect(tmp_path: Path):
+    """Resync must reach LOVR even though LOVR connects AFTER it starts.
+
+    The old path routed resync through ``forward()`` (NOBLOCK); a PUSH with no
+    connected peer returns EAGAIN immediately (SNDHWM only buffers after a peer
+    attaches), so every restore message was dropped. The blocking resync queues
+    once LOVR's PULL connects.
+    """
+    sock_path = _unique_ipc(tmp_path)
+    cfg = Config(
+        lovr_bin=Path("/nonexistent"), xr_app_dir=tmp_path,
+        scene_socket=sock_path, cloudxr_env_file=None,
+        host="127.0.0.1", port=0,
+    )
+    stack = contextlib.AsyncExitStack()
+    await stack.__aenter__()
+    pull = None
+    try:
+        disp = SceneDispatcher(cfg, stack)
+        # Two primitives "carried over" from a previous LOVR session.
+        a = disp.add("sphere", {"x": 0, "y": 0, "z": 0}, {"r": 1, "g": 0, "b": 0}, 0.1)
+        b = disp.add("box",    {"x": 1, "y": 2, "z": 3}, {"r": 0, "g": 1, "b": 0}, 0.2)
+
+        # Start the resync with NO peer connected. The old code would have
+        # dropped both messages instantly; the fix blocks until a peer attaches.
+        resync_task = asyncio.create_task(disp._resync_scene())
+        await asyncio.sleep(0.1)
+        assert not resync_task.done()  # waiting for LOVR, not dropping
+
+        # LOVR connects late.
+        ctx = zmq.asyncio.Context.instance()
+        pull = ctx.socket(zmq.PULL)
+        pull.setsockopt(zmq.LINGER, 0)
+        pull.connect(sock_path)
+
+        ops = [await _recv_op(pull, timeout=2.0) for _ in range(2)]
+        await asyncio.wait_for(resync_task, timeout=2.0)
+
+        assert all(o["op"] == "scene.add" for o in ops)
+        assert {o["value"]["id"] for o in ops} == {a, b}
+    finally:
+        if pull is not None:
+            pull.close(linger=0)
+        disp.close()
+        await stack.__aexit__(None, None, None)
+
+
+@_asyncio
+async def test_resync_is_bounded_when_lovr_never_connects(tmp_path: Path, monkeypatch):
+    """A LOVR that never connects must not wedge the spawn — resync returns
+    after the deadline instead of blocking forever."""
+    monkeypatch.setattr(render_main, "_RESYNC_TIMEOUT_S", 0.2)
+    sock_path = _unique_ipc(tmp_path)
+    cfg = Config(
+        lovr_bin=Path("/nonexistent"), xr_app_dir=tmp_path,
+        scene_socket=sock_path, cloudxr_env_file=None,
+        host="127.0.0.1", port=0,
+    )
+    stack = contextlib.AsyncExitStack()
+    await stack.__aenter__()
+    try:
+        disp = SceneDispatcher(cfg, stack)
+        disp.add("sphere", {"x": 0, "y": 0, "z": 0}, {"r": 1, "g": 1, "b": 1}, 0.1)
+
+        start = asyncio.get_running_loop().time()
+        # No peer ever connects; must return ~promptly, not hang.
+        await asyncio.wait_for(disp._resync_scene(), timeout=3.0)
+        elapsed = asyncio.get_running_loop().time() - start
+        assert elapsed < 2.0
+    finally:
+        disp.close()
+        await stack.__aexit__(None, None, None)


### PR DESCRIPTION
## Problem

Fixes #198. After a LOVR (re)spawn, `render-mcp`'s scene resync was silently dropped.

`start_lovr_once` sets `_lovr_started = True` then `await self._resync_scene()`, which re-pushed every stored primitive via `forward()`. `forward()` sends with `zmq.NOBLOCK`. But at that instant LOVR was just spawned and has **not yet connected** its PULL socket — and a ZMQ PUSH with **zero connected peers** does not enqueue up to `SNDHWM`; it returns `EAGAIN` immediately under `NOBLOCK`. So every resync message raised `zmq.Again` and was dropped (counted as `backpressure`). The `SNDHWM=256` "room while LOVR starts up" comment is misleading — HWM buffering only applies **after** a peer connects.

**Consequence:** after a crash/respawn the scene came back empty even though `_objects` still held everything.

## Fix

`_resync_scene` no longer routes through the live NOBLOCK `forward()` path. It now sends the restore as **blocking** sends:
- the first send waits until LOVR's PULL connects;
- the rest queue (up to `SNDHWM`) and return fast.

An overall `_RESYNC_TIMEOUT_S` (10s) deadline via `asyncio.wait_for` keeps a LOVR that never connects from wedging the spawn path (the spawn lock is held during resync). On timeout it logs an incomplete-resync warning instead of hanging.

The live `forward()` path is **unchanged** — NOBLOCK drop-on-backpressure remains correct for the 50 Hz scale-message stream.

## Tests

Added to the existing local/`gpu`-marked `tests/test_local_render_mcp.py` (real ZMQ ipc sockets):
- `test_resync_delivers_after_late_peer_connect` — starts resync with **no peer**, asserts it blocks (doesn't drop), then connects a PULL late and asserts **all** `scene.add` messages arrive. This is the exact scenario the old NOBLOCK path failed.
- `test_resync_is_bounded_when_lovr_never_connects` — with a short monkeypatched timeout, asserts resync returns promptly instead of hanging when no peer ever connects.

No `pyproject.toml` change (stdlib/zmq only), so no `DEPENDENCIES.md` update.

> Note: the regression tests live in the `gpu`-marked local suite (not in the CI matrix) and I couldn't run them in this environment (no local pytest/zmq). Verified via `py_compile` + inspection; please run `uv run pytest tests/test_local_render_mcp.py -k resync` on a dev box to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)