### PR TITLE
fix(server-runtime): hub & transport bug fixes + cleanups

### DIFF
--- a/server-runtime/xr_media_hub/__main__.py
+++ b/server-runtime/xr_media_hub/__main__.py
@@ -25,8 +25,6 @@ from xr_media_hub._errors import StartupError
 from xr_media_hub.ipc import AudioChunk, DataMessage, HubEndpoint, ParticipantEvent, SlotView
 from xr_media_hub.transport.livekit import LiveKitConnector, make_client_token
 
-PULL_ADDR      = "ipc:///tmp/xr_hub_in"
-PUB_ADDR       = "ipc:///tmp/xr_hub_pub"
 STATS_INTERVAL = 5.0
 
 _frame_counts: dict[str, int] = collections.defaultdict(int)
@@ -89,13 +87,14 @@ async def main(ready_file: Path | None = None) -> None:
 
     setup_logging("hub")
 
-    hub = HubEndpoint(pull_addr=PULL_ADDR, pub_addr=PUB_ADDR)
+    cfg = load_config()
+
+    hub = HubEndpoint(pull_addr=cfg.hub_push_addr, pub_addr=cfg.hub_sub_addr)
     hub.on_frame(on_frame)
     hub.on_audio(on_audio)
     hub.on_data(on_data)
     hub.on_participant(on_participant)
 
-    cfg = load_config()
     connector = LiveKitConnector(cfg)
     await connector.start()
 
@@ -136,7 +135,7 @@ async def main(ready_file: Path | None = None) -> None:
         ready_file.touch()
 
     stop = asyncio.Event()
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     for sig in (signal.SIGINT, signal.SIGTERM):
         loop.add_signal_handler(sig, stop.set)
 

--- a/server-runtime/xr_media_hub/_config_loader.py
+++ b/server-runtime/xr_media_hub/_config_loader.py
@@ -14,6 +14,7 @@ regardless of where the process is started from.
 from __future__ import annotations
 
 import argparse
+import dataclasses
 from pathlib import Path
 
 import yaml
@@ -61,7 +62,6 @@ def load_config() -> LiveKitConnectorConfig:
             data[key] = _resolve_path(data[key], base)
 
     # Filter to only fields that exist on the dataclass.
-    import dataclasses
     valid = {f.name for f in dataclasses.fields(LiveKitConnectorConfig)}
     filtered = {k: v for k, v in data.items() if k in valid}
 

--- a/server-runtime/xr_media_hub/ipc/_hub.py
+++ b/server-runtime/xr_media_hub/ipc/_hub.py
@@ -262,13 +262,19 @@ class HubEndpoint:
 
         elif type_id == MsgType.AUDIO_CHUNK:
             for cb in self._audio_cbs:
-                await cb(msg)
+                try:
+                    await cb(msg)
+                except Exception:
+                    logger.exception("audio callback error")
             topic = f"audio.{msg.participant_id}.{msg.track_id}".encode()
             await self._pub.send_multipart([topic, encode(MsgType.AUDIO_CHUNK, msg)])
 
         elif type_id == MsgType.DATA_MESSAGE:
             for cb in self._data_cbs:
-                await cb(msg)
+                try:
+                    await cb(msg)
+                except Exception:
+                    logger.exception("data callback error")
             topic = f"data.{msg.participant_id}.{msg.topic}".encode()
             await self._pub.send_multipart([topic, encode(MsgType.DATA_MESSAGE, msg)])
 
@@ -285,12 +291,18 @@ class HubEndpoint:
                     ring, view = self._latest_slots.pop(k)
                     ring.release_slot(view.signal.slot)
             for cb in self._participant_cbs:
-                await cb(msg)
+                try:
+                    await cb(msg)
+                except Exception:
+                    logger.exception("participant callback error")
             await self._pub.send_multipart([b"participant", encode(MsgType.PARTICIPANT_EVENT, msg)])
 
         elif type_id == MsgType.CONTROL:
             for cb in self._control_cbs:
-                await cb(msg)
+                try:
+                    await cb(msg)
+                except Exception:
+                    logger.exception("control callback error")
             await self._pub.send_multipart([TOPIC_CONTROL, encode(MsgType.CONTROL, msg)])
 
         elif type_id == MsgType.RETURN_AUDIO:

--- a/server-runtime/xr_media_hub/transport/livekit/_docker.py
+++ b/server-runtime/xr_media_hub/transport/livekit/_docker.py
@@ -137,7 +137,7 @@ class LiveKitDocker:
         # this is reliable even if the docker run process is also killed
         # externally (e.g. by the launcher's killpg).
         try:
-            await asyncio.get_event_loop().run_in_executor(
+            await asyncio.get_running_loop().run_in_executor(
                 None,
                 lambda: subprocess.run(
                     ["docker", "stop", "--time", str(int(_STOP_TIMEOUT)), _CONTAINER_NAME],
@@ -182,7 +182,7 @@ class LiveKitDocker:
             )
 
     async def _wait_ready(self, port: int) -> None:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         deadline = loop.time() + _READY_TIMEOUT
         while True:
             if self._proc is not None and self._proc.returncode is not None:

--- a/server-runtime/xr_media_hub/transport/livekit/_lk_proxy.py
+++ b/server-runtime/xr_media_hub/transport/livekit/_lk_proxy.py
@@ -90,8 +90,8 @@ async def pump_rtc_ws(
                             await client_ws.send_bytes(frame)
                         else:
                             await client_ws.send_text(frame)
-                except Exception:
-                    pass  # disconnect races during teardown
+                except Exception as exc:
+                    logger.debug("WS proxy /rtc l2c ended: {}", exc)
 
             await asyncio.gather(c2l(), l2c(), return_exceptions=True)
     except Exception as exc:

--- a/server-runtime/xr_media_hub/transport/livekit/_room_client.py
+++ b/server-runtime/xr_media_hub/transport/livekit/_room_client.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import asyncio
 import time
-from typing import TYPE_CHECKING
 
 import numpy as np
 from livekit import rtc
@@ -33,9 +32,6 @@ from xr_media_hub.ipc import (
 
 from ._token import make_client_token
 from .config import LiveKitConnectorConfig
-
-if TYPE_CHECKING:
-    pass
 
 
 def _now_us() -> int:
@@ -141,16 +137,7 @@ class RoomClient:
             _pub: rtc.RemoteTrackPublication,
             participant: rtc.RemoteParticipant,
         ) -> None:
-            if track.kind == rtc.TrackKind.KIND_VIDEO:
-                self._start_track_task(
-                    track.sid,
-                    self._stream_video(track, participant.identity, track.sid),
-                )
-            elif track.kind == rtc.TrackKind.KIND_AUDIO:
-                self._start_track_task(
-                    track.sid,
-                    self._stream_audio(track, participant.identity, track.sid),
-                )
+            self._maybe_start_track(track, participant.identity)
 
         @self._room.on("track_unsubscribed")
         def _on_track_end(
@@ -193,20 +180,18 @@ class RoomClient:
             await self._handle_joined(participant)
             for pub in participant.track_publications.values():
                 if pub.track is not None and pub.subscribed:
-                    if pub.track.kind == rtc.TrackKind.KIND_VIDEO:
-                        self._start_track_task(
-                            pub.track.sid,
-                            self._stream_video(
-                                pub.track, participant.identity, pub.track.sid
-                            ),
-                        )
-                    elif pub.track.kind == rtc.TrackKind.KIND_AUDIO:
-                        self._start_track_task(
-                            pub.track.sid,
-                            self._stream_audio(
-                                pub.track, participant.identity, pub.track.sid
-                            ),
-                        )
+                    self._maybe_start_track(pub.track, participant.identity)
+
+    def _maybe_start_track(self, track: rtc.Track, identity: str) -> None:
+        """Start a stream task for a video/audio track; ignore other kinds."""
+        if track.kind == rtc.TrackKind.KIND_VIDEO:
+            self._start_track_task(
+                track.sid, self._stream_video(track, identity, track.sid),
+            )
+        elif track.kind == rtc.TrackKind.KIND_AUDIO:
+            self._start_track_task(
+                track.sid, self._stream_audio(track, identity, track.sid),
+            )
 
     async def run(self) -> None:
         """Wait until stop() is called."""
@@ -230,6 +215,17 @@ class RoomClient:
         task = asyncio.create_task(coro)
         self._pending_tasks.add(task)
         task.add_done_callback(self._pending_tasks.discard)
+        task.add_done_callback(self._log_task_exception)
+
+    @staticmethod
+    def _log_task_exception(task: asyncio.Task) -> None:
+        # Surface failures in push_data/join/leave handlers instead of letting
+        # them stay silent until disconnect retrieves the exception.
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.opt(exception=exc).error("spawned room-client task failed")
 
     async def disconnect(self) -> None:
         for t in self._track_tasks.values():
@@ -251,8 +247,6 @@ class RoomClient:
 
     async def send_return_data(self, msg: DataMessage) -> None:
         """Publish data to the target participant via LiveKit data channel."""
-        if not self._room:
-            return
         try:
             await self._room.local_participant.publish_data(
                 msg.data,
@@ -271,8 +265,6 @@ class RoomClient:
         recv loop responsive so flush messages are not stuck FIFO
         behind a burst of chunks.
         """
-        if not self._room:
-            return
         pid   = chunk.participant_id
         entry = self._return_audio.get(pid)
         if entry is None:

--- a/server-runtime/xr_media_hub/transport/livekit/_token_server.py
+++ b/server-runtime/xr_media_hub/transport/livekit/_token_server.py
@@ -13,6 +13,7 @@ Serves:
 from __future__ import annotations
 
 import asyncio
+from contextlib import asynccontextmanager
 
 import httpx
 import uvicorn
@@ -25,28 +26,83 @@ from ._token import make_client_token
 from .config import LiveKitConnectorConfig
 
 # Max seconds start() waits for uvicorn to bind before treating startup as
-# failed. Binding the token port is near-instant (no model load); the bound is
-# a backstop for a startup that neither binds nor exits.
+# failed. Binding the port is near-instant (no model load); the bound is a
+# backstop for a startup that neither binds nor exits.
 _STARTUP_TIMEOUT_S = 10.0
+
+
+async def serve_safe(
+    server: uvicorn.Server, port: int, label: str,
+) -> BaseException | None:
+    """Run ``server.serve()``, swallowing uvicorn's bind-failure SystemExit.
+
+    uvicorn calls sys.exit(1) on bind failure; SystemExit is a BaseException
+    that ``await task`` in stop() would re-raise into the caller, aborting
+    graceful shutdown. Swallow it here and return the captured error so the
+    caller can surface the real cause (and the task's exception is retrieved).
+
+    CancelledError is intentionally NOT caught: start()'s timeout path cancels
+    this task and awaits it.
+    """
+    try:
+        await server.serve()
+    except SystemExit as exc:
+        logger.error(
+            "{} failed to start on port {} — is it already in use? (exit code {})",
+            label, port, exc.code,
+        )
+        return exc
+    except Exception as exc:
+        logger.error("{} crashed on port {}: {!r}", label, port, exc)
+        return exc
+    return None
+
+
+async def wait_until_bound(server: uvicorn.Server, task: asyncio.Task) -> None:
+    """Poll until *server* binds or *task* dies trying.
+
+    uvicorn sets ``started`` True only after a successful bind; on bind failure
+    startup() sys.exit(1)s first, so the task finishes with ``started`` False.
+    On timeout the task is cancelled and awaited so we don't orphan it.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + _STARTUP_TIMEOUT_S
+    while not server.started and not task.done():
+        if loop.time() >= deadline:
+            break
+        await asyncio.sleep(0.05)
+    if not server.started and not task.done():
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+def _proxy_client_lifespan(client: httpx.AsyncClient):
+    @asynccontextmanager
+    async def _lifespan(_app: FastAPI):
+        yield
+        await client.aclose()
+    return _lifespan
 
 
 def build_app(cfg: LiveKitConnectorConfig) -> FastAPI:
     lk_internal_http = f"http://127.0.0.1:{cfg.lk_port_ws}"
     lk_internal_ws   = f"ws://127.0.0.1:{cfg.lk_port_ws}"
 
-    app = FastAPI(title="XR-Media-Hub Token Server")
+    proxy_client = httpx.AsyncClient(timeout=5.0)
+
+    app = FastAPI(
+        title="XR-Media-Hub Token Server",
+        lifespan=_proxy_client_lifespan(proxy_client),
+    )
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["*"],
         allow_methods=["GET"],
         allow_headers=["*"],
     )
-
-    proxy_client = httpx.AsyncClient(timeout=5.0)
-
-    @app.on_event("shutdown")
-    async def _close_proxy_client() -> None:
-        await proxy_client.aclose()
 
     @app.get("/token")
     async def get_token(identity: str = Query(default="browser-user")) -> dict:
@@ -91,76 +147,33 @@ class TokenServer:
         else:
             scheme = "http"
 
+        port = self._cfg.token_server_port
         self._serve_error = None
         self._server = uvicorn.Server(uvicorn.Config(**uv_cfg))
-        self._task = asyncio.create_task(self._serve_safe())
+        self._task = asyncio.create_task(self._serve_safe(port))
 
-        # Wait until the server has actually bound (or the serve task died
-        # trying). _serve_safe swallows uvicorn's SystemExit so the SHUTDOWN
-        # path stays clean — but a bind failure must NOT look healthy here: the
-        # token server is the browser-facing auth/signaling entry point, so a
-        # non-bind has to abort connector startup loudly instead of leaving a
-        # dead endpoint that every browser client silently fails to reach.
-        # uvicorn sets `started` True only after a successful bind; on bind
-        # failure startup() sys.exit(1)s first, so the task finishes with
-        # `started` still False.
-        loop = asyncio.get_running_loop()
-        deadline = loop.time() + _STARTUP_TIMEOUT_S
-        while not self._server.started and not self._task.done():
-            if loop.time() >= deadline:
-                break
-            await asyncio.sleep(0.05)
+        # A bind failure must NOT look healthy: the token server is the
+        # browser-facing auth/signaling entry point, so a non-bind has to abort
+        # connector startup loudly instead of leaving a dead endpoint that every
+        # browser client silently fails to reach.
+        await wait_until_bound(self._server, self._task)
         if not self._server.started:
-            # Pathological case: the task neither bound nor exited within the
-            # timeout. Cancel and await it so we don't leave an orphan running,
-            # then drop the reference so a later stop() doesn't re-await (and
-            # re-raise) the cancelled task.
-            if not self._task.done():
-                self._task.cancel()
-                try:
-                    await self._task
-                except asyncio.CancelledError:
-                    # Expected: we just cancelled the serve task to avoid
-                    # leaving it orphaned during startup-timeout handling.
-                    pass
+            # Drop the references so a later stop() doesn't re-await (and
+            # re-raise) the cancelled task. Chain the captured cause.
             self._task = None
             self._server = None
-            # Chain the real cause (SystemExit with exit code, or any other
-            # serve() failure) captured by _serve_safe; None on pure timeout.
             raise RuntimeError(
                 f"Token server failed to start on "
-                f"{self._cfg.token_server_host}:{self._cfg.token_server_port} "
+                f"{self._cfg.token_server_host}:{port} "
                 "— port already in use, or startup timed out."
             ) from self._serve_error
         logger.info(
             "Token server → {}://{}:{}  room={!r}",
-            scheme, self._cfg.token_server_host, self._cfg.token_server_port,
-            self._cfg.room_name,
+            scheme, self._cfg.token_server_host, port, self._cfg.room_name,
         )
 
-    async def _serve_safe(self) -> None:
-        # uvicorn calls sys.exit(1) on bind failure; SystemExit is a BaseException
-        # that ``await self._task`` in stop() would re-raise into the caller,
-        # aborting the rest of graceful shutdown. Swallow it here (matches
-        # WebServer._serve_safe). Record the failure so start() can surface the
-        # real cause and the task's exception is always retrieved.
-        #
-        # CancelledError (a BaseException, not an Exception) is intentionally
-        # NOT caught: start()'s timeout path cancels this task and awaits it.
-        try:
-            await self._server.serve()
-        except SystemExit as exc:
-            self._serve_error = exc
-            logger.error(
-                "Token server failed to start on port {} — is it already in use? (exit code {})",
-                self._cfg.token_server_port, exc.code,
-            )
-        except Exception as exc:
-            self._serve_error = exc
-            logger.error(
-                "Token server crashed on port {}: {!r}",
-                self._cfg.token_server_port, exc,
-            )
+    async def _serve_safe(self, port: int) -> None:
+        self._serve_error = await serve_safe(self._server, port, "Token server")
 
     async def stop(self) -> None:
         if self._server:

--- a/server-runtime/xr_media_hub/transport/livekit/_token_server.py
+++ b/server-runtime/xr_media_hub/transport/livekit/_token_server.py
@@ -76,6 +76,8 @@ async def wait_until_bound(server: uvicorn.Server, task: asyncio.Task) -> None:
         try:
             await task
         except asyncio.CancelledError:
+            # Expected: we just cancelled `task` ourselves and await it only to
+            # let the cancellation propagate and the server unwind cleanly.
             pass
 
 

--- a/server-runtime/xr_media_hub/transport/livekit/_web_server.py
+++ b/server-runtime/xr_media_hub/transport/livekit/_web_server.py
@@ -30,27 +30,27 @@ from loguru import logger
 from . import _lk_proxy
 from ._tls import ensure_self_signed_cert
 from ._token import make_client_token
+from ._token_server import _proxy_client_lifespan, serve_safe, wait_until_bound
 from .config import LiveKitConnectorConfig
 
 
 def _build_app(cfg: LiveKitConnectorConfig, cert_bytes: bytes | None) -> FastAPI:
-    app = FastAPI(title="XR-Media-Hub Web Server", docs_url=None, redoc_url=None)
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=["*"],
-        allow_methods=["GET"],
-        allow_headers=["*"],
-    )
-
     lk_internal_http = f"http://127.0.0.1:{cfg.lk_port_ws}"
     lk_internal_ws   = f"ws://127.0.0.1:{cfg.lk_port_ws}"
 
     # Shared so /rtc/validate hits don't pay TCP+TLS startup per request.
     proxy_client = httpx.AsyncClient(timeout=5.0)
 
-    @app.on_event("shutdown")
-    async def _close_proxy_client() -> None:
-        await proxy_client.aclose()
+    app = FastAPI(
+        title="XR-Media-Hub Web Server", docs_url=None, redoc_url=None,
+        lifespan=_proxy_client_lifespan(proxy_client),
+    )
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_methods=["GET"],
+        allow_headers=["*"],
+    )
 
     @app.get("/cert")
     async def get_cert() -> Response:
@@ -99,6 +99,9 @@ class WebServer:
         self._cfg = cfg
         self._server: uvicorn.Server | None = None
         self._task: asyncio.Task | None = None
+        # Startup failure captured by _serve_safe so start() can surface the
+        # real cause (and so the serve task's exception is always retrieved).
+        self._serve_error: BaseException | None = None
 
     async def start(self) -> None:
         ssl_kwargs: dict = {}
@@ -128,24 +131,30 @@ class WebServer:
             log_level="warning",
             **ssl_kwargs,
         )
+        port = self._cfg.web_server_port
+        self._serve_error = None
         self._server = uvicorn.Server(uv_cfg)
-        self._task = asyncio.create_task(self._serve_safe())
+        self._task = asyncio.create_task(self._serve_safe(port))
+
+        # A port conflict must fail fast: a "started" log on a dead web server
+        # leaves every browser client silently unable to reach the client/token
+        # endpoint. Mirror TokenServer — poll for bind, raise on failure.
+        await wait_until_bound(self._server, self._task)
+        if not self._server.started:
+            self._task = None
+            self._server = None
+            raise RuntimeError(
+                f"Web server failed to start on {self._cfg.web_server_host}:{port} "
+                "— port already in use, or startup timed out."
+            ) from self._serve_error
         logger.info(
             "Web server → {}://{}:{}  client={!r}",
-            scheme, self._cfg.web_server_host, self._cfg.web_server_port,
+            scheme, self._cfg.web_server_host, port,
             self._cfg.web_client_dir or "<no static dir>",
         )
 
-    async def _serve_safe(self) -> None:
-        # uvicorn calls sys.exit(1) on bind failure; SystemExit is a BaseException
-        # and asyncio would re-raise it in the event loop, crashing the process.
-        try:
-            await self._server.serve()
-        except SystemExit as exc:
-            logger.error(
-                "Web server failed to start on port {} — is it already in use? (exit code {})",
-                self._cfg.web_server_port, exc.code,
-            )
+    async def _serve_safe(self, port: int) -> None:
+        self._serve_error = await serve_safe(self._server, port, "Web server")
 
     async def stop(self) -> None:
         if self._server:

--- a/server-runtime/xr_media_hub/transport/livekit/connector.py
+++ b/server-runtime/xr_media_hub/transport/livekit/connector.py
@@ -59,7 +59,6 @@ class LiveKitConnector:
             max_frame_bytes=self._cfg.shm_max_frame_bytes,
         )
         self._room_client = RoomClient(self._cfg, self._ep)
-        self._stop = asyncio.Event()
 
     # ── callback registration ─────────────────────────────────────────────────
 

--- a/server-runtime/xr_media_hub/video/_recorder.py
+++ b/server-runtime/xr_media_hub/video/_recorder.py
@@ -50,6 +50,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from loguru import logger
+from xr_ai_agent import PixelFormat
 
 if TYPE_CHECKING:
     from xr_media_hub.ipc import SlotView
@@ -188,6 +189,10 @@ class VideoRecorder:
 
             if enc.chunk_frames >= self._cfg.chunk_frames:
                 self._rotate_chunk(enc, pid)
+                # _rotate_chunk marks the track failed if it cannot recreate
+                # the encoder; bail before dereferencing enc.encoder=None.
+                if enc.failed:
+                    return
 
             encoded = enc.encoder.Encode(nv12)
             if encoded:
@@ -203,7 +208,17 @@ class VideoRecorder:
         except Exception as e:
             logger.warning("recorder  EndEncode error pid={!r}: {}", pid, e)
         self._flush_chunk(enc)
-        enc.encoder        = self._create_encoder(enc.width, enc.height)
+        try:
+            enc.encoder = self._create_encoder(enc.width, enc.height)
+        except Exception as e:
+            logger.error(
+                "recorder  CreateEncoder failed pid={!r} {}x{}: {} — "
+                "recording disabled for this track",
+                pid, enc.width, enc.height, e,
+            )
+            enc.encoder = None
+            enc.failed  = True
+            return
         enc.chunk_start_us = time.time_ns() // 1_000
         enc.chunk_frames   = 0
 
@@ -292,25 +307,29 @@ class VideoRecorder:
     # ── public API ────────────────────────────────────────────────────────────
 
     def close_participant(self, pid: str) -> None:
+        # Pop under the lock so a frame arriving mid-close can't re-insert an
+        # encoder that then never gets flushed/closed. Flush I/O stays outside
+        # self._lock (it only needs each encoder's own lock).
         with self._lock:
             keys = [k for k in self._encoders if k[0] == pid]
-        for key in keys:
-            enc = self._encoders.pop(key, None)
-            if enc:
-                with enc.lock:
+            encs = [enc for k in keys if (enc := self._encoders.pop(k, None))]
+        for enc in encs:
+            with enc.lock:
+                # enc.encoder is None on a track whose encoder (re)creation
+                # failed; skip EndEncode but still flush any buffered chunk.
+                if enc.encoder is not None:
                     try:
                         flushed = enc.encoder.EndEncode()
                         if flushed:
                             enc.chunk_buf.extend(flushed)
                     except Exception as e:
                         logger.warning("recorder  flush error pid={!r}: {}", pid, e)
-                    self._flush_chunk(enc)
+                self._flush_chunk(enc)
 
 
 # ── pixel format conversion ───────────────────────────────────────────────────
 
 def _to_nv12(data: bytes, width: int, height: int, fmt: object) -> np.ndarray | None:
-    from xr_ai_agent import PixelFormat
     arr = np.frombuffer(data, dtype=np.uint8)
 
     if fmt == PixelFormat.NV12:


### PR DESCRIPTION
Part of the repo cleanup batch (CLEANUP_PLAN.md WP-A/WP-G), server-runtime slice.

**Bug fixes:** A1 (WebServer.start reports success on failed port bind → mirror TokenServer bind-poll), A2 (guard encoder recreation in `_rotate_chunk`, set `enc.failed`), A3 (pop encoders inside the lock in `close_participant`), A4 (per-callback try/except for audio/data/participant loops).

**Cleanups:** B6/B7/B8 (dead `_stop` Event, empty TYPE_CHECKING block, always-true `if not self._room` guards), G2 (read IPC addrs from config), G4 (`get_running_loop` + FastAPI lifespan), G5 (`_maybe_start_track`), G6 (shared `_serve_safe`), G7 (done-callback logging on `_spawn`), G8 (`logger.debug` not bare pass), G10/G11 (top-level imports).

Excluded by design: G1 (now_us — cross-module follow-up), G3 (token-server default — human-gated), G9/J4 (P2 splits).

**Verification:** CPU suite + SPDX local; A2's NVENC-failure path needs GPU → flag for human run (`tests/run_local_gpu_tests.sh`). Base is `main`. Do not merge — human gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)