### PR TITLE
docs(guides): add contributing & conventions page

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build the XR-AI Sphinx docs. On every docs PR: strict build (warnings = errors).
+# On push to main of the canonical repo: build + deploy to GitHub Pages.
+# Deploy is a no-op until Pages is enabled for the repo (Settings → Pages → GitHub Actions).
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yaml"
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yaml"
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build (strict)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install doc deps
+        run: pip install -r docs/requirements.txt
+      - name: Strict Sphinx build
+        run: sphinx-build -W --keep-going -b html docs/source docs/_build
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.repository == 'NVIDIA/xr-ai'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build
+
+  deploy:
+    name: Deploy to GitHub Pages
+    if: github.event_name == 'push' && github.repository == 'NVIDIA/xr-ai'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+# Sphinx build output
+_build/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal Sphinx makefile. Usage:
+#   pip install -r requirements.txt
+#   make html        # build into _build/
+#   make strict      # build with warnings-as-errors (CI gate)
+
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = _build
+
+.PHONY: help html strict clean
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+html:
+	@$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+strict:
+	@$(SPHINXBUILD) -W --keep-going -b html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+clean:
+	rm -rf "$(BUILDDIR)"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,26 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-10 — Sphinx documentation site (isaacteleop-style), scaffold
+
+Stood up a Sphinx documentation site under `docs/source/`, mirroring the
+NVIDIA/IsaacTeleop docs setup (NVIDIA Sphinx theme, GitHub Pages publish). It
+uses **MyST** so the existing `docs/*.md` content is reused as Markdown pages
+rather than rewritten as reStructuredText. Organized into five sections —
+Overview, Getting Started, Components, Guides, Reference — each section index
+uses a **`:glob:` toctree** so new pages self-register by simply being dropped
+into the section directory (this is what lets documentation pages be authored as
+independent, individually-mergeable PRs without all touching a shared nav file).
+
+`.github/workflows/docs.yaml` runs a strict build (`sphinx-build -W`) on every
+docs PR and deploys to GitHub Pages on push to `main` of the canonical repo
+(deploy is a no-op until Pages is enabled in repo settings). `docs/requirements.txt`
+pins the toolchain to IsaacTeleop's versions. The existing `docs/*.md` files are
+intentionally **kept in place** (the README and in-flight PRs link to them); the
+site ingests/ports their content, and a later cleanup can collapse the
+duplication once the site is the source of truth. `sphinx-multiversion` is a
+deliberate follow-up — single-version first to de-risk CI.
+
 ### 2026-06-09 — render-mcp: scene resync survives a LOVR respawn (blocking send, not NOBLOCK)
 
 After a LOVR (re)start, `render-mcp` re-pushed every stored primitive via

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Pins for building the XR-AI Sphinx documentation site.
+# Mirrors the NVIDIA/IsaacTeleop docs toolchain.
+sphinx==8.1.3
+nvidia-sphinx-theme==0.0.9.post1
+myst-parser==4.0.0
+sphinx-copybutton==0.5.2
+sphinx-design==0.6.1
+linkify-it-py==2.0.3

--- a/docs/source/components/index.md
+++ b/docs/source/components/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Components
+
+The server runtime, agent SDK, MCP servers, AI services, and the launcher/process model.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/components/server-runtime.md
+++ b/docs/source/components/server-runtime.md
@@ -1,0 +1,12 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Server runtime
+
+The `server-runtime/` package hosts the **XR-Media-Hub** and the internal
+LiveKit transport — the entry point clients connect to.
+
+This page is a placeholder seeded by the docs scaffold; the full component
+reference is filled in by the components documentation units.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sphinx configuration for the XR-AI documentation site.
+
+Mirrors the NVIDIA/IsaacTeleop docs setup: the NVIDIA Sphinx theme + MyST so
+the existing Markdown under ``docs/`` is reused directly. Single-version for
+now; ``sphinx-multiversion`` is a deliberate follow-up (see docs changelog).
+"""
+from __future__ import annotations
+
+# -- Project information -----------------------------------------------------
+project = "XR-AI"
+copyright = "2026, NVIDIA CORPORATION & AFFILIATES"
+author = "NVIDIA"
+
+# -- General configuration ---------------------------------------------------
+extensions = [
+    "myst_parser",
+    "sphinx_copybutton",
+    "sphinx_design",
+    "sphinx.ext.githubpages",
+    "sphinx.ext.intersphinx",
+]
+
+# MyST Markdown is the page format (matches the repo's existing docs/*.md).
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
+
+myst_enable_extensions = [
+    "colon_fence",
+    "deflist",
+    "linkify",
+    "substitution",
+]
+myst_heading_anchors = 3
+
+# Don't choke the build on the bundled long-form changelog or build output.
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# -- HTML output -------------------------------------------------------------
+html_theme = "nvidia_sphinx_theme"
+html_show_sphinx = False
+html_title = "XR-AI"

--- a/docs/source/getting_started/index.md
+++ b/docs/source/getting_started/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Getting Started
+
+Requirements, the quickstart paths, connecting clients, networking, and credentials.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -1,0 +1,13 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Quickstart
+
+Every sample follows the same pattern: **start the server, then connect a
+client.** The three primary paths are the shared model servers, the
+`simple-vlm-example`, and the `xr-render-demo`.
+
+This page is a placeholder seeded by the docs scaffold; the full quickstart is
+ported from the repository README.

--- a/docs/source/guides/contributing-and-conventions.md
+++ b/docs/source/guides/contributing-and-conventions.md
@@ -1,0 +1,126 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Contributing and conventions
+
+The conventions every change to xr-ai must satisfy. The authoritative
+sources live at the repo root and override anything summarized here:
+
+- [`CONTRIBUTING.md`](https://github.com/NVIDIA/xr-ai/blob/main/CONTRIBUTING.md)
+  — how to build, test, and submit changes, plus the PR process and the
+  Developer Certificate of Origin (DCO) sign-off requirement.
+- [`AGENTS.md`](https://github.com/NVIDIA/xr-ai/blob/main/AGENTS.md) — despite
+  the name (which follows the [agents.md](https://agents.md) convention), this
+  is the working-conventions doc for **both human developers and AI
+  assistants**: architecture, the process model, sample layout, license-header
+  rules, and the change log.
+
+## Code style
+
+- Use meaningful, descriptive names for variables, functions, and types in all
+  languages.
+- Write short docstrings for public modules, classes, and functions.
+- Prefer clarity over clever tricks; keep code warnings and linter errors to a
+  minimum.
+
+Per-language specifics:
+
+| Language | Locations | Conventions |
+|---|---|---|
+| Python | `server-runtime/`, `agent-sdk/`, `utils/`, `ai-services/`, `agent-mcp-servers/`, `agent-samples/`, `cloudxr-runtime/`, `tests/` | Target Python 3.11+ (CI runs 3.11 and 3.12); follow PEP 8; use type annotations and f-strings; manage environments with `uv` (each sub-project is its own uv project — run `uv sync` in its directory). |
+| Swift | `client-samples/ios-visionos/` | Use the toolchain pinned by `// swift-tools-version:` in `Package.swift`; stick to Xcode's default formatting. |
+| Kotlin | `client-samples/android/` | Use the Kotlin / Android Gradle Plugin versions pinned in `gradle/libs.versions.toml`; follow the Kotlin official style. |
+| JavaScript | `client-samples/web/` | Plain ES modules, no build step; keep dependencies minimal. |
+
+## Documentation and changelog discipline
+
+A change is not done until the docs reflect it. Update `README.md` (and any
+relevant sub-repo docs), `AGENTS.md`, and `DEPENDENCIES.md` **in the same
+commit** as the code change. This applies to new packages, changed entry
+points, new quickstart flows, renamed commands, and new config files.
+
+Record significant new decisions in
+[`docs/changelog.md`](https://github.com/NVIDIA/xr-ai/blob/main/docs/changelog.md)
+(reverse chronological). Architectural rationale and historical context belong
+in the changelog, not in source comments.
+
+## Dependency discipline
+
+[`DEPENDENCIES.md`](https://github.com/NVIDIA/xr-ai/blob/main/DEPENDENCIES.md)
+at the repo root is the authoritative dependency map. **Any change to a
+`pyproject.toml` must update `DEPENDENCIES.md` in the same commit** — a change
+is not complete until `DEPENDENCIES.md` reflects it. Several hard rules follow
+from this map (for example, `utils/xr-ai-launcher/` is stdlib-only and
+`agent-sdk/xr-ai-agent` depends only on `pyzmq` + `msgpack`); see
+`DEPENDENCIES.md` for the full set.
+
+## SPDX license headers
+
+This repository uses [REUSE](https://reuse.software/) / SPDX headers on every
+source file we own. The hard rule lives in `AGENTS.md`: every new source file
+gets the SPDX header at the top. This section documents the comment-style
+choices and edge cases.
+
+### The header
+
+```
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+```
+
+The Apache-2.0 license text lives in
+[`LICENSE`](https://github.com/NVIDIA/xr-ai/blob/main/LICENSE). REUSE does not
+auto-update the copyright year when you touch a file; include the current year
+when adding or editing headers.
+
+### Comment style by file type
+
+Use the comment syntax for the file's language and place the header before any
+other content, with one blank line separating it from the body:
+
+| Style | Used for |
+|---|---|
+| `# …` | `.py`, `.yaml`/`.yml`, `.toml`, `.properties`, `.sh`, `.pro`, `.gitignore`, `.gitattributes`, `requirements.txt` |
+| `// …` | `.swift`, `.kt`/`.kts`, `.js`, `.ts`/`.tsx` |
+| `<!-- … -->` | `.xml`, `.html`, `.plist`, `.entitlements`, `.md` |
+
+Insert the header **after** these required first-line directives when present:
+`#!/...` shebangs, `<?xml …?>` declarations, `<!DOCTYPE …>`, and Swift's
+`// swift-tools-version:` directive.
+
+To add or fix headers, install the
+[reuse tool](https://github.com/fsfe/reuse-tool) (`uv tool install reuse`) and
+run, for example:
+
+```bash
+reuse annotate -t compact -l Apache-2.0 --skip-unrecognised -r path/to/file
+```
+
+### Files to skip
+
+Skip files that can't carry comments or aren't ours to license: `LICENSE`,
+`*.json`, `*.resolved`, binary assets (e.g. `*.gif`), `.gitkeep` markers,
+Xcode-managed files (`*.pbxproj`, `*.xcworkspacedata`), and third-party Gradle
+wrapper files (`gradlew`, `gradlew.bat`,
+`gradle/wrapper/gradle-wrapper.properties`).
+
+### Enforcement
+
+Headers are enforced locally by
+[`.github/scripts/check_spdx_headers.py`](https://github.com/NVIDIA/xr-ai/blob/main/.github/scripts/check_spdx_headers.py),
+wired into
+[`.pre-commit-config.yaml`](https://github.com/NVIDIA/xr-ai/blob/main/.pre-commit-config.yaml).
+Run `pre-commit install` once after cloning to enable it;
+`python3 .github/scripts/check_spdx_headers.py` audits the whole tree at any
+time. The same check runs in CI as a backstop:
+[`.github/workflows/spdx.yml`](https://github.com/NVIDIA/xr-ai/blob/main/.github/workflows/spdx.yml).
+
+## Pull requests
+
+Create a feature branch, keep code and docs in the same commit, ensure builds
+and tests pass locally and in CI, and describe motivation, changes, and testing
+in the PR. All commits must be signed off (`git commit -s`) per the DCO. See
+[`CONTRIBUTING.md`](https://github.com/NVIDIA/xr-ai/blob/main/CONTRIBUTING.md)
+for the full PR process and the DCO text.

--- a/docs/source/guides/index.md
+++ b/docs/source/guides/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Guides
+
+How-to guides: adding a sample, wiring CloudXR, troubleshooting, and contribution conventions.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/guides/troubleshooting.md
+++ b/docs/source/guides/troubleshooting.md
@@ -1,0 +1,11 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Troubleshooting
+
+Common setup and runtime frictions and their fixes.
+
+This page is a placeholder seeded by the docs scaffold; the full
+troubleshooting guide is ported from the repository's existing notes.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,0 +1,24 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# XR-AI
+
+Agentic AI for XR — an open-source foundation for multi-modal, real-time
+conversational AI within the CloudXR ecosystem.
+
+XR-AI connects web, iOS/visionOS, AR-glasses, and XR-headset clients to
+GPU-accelerated AI services, tool-using agents, and the CloudXR stack for remote
+rendering. This site documents the architecture, how to run the samples, each
+component, and the reference material for building on the stack.
+
+```{toctree}
+:maxdepth: 2
+
+overview/index
+getting_started/index
+components/index
+guides/index
+reference/index
+```

--- a/docs/source/overview/architecture.md
+++ b/docs/source/overview/architecture.md
@@ -1,0 +1,16 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Architecture
+
+XR-AI follows a **one hub, many clients, many agents** model. The
+**XR-Media-Hub** (server runtime) fans each client's inbound media to every
+agent and routes return traffic back to the originating client only. Clients
+reach the hub over a transport (LiveKit internally), agents attach over an IPC
+boundary, and MCP servers are the agent's only interface to XR data and
+rendering.
+
+This page is a placeholder seeded by the docs scaffold; the full architecture
+write-up is ported from the repository's existing architecture notes.

--- a/docs/source/overview/index.md
+++ b/docs/source/overview/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Overview
+
+What XR-AI is, the layer model, and how the hub, transport, and agents fit together.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/reference/changelog.md
+++ b/docs/source/reference/changelog.md
@@ -1,0 +1,12 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Decision changelog
+
+XR-AI records every non-trivial architectural or design decision, newest first,
+so the rationale is preserved. The canonical log lives in the repository at
+`docs/changelog.md`.
+
+This page is a placeholder seeded by the docs scaffold.

--- a/docs/source/reference/index.md
+++ b/docs/source/reference/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Reference
+
+Deep references: the xr-render-demo stack and the decision changelog.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```


### PR DESCRIPTION
## What

Adds `docs/source/guides/contributing-and-conventions.md` to the Sphinx docs site:

- **Ports** `docs/spdx-headers.md` in full: the SPDX header text, the comment-style-by-language table, the files-to-skip list, and the local/CI enforcement (`check_spdx_headers.py`, pre-commit, `spdx.yml`).
- **Summarizes** the contribution conventions from `CONTRIBUTING.md` and `AGENTS.md`: per-language code style, the docs/changelog discipline (docs updated in the same commit; decisions recorded in `docs/changelog.md`), the `DEPENDENCIES.md`-in-the-same-commit rule, and a pointer to the PR process + DCO sign-off.

Repo-root files live outside the doc tree, so they are linked via canonical `https://github.com/NVIDIA/xr-ai/blob/main/<file>` URLs rather than relative `{doc}`/`.md` links (which would warn under `-W`).

## Note on the diff

This branch is based on the unmerged `docs/sphinx-scaffold` branch (PR #220). Until that merges, this PR's diff against `main` will also show the scaffold files. Only `docs/source/guides/contributing-and-conventions.md` is new in this unit.

## Testing

```
python3 -m venv /tmp/v_contrib && . /tmp/v_contrib/bin/activate
pip install -r docs/requirements.txt
sphinx-build -W --keep-going -b html docs/source docs/_build
```

Exit 0, zero warnings. The page is auto-included via the guides `:glob:` toctree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)