### PR TITLE
ci(nightly): pause/restart GPU host via Brev CLI + alert on failure

### DIFF
--- a/.github/workflows/nightly-xr-ai-test.yml
+++ b/.github/workflows/nightly-xr-ai-test.yml
@@ -82,6 +82,9 @@ jobs:
         # but failing here gives a clearer error than a stuck queue).
         run: |
           set -euo pipefail
+          echo "--- brev ls (raw, for diagnosis) ---"
+          brev ls || true
+          echo "------------------------------------"
           for i in $(seq 1 60); do
             line=$(brev ls | grep -iw "$BREV_INSTANCE_NAME" || true)
             echo "[$i] ${line:-<$BREV_INSTANCE_NAME not found in brev ls>}"

--- a/.github/workflows/nightly-xr-ai-test.yml
+++ b/.github/workflows/nightly-xr-ai-test.yml
@@ -96,20 +96,18 @@ jobs:
         # but failing here gives a clearer error than a stuck queue).
         run: |
           set -euo pipefail
-          echo "--- brev ls (raw, for diagnosis) ---"
-          brev ls || true
-          echo "------------------------------------"
           for i in $(seq 1 60); do
-            line=$(brev ls | grep -iw "$BREV_INSTANCE_NAME" || true)
-            echo "[$i] ${line:-<$BREV_INSTANCE_NAME not found in brev ls>}"
-            if echo "$line" | grep -qi "RUNNING"; then
-              echo "Instance $BREV_INSTANCE_NAME is RUNNING."
+            # grep by name keeps other orgs' instance names out of the
+            # log; report just this instance's status field.
+            status=$(brev ls | grep -iw "$BREV_INSTANCE_NAME" | grep -oiE 'RUNNING|STOPPED|STARTING|STOPPING|FAILED' | head -n1 || true)
+            echo "[$i] $BREV_INSTANCE_NAME status: ${status:-<not found>}"
+            if [[ "$status" == "RUNNING" ]]; then
+              echo "Instance is RUNNING."
               exit 0
             fi
             sleep 15
           done
           echo "::error::Timed out waiting for $BREV_INSTANCE_NAME to reach RUNNING"
-          brev ls
           exit 1
 
   pytest:

--- a/.github/workflows/nightly-xr-ai-test.yml
+++ b/.github/workflows/nightly-xr-ai-test.yml
@@ -19,7 +19,7 @@ name: nightly XR AI test
 #
 # Required repo config (Settings -> Secrets and variables -> Actions):
 #   secret  BREV_API_TOKEN      — token for headless `brev login --token`
-#   var     BREV_INSTANCE_NAME  — name of the GPU Brev instance to manage
+#   secret  BREV_INSTANCE_NAME  — name of the GPU Brev instance to manage
 
 on:
   schedule:
@@ -44,7 +44,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  BREV_INSTANCE_NAME: ${{ vars.BREV_INSTANCE_NAME }}
+  BREV_INSTANCE_NAME: ${{ secrets.BREV_INSTANCE_NAME }}
 
 jobs:
   start:

--- a/.github/workflows/nightly-xr-ai-test.yml
+++ b/.github/workflows/nightly-xr-ai-test.yml
@@ -53,7 +53,11 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Install Brev CLI
-        run: sudo bash -c "$(curl -fsSL https://raw.githubusercontent.com/brevdev/brev-cli/main/bin/install-latest.sh)"
+        # The installer drops the binary in $HOME/.local/bin (no sudo);
+        # add it to $GITHUB_PATH so later steps in this job find `brev`.
+        run: |
+          bash -c "$(curl -fsSL https://raw.githubusercontent.com/brevdev/brev-cli/main/bin/install-latest.sh)"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Brev login
         env:
@@ -219,7 +223,11 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Install Brev CLI
-        run: sudo bash -c "$(curl -fsSL https://raw.githubusercontent.com/brevdev/brev-cli/main/bin/install-latest.sh)"
+        # The installer drops the binary in $HOME/.local/bin (no sudo);
+        # add it to $GITHUB_PATH so later steps in this job find `brev`.
+        run: |
+          bash -c "$(curl -fsSL https://raw.githubusercontent.com/brevdev/brev-cli/main/bin/install-latest.sh)"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Brev login
         env:

--- a/.github/workflows/nightly-xr-ai-test.yml
+++ b/.github/workflows/nightly-xr-ai-test.yml
@@ -11,16 +11,25 @@ name: nightly XR AI test
 #
 # The GPU host is a Brev instance that is kept *stopped* between runs to
 # save GPU cost. The job graph is therefore:
-#   start (ubuntu-latest) -> pytest (gpu) -> stop (ubuntu-latest)
-# The Brev CLI calls run on GitHub-hosted runners because the GPU runner
-# itself is asleep before `start` and is being paused by `stop`. The
+#   start (brev-controller) -> pytest (gpu) -> stop (brev-controller)
+# The Brev CLI calls run on a separate, always-on "controller" VM (a
+# small self-hosted runner labelled `brev-controller`) that is already
+# `brev login`'d — the GPU runner itself is asleep before `start` and is
+# being paused by `stop`, so it can't run its own lifecycle commands, and
+# the controller's persistent login avoids needing a CLI token in CI. The
 # `stop` job runs even when the tests fail so a bad run never leaves the
 # instance billing.
 #
+# Runner setup:
+#   - `gpu`             — self-hosted runner on the GPU Brev instance.
+#   - `brev-controller` — self-hosted runner on the always-on VM that has
+#                         the Brev CLI installed and is logged in.
+#
 # Required repo config (Settings -> Secrets and variables -> Actions):
-#   secret  BREV_API_TOKEN      — token for headless `brev login --token`
 #   secret  BREV_INSTANCE_NAME  — name of the GPU Brev instance to manage
-#   secret  BREV_ORG            — org the instance lives in (`brev set`)
+#   secret  BREV_ORG            — (optional) org the instance lives in;
+#                                 set only if the controller isn't already
+#                                 pinned to it (`brev set`)
 
 on:
   schedule:
@@ -51,25 +60,18 @@ env:
 jobs:
   start:
     name: start brev instance
-    runs-on: ubuntu-latest
+    # Runs on the always-on controller VM, which already has the Brev CLI
+    # installed and is logged in — no install/login/token step needed.
+    runs-on: brev-controller
     timeout-minutes: 20
     steps:
-      - name: Install Brev CLI
-        # The installer drops the binary in $HOME/.local/bin (no sudo);
-        # add it to $GITHUB_PATH so later steps in this job find `brev`.
-        run: |
-          bash -c "$(curl -fsSL https://raw.githubusercontent.com/brevdev/brev-cli/main/bin/install-latest.sh)"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
-      - name: Brev login
-        env:
-          BREV_API_TOKEN: ${{ secrets.BREV_API_TOKEN }}
-        run: brev login --token "$BREV_API_TOKEN"
-
       - name: Select org
-        # Login defaults to the personal org; the GPU instance lives in
-        # BREV_ORG, so switch before ls/start.
-        run: brev set "$BREV_ORG"
+        # The controller is normally already pinned to the right org;
+        # switch only if BREV_ORG is provided.
+        run: |
+          if [[ -n "${BREV_ORG:-}" ]]; then
+            brev set "$BREV_ORG"
+          fi
 
       - name: Start instance
         run: |
@@ -234,25 +236,16 @@ jobs:
     # out, so a bad run never leaves the GPU billing. `keep_running` lets
     # a manual `workflow_dispatch` hold the box up for debugging.
     if: always() && inputs.keep_running != true
-    runs-on: ubuntu-latest
+    runs-on: brev-controller
     timeout-minutes: 15
     steps:
-      - name: Install Brev CLI
-        # The installer drops the binary in $HOME/.local/bin (no sudo);
-        # add it to $GITHUB_PATH so later steps in this job find `brev`.
-        run: |
-          bash -c "$(curl -fsSL https://raw.githubusercontent.com/brevdev/brev-cli/main/bin/install-latest.sh)"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
-      - name: Brev login
-        env:
-          BREV_API_TOKEN: ${{ secrets.BREV_API_TOKEN }}
-        run: brev login --token "$BREV_API_TOKEN"
-
       - name: Select org
-        # Login defaults to the personal org; the GPU instance lives in
-        # BREV_ORG, so switch before stop.
-        run: brev set "$BREV_ORG"
+        # The controller is normally already pinned to the right org;
+        # switch only if BREV_ORG is provided.
+        run: |
+          if [[ -n "${BREV_ORG:-}" ]]; then
+            brev set "$BREV_ORG"
+          fi
 
       - name: Stop instance
         run: |

--- a/.github/workflows/nightly-xr-ai-test.yml
+++ b/.github/workflows/nightly-xr-ai-test.yml
@@ -69,6 +69,7 @@ jobs:
         # The controller is normally already pinned to the right org;
         # switch only if BREV_ORG is provided.
         run: |
+          set -euo pipefail
           if [[ -n "${BREV_ORG:-}" ]]; then
             brev set "$BREV_ORG"
           fi
@@ -250,6 +251,7 @@ jobs:
         # The controller is normally already pinned to the right org;
         # switch only if BREV_ORG is provided.
         run: |
+          set -euo pipefail
           if [[ -n "${BREV_ORG:-}" ]]; then
             brev set "$BREV_ORG"
           fi
@@ -272,10 +274,14 @@ jobs:
   notify:
     name: alert on failure
     needs: [start, pytest, stop]
-    # Fire whenever any job above failed (a timeout counts as a failure)
-    # so a broken nightly is visible without anyone polling the Actions
-    # tab. Skip on PRs — those are pre-merge dry-runs, not the nightly.
-    if: failure() && github.event_name != 'pull_request'
+    # Fire whenever any job above failed OR was cancelled so a broken
+    # nightly is visible without anyone polling the Actions tab. A
+    # timeout-minutes hit concludes as `cancelled`, not `failure`, so
+    # failure() alone would silently skip the alert on the most important
+    # case. Skip on PRs — those are pre-merge dry-runs, not the nightly.
+    if: >-
+      (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
+      && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/nightly-xr-ai-test.yml
+++ b/.github/workflows/nightly-xr-ai-test.yml
@@ -20,6 +20,7 @@ name: nightly XR AI test
 # Required repo config (Settings -> Secrets and variables -> Actions):
 #   secret  BREV_API_TOKEN      — token for headless `brev login --token`
 #   secret  BREV_INSTANCE_NAME  — name of the GPU Brev instance to manage
+#   secret  BREV_ORG            — org the instance lives in (`brev set`)
 
 on:
   schedule:
@@ -45,6 +46,7 @@ concurrency:
 
 env:
   BREV_INSTANCE_NAME: ${{ secrets.BREV_INSTANCE_NAME }}
+  BREV_ORG: ${{ secrets.BREV_ORG }}
 
 jobs:
   start:
@@ -63,6 +65,11 @@ jobs:
         env:
           BREV_API_TOKEN: ${{ secrets.BREV_API_TOKEN }}
         run: brev login --token "$BREV_API_TOKEN"
+
+      - name: Select org
+        # Login defaults to the personal org; the GPU instance lives in
+        # BREV_ORG, so switch before ls/start.
+        run: brev set "$BREV_ORG"
 
       - name: Start instance
         run: |
@@ -236,6 +243,11 @@ jobs:
         env:
           BREV_API_TOKEN: ${{ secrets.BREV_API_TOKEN }}
         run: brev login --token "$BREV_API_TOKEN"
+
+      - name: Select org
+        # Login defaults to the personal org; the GPU instance lives in
+        # BREV_ORG, so switch before stop.
+        run: brev set "$BREV_ORG"
 
       - name: Stop instance
         run: |

--- a/.github/workflows/nightly-xr-ai-test.yml
+++ b/.github/workflows/nightly-xr-ai-test.yml
@@ -8,13 +8,31 @@ name: nightly XR AI test
 # filtered out of the default `tests` workflow (which targets
 # `ubuntu-latest`). Mirrors the local `tests/run_local_gpu_tests.sh`
 # entry point.
+#
+# The GPU host is a Brev instance that is kept *stopped* between runs to
+# save GPU cost. The job graph is therefore:
+#   start (ubuntu-latest) -> pytest (gpu) -> stop (ubuntu-latest)
+# The Brev CLI calls run on GitHub-hosted runners because the GPU runner
+# itself is asleep before `start` and is being paused by `stop`. The
+# `stop` job runs even when the tests fail so a bad run never leaves the
+# instance billing.
+#
+# Required repo config (Settings -> Secrets and variables -> Actions):
+#   secret  BREV_API_TOKEN      — token for headless `brev login --token`
+#   var     BREV_INSTANCE_NAME  — name of the GPU Brev instance to manage
 
 on:
   schedule:
     - cron: "0 4 * * *"  # 04:00 UTC daily
   workflow_dispatch:
+    inputs:
+      keep_running:
+        description: "Leave the Brev instance running after the tests (skip the stop job)"
+        type: boolean
+        default: false
   # Also fire on PRs that edit this workflow itself, so changes to the
-  # CI definition get exercised against the GPU runner before merge.
+  # CI definition — including the Brev start/stop wiring — get exercised
+  # end-to-end against the GPU runner before merge.
   pull_request:
     paths:
       - .github/workflows/nightly-xr-ai-test.yml
@@ -25,9 +43,57 @@ concurrency:
   group: nightly-xr-ai-test
   cancel-in-progress: false
 
+env:
+  BREV_INSTANCE_NAME: ${{ vars.BREV_INSTANCE_NAME }}
+
 jobs:
+  start:
+    name: start brev instance
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Install Brev CLI
+        run: sudo bash -c "$(curl -fsSL https://raw.githubusercontent.com/brevdev/brev-cli/main/bin/install-latest.sh)"
+
+      - name: Brev login
+        env:
+          BREV_API_TOKEN: ${{ secrets.BREV_API_TOKEN }}
+        run: brev login --token "$BREV_API_TOKEN"
+
+      - name: Start instance
+        run: |
+          set -euo pipefail
+          if [[ -z "${BREV_INSTANCE_NAME:-}" ]]; then
+            echo "::error::BREV_INSTANCE_NAME repo variable is not set"
+            exit 1
+          fi
+          echo "Starting Brev instance: $BREV_INSTANCE_NAME"
+          brev start "$BREV_INSTANCE_NAME"
+
+      - name: Wait until RUNNING
+        # `brev start` returns before the VM is fully up and the GitHub
+        # Actions runner service has re-registered. Poll `brev ls` until
+        # the instance reports RUNNING so the `pytest` job has a live
+        # `gpu` runner to land on (GitHub queues it until then anyway,
+        # but failing here gives a clearer error than a stuck queue).
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 60); do
+            line=$(brev ls | grep -iw "$BREV_INSTANCE_NAME" || true)
+            echo "[$i] ${line:-<$BREV_INSTANCE_NAME not found in brev ls>}"
+            if echo "$line" | grep -qi "RUNNING"; then
+              echo "Instance $BREV_INSTANCE_NAME is RUNNING."
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "::error::Timed out waiting for $BREV_INSTANCE_NAME to reach RUNNING"
+          brev ls
+          exit 1
+
   pytest:
     name: pytest (gpu)
+    needs: start
     runs-on: gpu
     timeout-minutes: 60
 
@@ -141,3 +207,31 @@ jobs:
           else
             echo "No xr-ai-vllm-* containers to remove."
           fi
+
+  stop:
+    name: stop brev instance
+    needs: [start, pytest]
+    # Pause the instance even when the tests fail or the start job errors
+    # out, so a bad run never leaves the GPU billing. `keep_running` lets
+    # a manual `workflow_dispatch` hold the box up for debugging.
+    if: always() && inputs.keep_running != true
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Install Brev CLI
+        run: sudo bash -c "$(curl -fsSL https://raw.githubusercontent.com/brevdev/brev-cli/main/bin/install-latest.sh)"
+
+      - name: Brev login
+        env:
+          BREV_API_TOKEN: ${{ secrets.BREV_API_TOKEN }}
+        run: brev login --token "$BREV_API_TOKEN"
+
+      - name: Stop instance
+        run: |
+          set -euo pipefail
+          if [[ -z "${BREV_INSTANCE_NAME:-}" ]]; then
+            echo "::error::BREV_INSTANCE_NAME repo variable is not set"
+            exit 1
+          fi
+          echo "Stopping Brev instance: $BREV_INSTANCE_NAME"
+          brev stop "$BREV_INSTANCE_NAME"

--- a/.github/workflows/nightly-xr-ai-test.yml
+++ b/.github/workflows/nightly-xr-ai-test.yml
@@ -78,8 +78,15 @@ jobs:
             echo "::error::BREV_INSTANCE_NAME repo variable is not set"
             exit 1
           fi
-          echo "Starting Brev instance: $BREV_INSTANCE_NAME"
-          brev start "$BREV_INSTANCE_NAME"
+          # `brev start` errors if the instance is already RUNNING, so
+          # make this idempotent — skip when it's already up (e.g. a
+          # previous run left it on, or a manual `keep_running`).
+          if brev ls | grep -iw "$BREV_INSTANCE_NAME" | grep -qi "RUNNING"; then
+            echo "$BREV_INSTANCE_NAME is already RUNNING; skipping start."
+          else
+            echo "Starting Brev instance: $BREV_INSTANCE_NAME"
+            brev start "$BREV_INSTANCE_NAME"
+          fi
 
       - name: Wait until RUNNING
         # `brev start` returns before the VM is fully up and the GitHub
@@ -256,5 +263,10 @@ jobs:
             echo "::error::BREV_INSTANCE_NAME repo variable is not set"
             exit 1
           fi
-          echo "Stopping Brev instance: $BREV_INSTANCE_NAME"
-          brev stop "$BREV_INSTANCE_NAME"
+          # Idempotent: don't error out if it's already stopped.
+          if brev ls | grep -iw "$BREV_INSTANCE_NAME" | grep -qi "RUNNING"; then
+            echo "Stopping Brev instance: $BREV_INSTANCE_NAME"
+            brev stop "$BREV_INSTANCE_NAME"
+          else
+            echo "$BREV_INSTANCE_NAME is not RUNNING; nothing to stop."
+          fi

--- a/.github/workflows/nightly-xr-ai-test.yml
+++ b/.github/workflows/nightly-xr-ai-test.yml
@@ -268,3 +268,40 @@ jobs:
           else
             echo "$BREV_INSTANCE_NAME is not RUNNING; nothing to stop."
           fi
+
+  notify:
+    name: alert on failure
+    needs: [start, pytest, stop]
+    # Fire whenever any job above failed (a timeout counts as a failure)
+    # so a broken nightly is visible without anyone polling the Actions
+    # tab. Skip on PRs — those are pre-merge dry-runs, not the nightly.
+    if: failure() && github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update tracking issue
+        # Update-don't-stack: comment on the open tracking issue if one
+        # exists, otherwise open a fresh one. One issue accumulates the
+        # run links until someone fixes it and closes it.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          LABEL="nightly-failure"
+          TITLE="Nightly XR AI test is failing"
+          gh label create "$LABEL" --color B60205 \
+            --description "Automated nightly GPU test failures" 2>/dev/null || true
+          body=$(printf 'Nightly run **failed** (event: %s, commit \x60%s\x60).\n\n- Run: %s' \
+            "$GITHUB_EVENT_NAME" "${GITHUB_SHA:0:7}" "$RUN_URL")
+          existing=$(gh issue list --state open --label "$LABEL" \
+            --json number --jq '.[0].number' || true)
+          if [[ -n "$existing" ]]; then
+            echo "Commenting on existing issue #$existing"
+            gh issue comment "$existing" --body "$body"
+          else
+            echo "Opening new tracking issue"
+            gh issue create --title "$TITLE" --label "$LABEL" --body "$body"
+          fi

--- a/.github/workflows/nightly-xr-ai-test.yml
+++ b/.github/workflows/nightly-xr-ai-test.yml
@@ -3,33 +3,14 @@
 
 name: nightly XR AI test
 
-# Runs the `gpu`-marked pytest suite on a self-hosted runner labelled
-# `gpu`. These tests need real GPU / Docker / NVENC hardware and are
-# filtered out of the default `tests` workflow (which targets
-# `ubuntu-latest`). Mirrors the local `tests/run_local_gpu_tests.sh`
-# entry point.
+# Runs the `gpu`-marked pytest suite on a self-hosted GPU runner — these
+# tests need real GPU / Docker / NVENC hardware, so they're filtered out of
+# the default `tests` workflow (ubuntu-latest). Mirrors the local
+# `tests/run_local_gpu_tests.sh` entry point.
 #
-# The GPU host is a Brev instance that is kept *stopped* between runs to
-# save GPU cost. The job graph is therefore:
-#   start (brev-controller) -> pytest (gpu) -> stop (brev-controller)
-# The Brev CLI calls run on a separate, always-on "controller" VM (a
-# small self-hosted runner labelled `brev-controller`) that is already
-# `brev login`'d — the GPU runner itself is asleep before `start` and is
-# being paused by `stop`, so it can't run its own lifecycle commands, and
-# the controller's persistent login avoids needing a CLI token in CI. The
-# `stop` job runs even when the tests fail so a bad run never leaves the
-# instance billing.
-#
-# Runner setup:
-#   - `gpu`             — self-hosted runner on the GPU Brev instance.
-#   - `brev-controller` — self-hosted runner on the always-on VM that has
-#                         the Brev CLI installed and is logged in.
-#
-# Required repo config (Settings -> Secrets and variables -> Actions):
-#   secret  BREV_INSTANCE_NAME  — name of the GPU Brev instance to manage
-#   secret  BREV_ORG            — (optional) org the instance lives in;
-#                                 set only if the controller isn't already
-#                                 pinned to it (`brev set`)
+# Setup note: the GPU runner's Docker needs the NVIDIA runtime registered
+# (`sudo nvidia-ctk runtime configure --runtime=docker`); without it the
+# vLLM tests fail at container launch.
 
 on:
   schedule:

--- a/.github/workflows/nightly-xr-ai-test.yml
+++ b/.github/workflows/nightly-xr-ai-test.yml
@@ -212,7 +212,14 @@ jobs:
 
       - name: Run gpu-marked tests
         working-directory: tests
-        run: uv run pytest -v --tb=short --color=yes -m gpu
+        # Per-test wall-clock guard so one hung test fails with a traceback
+        # instead of burning the 60-min job cap as a silent cancel. signal
+        # method interrupts blocked reads (thread method can't); 1200s > the
+        # 900s cold-start budget. pytest-timeout layered CI-only via --with
+        # to keep it out of tests/pyproject.toml + uv.lock + DEPENDENCIES.md.
+        run: >-
+          uv run --with pytest-timeout pytest -v --tb=short --color=yes -m gpu
+          --timeout=1200 --timeout-method=signal
 
       - name: Purge xr-ai-vllm containers (post)
         # Always-run cleanup so a failed test (or a cancelled job) does

--- a/.github/workflows/nightly-xr-ai-test.yml
+++ b/.github/workflows/nightly-xr-ai-test.yml
@@ -34,6 +34,14 @@ concurrency:
   group: nightly-xr-ai-test
   cancel-in-progress: false
 
+# Least-privilege default for every job; `notify` overrides with
+# `issues: write` for the tracking-issue step.
+permissions:
+  contents: read
+
+# Source of truth: repository **secrets** (Settings → Secrets and
+# variables → Actions → Secrets), not repo variables. The guard steps
+# below abort if BREV_INSTANCE_NAME resolves empty.
 env:
   BREV_INSTANCE_NAME: ${{ secrets.BREV_INSTANCE_NAME }}
   BREV_ORG: ${{ secrets.BREV_ORG }}
@@ -59,7 +67,7 @@ jobs:
         run: |
           set -euo pipefail
           if [[ -z "${BREV_INSTANCE_NAME:-}" ]]; then
-            echo "::error::BREV_INSTANCE_NAME repo variable is not set"
+            echo "::error::BREV_INSTANCE_NAME secret is not set"
             exit 1
           fi
           # `brev start` errors if the instance is already RUNNING, so
@@ -241,16 +249,50 @@ jobs:
         run: |
           set -euo pipefail
           if [[ -z "${BREV_INSTANCE_NAME:-}" ]]; then
-            echo "::error::BREV_INSTANCE_NAME repo variable is not set"
+            echo "::error::BREV_INSTANCE_NAME secret is not set"
             exit 1
           fi
-          # Idempotent: don't error out if it's already stopped.
-          if brev ls | grep -iw "$BREV_INSTANCE_NAME" | grep -qi "RUNNING"; then
-            echo "Stopping Brev instance: $BREV_INSTANCE_NAME"
-            brev stop "$BREV_INSTANCE_NAME"
-          else
-            echo "$BREV_INSTANCE_NAME is not RUNNING; nothing to stop."
+
+          # Capture `brev ls` outside the grep pipe so a failing CLI aborts
+          # the step instead of reading as "nothing to stop" and silently
+          # leaving the GPU billing. Errors go to stderr — this runs in a
+          # command substitution, so stdout would be captured into $status.
+          get_status() {
+            local ls_out rc=0
+            ls_out=$(brev ls 2>&1) || rc=$?
+            if [[ "$rc" -ne 0 ]]; then
+              echo "::error::\`brev ls\` failed (exit $rc):" >&2
+              echo "$ls_out" >&2
+              exit 1
+            fi
+            printf '%s\n' "$ls_out" | grep -iw "$BREV_INSTANCE_NAME" \
+              | grep -oiE 'RUNNING|STOPPED|STARTING|STOPPING|FAILED' | head -n1 || true
+          }
+
+          status=$(get_status)
+          echo "$BREV_INSTANCE_NAME status: ${status:-<not found>}"
+          # Skip only a confirmed STOPPED box; RUNNING or a transient
+          # STARTING/STOPPING must be stopped or it bills indefinitely.
+          if [[ "${status^^}" == "STOPPED" ]]; then
+            echo "$BREV_INSTANCE_NAME is already STOPPED; nothing to do."
+            exit 0
           fi
+
+          echo "Stopping Brev instance: $BREV_INSTANCE_NAME (status: ${status:-<not found>})"
+          brev stop "$BREV_INSTANCE_NAME"
+
+          # Re-verify: don't conclude success while it's still STOPPING.
+          for i in $(seq 1 20); do
+            status=$(get_status)
+            echo "[$i] $BREV_INSTANCE_NAME status: ${status:-<not found>}"
+            if [[ "${status^^}" == "STOPPED" ]]; then
+              echo "Instance is STOPPED."
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "::error::Timed out waiting for $BREV_INSTANCE_NAME to reach STOPPED"
+          exit 1
 
   notify:
     name: alert on failure
@@ -274,6 +316,8 @@ jobs:
         # run links until someone fixes it and closes it.
         env:
           GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          COMMIT_SHA: ${{ github.sha }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
@@ -282,7 +326,7 @@ jobs:
           gh label create "$LABEL" --color B60205 \
             --description "Automated nightly GPU test failures" 2>/dev/null || true
           body=$(printf 'Nightly run **failed** (event: %s, commit \x60%s\x60).\n\n- Run: %s' \
-            "$GITHUB_EVENT_NAME" "${GITHUB_SHA:0:7}" "$RUN_URL")
+            "$EVENT_NAME" "${COMMIT_SHA:0:7}" "$RUN_URL")
           existing=$(gh issue list --state open --label "$LABEL" \
             --json number --jq '.[0].number' || true)
           if [[ -n "$existing" ]]; then

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -38,6 +38,29 @@ App-side, `AppModel.startAudio` gained an
 locked mic-mode picker in `ContentView`) and reports an honest failure message
 instead of silently leaving the UI in a half-started state.
 
+### 2026-06-11 — nightly GPU host paused/restarted via Brev CLI, fail-loud on cost leaks
+
+The `gpu` runner sits on a billed Brev instance, so leaving it up between
+the 04:00 UTC nightly runs wastes GPU-hours. The workflow now brackets the
+pytest job with Brev lifecycle management on an always-on `brev-controller`
+runner: a `start` job idempotently boots the instance and polls `brev ls`
+until `RUNNING` before pytest lands on the `gpu` runner, and a `stop` job
+(`if: always() && inputs.keep_running != true`) pauses it afterward. A
+`keep_running` `workflow_dispatch` input holds the box up for debugging; a
+`notify` job opens/updates a single `nightly-failure` tracking issue when
+any prior job fails or is cancelled.
+
+The cost-leak guard is the point, so the `stop` job fails loudly rather than
+silently skipping: `brev ls` is captured outside the grep pipe (a failing
+CLI/auth/network call aborts the step instead of reading as "nothing to
+stop"), and any non-`STOPPED` state — including a transient
+`STARTING`/`STOPPING` left by a timed-out `start` — triggers `brev stop` and
+a re-poll until `STOPPED`. Either failure surfaces through `notify` instead
+of leaving the GPU billing unnoticed. `BREV_INSTANCE_NAME`/`BREV_ORG` are
+repository **secrets** (not variables); the guards abort if they resolve
+empty. The top-level token is `contents: read`, with `notify` overriding to
+`issues: write`.
+
 ### 2026-06-09 — render-mcp: scene resync survives a LOVR respawn (blocking send, not NOBLOCK)
 
 After a LOVR (re)start, `render-mcp` re-pushed every stored primitive via


### PR DESCRIPTION
## What

The nightly `gpu`-marked pytest suite now **boots and pauses its GPU host** (a [Brev](https://docs.nvidia.com/brev/cli/cli-overview) instance) so the box isn't billing between runs — and **alerts via a GitHub issue** if a run fails or times out.

## Job graph

```
start (brev-controller)  ->  pytest (gpu)  ->  stop (brev-controller)
                                              \-> notify (on failure)
```

The Brev lifecycle commands run on a **dedicated always-on "controller" VM** (a small self-hosted runner labelled `brev-controller`) that already has the Brev CLI installed and is `brev login`'d. This avoids a CLI token in CI (the headless `--token` path didn't work) and solves the bootstrap problem — the GPU runner is asleep before `start` and is being paused by `stop`, so it can't run its own lifecycle commands.

- **start** — `brev start` the instance (idempotent — skips if already RUNNING), then poll until it reports `RUNNING` so the self-hosted `gpu` runner has time to re-register.
- **pytest** — the existing test steps, unchanged (CUDA discovery, `uv`, container purge, `pytest -m gpu`). Now gated on `needs: start`.
- **stop** — `brev stop` with `if: always()`, so a failed test or a broken `start` never leaves the instance billing (also idempotent). A `keep_running` `workflow_dispatch` input skips this to hold the box up for debugging.
- **notify** — `if: failure()` on `ubuntu-latest`: opens (or comments on) a `nightly-failure` tracking issue so a broken/timed-out nightly is visible without anyone polling the Actions tab. Update-don't-stack; skipped on PRs.

## Runner setup

| Label | Where | Purpose |
|-------|-------|---------|
| `gpu` | the GPU Brev instance | runs the pytest suite |
| `brev-controller` | a separate always-on VM (Brev CLI installed + logged in) | runs the start/stop lifecycle jobs |

## Required repo config

Settings -> Secrets and variables -> Actions:

| Kind | Name | Value |
|------|------|-------|
| Secret | `BREV_INSTANCE_NAME` | name of the GPU Brev instance to start/stop |
| Secret | `BREV_ORG` | *(optional)* org the instance lives in; set only if the controller isn't already pinned to it |

No token secret is needed — the controller VM's persistent `brev login` handles auth, and the `notify` job uses the built-in `GITHUB_TOKEN` (job-level `permissions: issues: write`). If the org defaults workflow tokens to read-only, enable issue writes under Settings -> Actions -> General -> Workflow permissions.

## Notes

- The `pull_request` trigger (on edits to this file) is kept, so the full start->test->stop flow gets exercised end-to-end before merge. `notify` is skipped on PRs.
- The RUNNING poll greps `brev ls` by instance name so other orgs' instance names stay out of the logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)