### PR TITLE
docs(guides): port troubleshooting guide to Sphinx site

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build the XR-AI Sphinx docs. On every docs PR: strict build (warnings = errors).
+# On push to main of the canonical repo: build + deploy to GitHub Pages.
+# Deploy is a no-op until Pages is enabled for the repo (Settings → Pages → GitHub Actions).
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yaml"
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yaml"
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build (strict)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install doc deps
+        run: pip install -r docs/requirements.txt
+      - name: Strict Sphinx build
+        run: sphinx-build -W --keep-going -b html docs/source docs/_build
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.repository == 'NVIDIA/xr-ai'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build
+
+  deploy:
+    name: Deploy to GitHub Pages
+    if: github.event_name == 'push' && github.repository == 'NVIDIA/xr-ai'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+# Sphinx build output
+_build/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal Sphinx makefile. Usage:
+#   pip install -r requirements.txt
+#   make html        # build into _build/
+#   make strict      # build with warnings-as-errors (CI gate)
+
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = _build
+
+.PHONY: help html strict clean
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+html:
+	@$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+strict:
+	@$(SPHINXBUILD) -W --keep-going -b html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+clean:
+	rm -rf "$(BUILDDIR)"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,26 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-10 — Sphinx documentation site (isaacteleop-style), scaffold
+
+Stood up a Sphinx documentation site under `docs/source/`, mirroring the
+NVIDIA/IsaacTeleop docs setup (NVIDIA Sphinx theme, GitHub Pages publish). It
+uses **MyST** so the existing `docs/*.md` content is reused as Markdown pages
+rather than rewritten as reStructuredText. Organized into five sections —
+Overview, Getting Started, Components, Guides, Reference — each section index
+uses a **`:glob:` toctree** so new pages self-register by simply being dropped
+into the section directory (this is what lets documentation pages be authored as
+independent, individually-mergeable PRs without all touching a shared nav file).
+
+`.github/workflows/docs.yaml` runs a strict build (`sphinx-build -W`) on every
+docs PR and deploys to GitHub Pages on push to `main` of the canonical repo
+(deploy is a no-op until Pages is enabled in repo settings). `docs/requirements.txt`
+pins the toolchain to IsaacTeleop's versions. The existing `docs/*.md` files are
+intentionally **kept in place** (the README and in-flight PRs link to them); the
+site ingests/ports their content, and a later cleanup can collapse the
+duplication once the site is the source of truth. `sphinx-multiversion` is a
+deliberate follow-up — single-version first to de-risk CI.
+
 ### 2026-06-09 — render-mcp: scene resync survives a LOVR respawn (blocking send, not NOBLOCK)
 
 After a LOVR (re)start, `render-mcp` re-pushed every stored primitive via

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Pins for building the XR-AI Sphinx documentation site.
+# Mirrors the NVIDIA/IsaacTeleop docs toolchain.
+sphinx==8.1.3
+nvidia-sphinx-theme==0.0.9.post1
+myst-parser==4.0.0
+sphinx-copybutton==0.5.2
+sphinx-design==0.6.1
+linkify-it-py==2.0.3

--- a/docs/source/components/index.md
+++ b/docs/source/components/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Components
+
+The server runtime, agent SDK, MCP servers, AI services, and the launcher/process model.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/components/server-runtime.md
+++ b/docs/source/components/server-runtime.md
@@ -1,0 +1,12 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Server runtime
+
+The `server-runtime/` package hosts the **XR-Media-Hub** and the internal
+LiveKit transport — the entry point clients connect to.
+
+This page is a placeholder seeded by the docs scaffold; the full component
+reference is filled in by the components documentation units.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sphinx configuration for the XR-AI documentation site.
+
+Mirrors the NVIDIA/IsaacTeleop docs setup: the NVIDIA Sphinx theme + MyST so
+the existing Markdown under ``docs/`` is reused directly. Single-version for
+now; ``sphinx-multiversion`` is a deliberate follow-up (see docs changelog).
+"""
+from __future__ import annotations
+
+# -- Project information -----------------------------------------------------
+project = "XR-AI"
+copyright = "2026, NVIDIA CORPORATION & AFFILIATES"
+author = "NVIDIA"
+
+# -- General configuration ---------------------------------------------------
+extensions = [
+    "myst_parser",
+    "sphinx_copybutton",
+    "sphinx_design",
+    "sphinx.ext.githubpages",
+    "sphinx.ext.intersphinx",
+]
+
+# MyST Markdown is the page format (matches the repo's existing docs/*.md).
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
+
+myst_enable_extensions = [
+    "colon_fence",
+    "deflist",
+    "linkify",
+    "substitution",
+]
+myst_heading_anchors = 3
+
+# Don't choke the build on the bundled long-form changelog or build output.
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# -- HTML output -------------------------------------------------------------
+html_theme = "nvidia_sphinx_theme"
+html_show_sphinx = False
+html_title = "XR-AI"

--- a/docs/source/getting_started/index.md
+++ b/docs/source/getting_started/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Getting Started
+
+Requirements, the quickstart paths, connecting clients, networking, and credentials.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -1,0 +1,13 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Quickstart
+
+Every sample follows the same pattern: **start the server, then connect a
+client.** The three primary paths are the shared model servers, the
+`simple-vlm-example`, and the `xr-render-demo`.
+
+This page is a placeholder seeded by the docs scaffold; the full quickstart is
+ported from the repository README.

--- a/docs/source/guides/index.md
+++ b/docs/source/guides/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Guides
+
+How-to guides: adding a sample, wiring CloudXR, troubleshooting, and contribution conventions.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/guides/troubleshooting.md
+++ b/docs/source/guides/troubleshooting.md
@@ -1,0 +1,11 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Troubleshooting
+
+Common setup and runtime frictions and their fixes.
+
+This page is a placeholder seeded by the docs scaffold; the full
+troubleshooting guide is ported from the repository's existing notes.

--- a/docs/source/guides/troubleshooting.md
+++ b/docs/source/guides/troubleshooting.md
@@ -5,7 +5,384 @@
 
 # Troubleshooting
 
-Common setup and runtime frictions and their fixes.
+Known frictions and their fixes. If you hit something not listed, please add
+it here in the same change that you understand it.
 
-This page is a placeholder seeded by the docs scaffold; the full
-troubleshooting guide is ported from the repository's existing notes.
+## Setup-time issues
+
+### DGX Spark — `uv sync` fails to build a wheel
+
+**Symptom:** `uv sync` fails on a DGX Spark system while building NeMo or
+vLLM wheels with errors mentioning missing `Python.h` or development
+headers.
+
+**Cause:** the system is missing CPython development headers.
+
+**Fix:** install before running `uv sync`:
+
+```bash
+sudo apt install python3-dev
+```
+
+This applies to the `xr-render-demo/yaml/spark/` profile.
+
+### DGX Spark — LOVR auto-download is not supported
+
+**Symptom:** `uv run xr_render_demo` exits at startup with:
+
+```
+xr-render-demo: LOVR auto-download is not supported on linux/aarch64.
+```
+
+**Cause:** upstream LOVR releases do not ship a prebuilt aarch64 Linux binary,
+so the orchestrator cannot fetch one. Build LOVR from source on the Spark and
+point `LOVR_BIN` at it.
+
+**Fix:**
+
+```bash
+sudo apt install -y cmake build-essential \
+                    libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
+                    libcurl4-openssl-dev libx11-xcb-dev
+
+git clone --recursive https://github.com/bjornbytes/lovr.git ~/lovr
+cd ~/lovr
+mkdir build && cd build
+cmake ..
+make -j$(nproc)
+
+export LOVR_BIN=~/lovr/build/bin/lovr
+```
+
+`export LOVR_BIN=…` only lasts for the current shell. To make it permanent,
+append the line to `~/.bashrc`, or set `lovr_bin: ~/lovr/build/bin/lovr` in
+`agent-mcp-servers/render-mcp/render_mcp.yaml` instead.
+
+If `git clone` was run without `--recursive`, run
+`git submodule update --init --recursive` inside `~/lovr` before `cmake ..`.
+
+### Blackwell GPUs (B200, RTX PRO 6000) — VLM fails to start
+
+**Symptom:** the VLM server logs FlashInfer or NVFP4 kernel errors and never
+becomes healthy on a Blackwell-class system.
+
+**Cause:** Blackwell FP4 MoE kernels need both the **NVIDIA Container Toolkit**
+and a working **CUDA NVCC** toolchain present on the host (the kernels are
+JIT-compiled at first use).
+
+**Fix:** install both before launching:
+
+```bash
+# NVIDIA Container Toolkit (covers both Docker and bare-metal CUDA driver bits)
+# Follow the latest instructions at:
+# https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
+
+# CUDA NVCC — install the matching CUDA toolkit for your driver
+sudo apt install nvidia-cuda-toolkit
+```
+
+This applies to the `xr-render-demo/yaml/96G_blackwell/` profile.
+
+### GPU service aborts with `cuDNN version incompatibility`
+
+**Symptom:** a GPU service (commonly the NeMo STT server) crashes at torch
+import with:
+
+```
+RuntimeError: cuDNN version incompatibility: PyTorch was compiled against
+(9, 20, 0) but found runtime version (9, 13, 1). ... Looks like your
+LD_LIBRARY_PATH contains incompatible version of cudnn.
+```
+
+**Cause:** the host exports an `LD_LIBRARY_PATH` that points at a system cuDNN
+(common on cloud GPU images). It shadows the cuDNN bundled in the service's
+venv — the exact version that venv's PyTorch was compiled against — so torch
+loads the wrong runtime and aborts.
+
+**Fix:** the launcher handles this automatically — `model_servers` /
+`xr_render_demo` strip any `libcudnn`-bearing directory from each child's
+`LD_LIBRARY_PATH` before spawning (logged once as a WARNING), so the
+venv-bundled cuDNN is used. If you hit this running a service **directly**
+(outside the launcher), clear the conflicting path yourself first:
+
+```bash
+# Inspect what's on the path
+echo "$LD_LIBRARY_PATH"
+# Run the service without the host cuDNN shadowing the venv copy
+env -u LD_LIBRARY_PATH uv run <command>
+```
+
+### `vllm_backend: docker` — image pull fails with "unauthorized" / "denied"
+
+**Symptom:** the wrapper logs `[<service>] Launching vLLM (docker)` and then
+`docker run` fails with one of:
+
+- `Error response from daemon: pull access denied for nvcr.io/nvidia/vllm`
+- `unauthorized: authentication required`
+- `denied: requested access to the resource is denied`
+
+**Cause:** docker is not authenticated to `nvcr.io`, so it cannot pull the
+NGC vLLM container.
+
+**Fix:** log in with your NGC API key once. Get a key from
+https://ngc.nvidia.com/setup/api-key and run:
+
+```bash
+docker login nvcr.io -u '$oauthtoken' -p $NGC_API_KEY
+```
+
+The credential is cached in `~/.docker/config.json` and reused on subsequent
+runs. Alternatively, save the key into the xr-ai credential cache so the
+wrapper can auto-login:
+
+```bash
+python3 -c "
+import json, os, pathlib
+p = pathlib.Path.home() / '.config/xr-ai/credentials.json'
+d = json.loads(p.read_text()) if p.exists() else {}
+d['NGC_API_KEY'] = os.environ['NGC_API_KEY']
+p.parent.mkdir(parents=True, exist_ok=True)
+p.write_text(json.dumps(d, indent=2))
+"
+```
+
+The orchestrator's `load_credentials()` injects `NGC_API_KEY` into the
+environment before each wrapper runs; the docker backend uses it to run
+`docker login nvcr.io --password-stdin` when no existing auth is found.
+
+### `vllm_backend: docker` — wrapper exits with `vLLM exited before /health became reachable`
+
+**Symptom:** the launcher reports
+
+```
+[<service>] vLLM exited before /health became reachable
+[<service>] exited (rc=1) before signaling ready
+```
+
+and the per-run log file under `/tmp/log_<sample>_<timestamp>/<service>.log`
+contains only wrapper messages — nothing from inside the container.
+
+**Health probe** — confirm vLLM never reached the `/health` endpoint:
+
+```bash
+curl -fsS http://127.0.0.1:8107/health   # nemotron3_nano (agent-llm)
+curl -fsS http://127.0.0.1:8100/health   # vlm_server
+curl -fsS http://127.0.0.1:8106/health   # llama_nemotron (llm)
+```
+
+**Container post-mortem** — the wrapper now streams `docker logs -f` into the
+per-run log file, so on the next run the actual vLLM error lands next to the
+wrapper messages. To inspect manually:
+
+```bash
+docker ps -a --filter name=xr-ai-vllm-
+docker logs --tail=200 <container-name>
+```
+
+**Cause:** vLLM crashed during startup — common reasons: model weights
+missing/inaccessible in the bind-mounted `model_cache`, GPU not visible to
+the container (`nvidia-container-cli` / `--gpus`), HF token missing for a
+gated model, or a reasoning-parser plugin file that is not present inside
+the container.
+
+**Fix:** read the container logs (the next run captures them automatically),
+address the root cause shown there, and retry. If the container was
+auto-removed by `--rm` before you could check, the next failed run will
+have the streamed output in the loguru log file — just re-run.
+
+### `vllm_backend: docker` — `docker run` fails with `could not select device driver`
+
+**Symptom:** `docker run` exits with a message mentioning `nvidia-container-cli`
+or "could not select device driver "" with capabilities: [[gpu]]".
+
+**Cause:** the NVIDIA Container Toolkit is not installed (or the daemon was
+not restarted after install), so docker cannot honor `--gpus`.
+
+**Fix:** install the toolkit and restart docker:
+https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
+
+Switch back to `vllm_backend: pip` in the service YAML if you only need the
+local install.
+
+### Hub fails immediately with `RuntimeError: missing libnvcuvid.so / libnvidia-encode.so`
+
+**Cause:** NVDEC (`libnvcuvid.so`) and NVENC (`libnvidia-encode.so`) are
+required — the hub refuses to start without them so it never silently falls
+back to OpenH264 (which is royalty-bearing). See
+{doc}`changelog <../reference/changelog>` entry **2026-04-21 — NVDEC/NVENC required**.
+
+**Fix:**
+- **Bare metal:** install/repair the NVIDIA driver. The libs ship with the
+  driver, not with CUDA.
+- **Docker:** pass `--gpus all` (or `--device /dev/nvidia*` plus the codec
+  device nodes) when starting the container.
+
+## Runtime / connection issues
+
+### Voice session drops / agent goes silent after a few minutes idle
+
+**Cause:** an idle-timeout that auto-cancels the voice pipeline after a stretch
+with no user/bot speech.
+
+**Status:** disabled by default. `make_voice_pipeline` passes
+`cancel_on_idle_timeout=False` (overriding pipecat's on-by-default
+`IDLE_TIMEOUT_SECS`), so a quiet session stays connected indefinitely.
+
+**If you want it:** set `idle_timeout_secs: <seconds>` (e.g. `300` for 5 min)
+in the sample's worker YAML (`simple_vlm_example_worker.yaml` /
+`xr_render_demo_worker.yaml`); `0` or unset keeps it disabled. The knob is
+threaded to `xr_ai_pipecat.make_voice_pipeline`, where it's documented.
+
+### Browser client connects but no audio / no video
+
+**Most common cause:** firewall blocking WebRTC media on UDP 7882 (LiveKit).
+
+**Fix:** open ports per [`docs/networking.md`](https://github.com/NVIDIA/xr-ai/blob/main/docs/networking.md). The web client
+will appear to connect (signaling on 7880 succeeds) but media frames are
+silently dropped without 7882.
+
+### HTTPS web client → `ws://` mixed-content warning
+
+**Symptom:** the LiveKit JS SDK logs a mixed-content error connecting to
+`ws://<host>:7880/…` from an HTTPS page.
+
+**Cause:** a stale client build (or a hand-rolled config) is pointing at
+LiveKit's native 7880 instead of the same-origin `wss://<host>:8080/rtc`
+proxy the hub exposes.
+
+**Fix:** rebuild against the current `client-samples/web` or `web-xr` —
+both auto-detect the page's protocol and use the wss proxy. If you're
+holding a `LiveKitConfig` directly, set `port` to the hub's
+`web_server_port` (8080) and let the SDK build `wss://host:8080`. The
+`secure` toggle is gone from the Android, iOS, and visionOS samples —
+wss is the only mode.
+
+### Android — connection fails with TLS / certificate errors
+
+**Symptom:** the Android sample fails to connect; the error shows an
+`SSLHandshakeException` or similar TLS error.
+
+**Cause:** the hub uses a self-signed cert by default. The Android sample
+no longer bypasses cert validation globally — it now validates against the
+system + user CA store, the same as iOS.
+
+**Fix:** install the hub's cert via the in-app button before connecting:
+
+1. In the Connection section, tap **Install hub certificate** (enabled once
+   Host is non-empty).
+2. The app fetches the cert from `https://<host>:<port>/cert` and opens the
+   system cert-install dialog.
+3. Confirm the install. After install, tap **Connect** — validation succeeds
+   automatically.
+
+Repeat for each hub host. Replace the auto-generated cert with one from a
+public CA via `cert_file` / `key_file` in `xr_media_hub.yaml` for
+production.
+
+### iOS / visionOS — connection fails with cert-trust errors
+
+**Symptom:** the iOS or visionOS sample fails to connect; the LiveKit
+WebSocket reports a TLS error (e.g. `NSURLErrorServerCertificateUntrusted`,
+`-1202`, "The certificate for this server is invalid").
+
+**Cause:** the LiveKit Swift SDK's `URLSession` does not expose a
+server-trust auth-challenge hook (`WebSocket.swift` Delegate only
+implements `didOpenWithProtocol` and `didCompleteWithError`), and ATS
+does not bypass certificate-chain validation regardless of
+`NSAllowsArbitraryLoads`. Until the hub's self-signed cert is trusted at
+the OS level, the wss handshake fails. The `TrustingSessionDelegate`
+inside `LiveKitBackend.swift` only covers the `/token` HTTP fetch.
+
+**Fix:** install the hub's cert as a trusted profile on the device:
+
+1. In Safari on the device, open `https://<host>:8080/cert` and tap
+   **Show Details → visit this website** past the cert warning.
+2. Approve the **Download Configuration Profile** prompt.
+3. Install via **Settings → General → VPN & Device Management**.
+4. Toggle **Settings → General → About → Certificate Trust Settings →
+   Enable Full Trust** for the new cert.
+
+If step 4 shows no toggle, the cached cert on the hub is from an older
+xr-ai build that wrote `BasicConstraints CA:FALSE` and iOS will not
+expose the trust toggle for it. Remove the installed profile via
+**VPN & Device Management** and restart the hub — it auto-detects the
+stale cert and regenerates as a self-signed CA (logged as `TLS: cached
+cert is not a CA cert — regenerating…`).
+
+If the toggle was enabled but the wss handshake still fails with
+`errSSLBadCert` / NSURLErrorDomain `-1202` and a message like *"pretending
+to be 10.29.90.196"* (i.e. the IP you typed into the app), the cert's
+SubjectAlternativeName doesn't cover that IP. The hub now detects local
+IPv4 addresses via a UDP-connect probe and auto-regenerates the cert
+whenever the SAN is missing one (logged as `TLS: cached cert SAN is
+missing local IP(s) … — regenerating…`); just restart the hub and
+re-install the profile on the device. To force regen explicitly, delete
+`~/.local/share/xr-ai/web-server.crt` and `web-server.key` before
+restarting.
+
+If the cert is trusted (no `-1202`) but the room connection still fails
+with HTTP 401 / "no permissions to access the room", the hub's wss /rtc
+proxy is dropping the `Authorization: Bearer <token>` header the Swift
+SDK sends (the JS SDK puts the JWT in the query string and never hit
+this code path). The current proxy forwards `Authorization` plus every
+other end-to-end header on both `/rtc/validate` and the WebSocket;
+pulling the latest hub and restarting fixes this without any
+client-side change.
+
+Repeat the install step per hub host, or replace the auto-generated cert
+with a public-CA cert via `cert_file` / `key_file` in `xr_media_hub.yaml`
+for production.
+
+### Chrome — Immersive Web extension cannot be enabled
+
+**Symptom:** the Immersive Web extension for Chrome cannot be enabled.
+
+**Status:** known issue, no workaround currently.
+
+**Workaround:** use a native client (Quest 3, Vision Pro) on the same LAN, or
+the IWER emulator built into the web client itself for desktop dev.
+
+### vLLM cold start takes 3–8 minutes
+
+**Symptom:** `vlm_server` / `nemotron3_nano_llm_server` weight load is fast,
+but the server then sits silent for several minutes before becoming healthy.
+
+**Cause:** CUDA graph capture + FlashInfer FP4 MoE autotune happen on first
+run after weight load. They are silent.
+
+**Fix:** the shipped YAMLs default to `enforce_eager: true` which avoids both.
+Eager mode is 10–20% slower per token but starts in ~5 s after weight load —
+imperceptible at <250 tokens/turn where STT+VAD+TTS dominate latency. Don't
+flip `enforce_eager: false` unless you have a measured reason.
+
+### `xr_render_demo` exits but VRAM is still pinned
+
+**By design.** The vLLM-backed servers (`vlm_server`,
+`llama_nemotron_llm_server`, `nemotron3_nano_llm_server`) survive stack
+restarts so model weights stay loaded across worker crashes and debug
+restarts. See [`docs/ai-services.md`](https://github.com/NVIDIA/xr-ai/blob/main/docs/ai-services.md) → *vLLM model
+persistence*.
+
+**Fix:** to fully release VRAM:
+
+```bash
+cd xr-ai/agent-samples/xr-render-demo
+uv run xr_render_demo --stop
+```
+
+For pip-mode servers this sends `SIGTERM` to each persisted process, waits up
+to 20 s, then `SIGKILL`s. For docker-mode servers it runs
+`docker stop <container_name>` (escalating to `docker kill` after 20 s). Safe
+to run while the stack is down.
+
+### First run downloads models silently
+
+**Symptom:** `uv run simple_vlm_example` appears to hang at startup the first
+time.
+
+**Cause:** model weights are downloading from HuggingFace into `models/` at
+the repo root (gitignored, ~16 GB for Cosmos-Reason1-7B alone).
+
+**Fix:** wait. Subsequent runs use the cached weights and start in
+~30–60 s. If a download fails, check that `HF_TOKEN` is set if the model
+needs it (see [`docs/credentials.md`](https://github.com/NVIDIA/xr-ai/blob/main/docs/credentials.md)).

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,0 +1,24 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# XR-AI
+
+Agentic AI for XR — an open-source foundation for multi-modal, real-time
+conversational AI within the CloudXR ecosystem.
+
+XR-AI connects web, iOS/visionOS, AR-glasses, and XR-headset clients to
+GPU-accelerated AI services, tool-using agents, and the CloudXR stack for remote
+rendering. This site documents the architecture, how to run the samples, each
+component, and the reference material for building on the stack.
+
+```{toctree}
+:maxdepth: 2
+
+overview/index
+getting_started/index
+components/index
+guides/index
+reference/index
+```

--- a/docs/source/overview/architecture.md
+++ b/docs/source/overview/architecture.md
@@ -1,0 +1,16 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Architecture
+
+XR-AI follows a **one hub, many clients, many agents** model. The
+**XR-Media-Hub** (server runtime) fans each client's inbound media to every
+agent and routes return traffic back to the originating client only. Clients
+reach the hub over a transport (LiveKit internally), agents attach over an IPC
+boundary, and MCP servers are the agent's only interface to XR data and
+rendering.
+
+This page is a placeholder seeded by the docs scaffold; the full architecture
+write-up is ported from the repository's existing architecture notes.

--- a/docs/source/overview/index.md
+++ b/docs/source/overview/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Overview
+
+What XR-AI is, the layer model, and how the hub, transport, and agents fit together.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/reference/changelog.md
+++ b/docs/source/reference/changelog.md
@@ -1,0 +1,12 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Decision changelog
+
+XR-AI records every non-trivial architectural or design decision, newest first,
+so the rationale is preserved. The canonical log lives in the repository at
+`docs/changelog.md`.
+
+This page is a placeholder seeded by the docs scaffold.

--- a/docs/source/reference/index.md
+++ b/docs/source/reference/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Reference
+
+Deep references: the xr-render-demo stack and the decision changelog.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```


### PR DESCRIPTION
Replaces the scaffold placeholder in \`docs/source/guides/troubleshooting.md\` with a faithful port of the repository's \`docs/troubleshooting.md\`.

## What
- **Setup-time issues:** DGX Spark (\`uv sync\` headers, LOVR aarch64 build-from-source), Blackwell VLM (Container Toolkit + NVCC), cuDNN/\`LD_LIBRARY_PATH\` shadowing, \`nvcr.io\` docker auth, vLLM \`/health\` post-mortem, \`could not select device driver\`, NVDEC/NVENC required.
- **Runtime / connection issues:** idle-timeout, WebRTC UDP 7882, mixed-content wss, Android/iOS/visionOS cert trust, Chrome Immersive Web, vLLM cold start, VRAM persistence, silent first-run model downloads.

## Link conversions
Relative \`docs/*.md\` links rewritten so nothing warns under \`-W\`:
- \`changelog.md\` → \`{doc}\` xref to the reference page (\`../reference/changelog\`).
- \`networking.md\`, \`ai-services.md\`, \`credentials.md\` → GitHub blob URLs (no Sphinx page exists on this branch).

## Gate
\`\`\`
sphinx-build -W --keep-going -b html docs/source docs/_build
\`\`\`
Exit 0, zero warnings.

## Note
Branch is based on the unmerged \`docs/sphinx-scaffold\` (scaffold PR #220). Until that merges, this PR's diff also shows the scaffold files; the only file this unit owns is \`docs/source/guides/troubleshooting.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)