### PR TITLE
docs(components): add launcher and process model page

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build the XR-AI Sphinx docs. On every docs PR: strict build (warnings = errors).
+# On push to main of the canonical repo: build + deploy to GitHub Pages.
+# Deploy is a no-op until Pages is enabled for the repo (Settings → Pages → GitHub Actions).
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yaml"
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yaml"
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build (strict)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install doc deps
+        run: pip install -r docs/requirements.txt
+      - name: Strict Sphinx build
+        run: sphinx-build -W --keep-going -b html docs/source docs/_build
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.repository == 'NVIDIA/xr-ai'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build
+
+  deploy:
+    name: Deploy to GitHub Pages
+    if: github.event_name == 'push' && github.repository == 'NVIDIA/xr-ai'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+# Sphinx build output
+_build/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal Sphinx makefile. Usage:
+#   pip install -r requirements.txt
+#   make html        # build into _build/
+#   make strict      # build with warnings-as-errors (CI gate)
+
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = _build
+
+.PHONY: help html strict clean
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+html:
+	@$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+strict:
+	@$(SPHINXBUILD) -W --keep-going -b html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+clean:
+	rm -rf "$(BUILDDIR)"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,26 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-10 — Sphinx documentation site (isaacteleop-style), scaffold
+
+Stood up a Sphinx documentation site under `docs/source/`, mirroring the
+NVIDIA/IsaacTeleop docs setup (NVIDIA Sphinx theme, GitHub Pages publish). It
+uses **MyST** so the existing `docs/*.md` content is reused as Markdown pages
+rather than rewritten as reStructuredText. Organized into five sections —
+Overview, Getting Started, Components, Guides, Reference — each section index
+uses a **`:glob:` toctree** so new pages self-register by simply being dropped
+into the section directory (this is what lets documentation pages be authored as
+independent, individually-mergeable PRs without all touching a shared nav file).
+
+`.github/workflows/docs.yaml` runs a strict build (`sphinx-build -W`) on every
+docs PR and deploys to GitHub Pages on push to `main` of the canonical repo
+(deploy is a no-op until Pages is enabled in repo settings). `docs/requirements.txt`
+pins the toolchain to IsaacTeleop's versions. The existing `docs/*.md` files are
+intentionally **kept in place** (the README and in-flight PRs link to them); the
+site ingests/ports their content, and a later cleanup can collapse the
+duplication once the site is the source of truth. `sphinx-multiversion` is a
+deliberate follow-up — single-version first to de-risk CI.
+
 ### 2026-06-09 — render-mcp: scene resync survives a LOVR respawn (blocking send, not NOBLOCK)
 
 After a LOVR (re)start, `render-mcp` re-pushed every stored primitive via

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Pins for building the XR-AI Sphinx documentation site.
+# Mirrors the NVIDIA/IsaacTeleop docs toolchain.
+sphinx==8.1.3
+nvidia-sphinx-theme==0.0.9.post1
+myst-parser==4.0.0
+sphinx-copybutton==0.5.2
+sphinx-design==0.6.1
+linkify-it-py==2.0.3

--- a/docs/source/components/index.md
+++ b/docs/source/components/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Components
+
+The server runtime, agent SDK, MCP servers, AI services, and the launcher/process model.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/components/launcher-and-process-model.md
+++ b/docs/source/components/launcher-and-process-model.md
@@ -1,0 +1,194 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Launcher and process model
+
+Every sample is self-contained: running it starts the hub and all required
+processes automatically. No separate server launch step.
+
+Each sample has **two sub-projects**:
+
+| Sub-project | Role | Dependencies |
+|---|---|---|
+| `<sample>/` | Orchestrator — declares process list in code, launches all | `xr-ai-launcher` only (stdlib) |
+| `<sample>/worker/` | Agent worker — connects to hub via IPC, runs agent logic | `xr-ai-agent`, numpy, etc. |
+
+**Config convention** — the YAML config path for each process is declared
+explicitly in the orchestrator's `PROCESSES` list via the `config=` field of
+`Process`. The launcher passes it as `--config <path>` to the subprocess.
+All sample configs live in the `yaml/` directory. Omit `config=` for
+processes that use their own internal defaults.
+
+The orchestrator declares the process sequence in code:
+
+```python
+_BASE = Path(__file__).resolve().parent   # sample root
+
+PROCESSES = [
+    Process("hub",    "../../server-runtime", "xr_media_hub",
+            config="yaml/xr_media_hub.yaml"),
+    Process("worker", "worker",               "my_agent_worker",
+            config="yaml/my_agent_worker.yaml"),
+    # Optional shared components — add as needed:
+    # Process("cloudxr", "../../cloudxr-runtime",       "cloudxr_runtime",
+    #         config="yaml/cloudxr_runtime.yaml"),
+    # Process("mcp",     "../../agent-mcp-servers/oxr-mcp", "oxr_mcp_server",
+    #         config="yaml/oxr_mcp_server.yaml"),
+]
+
+def run() -> None:
+    run_stack(PROCESSES, _BASE)
+```
+
+## Rules
+
+- **Processes start serially** — each process must create its `--ready-file`
+  before the next one starts. Declare processes in dependency order (hub
+  before workers, cloudxr before MCP servers that open OpenXR sessions, etc.).
+- **Every process accepts `--ready-file <path>`** and must `Path(path).touch()`
+  when it is fully initialized and ready to serve requests.
+- `xr_media_hub` always runs as its own process — never embedded in-process.
+- The worker never imports anything from `server-runtime` or `utils/xr-ai-launcher/`.
+- Process management lives in `utils/xr-ai-launcher/`, not inside any process it manages.
+- `run_stack` is fail-fast: if any process exits, the rest are terminated.
+
+## Serial and parallel items
+
+The stack is declared as a sequence of `Process` or `Parallel` items:
+
+- `Process` — started alone; the launcher waits for it to signal ready before
+  moving on.
+- `Parallel([p1, p2, ...])` — all processes in the group are started at once;
+  the launcher waits for *every* member to signal ready before the next item
+  in the sequence begins. If any member exits before signaling ready, the
+  launcher shuts everything down, just as it would for a serial process.
+
+```python
+PROCESSES = [
+    Process("hub",    "../../server-runtime", "xr_media_hub"),
+    Parallel([
+        Process("stt", "../../ai-services/stt-server", "stt_server"),
+        Process("tts", "../../ai-services/tts/piper",  "piper_tts_server"),
+    ]),
+    Process("worker", "worker", "my_agent_worker"),
+]
+```
+
+## How `run_stack` works
+
+For each process the launcher:
+
+1. Resolves the project directory and YAML config from the sample root (`base`
+   — all relative paths in `Process.project` and `Process.config` are resolved
+   against it).
+2. Spawns `uv run --project <dir> <command> --config <yaml> --ready-file <f>`
+   in a new process group, so the whole group (`uv` plus its children) can be
+   torn down together rather than leaving orphans.
+3. Waits for the process to create *<f>* (the ready file), printing a progress
+   line every five seconds so slow starts remain visible.
+4. Once all processes are ready, monitors them: any exit triggers a graceful
+   shutdown of the rest (SIGTERM, escalating to SIGKILL after a timeout).
+
+Each process is responsible for creating its own ready file at the moment it
+is fully initialized and able to serve requests — after model warm-up, after
+the IPC socket connects, after the HTTP server starts listening, etc.
+
+Pass `exit_after_ready=True` to `run_stack` to return immediately once
+everything is ready instead of monitoring — useful for launchers whose
+processes are all `launch_mode="persist"` and should outlive the orchestrator
+(e.g. `model-servers`).
+
+### The `--ready-file` protocol
+
+The launcher injects `--ready-file <path>` into every spawned command. The
+process must `Path(path).touch()` the moment it is fully initialized and able
+to serve requests. The launcher blocks on the file's existence; if the process
+exits before creating it, startup is aborted and the whole stack is torn down.
+This makes readiness explicit and process-defined: a model server signals ready
+after weights load, an HTTP server after it starts listening, a worker after
+its IPC socket connects.
+
+### `launch_mode`: own, persist, reuse
+
+`Process.launch_mode` controls spawn and shutdown behaviour:
+
+- `"own"` (default) — the launcher spawns this process and kills it on
+  shutdown.
+- `"persist"` — the launcher spawns this process but leaves it running on
+  shutdown. Use for heavy model servers that should survive stack restarts
+  (e.g. vLLM containers). Cleanup is the caller's responsibility. The optional
+  `port` field is used to stop such persistent services.
+- `"reuse"` — the launcher does **not** spawn this process; it is assumed to be
+  already running (e.g. started by `model-servers`). The entry in the process
+  list documents the dependency; the launcher skips it entirely and does not
+  kill it on shutdown.
+
+On a clean ready-exit, `persist` and `reuse` processes are left running. On an
+abort during startup (Ctrl-C, or a process exiting before it signals ready)
+the launcher tears down **everything**, including `persist` processes, so no
+half-started service is left behind.
+
+## Adding a new managed process
+
+There is no per-process launcher module to write — the launcher spawns any uv
+sub-project generically. To add a new process to a stack:
+
+1. Make the sub-project's entry-point command accept `--ready-file <path>`
+   (touch it once ready) and, if it takes config, `--config <path>`.
+2. Add a `Process` (or `Parallel`) entry to the orchestrator's `PROCESSES`
+   list, in dependency order, pointing at the sub-project directory and its
+   entry-point command — exactly like the `hub` and `worker` entries above.
+
+## Shared `utils/` packages
+
+The orchestrator's process management and several cross-cutting concerns live
+in single-purpose packages under `utils/`. Each is small and narrowly scoped,
+and most are deliberately dependency-light so they can be added to any
+sub-project without dragging in a heavy dependency chain.
+
+**`xr-ai-launcher`** — process management for the xr-ai stack: the `Process`,
+`Parallel`, and `run_stack` API described above, plus helpers for CloudXR
+environment setup, credential loading, and GPU detection. Intentionally
+stdlib-only so it can be added to any sample without pulling in the dependency
+chain of the processes it manages.
+
+**`xr-ai-logging`** — shared loguru setup for the monorepo. Every process calls
+`setup_logging()` once at startup to get a unified logging stack: a stderr sink
+(level controlled by `XR_AI_VERBOSE`), a DEBUG file sink under
+`/tmp/log_<namespace>_<timestamp>/`, and a stdlib bridge that routes records
+emitted via `logging.getLogger(...)` into loguru — so stdlib-only packages
+(`xr-ai-launcher`) and the agent SDK end up in the same sinks. The orchestrator
+stamps namespace/timestamp/root env vars so all spawned subprocesses write into
+the same per-run folder.
+
+**`xr-ai-vad`** — shared Silero-VAD utterance detector for agent workers. It
+consumes int16 LE PCM audio and emits int16 PCM utterance bytes via an async
+callback when speech ends, so workers get a single, consistent voice-activity
+boundary without each re-implementing VAD.
+
+**`xr-ai-voicegate`** — the speech-only opt-in gate shared by agent workers.
+It owns the magic-phrase, follow-up, and STOP ladder, the lazy listening chime,
+and the participant-joined greeting hook. Workers feed STT transcripts via
+`feed` and register handlers for the events it emits (query, stop, phrase-only,
+drop, participant-joined).
+
+**`xr-ai-vllm`** — pluggable vLLM backend for inference services. Each
+vLLM-backed service can host vllm via `pip` (the pip-installed `vllm` CLI in
+the wrapper's venv, the default) or `docker` (`docker run nvcr.io/nvidia/vllm`,
+an NGC container), chosen per-server via `vllm_backend: pip|docker` in the
+service YAML. Both paths honor identical config keys; only the runtime hosting
+vllm differs. Stdlib-only by contract, so the docker path stays light even when
+pip vllm is not installed.
+
+**`xr-ai-nemo-runtime`** — opt-in NGC NeMo container backend for the in-process
+NeMo servers (the STT server and the Magpie TTS server). The NeMo servers load
+torch+NeMo in the wrapper's venv and inherit the host's cuDNN/CUDA via
+`LD_LIBRARY_PATH`, which aborts at torch import on hosts whose system cuDNN
+differs from torch's bundled one. This runs the same FastAPI server inside an
+NGC NeMo image instead — so torch, NeMo, and cuDNN all come from the container
+and the host's libraries are irrelevant — opted into per-server via
+`backend: docker` in the service YAML (default `pip` keeps the in-venv
+behavior). It is a bespoke NeMo docker path, deliberately separate from
+`xr-ai-vllm`, and is stdlib-only by contract.

--- a/docs/source/components/server-runtime.md
+++ b/docs/source/components/server-runtime.md
@@ -1,0 +1,12 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Server runtime
+
+The `server-runtime/` package hosts the **XR-Media-Hub** and the internal
+LiveKit transport — the entry point clients connect to.
+
+This page is a placeholder seeded by the docs scaffold; the full component
+reference is filled in by the components documentation units.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sphinx configuration for the XR-AI documentation site.
+
+Mirrors the NVIDIA/IsaacTeleop docs setup: the NVIDIA Sphinx theme + MyST so
+the existing Markdown under ``docs/`` is reused directly. Single-version for
+now; ``sphinx-multiversion`` is a deliberate follow-up (see docs changelog).
+"""
+from __future__ import annotations
+
+# -- Project information -----------------------------------------------------
+project = "XR-AI"
+copyright = "2026, NVIDIA CORPORATION & AFFILIATES"
+author = "NVIDIA"
+
+# -- General configuration ---------------------------------------------------
+extensions = [
+    "myst_parser",
+    "sphinx_copybutton",
+    "sphinx_design",
+    "sphinx.ext.githubpages",
+    "sphinx.ext.intersphinx",
+]
+
+# MyST Markdown is the page format (matches the repo's existing docs/*.md).
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
+
+myst_enable_extensions = [
+    "colon_fence",
+    "deflist",
+    "linkify",
+    "substitution",
+]
+myst_heading_anchors = 3
+
+# Don't choke the build on the bundled long-form changelog or build output.
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# -- HTML output -------------------------------------------------------------
+html_theme = "nvidia_sphinx_theme"
+html_show_sphinx = False
+html_title = "XR-AI"

--- a/docs/source/getting_started/index.md
+++ b/docs/source/getting_started/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Getting Started
+
+Requirements, the quickstart paths, connecting clients, networking, and credentials.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -1,0 +1,13 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Quickstart
+
+Every sample follows the same pattern: **start the server, then connect a
+client.** The three primary paths are the shared model servers, the
+`simple-vlm-example`, and the `xr-render-demo`.
+
+This page is a placeholder seeded by the docs scaffold; the full quickstart is
+ported from the repository README.

--- a/docs/source/guides/index.md
+++ b/docs/source/guides/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Guides
+
+How-to guides: adding a sample, wiring CloudXR, troubleshooting, and contribution conventions.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/guides/troubleshooting.md
+++ b/docs/source/guides/troubleshooting.md
@@ -1,0 +1,11 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Troubleshooting
+
+Common setup and runtime frictions and their fixes.
+
+This page is a placeholder seeded by the docs scaffold; the full
+troubleshooting guide is ported from the repository's existing notes.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,0 +1,24 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# XR-AI
+
+Agentic AI for XR — an open-source foundation for multi-modal, real-time
+conversational AI within the CloudXR ecosystem.
+
+XR-AI connects web, iOS/visionOS, AR-glasses, and XR-headset clients to
+GPU-accelerated AI services, tool-using agents, and the CloudXR stack for remote
+rendering. This site documents the architecture, how to run the samples, each
+component, and the reference material for building on the stack.
+
+```{toctree}
+:maxdepth: 2
+
+overview/index
+getting_started/index
+components/index
+guides/index
+reference/index
+```

--- a/docs/source/overview/architecture.md
+++ b/docs/source/overview/architecture.md
@@ -1,0 +1,16 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Architecture
+
+XR-AI follows a **one hub, many clients, many agents** model. The
+**XR-Media-Hub** (server runtime) fans each client's inbound media to every
+agent and routes return traffic back to the originating client only. Clients
+reach the hub over a transport (LiveKit internally), agents attach over an IPC
+boundary, and MCP servers are the agent's only interface to XR data and
+rendering.
+
+This page is a placeholder seeded by the docs scaffold; the full architecture
+write-up is ported from the repository's existing architecture notes.

--- a/docs/source/overview/index.md
+++ b/docs/source/overview/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Overview
+
+What XR-AI is, the layer model, and how the hub, transport, and agents fit together.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```

--- a/docs/source/reference/changelog.md
+++ b/docs/source/reference/changelog.md
@@ -1,0 +1,12 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Decision changelog
+
+XR-AI records every non-trivial architectural or design decision, newest first,
+so the rationale is preserved. The canonical log lives in the repository at
+`docs/changelog.md`.
+
+This page is a placeholder seeded by the docs scaffold.

--- a/docs/source/reference/index.md
+++ b/docs/source/reference/index.md
@@ -1,0 +1,15 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Reference
+
+Deep references: the xr-render-demo stack and the decision changelog.
+
+```{toctree}
+:glob:
+:maxdepth: 1
+
+*
+```


### PR DESCRIPTION
## What

Adds `docs/source/components/launcher-and-process-model.md` to the Sphinx docs site:

- **Full port of `docs/process-model.md`** — two-sub-project layout, config convention, `PROCESSES`/`run_stack` mechanics, the serial/`Parallel` model, the `--ready-file` protocol, and `launch_mode` (own/persist/reuse), all reconciled against `utils/xr-ai-launcher/xr_ai_launcher/_stack.py`.
- **New `utils/` packages subsection** — one paragraph each for `xr-ai-launcher`, `xr-ai-logging`, `xr-ai-vad`, `xr-ai-voicegate`, `xr-ai-vllm`, and `xr-ai-nemo-runtime`, sourced from each package's docstrings.

The page is auto-included via the components `index.md` `:glob:` toctree (no index edit needed).

## Correctness note

The original `docs/process-model.md` "Adding a new managed process type" section was stale — it referenced a non-existent `_hub.py` and described `ManagedProcess` as a base class. Per the "port + read the code" convention, this page corrects it: the launcher spawns uv sub-projects generically (`_spawn` → `uv run … --config … --ready-file …`), so adding a process means giving a sub-project a `--ready-file`-aware entry point and adding a `Process` entry to `PROCESSES`. `ManagedProcess` is in fact an internal `@asynccontextmanager` helper used by render-mcp to spawn LOVR, not a stack extension point.

## Base / scaffold dependency

This branch is based on the unmerged `docs/sphinx-scaffold` branch (PR #220). Until that merges, this PR's diff against `main` shows the scaffold files plus this page. Once #220 merges, rebasing will leave only `launcher-and-process-model.md`.

## Test

E2E doc build gate passes clean:

```
sphinx-build -W --keep-going -b html docs/source docs/_build
```

Exit 0, zero warnings; the page renders in the build output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)