### PR TITLE
docs(getting-started): port requirements + quickstart from README

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build the XR-AI Sphinx docs. On every docs PR: strict build (warnings = errors).
+# On push to main of the canonical repo: build + deploy to GitHub Pages.
+# Deploy is a no-op until Pages is enabled for the repo (Settings → Pages → GitHub Actions).
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yaml"
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yaml"
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build (strict)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install doc deps
+        run: pip install -r docs/requirements.txt
+      - name: Strict Sphinx build
+        run: sphinx-build -W --keep-going -b html docs/source docs/_build
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.repository == 'NVIDIA/xr-ai'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build
+
+  deploy:
+    name: Deploy to GitHub Pages
+    if: github.event_name == 'push' && github.repository == 'NVIDIA/xr-ai'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+# Sphinx build output
+_build/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal Sphinx makefile. Usage:
+#   pip install -r requirements.txt
+#   make html        # build into _build/
+#   make strict      # build with warnings-as-errors (CI gate)
+
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = _build
+
+.PHONY: help html strict clean
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+html:
+	@$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+strict:
+	@$(SPHINXBUILD) -W --keep-going -b html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+clean:
+	rm -rf "$(BUILDDIR)"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,26 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-10 — Sphinx documentation site (isaacteleop-style), scaffold
+
+Stood up a Sphinx documentation site under `docs/source/`, mirroring the
+NVIDIA/IsaacTeleop docs setup (NVIDIA Sphinx theme, GitHub Pages publish). It
+uses **MyST** so the existing `docs/*.md` content is reused as Markdown pages
+rather than rewritten as reStructuredText. Organized into five sections —
+Overview, Getting Started, Components, Guides, Reference — each section index
+uses a **`:glob:` toctree** so new pages self-register by simply being dropped
+into the section directory (this is what lets documentation pages be authored as
+independent, individually-mergeable PRs without all touching a shared nav file).
+
+`.github/workflows/docs.yaml` runs a strict build (`sphinx-build -W`) on every
+docs PR and deploys to GitHub Pages on push to `main` of the canonical repo
+(deploy is a no-op until Pages is enabled in repo settings). `docs/requirements.txt`
+pins the toolchain to IsaacTeleop's versions. The existing `docs/*.md` files are
+intentionally **kept in place** (the README and in-flight PRs link to them); the
+site ingests/ports their content, and a later cleanup can collapse the
+duplication once the site is the source of truth. `sphinx-multiversion` is a
+deliberate follow-up — single-version first to de-risk CI.
+
 ### 2026-06-09 — render-mcp: scene resync survives a LOVR respawn (blocking send, not NOBLOCK)
 
 After a LOVR (re)start, `render-mcp` re-pushed every stored primitive via

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Pins for building the XR-AI Sphinx documentation site.
+# Mirrors the NVIDIA/IsaacTeleop docs toolchain.
+sphinx==8.1.3
+nvidia-sphinx-theme==0.0.9.post1
+myst-parser==4.0.0
+sphinx-copybutton==0.5.2
+sphinx-design==0.6.1
+linkify-it-py==2.0.3

--- a/docs/source/components/index.md
+++ b/docs/source/components/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Components
+
+The server runtime, agent SDK, MCP servers, AI services, and the launcher/process model.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/components/server-runtime.md
+++ b/docs/source/components/server-runtime.md
@@ -1,0 +1,12 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Server runtime
+
+The `server-runtime/` package hosts the **XR-Media-Hub** and the internal
+LiveKit transport — the entry point clients connect to.
+
+This page is a placeholder seeded by the docs scaffold; the full component
+reference is filled in by the components documentation units.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sphinx configuration for the XR-AI documentation site.
+
+Mirrors the NVIDIA/IsaacTeleop docs setup: the NVIDIA Sphinx theme + MyST so
+the existing Markdown under ``docs/`` is reused directly. Single-version for
+now; ``sphinx-multiversion`` is a deliberate follow-up (see docs changelog).
+"""
+from __future__ import annotations
+
+# -- Project information -----------------------------------------------------
+project = "XR-AI"
+copyright = "2026, NVIDIA CORPORATION & AFFILIATES"
+author = "NVIDIA"
+
+# -- General configuration ---------------------------------------------------
+extensions = [
+    "myst_parser",
+    "sphinx_copybutton",
+    "sphinx_design",
+    "sphinx.ext.githubpages",
+    "sphinx.ext.intersphinx",
+]
+
+# MyST Markdown is the page format (matches the repo's existing docs/*.md).
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
+
+myst_enable_extensions = [
+    "colon_fence",
+    "deflist",
+    "linkify",
+    "substitution",
+]
+myst_heading_anchors = 3
+
+# Don't choke the build on the bundled long-form changelog or build output.
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# -- HTML output -------------------------------------------------------------
+html_theme = "nvidia_sphinx_theme"
+html_show_sphinx = False
+html_title = "XR-AI"

--- a/docs/source/getting_started/index.md
+++ b/docs/source/getting_started/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Getting Started
+
+Requirements, the quickstart paths, connecting clients, networking, and credentials.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -6,8 +6,238 @@
 # Quickstart
 
 Every sample follows the same pattern: **start the server, then connect a
-client.** The three primary paths are the shared model servers, the
-`simple-vlm-example`, and the `xr-render-demo`.
+client.** Once it is ready, any supported client — web browser, Android app,
+iOS/visionOS app, or AR glasses — can join the session using the token printed
+on startup.
 
-This page is a placeholder seeded by the docs scaffold; the full quickstart is
-ported from the repository README.
+## Model servers (shared AI services)
+
+`model-servers` starts the four inference services used across demos and exits
+immediately — the services keep running in the background with weights hot.
+Start this once before running `xr-render-demo`, or whenever you want to
+pre-warm models:
+
+```bash
+cd agent-samples/model-servers
+uv sync
+uv run model_servers
+```
+
+GPU profiles are auto-detected (`dual_48G_ada` / `spark` / `96G_blackwell`).
+On first run each model downloads from HuggingFace (~50 GB total; can take
+tens of minutes). On subsequent runs the containers restart in under a minute.
+
+The default models are public, so no HuggingFace token is required. Set
+`HF_TOKEN` to lift download rate limits / speed, or to use a gated model — see
+the credentials guide. The launcher won't prompt; it prints a one-line notice
+and continues if the token is unset.
+
+To stop all model servers when done:
+
+```bash
+uv run model_servers --stop
+```
+
+## Simple VLM example (vision Q&A over voice + text)
+
+End-to-end voice + vision sample. Speak into the mic, type into the data
+channel, or send the literal text `"ping"` — all routes go through the same VLM
+pipeline against the latest video frame. Replies arrive as streaming Piper TTS
+audio plus a `vlm.response` text message.
+
+Uses `nvidia/Cosmos-Reason1-7B` (NVIDIA Open Model License + Apache 2.0).
+
+There are two ways to run it:
+
+**Standalone** (~23 GB VRAM) — starts its own VLM and STT, owns them for the
+session, and stops them when you exit:
+
+```bash
+cd agent-samples/simple-vlm-example
+uv sync
+uv run simple_vlm_example
+```
+
+On the very first run weights download from HuggingFace (~23 GB; can take
+several minutes). The default model is public — no HuggingFace token needed; set
+`HF_TOKEN` only to lift rate limits / speed or for a gated model (see the
+credentials guide).
+
+**With model-servers pre-running** — if VLM (port 8100) and STT (port 8103) are
+already up from `model-servers`, the demo detects them at startup and reuses
+them. No extra flags needed. When you exit, those services keep running.
+
+### Step 1 — Start the server
+
+```bash
+uv run simple_vlm_example
+```
+
+The hub, VLM, STT, and TTS start together (or reuse running services). When
+ready the hub prints:
+
+```
+[hub]   LiveKit URL : wss://0.0.0.0:8080
+[hub]   Room        : xr-room
+[hub]   Token       : eyJ…
+[hub]   Web client  : https://localhost:8080
+```
+
+### Step 2 — Connect a client
+
+Open `https://localhost:8080` in a browser. The samples ship with HTTPS on by
+default (a self-signed cert is generated on first run at
+`~/.local/share/xr-ai/web-server.crt`), so you'll see a "Your connection is not
+private" warning the first time — click **Advanced → Proceed** (Chrome/Edge) or
+**Accept the Risk and Continue** (Firefox). See the networking guide for trusting
+the cert permanently or running over plain HTTP instead.
+
+Leave **Token URL** blank — the web client fetches a token from the server
+automatically. Click **Connect**.
+
+You are now live in the XR session. To test the agent:
+
+- Type `ping` in the data channel → the agent describes what the camera sees.
+- Type any question → sent verbatim to the VLM.
+- Speak into your mic → speech is transcribed and sent as a query.
+
+A successful round trip: your query appears in the log, the agent responds after
+a moment, and you hear the reply through your speakers.
+
+**Local model** — override the model weights or GPU settings by editing
+`vlm_server.yaml` in the sample directory.
+
+**Remote model** — create a models overlay that points the VLM at your remote
+endpoint, then tell the worker to use it:
+
+```yaml
+# yaml/models.custom.yaml — overlay for a remote VLM endpoint
+vlm:
+  kind:     preset:cosmos_vlm
+  base_url: https://your-remote-vlm.example.com
+```
+
+```yaml
+# yaml/simple_vlm_example_worker.yaml — point the worker at the overlay
+models_yaml: yaml/models.custom.yaml
+```
+
+When pointing at a remote model, `vlm_server.yaml` is unused — remove the
+`vlm_server` entry from the launcher's process list so no local vLLM process is
+started.
+
+**Hosted NVIDIA NIM** — run the VLM on hosted NIM
+([build.nvidia.com](https://build.nvidia.com)) instead of locally (STT/TTS stay
+local) by setting **one key** in `simple_vlm_example_worker.yaml`:
+
+```yaml
+model_backend: nim     # default is "local"
+```
+
+The worker then loads the ready-made `yaml/models.nim.yaml` overlay and the
+orchestrator skips the local vlm-server automatically — no `main.py` edits. Pick
+the hosted model id in `models.nim.yaml` and provide an `NGC_API_KEY` as an
+**environment variable** (or save it once via the launcher credential prompt) —
+it is not stored in YAML; the overlay only names the env var via
+`api_key_env: NGC_API_KEY`. See the credentials and AI-services guides for full
+details (and self-hosted NIM containers).
+
+Each sample has its own `xr_media_hub.yaml` controlling the hub; see
+`server-runtime/xr_media_hub.yaml` for the full option list.
+
+## XR render demo (voice-driven sphere in CloudXR)
+
+Speak to the web client and a sphere in the streamed scene tracks your voice —
+radius follows loudness, colour and position follow spoken commands ("make it
+red", "put it to my left", "where I'm looking"). Runs against a Quest 3 / Vision
+Pro on the same LAN, or the IWER emulator built into the web client for desktop
+dev.
+
+Under the hood, the orchestrator launches twelve concurrent processes — hub,
+CloudXR runtime, STT / TTS / VLM / two LLM servers, four MCP servers, and the
+worker — wired together by a Pipecat pipeline that pairs a fast Llama-8B for
+quick-acks with a Nemotron-30B agentic tool-calling loop over `render-mcp` /
+`oxr-mcp` / `vlm-mcp` / `video-mcp`. See the xr-render-demo guide for the full
+process map, agentic-loop details, and the XR session lifecycle.
+
+**Requires `model-servers` to be running first** — the demo does not start its
+own model services.
+
+### Step 1 — Start model servers (once)
+
+```bash
+cd agent-samples/model-servers
+uv sync && uv run model_servers
+```
+
+This exits immediately once all four services are ready. Weights stay loaded in
+the background.
+
+### Step 2 — Start the demo
+
+This demo has two extra host prerequisites beyond the shared
+{doc}`Requirements <requirements>`:
+
+- **Vulkan loader + headers** — the CloudXR compositor and LOVR render through
+  Vulkan, so install them before running the demo: `sudo apt install libvulkan-dev`
+- **npm 18+** on PATH — the orchestrator builds the web vendor bundle on first
+  run (skipped on subsequent runs).
+
+```bash
+cd agent-samples/xr-render-demo
+uv sync
+uv run xr_render_demo
+```
+
+On first run the orchestrator automatically downloads LOVR v0.18.0 to
+`deps/lovr/` inside the repo and builds the web vendor bundle (requires npm and
+network access). Both steps are skipped on subsequent runs.
+
+**DGX Spark (aarch64):** LOVR does not publish a prebuilt aarch64 Linux binary,
+so the auto-download is not available — build LOVR from source and export
+`LOVR_BIN`. See the troubleshooting guide.
+
+To use a custom LOVR build:
+
+```bash
+export LOVR_BIN=/path/to/your/lovr   # or set lovr_bin: in render_mcp.yaml
+uv run xr_render_demo
+```
+
+**GPU pinning** for the XR side is controlled by `gpu_index` in
+`agent-samples/xr-render-demo/yaml/cloudxr_runtime.yaml`. cloudxr-runtime applies
+the pin to its own process and writes the selectors into `cloudxr.env`;
+render-mcp (and LOVR) inherit from that file. See the xr-render-demo guide for
+full details.
+
+To stop the model servers when done:
+
+```bash
+cd agent-samples/model-servers
+uv run model_servers --stop
+```
+
+**Hosted NVIDIA NIM** — run the LLMs and VLM on hosted NIM
+([build.nvidia.com](https://build.nvidia.com)) instead of local vLLM (STT/TTS
+stay local) by setting **one key** in `xr_render_demo_worker.yaml`:
+
+```yaml
+model_backend: nim     # default is "local"
+```
+
+The worker loads `yaml/models.nim.yaml` and the orchestrator points `vlm-mcp` at
+`yaml/vlm_mcp_server.nim.yaml` automatically — no `main.py` edits. Provide an
+`NGC_API_KEY` as an **environment variable** (or via the launcher credential
+prompt — not in YAML) and just don't start the local `llm` / `agent-llm` / `vlm`
+model-servers. See the AI-services guide.
+
+## Hub only (server-runtime standalone)
+
+```bash
+cd server-runtime
+uv sync
+uv run xr_media_hub
+```
+
+Useful for development or when running an agent in a separate terminal. The hub
+auto-discovers `server-runtime/xr_media_hub.yaml`.

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -1,0 +1,13 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Quickstart
+
+Every sample follows the same pattern: **start the server, then connect a
+client.** The three primary paths are the shared model servers, the
+`simple-vlm-example`, and the `xr-render-demo`.
+
+This page is a placeholder seeded by the docs scaffold; the full quickstart is
+ported from the repository README.

--- a/docs/source/getting_started/requirements.md
+++ b/docs/source/getting_started/requirements.md
@@ -1,0 +1,69 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Requirements
+
+## Hardware
+
+XR-AI samples are designed for a single NVIDIA RTX PRO 6000 Blackwell workstation
+GPU or an NVIDIA DGX Spark. Both provide enough VRAM to run the full model stack
+locally. If you prefer not to run models on local hardware, model endpoints are
+plain URLs — point the worker config at a cloud NIM or model endpoint and no
+local GPU is required for the agent or hub.
+
+| Sample | Local VRAM needed |
+|---|---|
+| model-servers (all 4 models) | ~70 GB |
+| simple-vlm-example (standalone) | ~23 GB |
+| xr-render-demo (requires model-servers) | ~70 GB (models) + ~2 GB (hub/TTS) |
+| Hub only | none |
+
+## Software
+
+| Requirement | Version | Notes |
+|---|---|---|
+| OS | Linux | Ubuntu 22.04 / 24.04 recommended |
+| Python | 3.11 or 3.12 | 3.10 and 3.13 are not supported |
+| [uv](https://docs.astral.sh/uv/) | latest | dependency manager used by all samples |
+| NVIDIA driver | 570+ | required for local model inference |
+| Docker | 24+ | required: all vLLM-backed services (LLM, VLM) run in `nvcr.io/nvidia/vllm` containers |
+| NVIDIA Container Toolkit | latest | required: gives Docker access to the GPU. Without it, `model_servers` fails with `failed to discover GPU vendor from CDI: no known GPU vendor found` |
+| npm | 18+ | required for xr-render-demo: the orchestrator builds the web vendor bundle on first run |
+
+`uv` handles all Python dependencies per-sample — no global `pip install` or
+virtual-environment setup needed. If you do not have it:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+The NVIDIA Container Toolkit install is one-time per host. Follow the official
+install guide and run the CDI / runtime-configure steps from there:
+
+> https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
+
+Quick smoke-test once installed:
+
+```bash
+docker run --rm --gpus all nvidia/cuda:13.0.3-base-ubuntu24.04 nvidia-smi
+```
+
+## GPU-profile prerequisites
+
+Install before `uv sync` for these targets:
+
+- **DGX Spark** (`xr-render-demo/yaml/spark/`): `sudo apt install python3-dev`
+
+All GPU profiles default to `vllm_backend: docker`, so the vLLM container ships
+nvcc + FlashInfer. If you switch a profile to `vllm_backend: pip`, see the
+troubleshooting guide for the host CUDA toolchain prerequisite.
+
+If `uv sync` or the VLM fails on first run, see the troubleshooting guide.
+
+## Network
+
+Open the firewall ports listed in the networking guide before connecting from
+another machine. UDP 7882 is a silent-failure path: signaling succeeds but media
+frames are dropped if it is closed.

--- a/docs/source/guides/index.md
+++ b/docs/source/guides/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Guides
+
+How-to guides: adding a sample, wiring CloudXR, troubleshooting, and contribution conventions.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/guides/troubleshooting.md
+++ b/docs/source/guides/troubleshooting.md
@@ -1,0 +1,11 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Troubleshooting
+
+Common setup and runtime frictions and their fixes.
+
+This page is a placeholder seeded by the docs scaffold; the full
+troubleshooting guide is ported from the repository's existing notes.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,0 +1,24 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# XR-AI
+
+Agentic AI for XR — an open-source foundation for multi-modal, real-time
+conversational AI within the CloudXR ecosystem.
+
+XR-AI connects web, iOS/visionOS, AR-glasses, and XR-headset clients to
+GPU-accelerated AI services, tool-using agents, and the CloudXR stack for remote
+rendering. This site documents the architecture, how to run the samples, each
+component, and the reference material for building on the stack.
+
+```{toctree}
+:maxdepth: 2
+
+overview/index
+getting_started/index
+components/index
+guides/index
+reference/index
+```

--- a/docs/source/overview/architecture.md
+++ b/docs/source/overview/architecture.md
@@ -1,0 +1,16 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Architecture
+
+XR-AI follows a **one hub, many clients, many agents** model. The
+**XR-Media-Hub** (server runtime) fans each client's inbound media to every
+agent and routes return traffic back to the originating client only. Clients
+reach the hub over a transport (LiveKit internally), agents attach over an IPC
+boundary, and MCP servers are the agent's only interface to XR data and
+rendering.
+
+This page is a placeholder seeded by the docs scaffold; the full architecture
+write-up is ported from the repository's existing architecture notes.

--- a/docs/source/overview/index.md
+++ b/docs/source/overview/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Overview
+
+What XR-AI is, the layer model, and how the hub, transport, and agents fit together.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/reference/changelog.md
+++ b/docs/source/reference/changelog.md
@@ -1,0 +1,12 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Decision changelog
+
+XR-AI records every non-trivial architectural or design decision, newest first,
+so the rationale is preserved. The canonical log lives in the repository at
+`docs/changelog.md`.
+
+This page is a placeholder seeded by the docs scaffold.

--- a/docs/source/reference/index.md
+++ b/docs/source/reference/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Reference
+
+Deep references: the xr-render-demo stack and the decision changelog.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```


### PR DESCRIPTION
## What

Authors the **Getting Started** unit of the Sphinx docs site:

- **`docs/source/getting_started/requirements.md`** (new) — hardware VRAM-per-sample table, software requirements table (OS / Python / uv / NVIDIA driver / Docker / NVIDIA Container Toolkit / **npm**), GPU-profile prerequisites, and the network note. Ported from the top-level `README.md` "Requirements" section.
- **`docs/source/getting_started/quickstart.md`** — replaces the scaffold seed placeholder with the full `README.md` "Quickstart" port: model-servers, simple-vlm-example, xr-render-demo, and hub-only, each as the start-server-then-connect-client pattern with the `uv run` commands.

Both pages auto-register via the section `index.md` `:glob:` toctree.

## Link handling (strict `-W` build)

Relative links to `docs/*.md` and repo source files would break the zero-warning build, so they are rendered as prose ("see the troubleshooting / networking / credentials / AI-services / xr-render-demo guide") or inline code (e.g. `server-runtime/xr_media_hub.yaml`). External `https://` URLs are kept. The README's `[Requirements](#requirements)` in-page anchor (now a separate page) is replaced with a `{doc}` xref to the sibling `requirements` page.

## Gate

```
sphinx-build -W --keep-going -b html docs/source docs/_build
```
Exit 0, zero warnings.

## Note on diff

This branch is based on `docs/sphinx-scaffold` (not yet merged — PR #220), so the diff also shows the scaffold files (`conf.py`, section index pages, `requirements.txt`, seed pages) until that lands. The Getting Started unit only touches `getting_started/requirements.md` and `getting_started/quickstart.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)