### PR TITLE
docs(sphinx): port AI inference servers page to components/

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build the XR-AI Sphinx docs. On every docs PR: strict build (warnings = errors).
+# On push to main of the canonical repo: build + deploy to GitHub Pages.
+# Deploy is a no-op until Pages is enabled for the repo (Settings → Pages → GitHub Actions).
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yaml"
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yaml"
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build (strict)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install doc deps
+        run: pip install -r docs/requirements.txt
+      - name: Strict Sphinx build
+        run: sphinx-build -W --keep-going -b html docs/source docs/_build
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.repository == 'NVIDIA/xr-ai'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build
+
+  deploy:
+    name: Deploy to GitHub Pages
+    if: github.event_name == 'push' && github.repository == 'NVIDIA/xr-ai'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+# Sphinx build output
+_build/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal Sphinx makefile. Usage:
+#   pip install -r requirements.txt
+#   make html        # build into _build/
+#   make strict      # build with warnings-as-errors (CI gate)
+
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = _build
+
+.PHONY: help html strict clean
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+html:
+	@$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+strict:
+	@$(SPHINXBUILD) -W --keep-going -b html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+clean:
+	rm -rf "$(BUILDDIR)"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,26 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-10 — Sphinx documentation site (isaacteleop-style), scaffold
+
+Stood up a Sphinx documentation site under `docs/source/`, mirroring the
+NVIDIA/IsaacTeleop docs setup (NVIDIA Sphinx theme, GitHub Pages publish). It
+uses **MyST** so the existing `docs/*.md` content is reused as Markdown pages
+rather than rewritten as reStructuredText. Organized into five sections —
+Overview, Getting Started, Components, Guides, Reference — each section index
+uses a **`:glob:` toctree** so new pages self-register by simply being dropped
+into the section directory (this is what lets documentation pages be authored as
+independent, individually-mergeable PRs without all touching a shared nav file).
+
+`.github/workflows/docs.yaml` runs a strict build (`sphinx-build -W`) on every
+docs PR and deploys to GitHub Pages on push to `main` of the canonical repo
+(deploy is a no-op until Pages is enabled in repo settings). `docs/requirements.txt`
+pins the toolchain to IsaacTeleop's versions. The existing `docs/*.md` files are
+intentionally **kept in place** (the README and in-flight PRs link to them); the
+site ingests/ports their content, and a later cleanup can collapse the
+duplication once the site is the source of truth. `sphinx-multiversion` is a
+deliberate follow-up — single-version first to de-risk CI.
+
 ### 2026-06-09 — render-mcp: scene resync survives a LOVR respawn (blocking send, not NOBLOCK)
 
 After a LOVR (re)start, `render-mcp` re-pushed every stored primitive via

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Pins for building the XR-AI Sphinx documentation site.
+# Mirrors the NVIDIA/IsaacTeleop docs toolchain.
+sphinx==8.1.3
+nvidia-sphinx-theme==0.0.9.post1
+myst-parser==4.0.0
+sphinx-copybutton==0.5.2
+sphinx-design==0.6.1
+linkify-it-py==2.0.3

--- a/docs/source/components/ai-services.md
+++ b/docs/source/components/ai-services.md
@@ -1,0 +1,340 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# AI inference servers
+
+Read this when adding, calling, or operating an inference server. For the
+orchestrator pattern that wires servers into a sample, see
+`docs/adding-a-sample.md`.
+
+Multiple reusable HTTP servers are available as launchable peers of
+`server-runtime/`. All expose an OpenAI-compatible REST API so agent workers
+can call them with any OpenAI SDK client or plain `httpx` / `requests`.
+Reference services cover vision-language reasoning, speech recognition,
+text-to-speech, and large language models. Three LLM backends ship
+side-by-side under `ai-services/llm/` — pick one per sample based on the
+tool-calling / reasoning / hardware trade-offs documented below.
+
+| Server | Command | Port | Model | Backend |
+|---|---|---|---|---|
+| `ai-services/vlm-server/` | `vlm_server` | 8100 | Cosmos-Reason1-7B | vLLM (pip or docker) |
+| `ai-services/stt-server/` | `stt_server` | 8103 | parakeet-tdt-0.6b-v3 | NeMo ASR in-process |
+| `ai-services/tts/magpie/` | `magpie_tts_server` | 8104 | magpie_tts_multilingual_357m | NeMo TTS in-process |
+| `ai-services/tts/piper/` | `piper_tts_server` | 8105 | rhasspy/piper-voices (ONNX) | piper-tts in-process |
+| `ai-services/llm/llama_nemotron/` | `llama_nemotron_llm_server` | 8106 | Llama-3.1-Nemotron-Nano-8B-v1 | vLLM (pip or docker) |
+| `ai-services/llm/nemotron3_nano/` | `nemotron3_nano_llm_server` | 8107 | NVIDIA-Nemotron-3-Nano-30B-A3B-{NVFP4,FP8} | vLLM (pip or docker) |
+| `ai-services/llm/nemotron_omni/` | `nemotron_omni_llm_server` | 8108 | Nemotron-3-Nano-Omni-30B-A3B-Reasoning (NVFP4 / FP8 / BF16, GPU-selected) | vLLM (pip or docker) — multimodal (text + video) |
+| `agent-mcp-servers/transcript-mcp/` | `transcript_mcp_server` | 8200 | — | JSONL + FastMCP |
+| `agent-mcp-servers/video-mcp/` | `video_mcp_server` | 8210 | — | FastMCP → hub |
+| `agent-mcp-servers/vlm-mcp/` | `vlm_mcp_server` | 8220 | — | FastMCP → vlm-server (`ask_image` tool) |
+
+All model weights land in `models/` at the repo root (gitignored, shared across
+all servers). Each YAML configures `model_cache` — resolved relative to the
+YAML file.
+
+## Adding a server to a sample
+
+**1 — Add the process to the orchestrator:**
+
+```python
+PROCESSES = [
+    Process("hub",    "../../server-runtime",                     "xr_media_hub"),
+    Process("vlm",    "../../ai-services/vlm-server",             "vlm_server"),   # ← add as needed
+    # Pick ONE LLM backend per sample — they bind different default ports
+    # (8106 / 8107) so running more than one at once is allowed but
+    # usually unnecessary.
+    Process("llm",    "../../ai-services/llm/llama_nemotron",     "llama_nemotron_llm_server"),
+    # Process("llm",  "../../ai-services/llm/nemotron3_nano",     "nemotron3_nano_llm_server"),
+    Process("stt",    "../../ai-services/stt-server",             "stt_server"),
+    # Pick one TTS server
+    Process("tts",    "../../ai-services/tts/piper",    "piper_tts_server"),
+    # Process("tts",    "../../ai-services/tts/magpie",             "magpie_tts_server"),
+    Process("worker", "worker",                                   "my_agent_worker"),
+]
+```
+
+The agent samples in this repo (`simple-vlm-example` and `xr-render-demo`)
+default to Piper TTS — it runs on CPU with ~100 ms/sentence latency and avoids
+the NeMo dep tree. Magpie is still a supported NVIDIA TTS option with better
+voice quality and multilingual support when GPU is available; swap the
+`Process` row and YAML.
+
+**2 — Copy the reference YAML to your sample's `yaml/` directory:**
+
+```bash
+mkdir -p yaml
+cp ../../ai-services/vlm-server/vlm_server.yaml ./yaml/vlm_server.yaml
+# Pick ONE LLM YAML — copy the one matching the Process you picked above.
+cp ../../ai-services/llm/llama_nemotron/llama_nemotron_llm_server.yaml ./yaml/llama_nemotron_llm_server.yaml
+# cp ../../ai-services/llm/nemotron3_nano/nemotron3_nano_llm_server.yaml ./yaml/nemotron3_nano_llm_server.yaml
+cp ../../ai-services/stt-server/stt_server.yaml ./yaml/stt_server.yaml
+cp ../../ai-services/tts/piper/piper_tts_server.yaml ./yaml/piper_tts_server.yaml
+# Or for Magpie (multilingual, GPU, ~2-5 s/sentence):
+cp ../../ai-services/tts/magpie/magpie_tts_server.yaml ./yaml/magpie_tts_server.yaml
+# MCP servers:
+cp ../../agent-mcp-servers/transcript-mcp/transcript_mcp_server.yaml ./yaml/transcript_mcp_server.yaml
+cp ../../agent-mcp-servers/video-mcp/video_mcp_server.yaml ./yaml/video_mcp_server.yaml
+```
+
+Edit the YAML as needed (model, port, device, etc.). The launcher auto-discovers
+`yaml/<command>.yaml` in the sample root and passes it as `--config`.
+
+## Calling these from a worker
+
+Workers do not hand-roll `httpx` clients against these endpoints.  They
+depend on [`agent-sdk/xr-ai-models`](https://github.com/NVIDIA/xr-ai/blob/main/agent-sdk/xr-ai-models/README.md),
+load a per-sample `yaml/models.yaml`, and construct service clients via
+`make_llm` / `make_vlm` / `make_stt` / `make_tts`.  The SDK encapsulates the
+OpenAI-compatible wire format and the per-model quirks (reasoning-field
+aliasing, `chat_template_kwargs`, served-model-name strings) so callers
+never branch on backend.
+
+```python
+from xr_ai_models import load_models_config, make_llm, ChatMessage
+
+config = load_models_config("yaml/models.yaml")
+async with make_llm(config, "agent_llm") as llm:
+    resp = await llm.chat(
+        [ChatMessage(role="user", content="hello")],
+        max_tokens=128,
+        enable_thinking=True,
+    )
+    print(resp.content, resp.reasoning)
+```
+
+A matching `models.yaml` for the four built-in service backends:
+
+```yaml
+agent_llm:
+  kind:     preset:nemotron3_nano
+  base_url: http://localhost:8107
+
+vlm:
+  kind:     preset:cosmos_vlm
+  base_url: http://localhost:8100
+
+stt:
+  kind:     preset:parakeet_stt
+  base_url: http://localhost:8103
+
+tts:
+  kind:     preset:piper_tts
+  base_url: http://localhost:8105
+```
+
+Swapping a backend is a `kind:` + `base_url:` edit in YAML; worker code does
+not change.  Full protocol surface, the preset table, and the explicit
+(no-preset) spec are in
+[`agent-sdk/xr-ai-models/README.md`](https://github.com/NVIDIA/xr-ai/blob/main/agent-sdk/xr-ai-models/README.md).
+
+## Hosting models on NVIDIA NIM
+
+The LLM and VLM can run on [NVIDIA NIM](https://build.nvidia.com) instead of
+local vLLM — NIM exposes the same OpenAI-compatible `/v1/chat/completions`
+API, so this is a `models.yaml` change with no worker code edits. STT and TTS
+stay local: hosted NIM speech (Riva) is not OpenAI `/v1/audio`-compatible.
+
+A NIM model entry differs from a local one in three fields:
+
+```yaml
+vlm:
+  kind:        openai_compat
+  category:    vlm
+  base_url:    https://integrate.api.nvidia.com   # client appends /v1/...
+  model_name:  nvidia/cosmos-reason1-7b           # confirm slug at build.nvidia.com
+  api_key_env: NGC_API_KEY                         # → Authorization: Bearer
+  health_check: false                              # hosted NIM has no /health
+  capabilities: { vision: true, streaming: true }
+```
+
+- **`api_key_env: NGC_API_KEY`** sends the key as a bearer token. The key is a
+  managed credential — `run_stack` injects a saved `NGC_API_KEY` into every
+  subprocess (see [`docs/credentials.md`](https://github.com/NVIDIA/xr-ai/blob/main/docs/credentials.md)); or export it.
+- **`health_check: false`** is required for hosted endpoints — they have no
+  local `/health` route, so the worker readiness gate must not probe them.
+  (Default is `true` for local servers.)
+- **`model_name`** is the hosted model id from [build.nvidia.com](https://build.nvidia.com).
+
+Each sample ships a ready-made `yaml/models.nim.yaml` overlay, selected by a
+**single key** — no `main.py` edits. To switch a sample to NIM:
+
+1. Set `model_backend: nim` in the sample's `*_worker.yaml` (default
+   `local`). The worker then loads `models.nim.yaml`, and the orchestrator
+   (which reads the same key) skips the local model server(s) NIM replaces —
+   for xr-render-demo it also points `vlm-mcp` at
+   `yaml/vlm_mcp_server.nim.yaml`.
+2. Provide `NGC_API_KEY` — in NIM mode the orchestrator prompts for it once
+   if it isn't already saved or exported.
+3. For xr-render-demo, run the demo without the local `llm` / `agent-llm` /
+   `vlm` model-servers (they're `launch_mode="reuse"`, so just don't start
+   them in the model-servers stack).
+
+Set `model_backend: local` to switch back. (The orchestrator reads
+`model_backend` from the worker YAML with a stdlib regex, so it stays
+pyyaml-free.)
+
+**Self-hosted NIM containers** work the same way — point `base_url` at the
+container (e.g. `http://localhost:8000`) and set `health_check: true` if it
+exposes `/v1/health`.
+
+## vLLM model persistence
+
+The persistent vLLM-backed servers (`vlm_server`, `llama_nemotron_llm_server`,
+`nemotron3_nano_llm_server`) **survive stack restarts by design**.
+`nemotron_omni_llm_server` is foreground (dies with the wrapper). Each
+persistent wrapper script checks its health endpoint before spawning vLLM:
+
+- **Already running** → touch the ready file immediately, then idle. Stack is
+  ready in seconds; no model reload.
+- **Not running** → spawn vLLM normally, wait for `/health`, touch ready file.
+
+In pip mode, vLLM is spawned with `start_new_session=True` so the launcher's
+`killpg()` does not reach it on shutdown. In docker mode, the container is
+launched detached (`docker run -d --name xr-ai-vllm-<service>`) so it
+similarly outlives the wrapper. Either way the wrapper exits cleanly and
+vLLM keeps running.
+
+**Stopping the persisted servers** — run from the sample directory:
+
+```bash
+uv run xr_render_demo --stop
+```
+
+This hits each model server's `/health` endpoint, then either runs
+`docker stop <container_name>` (docker-mode servers) or finds the listening
+PID via `ss`/`lsof` and sends `SIGTERM` (pip-mode), escalating to
+`docker kill` / `SIGKILL` after 20 s. It is safe to run while the stack is
+down — processes/containers that are not running are silently skipped.
+
+The target ports and container names are defined in `_PERSISTENT_SERVERS` in
+`main.py` and match the defaults in the per-profile YAML files. Update that
+list if you change the port or container name.
+
+## Choosing the vLLM runtime (pip vs Docker)
+
+All four vLLM-backed servers (`vlm_server`, `llama_nemotron_llm_server`,
+`nemotron3_nano_llm_server`, `nemotron_omni_llm_server`) accept a
+`vllm_backend:` key in their YAML to pick how vLLM is hosted:
+
+| `vllm_backend` | Runtime | Default | Use when |
+|---|---|---|---|
+| `pip` | `vllm serve` from the wrapper's venv | yes | Standard development; fastest iteration; works offline once weights are cached. |
+| `docker` | `docker run nvcr.io/nvidia/vllm:<tag> vllm serve …` | no | Trying NVIDIA's optimized vLLM container; pinning a specific NGC release; reproducing a deployment image. |
+
+Both modes honor identical config keys — same model, same port, same vLLM
+flags. The dispatcher lives in `utils/xr-ai-vllm/`. Switching is one YAML edit:
+
+```yaml
+vllm_backend: docker
+vllm_image:   nvcr.io/nvidia/vllm:26.04-py3
+```
+
+`vllm_image:` defaults to `nvcr.io/nvidia/vllm:26.04-py3`; override to pin
+another tag, an internal mirror, or a custom build.
+
+### docker mode — prerequisites
+
+- **Docker Engine** with the user in the `docker` group (`docker version`
+  must succeed without `sudo`).
+- **NVIDIA Container Toolkit** so `--gpus` works:
+  https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
+- **NGC pull access** for `nvcr.io/nvidia/vllm`. The wrapper auto-runs
+  `docker login nvcr.io` if `NGC_API_KEY` is in the environment (loaded by
+  `load_credentials()` from `~/.config/xr-ai/credentials.json` per
+  [`docs/credentials.md`](https://github.com/NVIDIA/xr-ai/blob/main/docs/credentials.md)). Otherwise log in manually once:
+
+  ```bash
+  docker login nvcr.io -u '$oauthtoken' -p $NGC_API_KEY
+  ```
+
+Existing `~/.docker/config.json` entries take priority and are not overwritten.
+
+### docker mode — runtime details
+
+- Container is launched with `--network host --ipc host --gpus …` (matches
+  the existing LiveKit container precedent and gives vLLM the shared-memory
+  region its workers expect).
+- The host `model_cache` is bind-mounted at the same path inside the
+  container and `HF_HOME` is set to it, so weights cached by pip mode are
+  reused by docker mode and vice versa.
+- Container name is deterministic per service: `xr-ai-vllm-vlm-server`,
+  `xr-ai-vllm-llama-nemotron-llm-server`,
+  `xr-ai-vllm-nemotron3-nano-llm-server`,
+  `xr-ai-vllm-nemotron-omni-llm-server`.
+- Persistence parity: `vlm_server`, `llama_nemotron_llm_server`, and
+  `nemotron3_nano_llm_server` run detached (`docker run -d --rm --name …`) so
+  the container survives stack restarts, mirroring their pip-mode
+  `start_new_session=True` behavior. `nemotron_omni_llm_server` runs
+  foreground (container exits with the wrapper) — same as its pip-mode
+  semantics.
+
+### Cleanup
+
+`uv run xr_render_demo --stop` works for both modes. The cleanup path probes
+`/health` first; for docker mode it then runs `docker stop <container_name>`
+(escalating to `docker kill` after 20 s); for pip mode it falls back to the
+port → PID → SIGTERM/SIGKILL path. Same UX for both.
+
+## Per-server notes
+
+- **vlm-server** is a thin launcher around `vllm serve` for Cosmos-Reason1-7B
+  (or any Qwen2.5-VL-compatible VLM). vLLM handles weight loading, image
+  decoding, and the OpenAI-compatible HTTP API. Hosting backend is selectable
+  per YAML — see *Choosing the vLLM runtime* above.
+- **llm/llama_nemotron** is a thin wrapper around `vllm serve` for
+  `Llama-3.1-Nemotron-Nano-8B-v1`. vLLM handles native Llama-3.1 tool calling
+  via the `llama3_json` parser — `tools=[...]` in the request is rendered via
+  the model's chat template and the resulting tool calls come back in OpenAI
+  wire format (`finish_reason: "tool_calls"`). Per-turn reasoning toggle via
+  `"detailed thinking on"` / `"detailed thinking off"` in a system or user
+  message; reasoning preamble is **not** stripped server-side. Hosting backend
+  is selectable per YAML (see *Choosing the vLLM runtime*). See
+  [`ai-services/llm/llama_nemotron/README.md`](https://github.com/NVIDIA/xr-ai/blob/main/ai-services/llm/llama_nemotron/README.md)
+  for the full HTTP contract and tuning knobs.
+- **llm/nemotron3_nano** is a thin wrapper around `vllm serve` for
+  `NVIDIA-Nemotron-3-Nano-30B-A3B-{NVFP4,FP8}` (auto-selected by GPU compute
+  capability). vLLM handles tool calling (`qwen3_coder` parser), reasoning
+  extraction (`nano_v3` parser — auto-fetched into `model_cache`), and
+  FlashInfer FP4 MoE kernels. Requires a Blackwell-class GPU (B200 / RTX PRO
+  6000) for native FP4; swap to FP8 / BF16 variants for Hopper/Ampere.
+  `enforce_eager: true` by default to avoid the silent 3–8 min CUDA graph +
+  FlashInfer autotune on cold start. Hosting backend is selectable per YAML
+  (see *Choosing the vLLM runtime*). See
+  [`ai-services/llm/nemotron3_nano/README.md`](https://github.com/NVIDIA/xr-ai/blob/main/ai-services/llm/nemotron3_nano/README.md)
+  for the vLLM flags it forwards and Blackwell prerequisites.
+- **llm/nemotron_omni** is a vLLM-backed multimodal LLM serving
+  `Nemotron-3-Nano-Omni-30B-A3B-Reasoning` (text + video input) at port 8108.
+  The YAML auto-selects between three model variants by detected GPU compute
+  capability: NVFP4 on Blackwell (SM100+), FP8 on Ada/Hopper, BF16 forced via
+  `use_bf16: true` for highest quality at the largest VRAM cost. Same
+  OpenAI-compatible HTTP contract as the other LLM servers — swap the port to
+  swap backends. Hosting backend is selectable per YAML (see *Choosing the
+  vLLM runtime*); runs foreground in both pip and docker modes (no
+  cross-restart persistence).
+- **stt-server** loads parakeet-tdt-0.6b-v3 via NeMo ASR in-process.
+  English-only; `language` / `temperature` form fields are accepted but ignored.
+- **tts/magpie** loads magpie_tts_multilingual_357m via NeMo TTS in-process.
+- **tts/piper** serves any rhasspy/piper-voices ONNX voice; ~100 ms/sentence on CPU.
+  All inference runs in a thread pool so the asyncio loop is never blocked.
+- **transcript-mcp-server** is pure FastMCP at `/mcp` on port 8200.
+  Records are keyed by free-form `source_id` (live participant identity
+  *or* an internal source name like `"agent-vlm"`). Tools:
+  `query_transcripts`, `add_transcript` (worker ingest), `list_sources`,
+  `get_transcript_stats`. Transcripts persist as JSONL alongside a
+  `.identity` sidecar so list/query round-trip raw IDs cleanly even
+  when sanitized filenames collide.
+- **video-mcp-server** is pure FastMCP at `/mcp` on port 8210.
+  Connects to the hub as a `ProcessorEndpoint` (`Subscribe.VIDEO`) for
+  live frames. Tools exposed depend on whether `recordings_dir` is set
+  in the YAML:
+  - **Always**: `list_live_participants`, `get_latest_frame` (live IPC frame, no recording needed).
+  - **Only when `recordings_dir` is configured**: `list_recorded_participants`,
+    `get_video_stats`, `query_video`, `get_frame_from_time` (historical
+    chunk lookup via NVDEC). Requires `video_recording.enabled: true`
+    in `xr_media_hub.yaml` with a matching `out_dir`.
+- Ports are configurable — avoid conflicts with LiveKit (7880–7882) and hub (8080, 8090).
+- **Sample YAMLs** for each service ship in their own service directory.
+  Copy them to your sample root and adjust `model_cache` (`../../models` resolves
+  to `xr-ai/models/` from any `agent-samples/<name>/` directory).

--- a/docs/source/components/index.md
+++ b/docs/source/components/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Components
+
+The server runtime, agent SDK, MCP servers, AI services, and the launcher/process model.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/components/server-runtime.md
+++ b/docs/source/components/server-runtime.md
@@ -1,0 +1,12 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Server runtime
+
+The `server-runtime/` package hosts the **XR-Media-Hub** and the internal
+LiveKit transport — the entry point clients connect to.
+
+This page is a placeholder seeded by the docs scaffold; the full component
+reference is filled in by the components documentation units.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sphinx configuration for the XR-AI documentation site.
+
+Mirrors the NVIDIA/IsaacTeleop docs setup: the NVIDIA Sphinx theme + MyST so
+the existing Markdown under ``docs/`` is reused directly. Single-version for
+now; ``sphinx-multiversion`` is a deliberate follow-up (see docs changelog).
+"""
+from __future__ import annotations
+
+# -- Project information -----------------------------------------------------
+project = "XR-AI"
+copyright = "2026, NVIDIA CORPORATION & AFFILIATES"
+author = "NVIDIA"
+
+# -- General configuration ---------------------------------------------------
+extensions = [
+    "myst_parser",
+    "sphinx_copybutton",
+    "sphinx_design",
+    "sphinx.ext.githubpages",
+    "sphinx.ext.intersphinx",
+]
+
+# MyST Markdown is the page format (matches the repo's existing docs/*.md).
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
+
+myst_enable_extensions = [
+    "colon_fence",
+    "deflist",
+    "linkify",
+    "substitution",
+]
+myst_heading_anchors = 3
+
+# Don't choke the build on the bundled long-form changelog or build output.
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# -- HTML output -------------------------------------------------------------
+html_theme = "nvidia_sphinx_theme"
+html_show_sphinx = False
+html_title = "XR-AI"

--- a/docs/source/getting_started/index.md
+++ b/docs/source/getting_started/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Getting Started
+
+Requirements, the quickstart paths, connecting clients, networking, and credentials.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -1,0 +1,13 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Quickstart
+
+Every sample follows the same pattern: **start the server, then connect a
+client.** The three primary paths are the shared model servers, the
+`simple-vlm-example`, and the `xr-render-demo`.
+
+This page is a placeholder seeded by the docs scaffold; the full quickstart is
+ported from the repository README.

--- a/docs/source/guides/index.md
+++ b/docs/source/guides/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Guides
+
+How-to guides: adding a sample, wiring CloudXR, troubleshooting, and contribution conventions.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/guides/troubleshooting.md
+++ b/docs/source/guides/troubleshooting.md
@@ -1,0 +1,11 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Troubleshooting
+
+Common setup and runtime frictions and their fixes.
+
+This page is a placeholder seeded by the docs scaffold; the full
+troubleshooting guide is ported from the repository's existing notes.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,0 +1,24 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# XR-AI
+
+Agentic AI for XR — an open-source foundation for multi-modal, real-time
+conversational AI within the CloudXR ecosystem.
+
+XR-AI connects web, iOS/visionOS, AR-glasses, and XR-headset clients to
+GPU-accelerated AI services, tool-using agents, and the CloudXR stack for remote
+rendering. This site documents the architecture, how to run the samples, each
+component, and the reference material for building on the stack.
+
+```{toctree}
+:maxdepth: 2
+
+overview/index
+getting_started/index
+components/index
+guides/index
+reference/index
+```

--- a/docs/source/overview/architecture.md
+++ b/docs/source/overview/architecture.md
@@ -1,0 +1,16 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Architecture
+
+XR-AI follows a **one hub, many clients, many agents** model. The
+**XR-Media-Hub** (server runtime) fans each client's inbound media to every
+agent and routes return traffic back to the originating client only. Clients
+reach the hub over a transport (LiveKit internally), agents attach over an IPC
+boundary, and MCP servers are the agent's only interface to XR data and
+rendering.
+
+This page is a placeholder seeded by the docs scaffold; the full architecture
+write-up is ported from the repository's existing architecture notes.

--- a/docs/source/overview/index.md
+++ b/docs/source/overview/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Overview
+
+What XR-AI is, the layer model, and how the hub, transport, and agents fit together.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/reference/changelog.md
+++ b/docs/source/reference/changelog.md
@@ -1,0 +1,12 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Decision changelog
+
+XR-AI records every non-trivial architectural or design decision, newest first,
+so the rationale is preserved. The canonical log lives in the repository at
+`docs/changelog.md`.
+
+This page is a placeholder seeded by the docs scaffold.

--- a/docs/source/reference/index.md
+++ b/docs/source/reference/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Reference
+
+Deep references: the xr-render-demo stack and the decision changelog.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```


### PR DESCRIPTION
## What

Ports `docs/ai-services.md` into the Sphinx docs site as a new page,
`docs/source/components/ai-services.md`. Covers the VLM/STT/TTS/LLM inference
servers under `ai-services/`, the `vllm_backend: pip|docker` choice, hosting
models on NVIDIA NIM, the model presets, and per-server notes.

## Details

- Full faithful port — body is byte-identical to the source except for link
  targets. Server names and ports cross-checked against the actual
  `ai-services/` layout.
- SPDX HTML-comment header; MyST Markdown.
- Relative `*.md` links with no ported `{doc}` target on this branch are
  rewritten to canonical `https://github.com/NVIDIA/xr-ai/blob/main/...` URLs
  (`agent-sdk/xr-ai-models`, `docs/credentials.md`, the two LLM READMEs). All
  target paths verified to exist in the repo. No relative `*.md` links remain.
- Auto-joins the `components/` `:glob:` toctree.

## Build gate

`sphinx-build -W --keep-going -b html docs/source docs/_build` → exit 0,
zero warnings.

## Note

This branch is based on `docs/sphinx-scaffold` (unmerged, scaffolded by #220).
Until that merges, the PR diff includes the scaffold files (`conf.py`, section
dirs, requirements) in addition to the new page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)