### PR TITLE
fix(client-samples): camera re-entrancy + reconnect reset; doc StreamKit parity

### DIFF
--- a/client-samples/STREAMKIT_PARITY.md
+++ b/client-samples/STREAMKIT_PARITY.md
@@ -1,0 +1,19 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# StreamKit cross-platform API parity
+
+The three StreamKit client SDKs (web `web/StreamKit/`, iOS/visionOS
+`ios-visionos/StreamKit/`, Android `android/.../streamkit/`) are intended to
+mirror one another. A full-repo audit found the divergences below. Each is
+tagged **idiom** (intentional — follows the platform's idiom; leave as-is) or
+**to-fix** (a real gap to close in future native-client work).
+
+| Surface | web | iOS / visionOS | Android | Status | Notes |
+|---|---|---|---|---|---|
+| `send()` topic param | `send(data, { reliable, topic })` — supports a per-message `topic` | `send(_ data:, reliable:)` — no topic | `send(data, reliable)` — no topic | **to-fix** | Only the web XR client publishes on a named topic (`xr.session.started`, consumed by render-mcp). Native samples send untopiced `ping`/custom data, so the gap is currently invisible — but any native client that needs topic-routed signaling will require the param. |
+| `AudioConfig` fields | `mode`, `echoCancellation` | `mode`, `highpassFilter`, `typingNoiseDetection` | `mode` only | **idiom** | Each platform exposes the DSP knobs its capture stack actually supports (WebRTC `echoCancellation`; AVAudioSession `highpassFilter`/`typingNoiseDetection`; Android relies on the `MicrophoneMode` preset). `mode` is the shared cross-platform contract. |
+| `CameraConfig.default` facing | `default` → front-facing | `default` → front-facing | `DEFAULT` → back-facing | **idiom** | Mobile/desktop default to the selfie camera; Android's sample is built around the rear/primary camera (and a synthetic provider), so its default differs deliberately. The sample apps select a camera explicitly, so the differing default does not change observed behavior. |
+| `stopAudio()` error contract | `async stopAudio()` — does not throw | `func stopAudio() async throws` | `suspend fun stopAudio()` — does not throw | **idiom** | Swift surfaces teardown failures via `throws`; JS and Kotlin do not (Kotlin has no checked exceptions and the call is best-effort cleanup). Callers on all three already treat stop as fire-and-forget. |

--- a/client-samples/android/app/src/main/java/com/nvidia/xrai/streamkitsample/AppViewModel.kt
+++ b/client-samples/android/app/src/main/java/com/nvidia/xrai/streamkitsample/AppViewModel.kt
@@ -344,6 +344,10 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
 
     fun stopCamera() {
         viewModelScope.launch {
+            // Clear any in-flight start guard first: a reconnect-triggered stop
+            // must not leave isCameraStarting stuck true, or a later startCamera()
+            // would be blocked by the guard at the top of startCamera().
+            isCameraStarting = false
             // Stop the synthetic feed BEFORE unpublishing the track, so a
             // trailing frame can't lazily republish the injected track after
             // stopCamera() tore it down.

--- a/client-samples/android/app/src/main/java/com/nvidia/xrai/streamkitsample/AppViewModel.kt
+++ b/client-samples/android/app/src/main/java/com/nvidia/xrai/streamkitsample/AppViewModel.kt
@@ -108,6 +108,9 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
         private set
     var isCameraActive by mutableStateOf(false)
         private set
+    /** Guards the physical-camera start path so two rapid taps can't interleave
+     *  stopCamera/startCamera (mirrors iOS `isCameraStarting`). */
+    private var isCameraStarting = false
     var isConnecting by mutableStateOf(false)
         private set
     val receivedMessages = mutableStateListOf<ReceivedMessage>()
@@ -171,6 +174,13 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
                         isCameraActive = false
                         agentStatus = null
                         agentResponse = null
+                    } else if (state == ConnectionState.RECONNECTING) {
+                        // Session persists across a reconnect, so unpublish the
+                        // camera (and stop the synthetic feed) to resume from a
+                        // known-off state. stopCamera() launches its own
+                        // coroutine, the only place the suspending unpublish can
+                        // run from this non-suspend callback. Mirrors web.
+                        stopCamera()
                     }
                 }
                 newSession.onAgentStatus = { status ->
@@ -264,6 +274,10 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
             startVirtualCamera()
             return
         }
+        // Check-and-set synchronously before launch: the guard inside the
+        // coroutine would let two rapid taps both pass before either runs.
+        if (isCameraStarting || isCameraActive) return
+        isCameraStarting = true
         viewModelScope.launch {
             try {
                 val info = availableCameras.firstOrNull { it.id == selectedCameraId }
@@ -272,6 +286,8 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
                 isCameraActive = true
             } catch (e: Exception) {
                 lastError = e.message
+            } finally {
+                isCameraStarting = false
             }
         }
     }

--- a/client-samples/android/app/src/main/java/com/nvidia/xrai/streamkitsample/streamkit/backends/livekit/LiveKitBackend.kt
+++ b/client-samples/android/app/src/main/java/com/nvidia/xrai/streamkitsample/streamkit/backends/livekit/LiveKitBackend.kt
@@ -247,8 +247,8 @@ internal class LiveKitBackend(
         connectionScope = null
         room?.disconnect()
         room = null
-        // Emit DISCONNECTED only when we initiated the teardown — a network-driven
-        // disconnect will have already fired via RoomEvent.Disconnected.
+        // connectionScope.cancel() above stops the RoomEvent collector, so this
+        // is the single DISCONNECTED notification emitted per teardown.
         onConnectionStateChanged?.invoke(ConnectionState.DISCONNECTED)
     }
 

--- a/client-samples/ios-visionos/App/AppModel.swift
+++ b/client-samples/ios-visionos/App/AppModel.swift
@@ -152,6 +152,11 @@ final class AppModel {
                 self.isCameraActive = false
                 self.agentStatus = nil
                 self.agentResponse = nil
+            } else if state == .reconnecting {
+                // Session persists across a reconnect, so stop the camera to
+                // resume from a known-off state. stopCamera() is async (the
+                // unpublish suspends) and clears isCameraActive. Mirrors web.
+                Task { await self.stopCamera() }
             }
         }
         newSession.onAgentStatus = { [weak self, weak newSession] status in

--- a/client-samples/web-xr/App/app.js
+++ b/client-samples/web-xr/App/app.js
@@ -244,7 +244,7 @@ async function stopXR() {
   if (!xrStream) return;
   try {
     await xrStream.stopXR();
-  } catch { /* stop failures surface via the CloudXR onStateChange handler */ }
+  } catch (err) { console.warn('stopXR failed (will surface via CloudXR onStateChange):', err); }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/client-samples/web-xr/App/app.js
+++ b/client-samples/web-xr/App/app.js
@@ -29,10 +29,6 @@ import {
   wireBaseEvents,
 } from '/App/core.js';
 
-const dbg = (typeof window !== 'undefined' && window.__dbg) || {
-  info: () => {}, warn: () => {}, err: () => {},
-};
-
 // ─────────────────────────────────────────────────────────────────────────────
 // Model state — base fields + XR extensions
 // ─────────────────────────────────────────────────────────────────────────────
@@ -86,11 +82,10 @@ function startCamera()      { return _startCamera(model, { render, showError, en
 function startAudio()       { return _startAudio(model, render, showError); }
 function stopAudio()        { return _stopAudio(model, render, showError); }
 function disconnect()       { return _disconnect(model, render); }
-function sendPing()         { return _sendPing(model, startCamera); }
+function sendPing()         { return _sendPing(model); }
 function sendCustom(text)   { return _sendCustom(model, text, showError); }
 
 function connect() {
-  dbg.info(`connect() ${model.secure ? 'wss' : 'ws'}://${model.host}:${model.port} identity=${model.identity}`);
   return _connect(model, {
     render,
     showError,
@@ -111,7 +106,6 @@ function connect() {
 function _onDataReceived(topic, _data) {
   // render.ready: agent confirms the XR scene is ready.
   if (topic === 'render.ready') {
-    dbg.info('render.ready received');
     return true;  // informational — don't clutter the message list
   }
   return false;
@@ -237,11 +231,9 @@ async function startXR() {
   model.xrError = null;
   const host = model.xrHost.trim() || window.location.hostname || 'localhost';
   const port = Number(model.xrPort) || 48322;
-  dbg.info(`startXR() ${host}:${port}`);
   try {
     await xrStream.startXR(host, port);
   } catch (err) {
-    dbg.err('startXR failed: ' + (err?.stack ?? err));
     model.xrError = String(err?.message ?? err);
     model.xrState = 'error';
     render();
@@ -250,12 +242,9 @@ async function startXR() {
 
 async function stopXR() {
   if (!xrStream) return;
-  dbg.info('stopXR()');
   try {
     await xrStream.stopXR();
-  } catch (err) {
-    dbg.err('stopXR failed: ' + (err?.stack ?? err));
-  }
+  } catch { /* stop failures surface via the CloudXR onStateChange handler */ }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -282,18 +271,16 @@ function wireEvents() {
 
   xrStream = new CloudXRStream({
     canvasId: 'xr-canvas',
-    dbg,
     onStateChange: (state, detail) => {
       model.xrState = state;
       if (state === 'error') model.xrError = detail ?? null;
       if (state === 'idle')  model.xrError = null;
-      dbg.info(`xr state → ${state}${detail ? ': ' + detail : ''}`);
 
       // Notify the agent that an XR client is now connected to CloudXR.
       // render-mcp gates its LOVR launch on this signal.
       if (state === 'streaming') {
         model.session?.send(new Uint8Array(0), { topic: 'xr.session.started' })
-          .catch((err) => dbg.warn('xr.session.started publish failed: ' + err));
+          .catch(() => {});
       }
 
       render();
@@ -301,7 +288,6 @@ function wireEvents() {
   });
 
   $('xr-launch-btn').addEventListener('click', () => {
-    dbg.info('xr-launch-btn clicked (state=' + model.xrState + ')');
     if (model.xrState === 'streaming') stopXR();
     else if (model.xrState === 'idle' || model.xrState === 'error') startXR();
   });

--- a/client-samples/web/App/app.js
+++ b/client-samples/web/App/app.js
@@ -158,7 +158,7 @@ async function disconnect() {
     render();
   }
 }
-function sendPing()         { return _sendPing(model, startCamera); }
+function sendPing()         { return _sendPing(model); }
 function sendCustom(text)   { return _sendCustom(model, text, showError); }
 function connect()          {
   return _connect(model, {

--- a/client-samples/web/App/core.js
+++ b/client-samples/web/App/core.js
@@ -505,11 +505,8 @@ export async function stopCamera(model, render, showError) {
   render();
 }
 
-/**
- * @param {object} model
- * @param {() => Promise<void>} _startCamera  bound startCamera for the caller
- */
-export async function sendPing(model, _startCamera) {
+/** @param {object} model */
+export async function sendPing(model) {
   try {
     await model.session?.send('ping');
   } catch { /* ignore */ }


### PR DESCRIPTION
Cleanup pass over `client-samples/` from the repo audit (WP-A8/A9, WP-B21/B22, WP-F7, WP-M3).

## Changes
- **A8 (Android)** — `startCamera()` physical path now guards with a synchronous `isCameraStarting` check-and-set *before* `viewModelScope.launch` (the iOS pattern). Setting it inside the coroutine would let two rapid taps both pass before either ran.
- **A9 (Android + iOS)** — reset camera state on `RECONNECTING`, matching the web client. The LiveKit session persists across a reconnect, so both platforms delegate to their existing `stopCamera()` (cancels synthetic feed on Android, unpublishes the track, clears `isCameraActive`).
- **B21 (web)** — removed the unused `_startCamera` param from `sendPing` in `core.js` and updated both call sites (`web`, `web-xr`).
- **B22 (web-xr)** — deleted the permanently no-op `dbg` logger and all `dbg.*` calls (`window.__dbg` was never set). `CloudXRStream` keeps its own internal no-op fallback, so dropping the passed-in `dbg` is safe.
- **F7 (Android)** — rewrote the `LiveKitBackend` teardown comment to state the actual mechanism: cancelling the connection scope stops the `RoomEvent` collector, so the unconditional emit is the single DISCONNECTED notification per teardown.
- **M3** — added `client-samples/STREAMKIT_PARITY.md` documenting four cross-platform StreamKit divergences (send() topic param, AudioConfig fields, CameraConfig.default facing, stopAudio throws), each tagged idiom or to-fix.

## Verification
- `python3 .github/scripts/check_spdx_headers.py` → exit 0 (new parity doc carries the `<!-- -->` SPDX header).
- web/web-xr JS verified by reading + `node --check` (syntax OK); no Python in scope, pytest e2e skipped.
- **Android (Kotlin) and iOS (Swift) edits were made by static reading only and need an on-device build to verify** — they cannot be compiled in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)