### PR TITLE
docs(components): document agent MCP servers

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build the XR-AI Sphinx docs. On every docs PR: strict build (warnings = errors).
+# On push to main of the canonical repo: build + deploy to GitHub Pages.
+# Deploy is a no-op until Pages is enabled for the repo (Settings → Pages → GitHub Actions).
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yaml"
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yaml"
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build (strict)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install doc deps
+        run: pip install -r docs/requirements.txt
+      - name: Strict Sphinx build
+        run: sphinx-build -W --keep-going -b html docs/source docs/_build
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.repository == 'NVIDIA/xr-ai'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build
+
+  deploy:
+    name: Deploy to GitHub Pages
+    if: github.event_name == 'push' && github.repository == 'NVIDIA/xr-ai'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+# Sphinx build output
+_build/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal Sphinx makefile. Usage:
+#   pip install -r requirements.txt
+#   make html        # build into _build/
+#   make strict      # build with warnings-as-errors (CI gate)
+
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = _build
+
+.PHONY: help html strict clean
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+html:
+	@$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+strict:
+	@$(SPHINXBUILD) -W --keep-going -b html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+clean:
+	rm -rf "$(BUILDDIR)"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,26 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-10 — Sphinx documentation site (isaacteleop-style), scaffold
+
+Stood up a Sphinx documentation site under `docs/source/`, mirroring the
+NVIDIA/IsaacTeleop docs setup (NVIDIA Sphinx theme, GitHub Pages publish). It
+uses **MyST** so the existing `docs/*.md` content is reused as Markdown pages
+rather than rewritten as reStructuredText. Organized into five sections —
+Overview, Getting Started, Components, Guides, Reference — each section index
+uses a **`:glob:` toctree** so new pages self-register by simply being dropped
+into the section directory (this is what lets documentation pages be authored as
+independent, individually-mergeable PRs without all touching a shared nav file).
+
+`.github/workflows/docs.yaml` runs a strict build (`sphinx-build -W`) on every
+docs PR and deploys to GitHub Pages on push to `main` of the canonical repo
+(deploy is a no-op until Pages is enabled in repo settings). `docs/requirements.txt`
+pins the toolchain to IsaacTeleop's versions. The existing `docs/*.md` files are
+intentionally **kept in place** (the README and in-flight PRs link to them); the
+site ingests/ports their content, and a later cleanup can collapse the
+duplication once the site is the source of truth. `sphinx-multiversion` is a
+deliberate follow-up — single-version first to de-risk CI.
+
 ### 2026-06-09 — render-mcp: scene resync survives a LOVR respawn (blocking send, not NOBLOCK)
 
 After a LOVR (re)start, `render-mcp` re-pushed every stored primitive via

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Pins for building the XR-AI Sphinx documentation site.
+# Mirrors the NVIDIA/IsaacTeleop docs toolchain.
+sphinx==8.1.3
+nvidia-sphinx-theme==0.0.9.post1
+myst-parser==4.0.0
+sphinx-copybutton==0.5.2
+sphinx-design==0.6.1
+linkify-it-py==2.0.3

--- a/docs/source/components/index.md
+++ b/docs/source/components/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Components
+
+The server runtime, agent SDK, MCP servers, AI services, and the launcher/process model.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/components/mcp-servers.md
+++ b/docs/source/components/mcp-servers.md
@@ -1,0 +1,295 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# MCP servers
+
+The agent's tool surface lives in `agent-mcp-servers/`. Each subdirectory is a
+standalone process that exposes its capabilities to the LLM as
+[Model Context Protocol](https://modelcontextprotocol.io/) tools. Every server
+is built on **FastMCP** and serves a single StreamableHTTP transport mounted at
+`/mcp` — there are no REST endpoints; *all* operations are MCP tools, including
+health checks. A worker (or any `fastmcp.Client`) reaches a server at
+`http://<host>:<port>/mcp` (use the URL without a trailing slash).
+
+The servers split cleanly by concern: `render-mcp` owns the LOVR scene,
+`oxr-mcp` reads head pose, `vec-mcp` does pose-free vector math, `video-mcp`
+serves camera frames and recordings, `vlm-mcp` answers visual questions, and
+`transcript-mcp` stores per-source transcript history. Each runs on its own
+fixed port so several can coexist on one host.
+
+| Server | Directory | Module | Port |
+|---|---|---|---|
+| `transcript-mcp` | `agent-mcp-servers/transcript-mcp/` | `transcript_mcp_server` | 8200 |
+| `video-mcp` | `agent-mcp-servers/video-mcp/` | `video_mcp_server` | 8210 |
+| `render-mcp` | `agent-mcp-servers/render-mcp/` | `render_mcp` | 8220 |
+| `oxr-mcp` | `agent-mcp-servers/oxr-mcp/` | `oxr_mcp_server` | 8230 |
+| `vlm-mcp` | `agent-mcp-servers/vlm-mcp/` | `vlm_mcp_server` | 8240 |
+| `vec-mcp` | `agent-mcp-servers/vec-mcp/` | `vec_mcp_server` | 8250 |
+
+## How the agent reaches the servers
+
+The `xr-render-demo` sample wires five of these servers into its worker. The
+base URLs live in `agent-samples/xr-render-demo/yaml/xr_render_demo_worker.yaml`:
+
+```yaml
+render_mcp_url: http://localhost:8220
+oxr_mcp_url:    http://localhost:8230
+vlm_mcp_url:    http://localhost:8240
+video_mcp_url:  http://localhost:8210
+vec_mcp_url:    http://localhost:8250
+```
+
+At worker startup `list_tools()` is called on every MCP client; the results are
+converted to OpenAI tool format and held in memory for the agentic loop. When
+the LLM emits a tool call the worker routes it to the owning server by tool name
+(`oxr-mcp` for pose helpers, `vec-mcp` for the pure-math primitives, `vlm-mcp`
+for `ask_image`, `video-mcp` for the video tools, and `render-mcp` for
+everything else). `start_xr` and `get_health` are excluded from the LLM tool
+list — the worker calls those directly.
+
+`transcript-mcp` is a standalone store: nothing in the in-tree samples wires it
+into the agentic loop, so it is reached by any `fastmcp.Client` that connects to
+`http://<host>:8200/mcp`.
+
+Each server auto-discovers its YAML config by the launcher's `<command>.yaml`
+convention, and a sample can override it by dropping a copy next to its
+orchestrator. Paths inside a config resolve relative to the config file's own
+directory.
+
+## render-mcp
+
+`render-mcp` owns the XR scene. It launches and supervises the **LOVR**
+OpenXR/CloudXR rendering app as a child process and is the only thing that
+pushes scene operations onto LOVR's socket. The server binds a ZMQ PUSH socket
+(`scene_socket`, default `ipc:///tmp/xr_render_scene`) and the LOVR Lua app
+(`xr_app/main.lua`) connects PULL and applies each op. LOVR itself is not
+bundled; point `lovr_bin` (or `$LOVR_BIN`) at an existing build.
+
+### render-mcp tools
+
+- `start_xr()` — spawn LOVR if it isn't already running. Idempotent and
+  non-blocking: the CloudXR-readiness wait and launch run in a background task,
+  so it returns `starting` / `already_started` / `error` immediately. Poll
+  `get_health` until `lovr_started` flips before sending ops you can't drop.
+- `add_primitive(prim_type, x, y, z, r, g, b, size)` — add a `sphere` or `box`
+  (others fall back to sphere) at a world-space position (OpenXR Y-up, metres),
+  with RGB color in `[0, 1]` and `size` in metres. Returns the server-assigned
+  `id`.
+- `update_primitive(obj_id, prim_type?, x?, y?, z?, r?, g?, b?, size?)` —
+  partial update of an existing primitive; omitted fields keep their values.
+  Passing `prim_type` converts the shape in place (preserving position, color,
+  size).
+- `remove_primitive(obj_id)` — delete a primitive by id.
+- `get_scene_state()` — return `{objects: [...]}` with each object's `id`,
+  `type`, `position`, `color`, and `size`.
+- `get_health()` — server status; use `lovr_started` as the readiness signal.
+
+### render-mcp config
+
+`render_mcp.yaml`:
+
+```yaml
+xr_app_dir: ./xr_app                          # LOVR project directory
+# lovr_bin: /home/you/hub/lovr/build/bin/lovr  # else falls back to $LOVR_BIN
+host: 0.0.0.0
+port: 8220
+scene_socket: ipc:///tmp/xr_render_scene       # render-mcp BINDS PUSH; LOVR CONNECTS PULL
+cloudxr_env_file: ~/.cloudxr/run/cloudxr.env   # sourced into the LOVR child env
+```
+
+The `cloudxr_env_file` is sourced into the LOVR child's environment so LOVR
+inherits `XR_RUNTIME_JSON` and the CloudXR pin. A missing file is tolerated
+(LOVR then uses the system OpenXR).
+
+## oxr-mcp
+
+`oxr-mcp` is the OpenXR tracking adapter. It opens a **second** OpenXR session
+against CloudXR in headless mode (`XR_MND_HEADLESS`) — separate from LOVR's
+rendering session — so the rendering client keeps full ownership of frame
+submission while `oxr-mcp` reads pose. The session opens lazily on the first
+tool call, and pose is fetched fresh per request via `xrLocateSpace` (no
+background polling).
+
+### oxr-mcp tools
+
+The pose-aware helpers take named directions and always-positive distances so
+the LLM never has to apply signs to user-frame axes:
+
+- `get_head_pose()` — LLM-friendly pose with derived spatial vectors (no raw
+  quaternions): `is_valid`, `position`, `forward`, `right`, `up`, `yaw_deg`,
+  `pitch_deg`, `ts`.
+- `position_ahead(distance)` — world position `distance` metres along the user's
+  gaze.
+- `position_relative(forward, right, up, origin_x?, origin_y?, origin_z?)` —
+  convert user-frame offsets to a world-space position (origin defaults to the
+  head).
+- `place_user_relative(direction, distance)` — world position a named direction
+  (`front`/`back`/`left`/`right`/`above`/`below`) from the user.
+- `place_object_relative(origin_x, origin_y, origin_z, direction, distance)` —
+  same, anchored on an existing object (`direction` also accepts `next_to`;
+  `front` means *toward the user*).
+- `place_inside_by_id(movee_id, container_x, container_y, container_z)` —
+  containment for "put X in Y"; returns `{obj_id, x, y, z}` ready to feed into
+  `update_primitive`.
+- `displace_object(current_x, current_y, current_z, right, up, forward)` —
+  user-frame displacement of one object (multi-axis in one call).
+- `displace_objects(object_ids, current_xs, current_ys, current_zs, right, up, forward)` —
+  the same delta applied to N objects in one call.
+- `get_health()` — `{status, session_open, open_attempts, last_open_error}`.
+
+### oxr-mcp config
+
+`oxr_mcp_server.yaml`:
+
+```yaml
+host: 0.0.0.0
+port: 8230
+cloudxr_env_file: ~/.cloudxr/run/cloudxr.env   # sourced so XR_RUNTIME_JSON is set before the OpenXR session opens
+```
+
+## vec-mcp
+
+`vec-mcp` provides pure-math spatial primitives — the vector arithmetic the LLM
+is unreliable at. It is pose-independent (no OpenXR session, no hub IPC) and
+simply transforms numbers. All results are rounded to three decimals and
+returned as dicts so they compose uniformly.
+
+### vec-mcp tools
+
+- `between_anchors(a_x, a_y, a_z, b_x, b_y, b_z)` — component-wise midpoint of
+  two world positions ("between A and B", "halfway between"). Returns
+  `{x, y, z}`.
+- `world_offset(origin, dx, dy, dz)` — `origin` shifted by axis-aligned deltas
+  (world Y-up), e.g. "30 cm above the sphere". Returns `{x, y, z}`.
+- `along_direction(origin, target, distance)` — `origin` moved `distance` metres
+  along the line toward `target` ("closer to / further from"). Returns
+  `{x, y, z}`.
+- `scale_value(current, factor)` — scalar multiply for sizes ("3× bigger",
+  "half"). Returns `{value}`.
+
+### vec-mcp config
+
+`vec_mcp_server.yaml`:
+
+```yaml
+host: 0.0.0.0
+port: 8250
+```
+
+## video-mcp
+
+`video-mcp` serves camera frames and recordings from two data paths:
+
+- **Historical chunks** — reads the H.264 Annex B chunks the hub's recorder
+  writes to disk (tmpfs by default). `recordings_dir` must match the hub's
+  `video_recording.out_dir`.
+- **Live frames** — connects to the hub as a processor endpoint, tracks the most
+  recent frame per participant, and pulls pixels on demand over the hub IPC
+  sockets (`hub_pub` / `hub_push`).
+
+All tools accept and return raw LiveKit participant identities; filesystem
+sanitization happens internally and is recovered via `.identity` sidecars.
+
+### video-mcp tools
+
+- `list_live_participants()` — identities currently connected to the hub (live
+  IPC roster). Always available.
+- `get_frame_from_time(participant_id, second_ago, reference_time_us=0)` — frame
+  at `anchor − second_ago` seconds, where the anchor is the wall clock
+  (`reference_time_us=0`) or an explicit Unix-µs timestamp. The anchored mode
+  reads recorded NVENC chunks and decodes via NVDEC; only the unanchored
+  `second_ago=0` short-circuits to the live IPC path. Returns a PNG path. This
+  replaces the deprecated `get_latest_frame` / `get_frame_at_time` tools.
+
+When recording is enabled the historical tools are also registered:
+
+- `list_recorded_participants()` — identities with at least one chunk on disk.
+- `get_video_stats(participant_id)` — `num_chunks`, `total_bytes`,
+  `avg_chunk_bytes`, `earliest_us`, `latest_us`.
+- `query_video(participant_id, start_us, end_us)` — concatenate the H.264 chunks
+  overlapping the window into a file and return its path; the stream starts with
+  an IDR frame.
+
+If recording is disabled (no chunk store), `video-mcp` instead registers a
+single live-only tool, `get_latest_frame(participant_id)`, which returns the
+current live frame as a PNG (`path`, `width`, `height`, `timestamp_us`).
+
+### video-mcp config
+
+`video_mcp_server.yaml`:
+
+```yaml
+recordings_dir: /dev/shm/xr-ai/recordings   # must match hub video_recording.out_dir
+out_dir:        /tmp/xr_video_queries        # where query/frame outputs are written
+hub_pub:        ipc:///tmp/xr_hub_pub        # hub PUB socket (live frames)
+hub_push:       ipc:///tmp/xr_hub_in         # hub PUSH socket (frame requests)
+host:           0.0.0.0
+port:           8210
+gpu_id:         0
+```
+
+## vlm-mcp
+
+`vlm-mcp` is a thin FastMCP wrapper around the vision-language model in
+`ai-services/vlm-server/` (Cosmos-Reason1-7B via vLLM). It has no hub IPC
+subscription and no `xr-ai-agent` dependency: it just reads a local image and
+forwards it to the VLM's OpenAI-compatible chat-completions endpoint via the
+`xr-ai-models` SDK.
+
+### vlm-mcp tools
+
+- `ask_image(question, image_path)` — read the local PNG at `image_path`, encode
+  it as a JPEG data URL, send it with `question` to `vlm-server`, and return the
+  model's answer text. The file is read in an executor so the asyncio loop is
+  never blocked.
+
+The typical two-step agent flow is to acquire a frame from `video-mcp`
+(`get_frame_from_time(participant_id, second_ago=0)`) and pass that PNG path
+straight into `ask_image`.
+
+### vlm-mcp config
+
+`vlm_mcp_server.yaml`:
+
+```yaml
+host:                  0.0.0.0
+port:                  8240
+models:
+  vlm:
+    kind:     preset:cosmos_vlm   # targets ai-services/vlm-server/
+    base_url: http://localhost:8100
+vlm_request_timeout_s: 60.0       # per-call httpx timeout
+enable_thinking:       false      # true enables VLM chain-of-thought (slower, more accurate)
+```
+
+## transcript-mcp
+
+`transcript-mcp` stores and queries transcript history keyed by a free-form
+`source_id` string. Sources can be real LiveKit participant identities
+(`alice@home`, `ipad-pro-1`) or synthetic names (`agent-vlm`, `tts`) — the store
+does not interpret the value. Records persist as per-source JSONL files
+(`{timestamp_us, text}` per line) alongside a `.identity` sidecar that recovers
+the original name, so list/query round-trip cleanly across restarts.
+
+### transcript-mcp tools
+
+- `add_transcript(source_id, timestamp_us, text)` — append a segment; returns
+  `{"ok": true}` (or an error if `text` is empty).
+- `query_transcripts(source_id, start_us, end_us)` — all stored segments for
+  `source_id` whose timestamp falls within `[start_us, end_us]` (Unix
+  microseconds).
+- `list_sources()` — all source IDs that have at least one stored transcript.
+- `get_transcript_stats(source_id)` — summary statistics (`count`,
+  `total_chars`, `earliest_us`, `latest_us`).
+
+### transcript-mcp config
+
+`transcript_mcp_server.yaml`:
+
+```yaml
+transcripts_dir: /tmp/xr_transcripts   # persistent JSONL storage
+host:            0.0.0.0
+port:            8200
+```

--- a/docs/source/components/server-runtime.md
+++ b/docs/source/components/server-runtime.md
@@ -1,0 +1,12 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Server runtime
+
+The `server-runtime/` package hosts the **XR-Media-Hub** and the internal
+LiveKit transport — the entry point clients connect to.
+
+This page is a placeholder seeded by the docs scaffold; the full component
+reference is filled in by the components documentation units.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sphinx configuration for the XR-AI documentation site.
+
+Mirrors the NVIDIA/IsaacTeleop docs setup: the NVIDIA Sphinx theme + MyST so
+the existing Markdown under ``docs/`` is reused directly. Single-version for
+now; ``sphinx-multiversion`` is a deliberate follow-up (see docs changelog).
+"""
+from __future__ import annotations
+
+# -- Project information -----------------------------------------------------
+project = "XR-AI"
+copyright = "2026, NVIDIA CORPORATION & AFFILIATES"
+author = "NVIDIA"
+
+# -- General configuration ---------------------------------------------------
+extensions = [
+    "myst_parser",
+    "sphinx_copybutton",
+    "sphinx_design",
+    "sphinx.ext.githubpages",
+    "sphinx.ext.intersphinx",
+]
+
+# MyST Markdown is the page format (matches the repo's existing docs/*.md).
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
+
+myst_enable_extensions = [
+    "colon_fence",
+    "deflist",
+    "linkify",
+    "substitution",
+]
+myst_heading_anchors = 3
+
+# Don't choke the build on the bundled long-form changelog or build output.
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# -- HTML output -------------------------------------------------------------
+html_theme = "nvidia_sphinx_theme"
+html_show_sphinx = False
+html_title = "XR-AI"

--- a/docs/source/getting_started/index.md
+++ b/docs/source/getting_started/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Getting Started
+
+Requirements, the quickstart paths, connecting clients, networking, and credentials.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -1,0 +1,13 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Quickstart
+
+Every sample follows the same pattern: **start the server, then connect a
+client.** The three primary paths are the shared model servers, the
+`simple-vlm-example`, and the `xr-render-demo`.
+
+This page is a placeholder seeded by the docs scaffold; the full quickstart is
+ported from the repository README.

--- a/docs/source/guides/index.md
+++ b/docs/source/guides/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Guides
+
+How-to guides: adding a sample, wiring CloudXR, troubleshooting, and contribution conventions.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/guides/troubleshooting.md
+++ b/docs/source/guides/troubleshooting.md
@@ -1,0 +1,11 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Troubleshooting
+
+Common setup and runtime frictions and their fixes.
+
+This page is a placeholder seeded by the docs scaffold; the full
+troubleshooting guide is ported from the repository's existing notes.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,0 +1,24 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# XR-AI
+
+Agentic AI for XR — an open-source foundation for multi-modal, real-time
+conversational AI within the CloudXR ecosystem.
+
+XR-AI connects web, iOS/visionOS, AR-glasses, and XR-headset clients to
+GPU-accelerated AI services, tool-using agents, and the CloudXR stack for remote
+rendering. This site documents the architecture, how to run the samples, each
+component, and the reference material for building on the stack.
+
+```{toctree}
+:maxdepth: 2
+
+overview/index
+getting_started/index
+components/index
+guides/index
+reference/index
+```

--- a/docs/source/overview/architecture.md
+++ b/docs/source/overview/architecture.md
@@ -1,0 +1,16 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Architecture
+
+XR-AI follows a **one hub, many clients, many agents** model. The
+**XR-Media-Hub** (server runtime) fans each client's inbound media to every
+agent and routes return traffic back to the originating client only. Clients
+reach the hub over a transport (LiveKit internally), agents attach over an IPC
+boundary, and MCP servers are the agent's only interface to XR data and
+rendering.
+
+This page is a placeholder seeded by the docs scaffold; the full architecture
+write-up is ported from the repository's existing architecture notes.

--- a/docs/source/overview/index.md
+++ b/docs/source/overview/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Overview
+
+What XR-AI is, the layer model, and how the hub, transport, and agents fit together.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/reference/changelog.md
+++ b/docs/source/reference/changelog.md
@@ -1,0 +1,12 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Decision changelog
+
+XR-AI records every non-trivial architectural or design decision, newest first,
+so the rationale is preserved. The canonical log lives in the repository at
+`docs/changelog.md`.
+
+This page is a placeholder seeded by the docs scaffold.

--- a/docs/source/reference/index.md
+++ b/docs/source/reference/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Reference
+
+Deep references: the xr-render-demo stack and the decision changelog.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```


### PR DESCRIPTION
## What

Adds `docs/source/components/mcp-servers.md` to the Sphinx site, documenting the agent's MCP interface layer under `agent-mcp-servers/`. One subsection per server — `render-mcp`, `oxr-mcp`, `vec-mcp`, `video-mcp`, `vlm-mcp`, `transcript-mcp` — covering each server's purpose, the tools it exposes, its port/config, and how the agent reaches it (StreamableHTTP at `/mcp`).

Content is sourced from each server's `__main__.py` tool definitions and `*.yaml` config, not from the (partly stale) tables in `docs/xr-render-demo.md`. Notable corrections captured from the code:
- `render-mcp` tools are `start_xr` / `add_primitive` / `update_primitive` / `remove_primitive` / `get_scene_state` / `get_health` (not the older `set_sphere_*`).
- `video-mcp` registers `get_frame_from_time` (replacing the deprecated `get_latest_frame` / `get_frame_at_time`); the historical tools register only when recording is enabled, and a live-only `get_latest_frame` is registered when it is disabled.
- `transcript-mcp` has no in-tree agentic-loop consumer; documented as a standalone store reached by any `fastmcp.Client` at `:8200/mcp`.

## Base / scaffold note

This branch is based on the unmerged `docs/sphinx-scaffold` branch (#220). Until that merges, the PR diff against `main` also shows the scaffold files (`docs/source/conf.py`, section `index.md`s, etc.). The only file owned by this PR is `docs/source/components/mcp-servers.md`.

## Test

```
python3 -m venv /tmp/v_mcp && . /tmp/v_mcp/bin/activate
pip install -r docs/requirements.txt
sphinx-build -W --keep-going -b html docs/source docs/_build
```

Exit 0, zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)