### PR TITLE
docs(overview): port architecture + add what-is-xr-ai page

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build the XR-AI Sphinx docs. On every docs PR: strict build (warnings = errors).
+# On push to main of the canonical repo: build + deploy to GitHub Pages.
+# Deploy is a no-op until Pages is enabled for the repo (Settings → Pages → GitHub Actions).
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yaml"
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yaml"
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build (strict)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install doc deps
+        run: pip install -r docs/requirements.txt
+      - name: Strict Sphinx build
+        run: sphinx-build -W --keep-going -b html docs/source docs/_build
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.repository == 'NVIDIA/xr-ai'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build
+
+  deploy:
+    name: Deploy to GitHub Pages
+    if: github.event_name == 'push' && github.repository == 'NVIDIA/xr-ai'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+# Sphinx build output
+_build/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal Sphinx makefile. Usage:
+#   pip install -r requirements.txt
+#   make html        # build into _build/
+#   make strict      # build with warnings-as-errors (CI gate)
+
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = _build
+
+.PHONY: help html strict clean
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+html:
+	@$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+strict:
+	@$(SPHINXBUILD) -W --keep-going -b html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+clean:
+	rm -rf "$(BUILDDIR)"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,26 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-10 — Sphinx documentation site (isaacteleop-style), scaffold
+
+Stood up a Sphinx documentation site under `docs/source/`, mirroring the
+NVIDIA/IsaacTeleop docs setup (NVIDIA Sphinx theme, GitHub Pages publish). It
+uses **MyST** so the existing `docs/*.md` content is reused as Markdown pages
+rather than rewritten as reStructuredText. Organized into five sections —
+Overview, Getting Started, Components, Guides, Reference — each section index
+uses a **`:glob:` toctree** so new pages self-register by simply being dropped
+into the section directory (this is what lets documentation pages be authored as
+independent, individually-mergeable PRs without all touching a shared nav file).
+
+`.github/workflows/docs.yaml` runs a strict build (`sphinx-build -W`) on every
+docs PR and deploys to GitHub Pages on push to `main` of the canonical repo
+(deploy is a no-op until Pages is enabled in repo settings). `docs/requirements.txt`
+pins the toolchain to IsaacTeleop's versions. The existing `docs/*.md` files are
+intentionally **kept in place** (the README and in-flight PRs link to them); the
+site ingests/ports their content, and a later cleanup can collapse the
+duplication once the site is the source of truth. `sphinx-multiversion` is a
+deliberate follow-up — single-version first to de-risk CI.
+
 ### 2026-06-09 — render-mcp: scene resync survives a LOVR respawn (blocking send, not NOBLOCK)
 
 After a LOVR (re)start, `render-mcp` re-pushed every stored primitive via

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Pins for building the XR-AI Sphinx documentation site.
+# Mirrors the NVIDIA/IsaacTeleop docs toolchain.
+sphinx==8.1.3
+nvidia-sphinx-theme==0.0.9.post1
+myst-parser==4.0.0
+sphinx-copybutton==0.5.2
+sphinx-design==0.6.1
+linkify-it-py==2.0.3

--- a/docs/source/components/index.md
+++ b/docs/source/components/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Components
+
+The server runtime, agent SDK, MCP servers, AI services, and the launcher/process model.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/components/server-runtime.md
+++ b/docs/source/components/server-runtime.md
@@ -1,0 +1,12 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Server runtime
+
+The `server-runtime/` package hosts the **XR-Media-Hub** and the internal
+LiveKit transport — the entry point clients connect to.
+
+This page is a placeholder seeded by the docs scaffold; the full component
+reference is filled in by the components documentation units.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sphinx configuration for the XR-AI documentation site.
+
+Mirrors the NVIDIA/IsaacTeleop docs setup: the NVIDIA Sphinx theme + MyST so
+the existing Markdown under ``docs/`` is reused directly. Single-version for
+now; ``sphinx-multiversion`` is a deliberate follow-up (see docs changelog).
+"""
+from __future__ import annotations
+
+# -- Project information -----------------------------------------------------
+project = "XR-AI"
+copyright = "2026, NVIDIA CORPORATION & AFFILIATES"
+author = "NVIDIA"
+
+# -- General configuration ---------------------------------------------------
+extensions = [
+    "myst_parser",
+    "sphinx_copybutton",
+    "sphinx_design",
+    "sphinx.ext.githubpages",
+    "sphinx.ext.intersphinx",
+]
+
+# MyST Markdown is the page format (matches the repo's existing docs/*.md).
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
+
+myst_enable_extensions = [
+    "colon_fence",
+    "deflist",
+    "linkify",
+    "substitution",
+]
+myst_heading_anchors = 3
+
+# Don't choke the build on the bundled long-form changelog or build output.
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# -- HTML output -------------------------------------------------------------
+html_theme = "nvidia_sphinx_theme"
+html_show_sphinx = False
+html_title = "XR-AI"

--- a/docs/source/getting_started/index.md
+++ b/docs/source/getting_started/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Getting Started
+
+Requirements, the quickstart paths, connecting clients, networking, and credentials.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -1,0 +1,13 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Quickstart
+
+Every sample follows the same pattern: **start the server, then connect a
+client.** The three primary paths are the shared model servers, the
+`simple-vlm-example`, and the `xr-render-demo`.
+
+This page is a placeholder seeded by the docs scaffold; the full quickstart is
+ported from the repository README.

--- a/docs/source/guides/index.md
+++ b/docs/source/guides/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Guides
+
+How-to guides: adding a sample, wiring CloudXR, troubleshooting, and contribution conventions.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/guides/troubleshooting.md
+++ b/docs/source/guides/troubleshooting.md
@@ -1,0 +1,11 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Troubleshooting
+
+Common setup and runtime frictions and their fixes.
+
+This page is a placeholder seeded by the docs scaffold; the full
+troubleshooting guide is ported from the repository's existing notes.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,0 +1,24 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# XR-AI
+
+Agentic AI for XR — an open-source foundation for multi-modal, real-time
+conversational AI within the CloudXR ecosystem.
+
+XR-AI connects web, iOS/visionOS, AR-glasses, and XR-headset clients to
+GPU-accelerated AI services, tool-using agents, and the CloudXR stack for remote
+rendering. This site documents the architecture, how to run the samples, each
+component, and the reference material for building on the stack.
+
+```{toctree}
+:maxdepth: 2
+
+overview/index
+getting_started/index
+components/index
+guides/index
+reference/index
+```

--- a/docs/source/overview/architecture.md
+++ b/docs/source/overview/architecture.md
@@ -5,12 +5,80 @@
 
 # Architecture
 
-XR-AI follows a **one hub, many clients, many agents** model. The
-**XR-Media-Hub** (server runtime) fans each client's inbound media to every
-agent and routes return traffic back to the originating client only. Clients
-reach the hub over a transport (LiveKit internally), agents attach over an IPC
-boundary, and MCP servers are the agent's only interface to XR data and
-rendering.
+Read this when working across module boundaries or onboarding to the
+overall design. For historical design decisions see the
+{doc}`/reference/changelog`.
 
-This page is a placeholder seeded by the docs scaffold; the full architecture
-write-up is ported from the repository's existing architecture notes.
+## Top-level layout
+
+```
+client-samples/     # Platform clients (Android, iOS/visionOS, Web)
+server-runtime/     # XR-Media-Hub core + LiveKit transport
+agent-sdk/          # xr-ai-agent: IPC client library (pyzmq + msgpack only)
+utils/              # Shared infra: stdlib-only launcher + loguru logging bridge
+cloudxr-runtime/    # Shared CloudXR OpenXR runtime + WSS proxy (opt-in per sample)
+ai-services/        # OpenAI-compatible AI inference servers (VLM, STT, TTS, LLM)
+agent-mcp-servers/  # MCP adapters: oxr, render, transcript, video, vlm
+agent-samples/      # End-to-end agent demos
+tests/              # Multi-client / multi-agent integration tests
+docs/               # Design docs and topic deep-dives
+```
+
+## Key design decisions
+
+- **One hub, many clients, many agents.** A single hub instance fans the
+  inbound stream out to every connected `ProcessorEndpoint` (agent) and
+  routes return traffic back to the originating client only — never to peers.
+- **XR-Media-Hub** is transport-agnostic at its IPC boundary. Agents connect
+  via IPC only.
+- **LiveKit** is an internal transport detail — not exposed to the agent layer.
+  When LiveKit is the transport, return audio is published as one track per
+  participant (`xr-hub-return-{pid}`) with subscribe permissions restricted to
+  that participant; return data uses `destination_identities` for the same
+  reason. Agents never need to know.
+- **`agent-sdk/`** (`xr-ai-agent`) contains only the agent-facing IPC layer.
+  Its sole runtime dependencies are `pyzmq` and `msgpack` — no LiveKit,
+  FastAPI, or uvicorn.
+- **MCP servers are the agent's only interface to XR data and rendering.**
+- **No API keys or tokens in source files** — use env vars or
+  `xr_media_hub.yaml` (see `docs/credentials.md`).
+
+For more on the hub and transport, see {doc}`/components/server-runtime`.
+
+## Hub config
+
+Each sample provides its own `xr_media_hub.yaml` in its `yaml/` directory
+(e.g. `agent-samples/simple-vlm-example/yaml/xr_media_hub.yaml`).
+`server-runtime/` also contains a reference copy documenting all available
+fields.
+
+Paths inside the YAML (e.g. `web_client_dir`) resolve relative to the YAML
+file's own directory, not CWD. `HubLauncher` finds the YAML automatically by
+searching upward from CWD when the orchestrator runs.
+
+## Known limitations
+
+For runtime symptoms and fixes that aren't architectural, see
+{doc}`/guides/troubleshooting`.
+
+### LiveKit signaling is fronted by a same-origin wss:// proxy
+
+LiveKit-server itself still runs plain `ws://` on the loopback interface
+(`127.0.0.1:7880`). The hub's web server (`_web_server.py`) terminates TLS
+on `web_server_port` (8080 by default) and exposes a same-origin
+`wss://<host>:8080/rtc` route that proxies LiveKit signaling
+bidirectionally (`_lk_proxy.py`). Every external client — browser, web-xr,
+Android, iOS, visionOS — connects only to that wss URL; nothing reaches
+LiveKit's 7880 from off-box.
+
+The `/token` endpoint returns `url: wss://<host>:<web_server_port>` when
+`web_server_tls: true` (the default), so the URL the client SDK uses comes
+straight from the server — no client-side toggle needed.
+
+WebRTC media (7881/TCP fallback, 7882/UDP) is DTLS/SRTP regardless, so no
+extra encryption is needed on those ports.
+
+To run a fully plain stack for `localhost` dev, set `web_server_tls: false`
+— `/token` then returns `ws://`, and the same-origin proxy serves plain
+WebSocket. `localhost` is the only context where browsers grant
+camera/mic permissions without HTTPS.

--- a/docs/source/overview/architecture.md
+++ b/docs/source/overview/architecture.md
@@ -1,0 +1,16 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Architecture
+
+XR-AI follows a **one hub, many clients, many agents** model. The
+**XR-Media-Hub** (server runtime) fans each client's inbound media to every
+agent and routes return traffic back to the originating client only. Clients
+reach the hub over a transport (LiveKit internally), agents attach over an IPC
+boundary, and MCP servers are the agent's only interface to XR data and
+rendering.
+
+This page is a placeholder seeded by the docs scaffold; the full architecture
+write-up is ported from the repository's existing architecture notes.

--- a/docs/source/overview/index.md
+++ b/docs/source/overview/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Overview
+
+What XR-AI is, the layer model, and how the hub, transport, and agents fit together.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/overview/what-is-xr-ai.md
+++ b/docs/source/overview/what-is-xr-ai.md
@@ -1,0 +1,83 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# What is XR-AI?
+
+XR-AI is a developer stack for building powerful XR and AI systems across
+devices, platforms, and deployment environments. It connects web,
+iOS/visionOS, AR glasses, and XR headset clients to GPU-accelerated AI
+services, tool-using agents, and the CloudXR stack for remote rendering.
+
+With XR-AI, developers can build agents that see and hear what the user
+experiences, reason over live physical context, call external tools through
+MCP, and respond with audio or data in the same XR session. The stack provides
+an end-to-end foundation for multimodal spatial computing applications:
+real-time media routing, participant-aware response handling, agent interfaces,
+AI service integration, remote rendering, and sample applications that show the
+pieces working together.
+
+The value is speed without lock-in. XR-AI is designed to work quickly with
+NVIDIA open models for vision, language, and speech, plus swappable speech
+synthesis services, while still giving developers the flexibility to bring
+their own models, services, tools, and application logic. Because it is built
+around NVIDIA GPU infrastructure, the same architecture can be deployed where
+the workload needs to run: cloud, data center, workstation, or edge.
+
+XR-AI also gives developers a practical path across product categories. Teams
+can start with AI glasses-style experiences that use live camera, audio, and
+agent responses, then extend the same framework to richer AR glasses or XR
+headset experiences that use CloudXR remote rendering. This lets developers
+build for today's lightweight AI devices while keeping a clear path to
+immersive, GPU-rendered spatial applications.
+
+XR-AI is especially useful when you need to:
+
+- **Build multimodal XR agents** that can see, hear, reason, use tools, and
+  respond in real time.
+- **Target multiple client platforms** including web, iOS/visionOS, AR
+  glasses, and XR headsets.
+- **Use NVIDIA open models out of the box** while preserving the flexibility to
+  bring your own models and services.
+- **Deploy wherever NVIDIA GPUs are available**, from cloud and data center to
+  workstation and edge.
+- **Start with AI glasses-style experiences and scale to CloudXR remote
+  rendering** for richer AR and XR applications.
+- **Keep transport, rendering, model services, tools, and agent logic
+  separated** so teams can evolve each layer independently.
+
+## The layer model
+
+XR-AI separates concerns into independent layers so teams can evolve each one
+on its own. Clients connect to the server runtime, agents attach over an IPC
+boundary, and AI inference is reached through swappable model services.
+
+| Layer | Directory | Description |
+|---|---|---|
+| Clients | `client-samples/` | Android, iOS/visionOS, Web, and native StreamKit clients |
+| Server runtime | `server-runtime/` | XR-Media-Hub + LiveKit internal transport |
+| Launcher | `utils/xr-ai-launcher/` | stdlib-only process manager used by samples |
+| Logging | `utils/xr-ai-logging/` | shared loguru sink + stdlib bridge for every process |
+| Agent interfaces | `agent-mcp-servers/` | MCP adapters for XR data & rendering |
+| Agent demos | `agent-samples/` | End-to-end agent pipelines |
+| Tests | `tests/` | Multi-client / multi-agent integration tests |
+
+Lightweight samples (`simple-vlm-example`) are self-contained — one command
+starts everything. Heavier demos (`xr-render-demo`) split model loading from
+the demo itself: start `model-servers` once, then run the demo as many times
+as you like without reloading weights.
+
+Every sample worker depends on `agent-sdk/xr-ai-models` — one SDK that
+abstracts the OpenAI-compatible HTTP wire format for LLM / VLM / STT / TTS
+behind four service protocols. Each sample ships a `yaml/models.yaml` that
+names the logical models the worker needs (`llm`, `vlm`, `stt`, …) with preset
+references that pre-fill model-specific quirks (reasoning-field aliasing,
+`chat_template_kwargs`, served-model-name strings). Workers call
+`make_llm(config, "llm")` / `make_vlm(config, "vlm")` / `make_stt(config,
+"stt")` / `make_tts(config, "tts")` — no hand-rolled httpx clients, no model
+quirks leaking out of the SDK. Full quickstart and the built-in preset table
+live in `agent-sdk/xr-ai-models/README.md`.
+
+For how the hub, transport, and agents fit together, see {doc}`architecture`.
+To run a sample, see the {doc}`/getting_started/quickstart`.

--- a/docs/source/reference/changelog.md
+++ b/docs/source/reference/changelog.md
@@ -1,0 +1,12 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Decision changelog
+
+XR-AI records every non-trivial architectural or design decision, newest first,
+so the rationale is preserved. The canonical log lives in the repository at
+`docs/changelog.md`.
+
+This page is a placeholder seeded by the docs scaffold.

--- a/docs/source/reference/index.md
+++ b/docs/source/reference/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Reference
+
+Deep references: the xr-render-demo stack and the decision changelog.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```


### PR DESCRIPTION
## Summary

Authors the **Overview** section pages for the XR-AI Sphinx docs site.

- **`docs/source/overview/architecture.md`** — replaces the scaffold's seed placeholder with a full port of the repo's `docs/architecture.md`: the one-hub/many-clients/many-agents model, hub ↔ transport ↔ agent boundaries, the same-origin `wss://` LiveKit signaling proxy, hub config, and known limitations. Repo-relative markdown links are converted to MyST `{doc}` xrefs (`/reference/changelog`, `/components/server-runtime`, `/guides/troubleshooting`); non-page mentions (`xr_media_hub.yaml`, `docs/credentials.md`) stay as code spans as in the source.
- **`docs/source/overview/what-is-xr-ai.md`** — new page porting the top-level `README.md` "What is XR-AI?" value proposition plus the "Architecture" layer-model table (Clients / Server runtime / Launcher / Logging / Agent interfaces / Agent demos / Tests) and the `xr-ai-models` SDK note. Cross-links to `architecture` and `/getting_started/quickstart`.

Both pages auto-register via the `overview/index.md` `:glob:` toctree.

## Testing

E2E doc-build gate (the gate for docs):

```
sphinx-build -W --keep-going -b html docs/source docs/_build
```

Exits 0 with **zero warnings**; both pages render and all `{doc}` xrefs resolve.

## Note

This branch is based on `docs/sphinx-scaffold` (PR #220, not yet merged on `main`), so the diff also shows the scaffold files until that merges — expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)