### PR TITLE
docs(server-runtime): write Components server-runtime page

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build the XR-AI Sphinx docs. On every docs PR: strict build (warnings = errors).
+# On push to main of the canonical repo: build + deploy to GitHub Pages.
+# Deploy is a no-op until Pages is enabled for the repo (Settings → Pages → GitHub Actions).
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yaml"
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yaml"
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build (strict)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install doc deps
+        run: pip install -r docs/requirements.txt
+      - name: Strict Sphinx build
+        run: sphinx-build -W --keep-going -b html docs/source docs/_build
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.repository == 'NVIDIA/xr-ai'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build
+
+  deploy:
+    name: Deploy to GitHub Pages
+    if: github.event_name == 'push' && github.repository == 'NVIDIA/xr-ai'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+# Sphinx build output
+_build/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal Sphinx makefile. Usage:
+#   pip install -r requirements.txt
+#   make html        # build into _build/
+#   make strict      # build with warnings-as-errors (CI gate)
+
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = _build
+
+.PHONY: help html strict clean
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+html:
+	@$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+strict:
+	@$(SPHINXBUILD) -W --keep-going -b html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+clean:
+	rm -rf "$(BUILDDIR)"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,26 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-10 — Sphinx documentation site (isaacteleop-style), scaffold
+
+Stood up a Sphinx documentation site under `docs/source/`, mirroring the
+NVIDIA/IsaacTeleop docs setup (NVIDIA Sphinx theme, GitHub Pages publish). It
+uses **MyST** so the existing `docs/*.md` content is reused as Markdown pages
+rather than rewritten as reStructuredText. Organized into five sections —
+Overview, Getting Started, Components, Guides, Reference — each section index
+uses a **`:glob:` toctree** so new pages self-register by simply being dropped
+into the section directory (this is what lets documentation pages be authored as
+independent, individually-mergeable PRs without all touching a shared nav file).
+
+`.github/workflows/docs.yaml` runs a strict build (`sphinx-build -W`) on every
+docs PR and deploys to GitHub Pages on push to `main` of the canonical repo
+(deploy is a no-op until Pages is enabled in repo settings). `docs/requirements.txt`
+pins the toolchain to IsaacTeleop's versions. The existing `docs/*.md` files are
+intentionally **kept in place** (the README and in-flight PRs link to them); the
+site ingests/ports their content, and a later cleanup can collapse the
+duplication once the site is the source of truth. `sphinx-multiversion` is a
+deliberate follow-up — single-version first to de-risk CI.
+
 ### 2026-06-09 — render-mcp: scene resync survives a LOVR respawn (blocking send, not NOBLOCK)
 
 After a LOVR (re)start, `render-mcp` re-pushed every stored primitive via

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Pins for building the XR-AI Sphinx documentation site.
+# Mirrors the NVIDIA/IsaacTeleop docs toolchain.
+sphinx==8.1.3
+nvidia-sphinx-theme==0.0.9.post1
+myst-parser==4.0.0
+sphinx-copybutton==0.5.2
+sphinx-design==0.6.1
+linkify-it-py==2.0.3

--- a/docs/source/components/index.md
+++ b/docs/source/components/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Components
+
+The server runtime, agent SDK, MCP servers, AI services, and the launcher/process model.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/components/server-runtime.md
+++ b/docs/source/components/server-runtime.md
@@ -1,0 +1,12 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Server runtime
+
+The `server-runtime/` package hosts the **XR-Media-Hub** and the internal
+LiveKit transport — the entry point clients connect to.
+
+This page is a placeholder seeded by the docs scaffold; the full component
+reference is filled in by the components documentation units.

--- a/docs/source/components/server-runtime.md
+++ b/docs/source/components/server-runtime.md
@@ -5,8 +5,197 @@
 
 # Server runtime
 
-The `server-runtime/` package hosts the **XR-Media-Hub** and the internal
-LiveKit transport — the entry point clients connect to.
+The `server-runtime/` package hosts the **XR-Media-Hub** — the single process
+clients connect to and agents fan out from. It owns the internal LiveKit
+transport, the shared-memory + ZMQ IPC boundary to agents, the per-participant
+return path, and the same-origin `wss://` proxy that fronts LiveKit signaling.
 
-This page is a placeholder seeded by the docs scaffold; the full component
-reference is filled in by the components documentation units.
+It runs as one process:
+
+```
+uv run xr_media_hub                       # auto-discovers ./xr_media_hub.yaml
+uv run xr_media_hub --config path.yaml    # explicit config
+python -m xr_media_hub                    # equivalent module form
+```
+
+Configuration comes from a `xr_media_hub.yaml` file (defaults are used when
+none is found). `server-runtime/xr_media_hub.yaml` is the reference copy
+documenting every field; each sample ships its own copy under its `yaml/`
+directory. Relative paths inside the YAML (such as `web_client_dir`) resolve
+against the YAML file's own directory, not the working directory.
+
+For where the hub sits in the wider system, see
+{doc}`Architecture </overview/architecture>`.
+
+## XR-Media-Hub
+
+The hub is one hub, many clients, many agents. A single instance fans the
+inbound media stream out to every connected agent and routes any return
+traffic back to the originating client only.
+
+On startup, `__main__.py` constructs a `HubEndpoint` (the IPC server),
+registers hub-local callbacks (`on_frame`, `on_audio`, `on_data`,
+`on_participant`), loads the config, and brings up the `LiveKitConnector`.
+The hub task and the connector task then run concurrently until `SIGINT` /
+`SIGTERM`. A periodic stats loop logs per-participant video/audio/data rates.
+
+### Isolation contract
+
+The hub is **not** a routing switch between participants. There is no supported
+path for participant A's media or data to reach participant B. The only
+supported flow is:
+
+```
+participant → hub → consumer (agent) → hub → same participant
+```
+
+This is enforced at several layers:
+
+- `send_return_audio` / `send_return_data` / `send_return_audio_flush`
+  validate that the target participant is currently connected; messages for
+  unknown participants are dropped with a warning.
+- Return-traffic topics (`return_audio.*`, `return_audio_flush.*`,
+  `return_data.*`) are connector-only — an agent's default subscription
+  excludes them.
+- On the LiveKit side, return audio is published as one track per participant
+  with subscribe permissions restricted to that participant, and return data
+  is addressed with `destination_identities` (see
+  [the per-participant return path](#per-participant-return-path)).
+
+## Internal LiveKit transport
+
+LiveKit is an internal transport implementation detail. It is not exposed to
+the agent or MCP layer — agents only ever speak the IPC protocol below, and
+never need to know which transport carries the media.
+
+`LiveKitConnector` (`transport/livekit/`) owns the transport lifecycle:
+
+1. Starts the LiveKit server in a Docker container, listening on the loopback
+   interface only (signaling `ws://127.0.0.1:7880`, plus WebRTC TCP/UDP media
+   ports 7881/7882).
+2. Optionally starts the browser-facing web server and/or token server.
+3. Registers itself as a `ConnectorEndpoint` with the IPC layer.
+4. Connects a Python `RoomClient` to the LiveKit room. The room client is
+   subscribe-only — it never publishes media of its own except per-participant
+   return-audio tracks.
+
+The connector translates LiveKit room events into IPC messages: it pushes
+decoded frames, audio chunks, and data into the hub, and emits participant
+join/leave events. NVENC/NVDEC hardware video codecs are required and checked
+at startup.
+
+## IPC boundary to agents
+
+The hub and its producers/consumers communicate over ZMQ using msgpack-encoded
+messages. The layer lives in `server-runtime/xr_media_hub/ipc/` and defines
+three endpoints:
+
+| Endpoint | Role | Who |
+| --- | --- | --- |
+| `ConnectorEndpoint` | producer + return-traffic receiver | LiveKit connector process |
+| `HubEndpoint` | server: dispatch + fan-out | XR-Media-Hub process |
+| `ProcessorEndpoint` | subscriber + publisher | agents, analytics, downstream processors |
+
+The hub binds two sockets (defaults shown):
+
+- `PULL` on `ipc:///tmp/xr_hub_in` — connectors `PUSH` inbound media here.
+- `PUB` on `ipc:///tmp/xr_hub_pub` — consumers `SUB` here for the fanned-out
+  stream.
+
+```
+connector_A ──PUSH──┐
+connector_B ──PUSH──┤─► PULL   HubEndpoint   PUB ──SUB──► consumers (agents)
+connector_N ──PUSH──┘    ↓ dispatch
+                      on_frame / on_audio / on_data / on_participant
+```
+
+Each connector owns and creates its own shared-memory ring buffer and
+announces it to the hub with a `ConnectorRegistration` message; the hub opens
+that buffer on demand. Video frames travel zero-copy through the ring buffer:
+the connector writes pixels into a slot and pushes a lightweight
+`FRAME_SIGNAL` (metadata) at full frame rate; consumers that want the pixels
+issue a `FRAME_REQUEST`, and the hub replies with the held slot's
+`FRAME_DATA`. Audio, data, and participant events are carried inline as
+msgpack payloads.
+
+Messages are tagged with a `MsgType` and routed by topic. Topics follow the
+`"<type>.<participant_id>.<track_or_topic>"` convention, and ZMQ's byte-prefix
+subscription lets a consumer subscribe at any granularity:
+
+```
+audio                    — all audio, all participants
+audio.alice              — all of alice's audio tracks
+audio.alice.TR_mic_001   — alice's specific mic track
+data.alice.chat          — alice's "chat" data channel only
+participant              — join/leave events
+```
+
+The message types and codec are extensible: new `MsgType` IDs can be
+registered at import time via `register_encoder` / `register_decoder`.
+
+```{note}
+Agent code should import the IPC types and `ProcessorEndpoint` from
+`xr_ai_agent` directly, **not** from `xr_media_hub.ipc`. The agent SDK's only
+runtime dependencies are `pyzmq` and `msgpack` — importing from the agent SDK
+avoids pulling in the full server-runtime dependency tree (LiveKit, FastAPI,
+uvicorn, GPU codecs). `xr_media_hub.ipc` re-exports the same names for the
+server side.
+```
+
+## Per-participant return path
+
+Agents send audio, data, and flush signals back toward a specific participant
+through the same IPC channel. The hub guards every return path by participant
+id:
+
+- `send_return_audio` publishes on topic `return_audio.{pid}.`, dropping the
+  chunk if `{pid}` is not connected.
+- `send_return_data` publishes on `return_data.{pid}.{topic}`, with the same
+  connectivity guard.
+- `send_return_audio_flush` publishes on `return_audio_flush.{pid}.` so a
+  processor can cleanly interrupt the agent's own audio playback.
+
+The trailing `.` after the participant id terminates the pid segment so that a
+subscription for `alice` does not byte-prefix-match a topic addressed to
+`alice2`; the connector subscribes with the identical delimiter when a
+participant joins, and unsubscribes when they leave.
+
+On the LiveKit side the return path maps to per-participant resources: the room
+client lazily publishes one `xr-hub-return-{pid}` audio track per participant
+and refreshes subscribe permissions so each participant may subscribe only to
+their own return track. Return data is sent with `destination_identities` set
+to the target participant, so it is never broadcast to peers. Return audio is
+paced into LiveKit at audio rate by a per-participant pipe, which a flush can
+drain to interrupt playback.
+
+## Same-origin wss proxy
+
+LiveKit server itself runs plain `ws://` on the loopback interface
+(`127.0.0.1:7880`) and nothing reaches that port from off-box. External
+clients — browser, web-xr, Android, iOS, visionOS — connect only to a
+same-origin `wss://` URL exposed by the hub's web server.
+
+When `web_server_tls` is enabled (the default), the web server
+(`_web_server.py`) terminates TLS on `web_server_port` (8080 by default) and
+mounts a `/rtc` route that proxies LiveKit signaling bidirectionally to the
+internal `ws://127.0.0.1:7880` (`_lk_proxy.py`). A self-signed certificate is
+auto-generated on first run; supply `cert_file` / `key_file` to use your own.
+The proxy forwards end-to-end headers so SDK auth (such as the LiveKit Swift
+SDK's `Authorization: Bearer`) reaches the server, and handles both the
+versioned (`/rtc/v1`) and legacy (`/rtc`) signaling paths.
+
+The web server's `/token` endpoint returns a signed LiveKit JWT together with
+the URL the client should use. With TLS on, that URL is the same-origin
+`wss://<host>:<web_server_port>` — so the client SDK never needs a
+per-deployment toggle. A `/cert` endpoint serves the active certificate as an
+installable iOS profile.
+
+Set `web_server_tls: false` for the two cases where the hub should not
+terminate TLS itself: a TLS-terminating reverse proxy (nginx, Caddy,
+Cloudflare Tunnel) sits in front and speaks plain `http://` + `ws://` to the
+hub on the loopback, or localhost-only dev where browsers already grant
+camera/mic on `http://localhost`. In that mode `/token` returns a plain
+`ws://` URL and the proxy carries plain WebSocket.
+
+For runtime symptoms and fixes, see
+{doc}`Troubleshooting </guides/troubleshooting>`.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sphinx configuration for the XR-AI documentation site.
+
+Mirrors the NVIDIA/IsaacTeleop docs setup: the NVIDIA Sphinx theme + MyST so
+the existing Markdown under ``docs/`` is reused directly. Single-version for
+now; ``sphinx-multiversion`` is a deliberate follow-up (see docs changelog).
+"""
+from __future__ import annotations
+
+# -- Project information -----------------------------------------------------
+project = "XR-AI"
+copyright = "2026, NVIDIA CORPORATION & AFFILIATES"
+author = "NVIDIA"
+
+# -- General configuration ---------------------------------------------------
+extensions = [
+    "myst_parser",
+    "sphinx_copybutton",
+    "sphinx_design",
+    "sphinx.ext.githubpages",
+    "sphinx.ext.intersphinx",
+]
+
+# MyST Markdown is the page format (matches the repo's existing docs/*.md).
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
+
+myst_enable_extensions = [
+    "colon_fence",
+    "deflist",
+    "linkify",
+    "substitution",
+]
+myst_heading_anchors = 3
+
+# Don't choke the build on the bundled long-form changelog or build output.
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# -- HTML output -------------------------------------------------------------
+html_theme = "nvidia_sphinx_theme"
+html_show_sphinx = False
+html_title = "XR-AI"

--- a/docs/source/getting_started/index.md
+++ b/docs/source/getting_started/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Getting Started
+
+Requirements, the quickstart paths, connecting clients, networking, and credentials.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -1,0 +1,13 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Quickstart
+
+Every sample follows the same pattern: **start the server, then connect a
+client.** The three primary paths are the shared model servers, the
+`simple-vlm-example`, and the `xr-render-demo`.
+
+This page is a placeholder seeded by the docs scaffold; the full quickstart is
+ported from the repository README.

--- a/docs/source/guides/index.md
+++ b/docs/source/guides/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Guides
+
+How-to guides: adding a sample, wiring CloudXR, troubleshooting, and contribution conventions.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/guides/troubleshooting.md
+++ b/docs/source/guides/troubleshooting.md
@@ -1,0 +1,11 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Troubleshooting
+
+Common setup and runtime frictions and their fixes.
+
+This page is a placeholder seeded by the docs scaffold; the full
+troubleshooting guide is ported from the repository's existing notes.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,0 +1,24 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# XR-AI
+
+Agentic AI for XR — an open-source foundation for multi-modal, real-time
+conversational AI within the CloudXR ecosystem.
+
+XR-AI connects web, iOS/visionOS, AR-glasses, and XR-headset clients to
+GPU-accelerated AI services, tool-using agents, and the CloudXR stack for remote
+rendering. This site documents the architecture, how to run the samples, each
+component, and the reference material for building on the stack.
+
+```{toctree}
+:maxdepth: 2
+
+overview/index
+getting_started/index
+components/index
+guides/index
+reference/index
+```

--- a/docs/source/overview/architecture.md
+++ b/docs/source/overview/architecture.md
@@ -1,0 +1,16 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Architecture
+
+XR-AI follows a **one hub, many clients, many agents** model. The
+**XR-Media-Hub** (server runtime) fans each client's inbound media to every
+agent and routes return traffic back to the originating client only. Clients
+reach the hub over a transport (LiveKit internally), agents attach over an IPC
+boundary, and MCP servers are the agent's only interface to XR data and
+rendering.
+
+This page is a placeholder seeded by the docs scaffold; the full architecture
+write-up is ported from the repository's existing architecture notes.

--- a/docs/source/overview/index.md
+++ b/docs/source/overview/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Overview
+
+What XR-AI is, the layer model, and how the hub, transport, and agents fit together.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/reference/changelog.md
+++ b/docs/source/reference/changelog.md
@@ -1,0 +1,12 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Decision changelog
+
+XR-AI records every non-trivial architectural or design decision, newest first,
+so the rationale is preserved. The canonical log lives in the repository at
+`docs/changelog.md`.
+
+This page is a placeholder seeded by the docs scaffold.

--- a/docs/source/reference/index.md
+++ b/docs/source/reference/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Reference
+
+Deep references: the xr-render-demo stack and the decision changelog.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```


### PR DESCRIPTION
## What

Replaces the scaffold placeholder in `docs/source/components/server-runtime.md` with a real reference page for the `server-runtime/` package, covering the five required topics:

- **XR-Media-Hub** — single hub process (`__main__.py`), one hub / many clients / many agents, with the participant isolation contract.
- **Internal LiveKit transport** — `transport/livekit/`, Docker-launched LiveKit on the loopback, subscribe-only room client; an internal detail not exposed to agents.
- **IPC boundary to agents** — `ConnectorEndpoint` / `HubEndpoint` / `ProcessorEndpoint`, the two ZMQ sockets (`ipc:///tmp/xr_hub_in` PULL, `ipc:///tmp/xr_hub_pub` PUB), msgpack + `MsgType`, zero-copy shm ring buffer for frames, topic-prefix fan-out, and the `xr_ai_agent` (pyzmq+msgpack-only) import boundary.
- **Per-participant return path** — `send_return_audio/data/flush` connectivity guards, trailing-dot pid topic guard, per-pid `xr-hub-return-{pid}` tracks with restricted subscribe perms, return data via `destination_identities`.
- **Same-origin wss proxy** — TLS terminated on `web_server_port` (8080), `/rtc` proxy to loopback `ws://127.0.0.1:7880`, `/token` returning the same-origin `wss://` URL, and the `web_server_tls: false` escape hatch.

## Notes

- Branched from the unmerged `docs/sphinx-scaffold`; PR base is set to that branch, so the diff is limited to the one page. Once the scaffold PR (#220) lands, this can be retargeted to `main`.
- Only `docs/source/components/server-runtime.md` is touched.
- E2E gate (`sphinx-build -W --keep-going`) passes with exit 0 and zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)