### PR TITLE
chore(agent-mcp-servers): harmonize startup, prune dead code, fix comments

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -147,6 +147,7 @@ vlm-mcp-server  (agent-mcp-servers/vlm-mcp/)
     └── fastmcp >=0.4
     └── pyyaml >=6.0
     └── Pillow >=10.0
+    └── httpx >=0.27   (imported directly to catch httpx.HTTPError from xr-ai-models)
     └── xr-ai-logging  [editable: ../../utils/xr-ai-logging]
     └── xr-ai-models   [editable: ../../agent-sdk/xr-ai-models]
     Pure FastMCP — one tool at /mcp (no REST). Reads a local image file,
@@ -165,7 +166,8 @@ video-mcp-server  (agent-mcp-servers/video-mcp/)
     Pure FastMCP — every operation is an MCP tool at /mcp (no REST).
     Reads NVENC H.264 chunks written by the hub from disk for historical
     queries; connects to the hub as a ProcessorEndpoint to fetch live
-    frames for `get_latest_frame`. Decodes chunks via NVDEC and
+    frames for `get_frame_from_time` (the live-only path; `get_latest_frame`
+    remains as a deprecated alias). Decodes chunks via NVDEC and
     re-encodes selected frames as PNG via Pillow.
 
 cloudxr-runtime  (cloudxr-runtime/)
@@ -177,9 +179,9 @@ render-mcp-server  (agent-mcp-servers/render-mcp/)
     └── pyzmq >=27.0       (PUSH socket → LOVR; libzmq.so reused by LOVR FFI)
     └── msgpack >=1.0      (wire format for LOVR ops)
     └── pyyaml >=6.0
-    └── fastapi >=0.111
     └── uvicorn[standard] >=0.29
     └── fastmcp >=0.4
+    Pure FastMCP at /mcp → LOVR (msgpack/ZMQ); no REST routes.
     Spawns LOVR (the OpenXR rendering app) on the first start_xr call.
     cloudxr-runtime must start before render-mcp (serial launch order);
     cloudxr.env is read synchronously via load_cloudxr_env at start_xr time.
@@ -198,6 +200,7 @@ vec-mcp-server  (agent-mcp-servers/vec-mcp/)
     └── uvicorn[standard] >=0.29
     └── fastmcp >=0.4
     └── pyyaml >=6.0
+    └── xr-ai-logging  [editable: ../../utils/xr-ai-logging]
     Pure FastMCP at /mcp. Deterministic spatial-math primitives
     (between_anchors, world_offset, along_direction, scale_value).
     Offloads vector arithmetic from the LLM.
@@ -339,7 +342,7 @@ piper-tts-server  (ai-services/tts/piper/)
 | `ai-services/llm/nemotron_omni/` | `nemotron-omni-llm-server` | `nemotron_omni_llm_server` | 8108 | Nemotron-3-Nano-Omni-30B-A3B-Reasoning-{NVFP4,FP8,BF16} | vLLM (pip or docker) — multimodal text+video |
 | `agent-mcp-servers/transcript-mcp/` | `transcript-mcp-server` | `transcript_mcp_server` | 8200 | — | Pure FastMCP (JSONL storage) |
 | `agent-mcp-servers/video-mcp/` | `video-mcp-server` | `video_mcp_server` | 8210 | — | Pure FastMCP (reads NVENC chunks from disk) |
-| `agent-mcp-servers/render-mcp/` | `render-mcp-server` | `render_mcp_server` | 8220 | — | FastAPI streaming + FastMCP tools → LOVR (msgpack/ZMQ) |
+| `agent-mcp-servers/render-mcp/` | `render-mcp-server` | `render_mcp_server` | 8220 | — | Pure FastMCP → LOVR (msgpack/ZMQ) |
 | `agent-mcp-servers/oxr-mcp/` | `oxr-mcp-server` | `oxr_mcp_server` | 8230 | — | Pure FastMCP → headless OpenXR / CloudXR |
 | `agent-mcp-servers/vlm-mcp/` | `vlm-mcp-server` | `vlm_mcp_server` | 8240 | — | Pure FastMCP; forwards images to vlm-server via xr-ai-models |
 | `agent-mcp-servers/vec-mcp/` | `vec-mcp-server` | `vec_mcp_server` | 8250 | — | Pure FastMCP; deterministic spatial-math primitives (no model) |

--- a/agent-mcp-servers/render-mcp/pyproject.toml
+++ b/agent-mcp-servers/render-mcp/pyproject.toml
@@ -14,9 +14,6 @@ dependencies = [
     "xr-ai-launcher",
     "xr-ai-logging",
     "pyyaml>=6.0",
-    # FastAPI hosts the high-rate /sphere/radius route alongside the FastMCP
-    # tool surface (mounted at /mcp) for the discrete tools.
-    "fastapi>=0.111",
     "uvicorn[standard]>=0.29",
     "fastmcp>=0.4",
     # render-mcp → LOVR uses ZMQ PUSH/PULL with msgpack-encoded {op, ...} frames.

--- a/agent-mcp-servers/render-mcp/render_mcp/__main__.py
+++ b/agent-mcp-servers/render-mcp/render_mcp/__main__.py
@@ -41,7 +41,7 @@ import zmq.asyncio
 from fastmcp import FastMCP
 from loguru import logger
 
-from xr_ai_launcher import ManagedProcess, XR_RUNTIME_VAR, load_cloudxr_env
+from xr_ai_launcher import ManagedProcess, load_cloudxr_env
 from xr_ai_logging import setup_logging
 
 _DEFAULT_YAML = Path(__file__).resolve().parent.parent / "render_mcp.yaml"
@@ -168,11 +168,8 @@ class SceneDispatcher:
 
         ctx = zmq.asyncio.Context.instance()
         self._push: zmq.asyncio.Socket = ctx.socket(zmq.PUSH)
-        # 8 = enough headroom for a single LLM-round-trip burst, small enough
-        # that anything beyond a burst is dropped via NOBLOCK rather than queued.
-        # 256 = room for ~5 s of 50 Hz scale messages while LOVR starts up,
-        # plus command messages. The old value of 8 let scale messages crowd
-        # out scene.add before LOVR connected.
+        # SNDHWM 256: headroom for a burst of scene ops while LOVR's PULL socket
+        # connects on spawn; anything beyond that is NOBLOCK-dropped, not queued.
         self._push.setsockopt(zmq.SNDHWM, 256)
         self._push.bind(cfg.scene_socket)
         logger.info("render-mcp: bound PUSH on {}", cfg.scene_socket)
@@ -185,7 +182,7 @@ class SceneDispatcher:
         # Per-launch context for the current LOVR child. Each launch gets its
         # own AsyncExitStack so its ManagedProcess teardown (pipe-task cancel +
         # log-sink close) can run on respawn instead of piling up in the
-        # app-lifetime stack until whole-process shutdown (issue #196).
+        # app-lifetime stack until whole-process shutdown.
         self._launch_stack: contextlib.AsyncExitStack | None = None
         # Safety net: close whatever launch context is live when the server
         # shuts down (LOVR still running). Registered once on the app-lifetime
@@ -245,7 +242,7 @@ class SceneDispatcher:
                 # Tear down this launch's context (cancel the two pipe-forward
                 # tasks, close the log sink; terminate is a no-op since the
                 # child already exited) BEFORE allowing a respawn, so dead
-                # contexts don't accumulate in the app-lifetime stack (#196).
+                # contexts don't accumulate in the app-lifetime stack.
                 with contextlib.suppress(Exception):
                     await launch_stack.aclose()
                 if self._launch_stack is launch_stack:
@@ -259,8 +256,8 @@ class SceneDispatcher:
             # (blocking) send is parked waiting for LOVR's PULL to attach,
             # ``_lovr_started`` stays False so concurrent live ``forward()`` ops
             # keep fast-dropping as "not_started" instead of queueing behind the
-            # parked send on the shared PUSH socket (PR #219 review nit). It also
-            # makes the flag mean what it says: LOVR connected AND scene restored.
+            # parked send on the shared PUSH socket. It also makes the flag mean
+            # what it says: LOVR connected AND scene restored.
             await self._resync_scene()
             # Only advertise started if LOVR is still alive — it may have exited
             # during the resync wait, in which case ``_watch`` has already run to
@@ -276,8 +273,8 @@ class SceneDispatcher:
         LOVR has just been spawned and has NOT yet connected its PULL socket.
         A PUSH socket with zero connected peers does NOT buffer up to SNDHWM —
         it returns ``EAGAIN`` immediately under ``NOBLOCK`` — so routing the
-        resync through the live ``forward()`` path silently dropped the entire
-        restore (issue #198). Send these as *blocking* sends instead, so each
+        resync through the live ``forward()`` path silently drops the entire
+        restore. Send these as *blocking* sends instead, so each
         one queues the moment LOVR attaches, bounded by an overall deadline so
         a LOVR that never connects can't wedge the spawn (we hold the spawn
         lock here)."""
@@ -621,7 +618,8 @@ async def _serve(cfg: Config, ready_file: Path | None = None) -> None:
         disp = SceneDispatcher(cfg, stack)
         try:
             app = build_app(disp)
-            uv_cfg = uvicorn.Config(app, host=cfg.host, port=cfg.port, log_level="warning")
+            uv_cfg = uvicorn.Config(app, host=cfg.host, port=cfg.port,
+                                    log_level="warning", log_config=None)
             server = uvicorn.Server(uv_cfg)
             logger.info(
                 "render-mcp  mcp=/mcp  port={}  scene_socket={}",

--- a/agent-mcp-servers/render-mcp/xr_app/conf.lua
+++ b/agent-mcp-servers/render-mcp/xr_app/conf.lua
@@ -1,9 +1,7 @@
 -- LOVR configuration for the render-mcp scene.
 --
--- Kept intentionally minimal — matches the known-working `green-dot` sample
--- (lovr-apps/green-dot/conf.lua). Past attempts to disable extra modules /
--- toggle graphics flags caused `lovr.headset.connect()` to silently fail;
--- treat any deviation from this as a deliberate, tested change.
+-- Changes to this file must be tested end-to-end against a headset: module and
+-- graphics flags can make `lovr.headset.connect()` fail silently.
 
 -- LOVR runs as a child of render-mcp and our stdout is a pipe, not a tty.
 -- Without explicit line buffering, every print() is held until the process

--- a/agent-mcp-servers/render-mcp/xr_app/main.lua
+++ b/agent-mcp-servers/render-mcp/xr_app/main.lua
@@ -7,7 +7,6 @@
 --   { op="scene.add",    value={ id, type, position={x,y,z}, color={r,g,b}, scale } }
 --   { op="scene.update", value={ id, [position=…], [color=…], [scale=…] } }
 --   { op="scene.remove", value={ id } }
---   { op="scene.scale",  value={ id, scale } }    -- high-frequency audio path
 
 -- ── lovr.log override ────────────────────────────────────────────────────────
 -- Emit a tab-separated marker so render-mcp's Python side (the
@@ -30,7 +29,6 @@ lovr.log("lib.zmq + lib.msgpack loaded", "info", "render-mcp-scene")
 -- ── Scene state ───────────────────────────────────────────────────────────────
 
 local primitives      = {}
-local scale_warned    = {}   -- set of ids for which the "unknown scale" warning was printed
 
 local pos_lerp   = 6.0
 local color_lerp = 6.0
@@ -91,7 +89,6 @@ local function handle_scene_add(v)
     local cr, cg, cb = read_vec3(v.color, 0.2, 0.9, 1.0)
     local size       = tonumber(v.size) or 0.1
     primitives[id]   = make_primitive(ptype, px, py, pz, cr, cg, cb, size)
-    scale_warned[id] = nil   -- clear so the id can warn again if it goes missing
     lovr.log(string.format(
         "scene.add  id=%s type=%s pos=(%.2f,%.2f,%.2f) color=(%.2f,%.2f,%.2f) size=%.3fm  total=%d",
         id, ptype, px, py, pz, cr, cg, cb, size, count_primitives()),
@@ -137,20 +134,6 @@ local function handle_scene_remove(v)
                  "info", "render-mcp-scene")
     elseif id then
         lovr.log(string.format("scene.remove: unknown id=%s", id),
-                 "info", "render-mcp-scene")
-    end
-end
-
-local function handle_scene_scale(v)
-    local id  = v.id
-    local obj = id and primitives[id]
-    if obj then
-        local s = tonumber(v.size)
-        if s then obj.target_scale = s end
-    elseif id and not scale_warned[id] then
-        -- Log exactly once per unknown id so it doesn't drown other output.
-        scale_warned[id] = true
-        lovr.log(string.format("scene.scale: unknown id=%s (logged once)", tostring(id)),
                  "info", "render-mcp-scene")
     end
 end
@@ -201,7 +184,6 @@ local function drain_commands()
         if     op == "scene.add"    then ok_h, herr = pcall(handle_scene_add,    v)
         elseif op == "scene.update" then ok_h, herr = pcall(handle_scene_update, v)
         elseif op == "scene.remove" then ok_h, herr = pcall(handle_scene_remove, v)
-        elseif op == "scene.scale"  then ok_h, herr = pcall(handle_scene_scale,  v)
         elseif op ~= nil then
             lovr.log("unknown op=" .. tostring(op), "info", "render-mcp-scene")
         else

--- a/agent-mcp-servers/transcript-mcp/transcript_mcp_server/__main__.py
+++ b/agent-mcp-servers/transcript-mcp/transcript_mcp_server/__main__.py
@@ -58,6 +58,7 @@ import asyncio
 import json
 import os
 import pathlib
+import sys
 
 import uvicorn
 import yaml
@@ -305,6 +306,8 @@ def run() -> None:
             cfg = yaml.safe_load(f) or {}
 
     setup_logging("transcript-mcp")
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
 
     _run_dir = os.environ.get("XR_RUN_DIR")
     _default_transcripts = (
@@ -318,7 +321,8 @@ def run() -> None:
     app   = build_app(store)
 
     async def _serve() -> None:
-        config = uvicorn.Config(app, host=host, port=port, log_level="warning")
+        config = uvicorn.Config(app, host=host, port=port, log_level="warning",
+                                log_config=None)
         server = uvicorn.Server(config)
         logger.info("transcript-mcp-server  mcp=/mcp  port={}  dir={}", port, transcripts_dir)
         if ns.ready_file:

--- a/agent-mcp-servers/transcript-mcp/transcript_mcp_server/__main__.py
+++ b/agent-mcp-servers/transcript-mcp/transcript_mcp_server/__main__.py
@@ -305,9 +305,9 @@ def run() -> None:
         with open(ns.config) as f:
             cfg = yaml.safe_load(f) or {}
 
-    setup_logging("transcript-mcp")
     sys.stdout.reconfigure(line_buffering=True)
     sys.stderr.reconfigure(line_buffering=True)
+    setup_logging("transcript-mcp")
 
     _run_dir = os.environ.get("XR_RUN_DIR")
     _default_transcripts = (

--- a/agent-mcp-servers/vec-mcp/pyproject.toml
+++ b/agent-mcp-servers/vec-mcp/pyproject.toml
@@ -13,7 +13,11 @@ dependencies = [
     "uvicorn[standard]>=0.29",
     "fastmcp>=0.4",
     "pyyaml>=6.0",
+    "xr-ai-logging",
 ]
+
+[tool.uv.sources]
+xr-ai-logging = { path = "../../utils/xr-ai-logging", editable = true }
 
 [project.scripts]
 vec_mcp_server = "vec_mcp_server.__main__:run"

--- a/agent-mcp-servers/vec-mcp/vec_mcp_server/__main__.py
+++ b/agent-mcp-servers/vec-mcp/vec_mcp_server/__main__.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import logging
 import math
 import sys
 from dataclasses import dataclass
@@ -39,8 +38,8 @@ from pathlib import Path
 import uvicorn
 import yaml
 from fastmcp import FastMCP
-
-log = logging.getLogger("vec_mcp_server")
+from loguru import logger
+from xr_ai_logging import setup_logging
 
 _DEFAULT_YAML = Path(__file__).resolve().parent.parent / "vec_mcp_server.yaml"
 
@@ -151,9 +150,10 @@ def build_mcp() -> FastMCP:
 
 async def _serve(cfg: Config, ready_file: Path | None = None) -> None:
     app = build_mcp().http_app(path="/mcp")
-    uv_cfg = uvicorn.Config(app, host=cfg.host, port=cfg.port, log_level="warning")
+    uv_cfg = uvicorn.Config(app, host=cfg.host, port=cfg.port,
+                            log_level="warning", log_config=None)
     server = uvicorn.Server(uv_cfg)
-    log.info("vec-mcp  mcp=/mcp  port=%d", cfg.port)
+    logger.info("vec-mcp  mcp=/mcp  port={}", cfg.port)
     if ready_file:
         ready_file.touch()
     await server.serve()
@@ -165,10 +165,7 @@ def run() -> None:
     p.add_argument("--ready-file", type=Path, default=None)
     ns, _ = p.parse_known_args()
 
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s %(name)s %(levelname)s %(message)s",
-    )
+    setup_logging("vec-mcp")
     sys.stdout.reconfigure(line_buffering=True)
     sys.stderr.reconfigure(line_buffering=True)
 

--- a/agent-mcp-servers/vec-mcp/vec_mcp_server/__main__.py
+++ b/agent-mcp-servers/vec-mcp/vec_mcp_server/__main__.py
@@ -165,9 +165,9 @@ def run() -> None:
     p.add_argument("--ready-file", type=Path, default=None)
     ns, _ = p.parse_known_args()
 
-    setup_logging("vec-mcp")
     sys.stdout.reconfigure(line_buffering=True)
     sys.stderr.reconfigure(line_buffering=True)
+    setup_logging("vec-mcp")
 
     yaml_path = ns.config or _DEFAULT_YAML
     raw = _load_raw(yaml_path) if yaml_path.exists() else {}

--- a/agent-mcp-servers/video-mcp/video_mcp_server/__main__.py
+++ b/agent-mcp-servers/video-mcp/video_mcp_server/__main__.py
@@ -459,7 +459,9 @@ def build_mcp(
 
             Keys: path, width, height, timestamp_us, second_ago,
             actual_second_ago. Returns ``{"error": "..."}`` if the participant
-            has no live frame or a past frame is requested.
+            has no live frame or a past frame is requested. Use
+            ``list_live_participants`` to confirm which participants have an
+            active camera feed before calling this tool.
             """
             if second_ago != 0 or reference_time_us != 0:
                 return {"error": "recording disabled — only second_ago=0 (live) is available"}
@@ -749,9 +751,9 @@ def run() -> None:
         with open(ns.config) as f:
             cfg = yaml.safe_load(f) or {}
 
-    setup_logging("video-mcp")
     sys.stdout.reconfigure(line_buffering=True)
     sys.stderr.reconfigure(line_buffering=True)
+    setup_logging("video-mcp")
     asyncio.run(_serve(cfg, ready_file=ns.ready_file))
 
 

--- a/agent-mcp-servers/video-mcp/video_mcp_server/__main__.py
+++ b/agent-mcp-servers/video-mcp/video_mcp_server/__main__.py
@@ -66,6 +66,7 @@ import ctypes
 import json
 import os
 import pathlib
+import sys
 import time
 
 import numpy as np
@@ -322,6 +323,41 @@ def _save_png(rgb: np.ndarray, out_path: pathlib.Path) -> None:
     Image.fromarray(rgb, "RGB").save(out_path, "PNG")
 
 
+async def _live_frame_result(
+    provider: "FrameProvider",
+    participant_id: str,
+    out_dir: pathlib.Path,
+    now_us: int,
+) -> dict:
+    """Fetch the latest live IPC frame for *participant_id*, encode it to PNG,
+    and return the ``get_frame_from_time(second_ago=0)`` result dict (or an
+    error dict). Shared by the live-only and full tool surfaces so the two
+    registrations can't drift."""
+    frame = await provider.fetch_latest(participant_id)
+    if frame is None:
+        return {"error": f"No live frame available for {participant_id!r}"}
+    try:
+        rgb = _frame_to_rgb(frame.data, frame.width, frame.height, frame.fmt)
+    except ValueError as exc:
+        return {"error": str(exc)}
+    safe     = _safe_name(participant_id)
+    out_path = out_dir / f"{safe}_ago0_{frame.pts_us}.png"
+    _save_png(rgb, out_path)
+    actual = (now_us - frame.pts_us) / 1_000_000
+    logger.debug(
+        "get_frame_from_time(0)  pid={!r}  {}x{}  ts={} (~{:.2f}s ago, live) → {}",
+        participant_id, frame.width, frame.height, frame.pts_us, actual, out_path,
+    )
+    return {
+        "path":              str(out_path),
+        "width":             frame.width,
+        "height":            frame.height,
+        "timestamp_us":      frame.pts_us,
+        "second_ago":        0,
+        "actual_second_ago": actual,
+    }
+
+
 # ── H.264 decode (PyNvVideoCodec) ────────────────────────────────────────────
 
 def _decoded_frame_to_nv12(frame) -> np.ndarray:
@@ -390,11 +426,12 @@ def build_mcp(
     """Return a composed FastMCP server with video tools bound.
 
     When *store* is ``None`` (recording disabled) only live tools are
-    registered: ``list_live_participants`` and ``get_frame_from_time``
-    (live-only path).  Historical tools — ``list_recorded_participants``,
-    ``get_video_stats``, ``query_video``, and the chunk-lookup path of
-    ``get_frame_from_time`` — are omitted entirely so the LLM never sees
-    them and cannot attempt to call them.
+    registered: ``list_live_participants`` and a live-only
+    ``get_frame_from_time`` (plus the deprecated ``get_latest_frame``).
+    Historical tools — ``list_recorded_participants``, ``get_video_stats``,
+    ``query_video``, and the chunk-lookup path of ``get_frame_from_time`` —
+    are omitted entirely so the LLM never sees them and cannot attempt to
+    call them.
     """
     mcp = FastMCP("video-mcp")
 
@@ -406,12 +443,34 @@ def build_mcp(
         a live frame."""
         return sorted(provider.connected_participants())
 
-    # ── recording disabled: live-only tool ───────────────────────────────────
+    # ── recording disabled: live-only tools ──────────────────────────────────
     if store is None:
+        @mcp.tool()
+        async def get_frame_from_time(
+            participant_id:    str,
+            second_ago:        int = 0,
+            reference_time_us: int = 0,
+        ) -> dict:
+            """Return the current live camera frame for *participant_id* as a PNG.
+
+            Recording is disabled on this server, so only the live frame is
+            available: ``second_ago`` and ``reference_time_us`` must both be
+            ``0`` (any past lookup needs the recorded chunk store).
+
+            Keys: path, width, height, timestamp_us, second_ago,
+            actual_second_ago. Returns ``{"error": "..."}`` if the participant
+            has no live frame or a past frame is requested.
+            """
+            if second_ago != 0 or reference_time_us != 0:
+                return {"error": "recording disabled — only second_ago=0 (live) is available"}
+            now_us = int(time.time() * 1_000_000)
+            return await _live_frame_result(provider, participant_id, out_dir, now_us)
+
         @mcp.tool()
         async def get_latest_frame(participant_id: str) -> dict:
             """Return the current live camera frame for *participant_id* as a PNG.
 
+            Deprecated — prefer ``get_frame_from_time(participant_id)``.
             Keys: path, width, height, timestamp_us.
             Returns ``{"error": "..."}`` if the participant has no live frame.
             """
@@ -550,29 +609,7 @@ def build_mcp(
 
         # Live IPC path: caller wants "right now, wall clock" (no anchor, no offset).
         if reference_time_us == 0 and second_ago == 0:
-            frame = await provider.fetch_latest(participant_id)
-            if frame is None:
-                return {"error": f"No live frame available for {participant_id!r}"}
-            try:
-                rgb = _frame_to_rgb(frame.data, frame.width, frame.height, frame.fmt)
-            except ValueError as exc:
-                return {"error": str(exc)}
-            safe     = _safe_name(participant_id)
-            out_path = out_dir / f"{safe}_ago0_{frame.pts_us}.png"
-            _save_png(rgb, out_path)
-            actual = (now_us - frame.pts_us) / 1_000_000
-            logger.debug(
-                "get_frame_from_time(0)  pid={!r}  {}x{}  ts={} (~{:.2f}s ago, live) → {}",
-                participant_id, frame.width, frame.height, frame.pts_us, actual, out_path,
-            )
-            return {
-                "path":              str(out_path),
-                "width":             frame.width,
-                "height":            frame.height,
-                "timestamp_us":      frame.pts_us,
-                "second_ago":        0,
-                "actual_second_ago": actual,
-            }
+            return await _live_frame_result(provider, participant_id, out_dir, now_us)
 
         # Anchored chunk lookup (recording path).
         target_us = anchor_us - second_ago * 1_000_000
@@ -660,7 +697,7 @@ async def _serve(cfg: dict, ready_file: pathlib.Path | None = None) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
 
     # store is None when recordings_dir is not configured; historical tools
-    # are hidden and only get_latest_frame is exposed.
+    # are hidden and only the live-frame tools are exposed.
     store: ChunkStore | None = (
         ChunkStore(pathlib.Path(recordings_dir_raw)) if recordings_dir_raw else None
     )
@@ -673,7 +710,8 @@ async def _serve(cfg: dict, ready_file: pathlib.Path | None = None) -> None:
     provider = FrameProvider(ep)
     app      = build_app(store, out_dir, provider, gpu_id=gpu_id)
 
-    config = uvicorn.Config(app, host=host, port=port, log_level="warning")
+    config = uvicorn.Config(app, host=host, port=port, log_level="warning",
+                            log_config=None)
     server = uvicorn.Server(config)
 
     ep_task = asyncio.create_task(ep.run(), name="video_mcp_processor")
@@ -712,6 +750,8 @@ def run() -> None:
             cfg = yaml.safe_load(f) or {}
 
     setup_logging("video-mcp")
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
     asyncio.run(_serve(cfg, ready_file=ns.ready_file))
 
 

--- a/agent-mcp-servers/vlm-mcp/pyproject.toml
+++ b/agent-mcp-servers/vlm-mcp/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
     "fastmcp>=0.4",
     "pyyaml>=6.0",
     "Pillow>=10.0",
+    # Imported directly to catch httpx.HTTPError from xr-ai-models' transport.
+    "httpx>=0.27",
     "xr-ai-logging",
     "xr-ai-models",
 ]

--- a/agent-mcp-servers/vlm-mcp/vlm_mcp_server/__main__.py
+++ b/agent-mcp-servers/vlm-mcp/vlm_mcp_server/__main__.py
@@ -52,6 +52,7 @@ import base64
 import io
 import pathlib
 import re
+import sys
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -290,7 +291,8 @@ async def _serve(cfg: dict, ready_file: pathlib.Path | None = None) -> None:
 
     app.router.lifespan_context = _combined
 
-    config = uvicorn.Config(app, host=host, port=port, log_level="warning")
+    config = uvicorn.Config(app, host=host, port=port, log_level="warning",
+                            log_config=None)
     server = uvicorn.Server(config)
 
     logger.info(
@@ -314,6 +316,8 @@ def run() -> None:
             cfg = yaml.safe_load(f) or {}
 
     setup_logging("vlm-mcp")
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
     asyncio.run(_serve(cfg, ready_file=ns.ready_file))
 
 

--- a/agent-mcp-servers/vlm-mcp/vlm_mcp_server/__main__.py
+++ b/agent-mcp-servers/vlm-mcp/vlm_mcp_server/__main__.py
@@ -315,9 +315,9 @@ def run() -> None:
         with open(ns.config) as f:
             cfg = yaml.safe_load(f) or {}
 
-    setup_logging("vlm-mcp")
     sys.stdout.reconfigure(line_buffering=True)
     sys.stderr.reconfigure(line_buffering=True)
+    setup_logging("vlm-mcp")
     asyncio.run(_serve(cfg, ready_file=ns.ready_file))
 
 


### PR DESCRIPTION
## What

MCP-server cleanup across the six adapters under `agent-mcp-servers/` (audit WP-A7/B/E/F/L, server-side scope only).

### A7 — video-mcp tool migration (server side)
- Register `get_frame_from_time` in the `store is None` branch using its live-only IPC path (needs no chunk store). **Kept** the deprecated `get_latest_frame` registered (final removal is a separate follow-up; a sibling worker drops it from the worker's tool list).
- Extracted a shared `_live_frame_result` helper so the live path can't drift between the two tool surfaces.
- Fixed the stale `build_mcp` docstring and the "only get_latest_frame is exposed" comment.

### WP-B — dead code / deps
- **B9/L4** render-mcp: removed unused `fastapi>=0.111` + `/sphere/radius` comment; DEPENDENCIES.md row → "Pure FastMCP → LOVR".
- **B10** render-mcp: dropped unused `XR_RUNTIME_VAR` import.
- **B11** render-mcp Lua: grep confirmed `scene.scale` has no Python sender → removed the handler, op-table entry, wire-op doc line, and now-dead `scale_warned` state. Kept `scale_lerp`/`target_scale`/`current_scale` (drive size animation).
- **B12** vlm-mcp: declared `httpx>=0.27` as a direct dep (imported for `httpx.HTTPError`, previously transitive).

### WP-E — startup harmonization
- **E1**: stdout/stderr `reconfigure(line_buffering=True)` added to transcript/video/vlm `run()`.
- **E2**: `log_config=None` passed to `uvicorn.Config(...)` in render/transcript/video/vlm **and vec** (vec joins via E3's loguru switch).
- **E3** vec-mcp: `setup_logging("vec-mcp")` replaces stdlib `logging.basicConfig`.

### WP-F — comments
- **F5** render-mcp: stripped `#196`/`#198`/`#219`/"old value of 8" references; kept invariants.
- **F6** render-mcp conf.lua: replaced "Past attempts…" narration with one sentence.

## Skipped (noted as follow-ups)
- **E4** — left the legacy `vlm_server:` deprecation branch intact: the only remaining user is `agent-samples/xr-render-demo/yaml/vlm_mcp_server.yaml` (out of scope, still on the old key). DEPENDENCIES.md back-compat note kept.
- **E5** — config-loading unification skipped (P2): transcript/video/vlm/vec legitimately run configless; vec-mcp is launched **without** `--config` by the sample orchestrator, so tolerate-missing is load-bearing. Unifying on exit-on-missing would break that launch.

## Notes
- `uv.lock` is gitignored repo-wide and untracked; `uv lock` was re-run cleanly for each edited pyproject (render-mcp, vlm-mcp, vec-mcp) but lockfiles are not committed, per repo convention.
- Did not touch `tests/`, `docs/changelog.md`, or `agent-samples/`.

## Test
- SPDX header check: pass (347 files, no new files).
- `uv run pytest -m "not gpu"` → **416 passed, 37 deselected**.
- GPU/headset paths (NVDEC decode in video-mcp, LOVR rendering in render-mcp) are not exercised by the CPU suite — flag for human GPU/headset run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)