### PR TITLE
docs(guides): port adding-a-sample and adding-cloudxr to Sphinx

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build the XR-AI Sphinx docs. On every docs PR: strict build (warnings = errors).
+# On push to main of the canonical repo: build + deploy to GitHub Pages.
+# Deploy is a no-op until Pages is enabled for the repo (Settings → Pages → GitHub Actions).
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yaml"
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yaml"
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build (strict)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install doc deps
+        run: pip install -r docs/requirements.txt
+      - name: Strict Sphinx build
+        run: sphinx-build -W --keep-going -b html docs/source docs/_build
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.repository == 'NVIDIA/xr-ai'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build
+
+  deploy:
+    name: Deploy to GitHub Pages
+    if: github.event_name == 'push' && github.repository == 'NVIDIA/xr-ai'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+# Sphinx build output
+_build/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal Sphinx makefile. Usage:
+#   pip install -r requirements.txt
+#   make html        # build into _build/
+#   make strict      # build with warnings-as-errors (CI gate)
+
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = _build
+
+.PHONY: help html strict clean
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+html:
+	@$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+strict:
+	@$(SPHINXBUILD) -W --keep-going -b html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+clean:
+	rm -rf "$(BUILDDIR)"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,26 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-10 — Sphinx documentation site (isaacteleop-style), scaffold
+
+Stood up a Sphinx documentation site under `docs/source/`, mirroring the
+NVIDIA/IsaacTeleop docs setup (NVIDIA Sphinx theme, GitHub Pages publish). It
+uses **MyST** so the existing `docs/*.md` content is reused as Markdown pages
+rather than rewritten as reStructuredText. Organized into five sections —
+Overview, Getting Started, Components, Guides, Reference — each section index
+uses a **`:glob:` toctree** so new pages self-register by simply being dropped
+into the section directory (this is what lets documentation pages be authored as
+independent, individually-mergeable PRs without all touching a shared nav file).
+
+`.github/workflows/docs.yaml` runs a strict build (`sphinx-build -W`) on every
+docs PR and deploys to GitHub Pages on push to `main` of the canonical repo
+(deploy is a no-op until Pages is enabled in repo settings). `docs/requirements.txt`
+pins the toolchain to IsaacTeleop's versions. The existing `docs/*.md` files are
+intentionally **kept in place** (the README and in-flight PRs link to them); the
+site ingests/ports their content, and a later cleanup can collapse the
+duplication once the site is the source of truth. `sphinx-multiversion` is a
+deliberate follow-up — single-version first to de-risk CI.
+
 ### 2026-06-09 — render-mcp: scene resync survives a LOVR respawn (blocking send, not NOBLOCK)
 
 After a LOVR (re)start, `render-mcp` re-pushed every stored primitive via

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Pins for building the XR-AI Sphinx documentation site.
+# Mirrors the NVIDIA/IsaacTeleop docs toolchain.
+sphinx==8.1.3
+nvidia-sphinx-theme==0.0.9.post1
+myst-parser==4.0.0
+sphinx-copybutton==0.5.2
+sphinx-design==0.6.1
+linkify-it-py==2.0.3

--- a/docs/source/components/index.md
+++ b/docs/source/components/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Components
+
+The server runtime, agent SDK, MCP servers, AI services, and the launcher/process model.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/components/server-runtime.md
+++ b/docs/source/components/server-runtime.md
@@ -1,0 +1,12 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Server runtime
+
+The `server-runtime/` package hosts the **XR-Media-Hub** and the internal
+LiveKit transport — the entry point clients connect to.
+
+This page is a placeholder seeded by the docs scaffold; the full component
+reference is filled in by the components documentation units.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sphinx configuration for the XR-AI documentation site.
+
+Mirrors the NVIDIA/IsaacTeleop docs setup: the NVIDIA Sphinx theme + MyST so
+the existing Markdown under ``docs/`` is reused directly. Single-version for
+now; ``sphinx-multiversion`` is a deliberate follow-up (see docs changelog).
+"""
+from __future__ import annotations
+
+# -- Project information -----------------------------------------------------
+project = "XR-AI"
+copyright = "2026, NVIDIA CORPORATION & AFFILIATES"
+author = "NVIDIA"
+
+# -- General configuration ---------------------------------------------------
+extensions = [
+    "myst_parser",
+    "sphinx_copybutton",
+    "sphinx_design",
+    "sphinx.ext.githubpages",
+    "sphinx.ext.intersphinx",
+]
+
+# MyST Markdown is the page format (matches the repo's existing docs/*.md).
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
+
+myst_enable_extensions = [
+    "colon_fence",
+    "deflist",
+    "linkify",
+    "substitution",
+]
+myst_heading_anchors = 3
+
+# Don't choke the build on the bundled long-form changelog or build output.
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# -- HTML output -------------------------------------------------------------
+html_theme = "nvidia_sphinx_theme"
+html_show_sphinx = False
+html_title = "XR-AI"

--- a/docs/source/getting_started/index.md
+++ b/docs/source/getting_started/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Getting Started
+
+Requirements, the quickstart paths, connecting clients, networking, and credentials.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -1,0 +1,13 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Quickstart
+
+Every sample follows the same pattern: **start the server, then connect a
+client.** The three primary paths are the shared model servers, the
+`simple-vlm-example`, and the `xr-render-demo`.
+
+This page is a placeholder seeded by the docs scaffold; the full quickstart is
+ported from the repository README.

--- a/docs/source/guides/adding-a-sample.md
+++ b/docs/source/guides/adding-a-sample.md
@@ -1,0 +1,268 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Adding a new sample
+
+Read this when scaffolding a new agent sample. For a working reference, see
+`agent-samples/simple-vlm-example/`. Hard rules and the checklist live in
+`AGENTS.md`; this file holds the boilerplate templates.
+
+## Naming conventions
+
+Choose a kebab-case sample name (e.g. `simple-vlm-example`).
+Derive all other names from it mechanically:
+
+| Thing | Convention | Example |
+|---|---|---|
+| Sample directory | `agent-samples/<kebab-name>/` | `simple-vlm-example/` |
+| Orchestrator module | `<snake_name>.py` | `simple_vlm_example.py` |
+| Orchestrator entry point | `<snake_name>` | `simple_vlm_example` |
+| Worker entry module | `<snake_name>_worker.py` | `simple_vlm_example_worker.py` |
+| Worker entry point | `<snake_name>_worker` | `simple_vlm_example_worker` |
+| Agent class | `<CamelName>Agent` | `SimpleVlmAgent` |
+| Logger name | `"<snake_name>"` | `"simple_vlm_example"` |
+| pyproject name (orch) | `"<kebab-name>"` | `"simple-vlm-example"` |
+| pyproject name (worker) | `"<kebab-name>-worker"` | `"simple-vlm-example-worker"` |
+
+## Directory layout
+
+Both sub-projects use **flat module layouts** — no nested package
+directories, no `__main__.py`, no `__init__.py`. Hatchling ships the
+listed `.py` files as top-level modules in each sub-project's isolated
+venv.
+
+```
+agent-samples/<name>/
+├── pyproject.toml                  ← orchestrator project
+├── main.py                         ← orchestrator (declare PROCESSES, call run_stack)
+├── yaml/                           ← all YAML configs for this sample
+│   ├── xr_media_hub.yaml
+│   ├── <command>.yaml              ← one per launchable process
+│   ├── models.yaml                 ← logical model names + preset references
+│   └── …
+└── worker/
+    ├── pyproject.toml              ← worker project
+    ├── <snake_name>_worker.py      ← entry point: parses config, runs main loop
+    ├── agent.py                    ← <CamelName>Agent class
+    └── …                           ← split helpers as needed (audio.py, services.py, …)
+```
+
+`yaml/models.yaml` names the logical models the worker needs (`llm`,
+`vlm`, `stt`, `tts`, or any sample-specific name) with `kind:
+preset:<name>` + `base_url:` entries.  The worker passes its path to
+`load_models_config(...)` and constructs services via `make_llm` /
+`make_vlm` / `make_stt` / `make_tts` from `xr_ai_models`.  Schema, preset
+table, and the explicit (no-preset) spec are in
+[`agent-sdk/xr-ai-models/README.md`](https://github.com/NVIDIA/xr-ai/blob/main/agent-sdk/xr-ai-models/README.md).
+
+When the worker is small (≲ 100 lines) keep it as a single file —
+`worker/<snake_name>_worker.py` containing everything. Only split once
+the file makes the agent logic harder to read; aim for a few focused
+modules over one monolith *or* a swarm of tiny files.
+
+Suggested split (used by `simple-vlm-example`):
+
+| File | Responsibility |
+|---|---|
+| `<snake>_worker.py` | Entry point: config parsing, signal handling, lifecycle |
+| `agent.py` | The agent class — IPC callbacks and orchestration |
+| `audio.py` | WAV/PCM helpers, pixel-format conversion (rename if not audio) |
+| `services.py` | Thin HTTP/MCP clients for external services + readiness probe |
+| `voice.py` | Per-participant bookkeeping for `xr-ai-vad`'s `VadDetector` + in-flight STT/response state (when applicable) |
+
+## Orchestrator `pyproject.toml`
+
+```text
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "<kebab-name>"
+version = "0.1.0"
+requires-python = ">=3.11,<3.13"
+dependencies = ["xr-ai-launcher"]
+
+[tool.uv.sources]
+xr-ai-launcher = { path = "../../utils/xr-ai-launcher", editable = true }
+
+[project.scripts]
+<snake_name> = "main:run"
+
+[tool.hatch.build.targets.wheel]
+only-include = ["main.py"]
+```
+
+## Worker `pyproject.toml`
+
+```text
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "<kebab-name>-worker"
+version = "0.1.0"
+requires-python = ">=3.11,<3.13"
+dependencies = [
+    "xr-ai-agent",
+    "xr-ai-models",
+    # add task-specific deps here: numpy, torch, etc.
+]
+
+[tool.uv.sources]
+xr-ai-agent  = { path = "../../../agent-sdk",              editable = true }
+xr-ai-models = { path = "../../../agent-sdk/xr-ai-models", editable = true }
+
+[project.scripts]
+<snake_name>_worker = "<snake_name>_worker:run"
+
+[tool.hatch.build.targets.wheel]
+only-include = [
+    "<snake_name>_worker.py",
+    "agent.py",
+    # add other split modules here
+]
+```
+
+When the worker is a single file, drop the extra entries:
+
+```toml
+[tool.hatch.build.targets.wheel]
+only-include = ["<snake_name>_worker.py"]
+```
+
+## Orchestrator `main.py`
+
+Exact boilerplate — do not add logic here:
+
+```python
+"""
+<Name> agent orchestrator.  Runs the process stack for this sample.
+
+How to run (from agent-samples/<name>/):
+    uv sync && uv run <snake_name>
+"""
+from pathlib import Path
+
+from xr_ai_launcher import Process, run_stack
+
+_BASE = Path(__file__).resolve().parent
+
+PROCESSES = [
+    Process("hub",    "../../server-runtime", "xr_media_hub"),
+    Process("worker", "worker",               "<snake_name>_worker"),
+]
+
+
+def run() -> None:
+    run_stack(PROCESSES, _BASE)
+
+
+if __name__ == "__main__":
+    run()
+```
+
+## Worker `<snake_name>_worker.py`
+
+Follow this structure exactly. Fill in the sections marked `# ← FILL IN`.
+
+```text
+"""
+<Name> agent worker — <one-line description>.
+
+Launched as a subprocess by ``uv run <snake_name>`` (the orchestrator).
+Do not run this directly.
+
+Protocol                            # ← include only if the worker sends/receives data msgs
+--------
+Client → agent  (topic "<in.topic>"):
+    <description>
+
+Agent → client  (topic "<out.topic>"):
+    <description>
+
+Environment                         # ← include only if env vars are read
+-----------
+    ENV_VAR   description (default: value)
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import signal
+from pathlib import Path
+
+from xr_ai_agent import (          # ← import only what you use
+    AudioChunk, DataMessage, FrameSignal, ParticipantEvent, ProcessorEndpoint,
+    Subscribe,                     # ← only needed when scoping subscriptions
+)
+
+log = logging.getLogger("<snake_name>")
+
+_HUB_PUB  = "ipc:///tmp/xr_hub_pub"
+_HUB_PUSH = "ipc:///tmp/xr_hub_in"
+
+
+class <CamelName>Agent:            # ← FILL IN agent logic
+
+    def __init__(self) -> None:
+        self._ep = ProcessorEndpoint(sub_addr=_HUB_PUB, push_addr=_HUB_PUSH)
+        self._ep.on_frame(self._on_frame)       # ← remove callbacks you don't use
+        self._ep.on_audio(self._on_audio)
+        self._ep.on_data(self._on_data)
+        self._ep.on_participant(self._on_participant)
+
+    # ── callbacks ─────────────────────────────────────────────────────────────
+
+    async def _on_frame(self, sig: FrameSignal) -> None: ...
+    async def _on_audio(self, chunk: AudioChunk) -> None: ...
+    async def _on_data(self, msg: DataMessage) -> None: ...
+    async def _on_participant(self, event: ParticipantEvent) -> None: ...
+
+    # ── lifecycle ─────────────────────────────────────────────────────────────
+
+    async def run(self) -> None:
+        await self._ep.run()        # ← start any background tasks before this line
+
+    def shutdown(self) -> None:
+        # ← cancel any background tasks here first
+        self._ep.stop()
+        self._ep.close()
+
+
+async def main(ready_file: Path | None = None) -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+
+    agent = <CamelName>Agent()
+
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, agent.shutdown)
+
+    if ready_file:
+        ready_file.touch()
+
+    log.info("<snake_name> connecting  sub=%s  push=%s", _HUB_PUB, _HUB_PUSH)
+    try:
+        await agent.run()
+    finally:
+        agent.shutdown()
+
+
+def run() -> None:
+    p = argparse.ArgumentParser(add_help=False)
+    p.add_argument("--ready-file", type=Path, default=None)
+    ns, _ = p.parse_known_args()
+    asyncio.run(main(ready_file=ns.ready_file))
+
+
+if __name__ == "__main__":
+    run()
+```

--- a/docs/source/guides/adding-cloudxr.md
+++ b/docs/source/guides/adding-cloudxr.md
@@ -1,0 +1,59 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Adding CloudXR to a sample
+
+`cloudxr-runtime/` is a shared top-level component, like `server-runtime/`.
+Any sample can stream XR content to a device by adding one line to its
+orchestrator and a config file in the sample root. For the broader
+orchestrator pattern see `docs/adding-a-sample.md`.
+
+## 1 — Add the process to the orchestrator
+
+```python
+PROCESSES = [
+    Process("hub",     "../../server-runtime",  "xr_media_hub"),
+    Process("cloudxr", "../../cloudxr-runtime", "cloudxr_runtime"),  # ← add this
+    Process("worker",  "worker",                "my_agent_worker"),
+]
+```
+
+## 2 — Add `cloudxr_runtime.yaml` to the sample root
+
+The launcher auto-discovers this file and passes it as `--config`.
+
+```yaml
+# CloudXR runtime configuration.
+cloudxr_install_dir: ~/.cloudxr
+
+# Accept the NVIDIA CloudXR EULA non-interactively.
+# View: https://github.com/NVIDIA/IsaacTeleop/blob/main/deps/cloudxr/CLOUDXR_LICENSE
+# Written once to <cloudxr_install_dir>/run/eula_accepted; ignored on subsequent runs.
+accept_eula: true
+
+# Device profile — controls transport and XR device defaults.
+# Valid: auto-native | auto-webrtc | apple-vision-pro | ipad-pro | quest3
+cloudxr_env:
+  NV_DEVICE_PROFILE: auto-webrtc
+
+# ── Ports (do not conflict with LiveKit) ──────────────────────────────────────
+# CloudXR native service:  localhost:49100  (internal)
+# WSS proxy (TLS):         0.0.0.0:48322   (XR clients connect here; auto-webrtc only)
+```
+
+## Notes
+
+- CloudXR and the hub are **independent stacks**. CloudXR streams sim/render
+  content directly to XR devices over WebRTC; the hub handles agent media via
+  LiveKit. They share no ports.
+- `auto-webrtc` profile starts a WSS proxy on port 48322 for WebRTC signaling.
+  `auto-native` uses a direct native transport and does not need the proxy.
+- After CloudXR is ready, activate its environment in a separate terminal to
+  run an OpenXR app against it:
+  ```bash
+  source ~/.cloudxr/run/cloudxr.env
+  ```
+- Full list of supported `NV_*` env vars: `cloudxr-openxr-runtime` source,
+  `env_config` / `nv_config.h`.

--- a/docs/source/guides/index.md
+++ b/docs/source/guides/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Guides
+
+How-to guides: adding a sample, wiring CloudXR, troubleshooting, and contribution conventions.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/guides/troubleshooting.md
+++ b/docs/source/guides/troubleshooting.md
@@ -1,0 +1,11 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Troubleshooting
+
+Common setup and runtime frictions and their fixes.
+
+This page is a placeholder seeded by the docs scaffold; the full
+troubleshooting guide is ported from the repository's existing notes.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,0 +1,24 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# XR-AI
+
+Agentic AI for XR — an open-source foundation for multi-modal, real-time
+conversational AI within the CloudXR ecosystem.
+
+XR-AI connects web, iOS/visionOS, AR-glasses, and XR-headset clients to
+GPU-accelerated AI services, tool-using agents, and the CloudXR stack for remote
+rendering. This site documents the architecture, how to run the samples, each
+component, and the reference material for building on the stack.
+
+```{toctree}
+:maxdepth: 2
+
+overview/index
+getting_started/index
+components/index
+guides/index
+reference/index
+```

--- a/docs/source/overview/architecture.md
+++ b/docs/source/overview/architecture.md
@@ -1,0 +1,16 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Architecture
+
+XR-AI follows a **one hub, many clients, many agents** model. The
+**XR-Media-Hub** (server runtime) fans each client's inbound media to every
+agent and routes return traffic back to the originating client only. Clients
+reach the hub over a transport (LiveKit internally), agents attach over an IPC
+boundary, and MCP servers are the agent's only interface to XR data and
+rendering.
+
+This page is a placeholder seeded by the docs scaffold; the full architecture
+write-up is ported from the repository's existing architecture notes.

--- a/docs/source/overview/index.md
+++ b/docs/source/overview/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Overview
+
+What XR-AI is, the layer model, and how the hub, transport, and agents fit together.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/reference/changelog.md
+++ b/docs/source/reference/changelog.md
@@ -1,0 +1,12 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Decision changelog
+
+XR-AI records every non-trivial architectural or design decision, newest first,
+so the rationale is preserved. The canonical log lives in the repository at
+`docs/changelog.md`.
+
+This page is a placeholder seeded by the docs scaffold.

--- a/docs/source/reference/index.md
+++ b/docs/source/reference/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Reference
+
+Deep references: the xr-render-demo stack and the decision changelog.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```


### PR DESCRIPTION
Ports the two how-to guides into the Sphinx site under `docs/source/guides/`:

- `guides/adding-a-sample.md` — full port of `docs/adding-a-sample.md` (naming conventions, dir layout, orchestrator & worker `pyproject.toml`/`main.py` boilerplate).
- `guides/adding-cloudxr.md` — full port of `docs/adding-cloudxr.md` (process config, EULA, device profile, port layout).

Both are faithful copies of the repo prose with the SPDX HTML-comment header, picked up automatically by the guides `:glob:` toctree.

### Deviations from source (only four lines)
Both forced by the zero-warning `-W` gate / scaffold conventions:
- README cross-doc link rewritten from relative `../agent-sdk/...` to the GitHub blob URL — a relative non-doctree `.md` link warns under `-W`.
- Three template code fences (orchestrator/worker `pyproject`, worker `.py`) retagged `toml`/`python` → `text`: the `<kebab-name>`/`<CamelName>` placeholders make Pygments' lexers emit `highlighting_failure` under `-W`.

### Build gate
```
sphinx-build -W --keep-going -b html docs/source docs/_build
```
Exit 0, zero warnings.

### Base branch note
Based on `docs/sphinx-scaffold` (PR #220, still open) rather than `main`, since the scaffold (`conf.py`, section dirs, toctrees) is not yet merged. Once #220 merges this can be retargeted to `main`; the diff then shows only the two guide files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)