### PR TITLE
docs(components): add Agent SDK reference page

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build the XR-AI Sphinx docs. On every docs PR: strict build (warnings = errors).
+# On push to main of the canonical repo: build + deploy to GitHub Pages.
+# Deploy is a no-op until Pages is enabled for the repo (Settings → Pages → GitHub Actions).
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yaml"
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yaml"
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build (strict)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install doc deps
+        run: pip install -r docs/requirements.txt
+      - name: Strict Sphinx build
+        run: sphinx-build -W --keep-going -b html docs/source docs/_build
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.repository == 'NVIDIA/xr-ai'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build
+
+  deploy:
+    name: Deploy to GitHub Pages
+    if: github.event_name == 'push' && github.repository == 'NVIDIA/xr-ai'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+# Sphinx build output
+_build/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal Sphinx makefile. Usage:
+#   pip install -r requirements.txt
+#   make html        # build into _build/
+#   make strict      # build with warnings-as-errors (CI gate)
+
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = _build
+
+.PHONY: help html strict clean
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+html:
+	@$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+strict:
+	@$(SPHINXBUILD) -W --keep-going -b html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+clean:
+	rm -rf "$(BUILDDIR)"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,26 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-10 — Sphinx documentation site (isaacteleop-style), scaffold
+
+Stood up a Sphinx documentation site under `docs/source/`, mirroring the
+NVIDIA/IsaacTeleop docs setup (NVIDIA Sphinx theme, GitHub Pages publish). It
+uses **MyST** so the existing `docs/*.md` content is reused as Markdown pages
+rather than rewritten as reStructuredText. Organized into five sections —
+Overview, Getting Started, Components, Guides, Reference — each section index
+uses a **`:glob:` toctree** so new pages self-register by simply being dropped
+into the section directory (this is what lets documentation pages be authored as
+independent, individually-mergeable PRs without all touching a shared nav file).
+
+`.github/workflows/docs.yaml` runs a strict build (`sphinx-build -W`) on every
+docs PR and deploys to GitHub Pages on push to `main` of the canonical repo
+(deploy is a no-op until Pages is enabled in repo settings). `docs/requirements.txt`
+pins the toolchain to IsaacTeleop's versions. The existing `docs/*.md` files are
+intentionally **kept in place** (the README and in-flight PRs link to them); the
+site ingests/ports their content, and a later cleanup can collapse the
+duplication once the site is the source of truth. `sphinx-multiversion` is a
+deliberate follow-up — single-version first to de-risk CI.
+
 ### 2026-06-09 — render-mcp: scene resync survives a LOVR respawn (blocking send, not NOBLOCK)
 
 After a LOVR (re)start, `render-mcp` re-pushed every stored primitive via

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Pins for building the XR-AI Sphinx documentation site.
+# Mirrors the NVIDIA/IsaacTeleop docs toolchain.
+sphinx==8.1.3
+nvidia-sphinx-theme==0.0.9.post1
+myst-parser==4.0.0
+sphinx-copybutton==0.5.2
+sphinx-design==0.6.1
+linkify-it-py==2.0.3

--- a/docs/source/components/agent-sdk.md
+++ b/docs/source/components/agent-sdk.md
@@ -235,9 +235,10 @@ user/bot speech.
 
 ### Writing a brain
 
-Subclass `BrainProcessor` and implement `handle_query`. Return either a single
-string (one downstream `TextFrame`) or an async iterator of strings (one
-`TextFrame` per yielded chunk — this is how token streaming reaches TTS):
+Subclass `BrainProcessor` and implement `handle_query`. It is a coroutine that
+*returns* either a single string (one downstream `TextFrame`) or an async
+iterator of strings (one `TextFrame` per chunk — this is how token streaming
+reaches TTS). Note it returns the iterator; it is not itself a generator:
 
 ```python
 from xr_ai_pipecat import BrainProcessor
@@ -248,8 +249,10 @@ class MyBrain(BrainProcessor):
         self._llm = llm          # the sample injects its own LLMService
 
     async def handle_query(self, pid, text, fresh_match):
-        async for chunk in self._llm.stream([...]):
-            yield chunk
+        # Return the AsyncIterator[str]; the base class consumes it and
+        # pushes one TextFrame per chunk. For a non-streaming brain,
+        # `return resp.content` (a single string) instead.
+        return self._llm.stream([...])
 ```
 
 The base class owns the per-participant in-flight task, cancellation, and the

--- a/docs/source/components/agent-sdk.md
+++ b/docs/source/components/agent-sdk.md
@@ -1,0 +1,403 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Agent SDK
+
+The `agent-sdk/` workspace holds the three libraries an xr-ai agent is built
+from:
+
+- **`xr-ai-models`** — unified service protocols (`LLMService`, `VLMService`,
+  `STTService`, `TTSService`) plus OpenAI-compatible HTTP clients, driven by a
+  `models.yaml` preset config. Swapping a backend is a config edit, not a code
+  edit.
+- **`xr-ai-pipecat`** — the unified voice pipeline. One call,
+  `make_voice_pipeline`, composes input → VAD/STT → voice gate → brain →
+  streaming TTS → output. Sample workers subclass one class (`BrainProcessor`)
+  and hand it to the factory.
+- **`xr-ai-agent`** — the minimal pyzmq + msgpack IPC library every agent uses
+  to talk to the XR-Media-Hub (see {doc}`server-runtime`). No LiveKit / FastAPI
+  dependency.
+
+---
+
+## xr-ai-models
+
+Worker code depends on the four service protocols and constructs concrete
+clients from a `models.yaml` config — no hand-rolled `httpx` calls in callers,
+no model quirks leaking out of this package.
+
+Before this package, every consumer (vlm-mcp, the simple-vlm-example worker,
+the xr-render-demo worker, xr-ai-pipecat) rolled its own `httpx` wrappers and
+hard-coded model quirks (`chat_template_kwargs`, served-model-name strings, the
+`reasoning` vs `reasoning_content` field difference between the nano_v3 and
+nemotron_v3 parsers). Swapping an LLM meant editing N files.
+
+After: one `models.yaml` per sample names the logical models the worker needs;
+`make_llm(config, "agent_llm")` returns something that satisfies `LLMService`
+regardless of which backend or quirks are involved.
+
+### Quickstart
+
+```python
+from xr_ai_models import load_models_config, make_llm, ChatMessage
+
+config = load_models_config("yaml/models.yaml")
+async with make_llm(config, "agent_llm") as llm:
+    resp = await llm.chat(
+        [ChatMessage(role="user", content="hello")],
+        max_tokens=128,
+        enable_thinking=True,
+    )
+    print(resp.content, resp.reasoning)
+```
+
+`models.yaml`:
+
+```yaml
+agent_llm:
+  kind:     preset:nemotron3_nano
+  base_url: http://localhost:8107
+
+vlm:
+  kind:     preset:cosmos_vlm
+  base_url: http://localhost:8100
+
+stt:
+  kind:     preset:parakeet_stt
+  base_url: http://localhost:8103
+
+tts:
+  kind:     preset:piper_tts
+  base_url: http://localhost:8105
+```
+
+### Built-in presets
+
+See `xr_ai_models/presets/`:
+
+| Preset | Service it targets | Notes |
+|---|---|---|
+| `cosmos_vlm`     | vlm-server                | image + video; `enable_thinking=false` by default. Video requires vlm-server's `max_videos_per_prompt >= 1` |
+| `llama_nemotron` | llama-nemotron-llm-server | OpenAI tool calling via llama3_json (server-side) |
+| `nemotron3_nano` | nemotron3-nano-llm-server | reasoning field: `reasoning` |
+| `nemotron_omni`  | nemotron-omni-llm-server  | reasoning field: `reasoning_content`, vision + video |
+| `parakeet_stt`   | stt-server                | |
+| `piper_tts`      | tts/piper                 | |
+| `magpie_tts`     | tts/magpie                | |
+
+### Explicit (no-preset) spec
+
+```yaml
+agent_llm:
+  kind:       openai_compat
+  category:   llm
+  base_url:   http://localhost:8107
+  model_name: llm
+  capabilities: { tool_calls: true, reasoning: true }
+  reasoning_field: reasoning
+  default_extras:
+    chat_template_kwargs: { enable_thinking: false }
+  timeout: 60.0
+```
+
+`category:` is required when not using a preset.
+
+### Protocols
+
+```python
+class LLMService(Protocol):
+    capabilities: Capabilities
+    async def chat(self, messages, *, tools=None, max_tokens=None,
+                   temperature=None, enable_thinking=False,
+                   thinking_budget=None, timeout=None) -> ChatResponse: ...
+    def stream(self, messages, *, ...) -> AsyncIterator[str]: ...
+    async def health(self) -> bool: ...
+    async def close(self) -> None: ...
+
+class VLMService(Protocol):
+    capabilities: Capabilities
+    async def ask_image(self, image, question, *, system_prompt="",
+                        max_tokens=None, temperature=None,
+                        timeout=None) -> ChatResponse: ...
+    async def ask_video(self, video, question, *, system_prompt="",
+                        max_tokens=None, temperature=None,
+                        timeout=None) -> ChatResponse: ...
+    async def health(self) -> bool: ...
+
+class STTService(Protocol):
+    async def transcribe(self, audio: bytes, *, sample_rate=None,
+                         channels=1, timeout=None) -> str: ...
+    async def health(self) -> bool: ...
+
+class TTSService(Protocol):
+    async def synthesize(self, text: str, *, response_format="wav",
+                         timeout=None) -> bytes: ...
+    async def health(self) -> bool: ...
+```
+
+`ChatResponse.reasoning` is the canonical reasoning field — the
+`reasoning_field` knob normalizes `reasoning_content` (the nemotron_v3 parser)
+into the same surface.
+
+### Remote / hosted-NIM endpoints
+
+Cloud / remote endpoints (e.g. hosted [NVIDIA NIM](https://build.nvidia.com))
+are a config change — point `base_url` at the OpenAI-compatible URL and set
+`api_key_env`:
+
+```yaml
+vlm:
+  kind:        openai_compat
+  category:    vlm
+  base_url:    https://integrate.api.nvidia.com
+  model_name:  nvidia/cosmos-reason1-7b
+  api_key_env: NGC_API_KEY    # → Authorization: Bearer <env value>
+  health_check: false         # remote endpoints have no local /health route
+```
+
+`api_key_env` names the environment variable holding the API key; its value is
+sent as an `Authorization: Bearer <value>` header on every request.
+
+`health_check` (default `true`) gates whether `health()` probes
+`base_url/health`. Remote endpoints don't expose that route, so `false` makes
+`health()` return `True` without a request — otherwise a worker's readiness
+gate would block forever.
+
+Future non-OpenAI-compatible backends (LiteLLM, vendor SDKs) plug in as new
+`kind`s in `factory.py::make_*`; the protocols and callers do not change.
+
+### Tests
+
+`tests/test_models_*.py` exercise the wire format against a
+`tests/_stub_openai.StubOpenAI` `httpx` `MockTransport` — no GPU required.
+
+---
+
+## xr-ai-pipecat
+
+The unified [Pipecat](https://github.com/pipecat-ai/pipecat) voice pipeline for
+xr-ai agents. The top-level entry point is `make_voice_pipeline`; sample
+workers subclass `BrainProcessor` and hand the instance to the factory.
+Everything else — VAD/STT, voice gate, streaming TTS — is provided.
+
+### make_voice_pipeline
+
+One call composes the chain and returns the assembled pipeline plus a
+`PipelineWorker` ready to run:
+
+```python
+from xr_ai_pipecat import make_voice_pipeline, VadConfig
+
+pipeline, worker = make_voice_pipeline(
+    transport      = transport,        # XRMediaHubTransport
+    stt            = stt,              # STTService  (from xr-ai-models)
+    tts            = tts,              # TTSService  (from xr-ai-models)
+    brain          = my_brain,         # BrainProcessor subclass
+    vad_cfg        = VadConfig(),
+    voice_gate_cfg = voice_gate_cfg,   # xr_ai_voicegate.VoiceGateConfig
+    text_topic     = "agent.response",
+    idle_timeout_secs = None,
+)
+```
+
+The resulting pipeline is:
+
+```text
+input → VadStt → VoiceGate → brain → StreamingTts → output
+```
+
+| Stage | Processor | Role |
+|---|---|---|
+| input        | `transport.input()`     | inbound mic audio frames from the hub |
+| VAD/STT      | `VadSttProcessor`       | Silero-VAD utterance detection → `STTService.transcribe` → `TranscriptionFrame`; emits start/stop speech frames and a fast-path STOP probe |
+| voice gate   | `VoiceGateProcessor`    | wraps `xr_ai_voicegate.VoiceGate`; wake-phrase / stop gating, chime + stop-ack audio |
+| brain        | `BrainProcessor`        | the sample-specific reasoning (you subclass this) |
+| streaming TTS| `StreamingTtsProcessor` | sentence-batched parallel `TTSService.synthesize`, monotonic playback, per-turn data echo |
+| output       | `transport.output()`    | return audio + data back to the hub |
+
+`text_topic` controls the per-turn data-channel echo emitted by the streaming
+TTS processor. Set it to `""` to opt out — samples whose brain pushes its own
+response data message (e.g. xr-render-demo) want this off to avoid duplicate
+sends.
+
+#### The idle-timeout knob
+
+`idle_timeout_secs` controls Pipecat's idle-timeout auto-cancel and is
+**disabled by default** (`None`): the pipeline is *never* cancelled for
+inactivity, so a quiet session stays connected indefinitely — important for XR
+sessions where the user may simply not be speaking. This deliberately overrides
+Pipecat's upstream default (`cancel_on_idle_timeout=True`), which would
+silently drop idle sessions. Set a positive number of seconds to opt in: the
+worker then cancels the pipeline (and its runner) after that long with no
+user/bot speech.
+
+### Writing a brain
+
+Subclass `BrainProcessor` and implement `handle_query`. Return either a single
+string (one downstream `TextFrame`) or an async iterator of strings (one
+`TextFrame` per yielded chunk — this is how token streaming reaches TTS):
+
+```python
+from xr_ai_pipecat import BrainProcessor
+
+class MyBrain(BrainProcessor):
+    def __init__(self, *, llm, **kw):
+        super().__init__(**kw)
+        self._llm = llm          # the sample injects its own LLMService
+
+    async def handle_query(self, pid, text, fresh_match):
+        async for chunk in self._llm.stream([...]):
+            yield chunk
+```
+
+The base class owns the per-participant in-flight task, cancellation, and the
+lifecycle hooks. Key semantics:
+
+- A new `GatedQueryFrame` supersedes any prior in-flight response for the same
+  participant — the prior brain task is cancelled automatically. You cannot
+  have two queries in flight for one participant.
+- `UserStartedSpeakingFrame` is a **hook only**; it does *not* cancel in-flight
+  work. Cancelling on every speech onset would interrupt the agent mid-sentence
+  on a follow-up, and any acoustic-echo leak of the agent's own TTS would make
+  it cancel itself. The voice gate emits an explicit `InterruptionFrame` when
+  the user actually says "stop"; that is the real cancel signal.
+
+Optional overrides (all default to no-op):
+
+| Hook | Fires when | Typical use |
+|---|---|---|
+| `on_user_started_speaking(pid)` | speech onset | speculative warmup (camera, image fetch) |
+| `on_query_superseded(pid)`      | every non-first query for a pid | drain in-flight TTS audio (push `InterruptionFrame`) |
+| `on_participant_joined(pid)`    | participant joins | per-pid setup |
+| `on_participant_left(pid)`      | participant leaves | per-pid teardown |
+
+### VAD config
+
+`VadConfig` mirrors the constructor of `xr_ai_vad.VadDetector`:
+
+| Field | Default | Meaning |
+|---|---|---|
+| `silence_duration`   | `0.8`  | seconds of silence that finalize an utterance |
+| `min_speech`         | `0.15` | minimum speech duration to count as an utterance |
+| `silero_threshold`   | `0.5`  | Silero VAD speech-probability threshold |
+| `stop_probe_after_s` | `0.4`  | seconds after speech-start to run an early STT pass and check for a STOP phrase; `0` or negative disables the probe |
+
+The early STOP probe lets brief commands ("stop", "be quiet") interrupt the
+agent without waiting for the full `silence_duration` finalize window. On a
+STOP match the processor pushes an `InterruptionFrame` immediately and lets the
+gate handle the canned acknowledgement; the eventual VAD-finalize for the same
+utterance is suppressed so the stop-ack does not double.
+
+### Dependencies
+
+`xr-ai-pipecat` builds on `xr-ai-agent`, `xr-ai-models`, `xr-ai-vad`,
+`xr-ai-voicegate`, and `pipecat-ai`.
+
+---
+
+## xr-ai-agent
+
+The lightweight, agent-side IPC library for the XR-Media-Hub. Agents only need
+this package — its sole runtime dependencies are `pyzmq` and `msgpack`. The
+heavy server runtime (LiveKit, FastAPI, uvicorn) is **not** a dependency, so an
+agent process stays small.
+
+### ProcessorEndpoint
+
+`ProcessorEndpoint` connects to the hub's PUB socket to receive real-time video
+signals, audio, data, and participant events, and connects a PUSH socket to
+send return-data, return-audio, and frame requests back. It works for any
+downstream workload — analytics, ML inference, transcription, echo, recording
+— not just agentic pipelines.
+
+```python
+from xr_ai_agent import ProcessorEndpoint, Subscribe
+
+ep = ProcessorEndpoint(
+    sub_addr  = "ipc:///tmp/xr_hub_pub",
+    push_addr = "ipc:///tmp/xr_hub_in",
+)
+ep.on_frame(handle_frame_signal)   # metadata — fires at full frame rate
+ep.on_audio(my_audio_handler)
+ep.on_data(my_data_handler)
+ep.on_participant(handle_participant)  # optional — set is auto-maintained
+await ep.run()
+```
+
+#### Subscription model
+
+Participants are the unit of subscription. By default the endpoint subscribes
+to every participant who joins (and unsubscribes on leave), giving each agent
+the full inbound stream — data, audio, and video — for every client. Two knobs
+control this:
+
+- `filter` — a `Subscribe` flag that drops whole categories
+  (`DATA` / `AUDIO` / `VIDEO`) at the ZMQ kernel level for efficiency. Default
+  is `Subscribe.ALL`. Combine flags with `|` to scope down:
+
+  ```python
+  # Audio-only processor; ignores data + video on every pid.
+  ep = ProcessorEndpoint(..., filter=Subscribe.AUDIO)
+  ```
+
+- `auto_subscribe` — when `True` (default), the endpoint subscribes on join and
+  unsubscribes on leave. Set to `False` for agents that service a fixed set of
+  participants, then call `subscribe(pid)` yourself (it may be called before
+  that participant has even joined — ZMQ holds the subscription until matching
+  traffic arrives).
+
+Endpoints created mid-session issue a roster request so they learn about
+participants who joined before they did: the hub re-publishes a "joined" event
+for every current pid, so already-connected pids are auto-subscribed
+retroactively. Because the replays go on the regular `participant` topic, keep
+your `on_participant` callbacks idempotent.
+
+#### On-demand frame pixels
+
+Video frame access is two-step, so an agent only pays for the pixels it
+actually uses:
+
+1. The `on_frame` callback receives `FrameSignal` metadata (always, at full
+   frame rate).
+2. Call `await ep.request_frame(signal)` to pull pixel data on demand. The hub
+   serves from a small cache and copies pixels only when a request arrives;
+   returns `None` if the frame has expired or on timeout. Concurrent requests
+   for the same `(participant, track)` are coalesced into one `FRAME_REQUEST`.
+
+#### Return path
+
+| Method | Sends |
+|---|---|
+| `send_return_data(msg)`              | a `DataMessage` back to a client (text/binary on a topic) |
+| `send_return_audio(chunk)`           | an `AudioChunk` of agent/TTS audio to a client |
+| `flush_return_audio(pid)`            | drops audio queued at the hub for `pid` — interrupts the agent's own playback |
+| `set_status(status, pid=None)`       | publishes agent status (e.g. `"idle"`, `"processing"`) on the reserved `_agent.status` channel; broadcasts when `pid` is omitted |
+| `request_roster()`                   | asks the hub to replay "joined" events for all current pids |
+
+### IPC message types
+
+The codec is msgpack with a small `MsgType` tag. New types can be appended
+without breaking existing code.
+
+| `MsgType` | Direction | Meaning |
+|---|---|---|
+| `FRAME_SIGNAL`       | connector → hub | a decoded frame was written to the shared-memory ring buffer |
+| `AUDIO_CHUNK`        | connector → hub | raw PCM audio chunk |
+| `CONTROL`            | connector → hub | extensible key/value control message |
+| `DATA_MESSAGE`       | connector → hub | LiveKit data-channel payload (routed by topic) |
+| `RETURN_AUDIO`       | hub → connector | agent/TTS audio for a specific client |
+| `RETURN_DATA`        | hub → connector | agent text/binary for a specific client |
+| `PARTICIPANT_EVENT`  | bidirectional   | participant joined or left the room |
+| `CONNECTOR_REGISTER` | connector → hub | connector announces itself + its shm name |
+| `FRAME_REQUEST`      | processor → hub | request pixel data for a frame |
+| `FRAME_DATA`         | hub → processor | pixel data delivered to the requester |
+| `RETURN_AUDIO_FLUSH` | processor → hub | drop audio queued for a participant's return track |
+| `ROSTER_REQUEST`     | processor → hub | replay joined-events for the current roster |
+
+### Shared memory
+
+`ShmRingBuffer` / `SlotView` give agents that read raw pixels a zero-copy view
+into the hub's shared-memory ring buffer. The codec is extensible via
+`register_encoder` / `register_decoder` for custom payload types.

--- a/docs/source/components/index.md
+++ b/docs/source/components/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Components
+
+The server runtime, agent SDK, MCP servers, AI services, and the launcher/process model.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/components/server-runtime.md
+++ b/docs/source/components/server-runtime.md
@@ -1,0 +1,12 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Server runtime
+
+The `server-runtime/` package hosts the **XR-Media-Hub** and the internal
+LiveKit transport — the entry point clients connect to.
+
+This page is a placeholder seeded by the docs scaffold; the full component
+reference is filled in by the components documentation units.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sphinx configuration for the XR-AI documentation site.
+
+Mirrors the NVIDIA/IsaacTeleop docs setup: the NVIDIA Sphinx theme + MyST so
+the existing Markdown under ``docs/`` is reused directly. Single-version for
+now; ``sphinx-multiversion`` is a deliberate follow-up (see docs changelog).
+"""
+from __future__ import annotations
+
+# -- Project information -----------------------------------------------------
+project = "XR-AI"
+copyright = "2026, NVIDIA CORPORATION & AFFILIATES"
+author = "NVIDIA"
+
+# -- General configuration ---------------------------------------------------
+extensions = [
+    "myst_parser",
+    "sphinx_copybutton",
+    "sphinx_design",
+    "sphinx.ext.githubpages",
+    "sphinx.ext.intersphinx",
+]
+
+# MyST Markdown is the page format (matches the repo's existing docs/*.md).
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
+
+myst_enable_extensions = [
+    "colon_fence",
+    "deflist",
+    "linkify",
+    "substitution",
+]
+myst_heading_anchors = 3
+
+# Don't choke the build on the bundled long-form changelog or build output.
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# -- HTML output -------------------------------------------------------------
+html_theme = "nvidia_sphinx_theme"
+html_show_sphinx = False
+html_title = "XR-AI"

--- a/docs/source/getting_started/index.md
+++ b/docs/source/getting_started/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Getting Started
+
+Requirements, the quickstart paths, connecting clients, networking, and credentials.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -1,0 +1,13 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Quickstart
+
+Every sample follows the same pattern: **start the server, then connect a
+client.** The three primary paths are the shared model servers, the
+`simple-vlm-example`, and the `xr-render-demo`.
+
+This page is a placeholder seeded by the docs scaffold; the full quickstart is
+ported from the repository README.

--- a/docs/source/guides/index.md
+++ b/docs/source/guides/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Guides
+
+How-to guides: adding a sample, wiring CloudXR, troubleshooting, and contribution conventions.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/guides/troubleshooting.md
+++ b/docs/source/guides/troubleshooting.md
@@ -1,0 +1,11 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Troubleshooting
+
+Common setup and runtime frictions and their fixes.
+
+This page is a placeholder seeded by the docs scaffold; the full
+troubleshooting guide is ported from the repository's existing notes.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,0 +1,24 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# XR-AI
+
+Agentic AI for XR — an open-source foundation for multi-modal, real-time
+conversational AI within the CloudXR ecosystem.
+
+XR-AI connects web, iOS/visionOS, AR-glasses, and XR-headset clients to
+GPU-accelerated AI services, tool-using agents, and the CloudXR stack for remote
+rendering. This site documents the architecture, how to run the samples, each
+component, and the reference material for building on the stack.
+
+```{toctree}
+:maxdepth: 2
+
+overview/index
+getting_started/index
+components/index
+guides/index
+reference/index
+```

--- a/docs/source/overview/architecture.md
+++ b/docs/source/overview/architecture.md
@@ -1,0 +1,16 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Architecture
+
+XR-AI follows a **one hub, many clients, many agents** model. The
+**XR-Media-Hub** (server runtime) fans each client's inbound media to every
+agent and routes return traffic back to the originating client only. Clients
+reach the hub over a transport (LiveKit internally), agents attach over an IPC
+boundary, and MCP servers are the agent's only interface to XR data and
+rendering.
+
+This page is a placeholder seeded by the docs scaffold; the full architecture
+write-up is ported from the repository's existing architecture notes.

--- a/docs/source/overview/index.md
+++ b/docs/source/overview/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Overview
+
+What XR-AI is, the layer model, and how the hub, transport, and agents fit together.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/reference/changelog.md
+++ b/docs/source/reference/changelog.md
@@ -1,0 +1,12 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Decision changelog
+
+XR-AI records every non-trivial architectural or design decision, newest first,
+so the rationale is preserved. The canonical log lives in the repository at
+`docs/changelog.md`.
+
+This page is a placeholder seeded by the docs scaffold.

--- a/docs/source/reference/index.md
+++ b/docs/source/reference/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Reference
+
+Deep references: the xr-render-demo stack and the decision changelog.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```


### PR DESCRIPTION
## What

Adds `docs/source/components/agent-sdk.md` — a Sphinx (MyST) reference page for the `agent-sdk/` workspace, documenting all three libraries:

- **xr-ai-models** — the unified `LLMService` / `VLMService` / `STTService` / `TTSService` protocols, the `models.yaml` preset config (built-in presets table + explicit no-preset spec), OpenAI-compatible clients, and the hosted-NIM knobs (`api_key_env` → Bearer header, `health_check: false` for remote endpoints).
- **xr-ai-pipecat** — `make_voice_pipeline` composition (input → VAD/STT → voice gate → brain → streaming TTS → output), the idle-timeout knob (disabled-by-default, overrides Pipecat's on-by-default cancel), `BrainProcessor` subclassing + lifecycle-hook semantics, and `VadConfig` tuning.
- **xr-ai-agent** — `ProcessorEndpoint` subscription model (`filter` / `auto_subscribe` / mid-session roster), on-demand frame pixels, the return path, the `MsgType` IPC table, and shared memory.

Ported from `agent-sdk/xr-ai-models/README.md` and the in-tree sources. SPDX header; cross-links via `{doc}` only to pages on this branch; no `docs/*.md` relative links; no hardcoded Pages URL.

## Testing

E2E doc-build gate is clean:

```
sphinx-build -W --keep-going -b html docs/source docs/_build
```

Exit 0, zero warnings.

## Note

Branch is based on the unmerged `docs/sphinx-scaffold` (the scaffold PR). Until that merges, this PR's diff against `main` will also show the scaffold files (conf.py, section index pages, requirements, etc.) in addition to the one new page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
