### PR TITLE
refactor(xr-ai-pipecat): dedup PCM/WAV helpers, drop dead code

### DIFF
--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/audio.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/audio.py
@@ -2,22 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Audio helpers: PCM ↔ WAV conversion, sentence-batched TTS, VAD bookkeeping.
+Audio helpers: PCM ↔ WAV conversion, float32 ↔ int16, VAD bookkeeping.
 """
 from __future__ import annotations
 
-import asyncio
 import io
-import re
 import time
 import wave
 
 import numpy as np
-from loguru import logger
+from pipecat.frames.frames import OutputAudioRawFrame
 
-from xr_ai_agent import AudioChunk, ProcessorEndpoint
-
-SENTENCE_RE = re.compile(r"(?<=[.!?])\s+")
+from xr_ai_agent import AudioChunk
 
 _CHUNK_MS = 20
 _CHUNK_US = _CHUNK_MS * 1_000
@@ -27,9 +23,14 @@ def now_us() -> int:
     return time.time_ns() // 1_000
 
 
-def rms_float32(data: bytes) -> float:
-    arr = np.frombuffer(data, dtype=np.float32)
-    return float(np.sqrt(np.mean(arr ** 2))) if len(arr) else 0.0
+def float32_to_int16(data: bytes) -> bytes:
+    f32 = np.frombuffer(data, dtype=np.float32)
+    return np.clip(f32 * 32767.0, -32768, 32767).astype(np.int16).tobytes()
+
+
+def int16_to_float32(data: bytes) -> bytes:
+    i16 = np.frombuffer(data, dtype=np.int16)
+    return (i16.astype(np.float32) / 32767.0).tobytes()
 
 
 def chunks_to_wav(chunks: list[AudioChunk]) -> bytes:
@@ -73,58 +74,21 @@ def wav_to_chunks(wav_bytes: bytes, participant_id: str) -> list[AudioChunk]:
     return out
 
 
-def split_sentences(text: str) -> list[str]:
-    parts = SENTENCE_RE.split(text.strip())
-    return [s.strip() for s in parts if s.strip()]
+def wav_to_output_frames(wav_bytes: bytes, pid: str) -> list[OutputAudioRawFrame]:
+    """Decode a WAV blob into 20 ms int16 ``OutputAudioRawFrame``s for *pid*.
 
-
-async def stream_sentences_to_audio(
-    endpoint: ProcessorEndpoint,
-    tts_synth,
-    text: str,
-    participant_id: str,
-) -> float:
-    """Split *text* into sentences, synthesise in parallel, send in order."""
-    sentences = split_sentences(text)
-    if not sentences:
-        return 0.0
-
-    queue: asyncio.Queue = asyncio.Queue()
-    total_samples = 0
-    sample_rate   = 0
-
-    async def _sender() -> None:
-        nonlocal total_samples, sample_rate
-        while True:
-            task = await queue.get()
-            if task is None:
-                return
-            try:
-                wav = await task
-            except Exception:
-                logger.exception("tts synth failed  pid={!r}", participant_id)
-                continue
-            if not wav:
-                continue
-            try:
-                for chunk in wav_to_chunks(wav, participant_id):
-                    await endpoint.send_return_audio(chunk)
-                    total_samples += chunk.samples
-                    if sample_rate == 0:
-                        sample_rate = chunk.sample_rate
-            except Exception:
-                logger.exception("send_return_audio failed  pid={!r}", participant_id)
-
-    sender = asyncio.create_task(_sender(), name=f"tts-sender-{participant_id}")
-    try:
-        for i, sentence in enumerate(sentences):
-            await queue.put(asyncio.create_task(
-                tts_synth(sentence),
-                name=f"tts-synth-{participant_id}-{i}",
-            ))
-    finally:
-        await queue.put(None)
-        if not sender.done():
-            await asyncio.gather(sender)
-
-    return (total_samples / sample_rate) if sample_rate else 0.0
+    ``wav_to_chunks`` yields float32 ``AudioChunk``s; pipecat's output path
+    expects int16 PCM, so each chunk is converted here and stamped with
+    ``transport_destination`` so the output transport knows which participant
+    to address. Raises on a malformed WAV — callers log and skip.
+    """
+    frames: list[OutputAudioRawFrame] = []
+    for c in wav_to_chunks(wav_bytes, pid):
+        out = OutputAudioRawFrame(
+            audio        = float32_to_int16(c.data),
+            sample_rate  = c.sample_rate,
+            num_channels = c.channels,
+        )
+        out.transport_destination = pid
+        frames.append(out)
+    return frames

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/frames.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/frames.py
@@ -61,8 +61,7 @@ class BrainResponseEndFrame(DataFrame):
     Emitted by :class:`BrainProcessor` in :meth:`_run_query`'s finally
     block. Carries ``text`` — the full assembled response — so the
     downstream :class:`StreamingTtsProcessor` can echo the per-turn
-    response on the data channel exactly once, matching the
-    pre-migration "send full response at end" behavior. ``pid`` is the
+    response on the data channel exactly once. ``pid`` is the
     participant whose turn ended; the data echo addresses the same pid.
 
     A turn that was cancelled (new query, interruption) still produces

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/streaming_tts.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/streaming_tts.py
@@ -28,12 +28,10 @@ import asyncio
 import re
 from typing import TYPE_CHECKING
 
-import numpy as np
 from loguru import logger
 from pipecat.frames.frames import (
     Frame,
     InterruptionFrame,
-    OutputAudioRawFrame,
     TextFrame,
 )
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
@@ -42,7 +40,7 @@ from xr_ai_agent import DataMessage
 from xr_ai_models import TTSService
 from xr_ai_voicegate import VoiceGate
 
-from ..audio import wav_to_chunks
+from ..audio import wav_to_output_frames
 from ..frames import BrainResponseEndFrame
 
 if TYPE_CHECKING:
@@ -62,9 +60,8 @@ _TRAILING_SENTENCE_END = re.compile(r"""[.!?]["')\]]*\s*$""")
 class StreamingTtsProcessor(FrameProcessor):
     """Sentence-batched parallel TTS at the tail of the voice pipeline.
 
-    Lifts the parallel-synth-with-ordered-send pattern from
-    :func:`xr_ai_pipecat.audio.stream_sentences_to_audio` and exposes it
-    as a frame processor.
+    Synthesizes each sentence in parallel and streams the WAVs out in
+    order so playback stays monotonic.
 
     ``transport`` and ``text_topic`` are optional; when both are
     supplied (and the topic is non-empty), the processor emits one
@@ -247,19 +244,11 @@ class StreamingTtsProcessor(FrameProcessor):
 
     async def _push_wav(self, wav_bytes: bytes, *, pid: str) -> None:
         try:
-            chunks = wav_to_chunks(wav_bytes, pid)
+            frames = wav_to_output_frames(wav_bytes, pid)
         except Exception:
             logger.exception("tts WAV decode failed pid={!r}", pid)
             return
-        for c in chunks:
-            f32 = np.frombuffer(c.data, dtype=np.float32)
-            i16 = np.clip(f32 * 32767.0, -32768, 32767).astype(np.int16).tobytes()
-            out = OutputAudioRawFrame(
-                audio        = i16,
-                sample_rate  = c.sample_rate,
-                num_channels = c.channels,
-            )
-            out.transport_destination = pid
+        for out in frames:
             await self.push_frame(out)
 
     async def _drain_on_interrupt(self) -> None:

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/vad_stt.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/vad_stt.py
@@ -131,18 +131,8 @@ class VadSttProcessor(FrameProcessor):
 
         async def on_speech_start() -> None:
             self._current_pid = pid
-            # Reset probe state for the new utterance. Any leftover task
-            # from a previous utterance is cancelled AND awaited to
-            # completion before scheduling the next probe — otherwise the
-            # cancelled task may still be mid ``await self.push_frame(...)``
-            # when the new probe task starts, leaving its
-            # ``__process_frame_task_handler`` coroutine in pipecat's
-            # downstream processor in a state where its cancellation
-            # propagates after a fresh one has already been scheduled.
-            # That overlap was the source of intermittent
-            # "coroutine '...__process_frame_task_handler' was never
-            # awaited" RuntimeWarnings observed in production right after
-            # a probe-STOP match.
+            # Await the cancelled task before scheduling the next probe so
+            # the two tasks never overlap mid-push_frame.
             self._stop_fired_for_current_utterance.discard(pid)
             await self._cancel_probe_task(pid)
             self._probe_buffer[pid] = bytearray()

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/voice_gate.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/voice_gate.py
@@ -19,12 +19,10 @@ from __future__ import annotations
 
 import time
 
-import numpy as np
 from loguru import logger
 from pipecat.frames.frames import (
     Frame,
     InterruptionFrame,
-    OutputAudioRawFrame,
     TextFrame,
     TranscriptionFrame,
 )
@@ -33,7 +31,7 @@ from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 from xr_ai_models import TTSService
 from xr_ai_voicegate import VoiceGate, VoiceGateConfig
 
-from ..audio import wav_to_chunks
+from ..audio import wav_to_output_frames
 from ..frames import GatedQueryFrame, ParticipantJoinedFrame, ParticipantLeftFrame
 
 
@@ -93,22 +91,11 @@ class VoiceGateProcessor(FrameProcessor):
         transport knows which participant to send the audio back to.
         """
         try:
-            chunks = wav_to_chunks(wav_bytes, pid)
+            frames = wav_to_output_frames(wav_bytes, pid)
         except Exception:
             logger.exception("voice-gate audio sink decode failed pid={!r}", pid)
             return
-        for c in chunks:
-            # AudioChunk holds float32 in `.data`; OutputAudioRawFrame is
-            # int16. Convert here so callers never have to think about
-            # the dtype mismatch.
-            f32 = np.frombuffer(c.data, dtype=np.float32)
-            i16 = np.clip(f32 * 32767.0, -32768, 32767).astype(np.int16).tobytes()
-            out = OutputAudioRawFrame(
-                audio        = i16,
-                sample_rate  = c.sample_rate,
-                num_channels = c.channels,
-            )
-            out.transport_destination = pid
+        for out in frames:
             await self.push_frame(out)
 
     # ── pipecat frame entrypoint ──────────────────────────────────────────────

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/transport.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/transport.py
@@ -40,6 +40,7 @@ from xr_ai_agent import (
     Subscribe,
 )
 
+from .audio import float32_to_int16, int16_to_float32
 from .frames import ParticipantJoinedFrame, ParticipantLeftFrame
 
 _HUB_PUB  = "ipc:///tmp/xr_hub_pub"
@@ -48,16 +49,6 @@ _HUB_PUSH = "ipc:///tmp/xr_hub_in"
 SAMPLE_RATE            = 16_000
 NUM_CHANNELS           = 1
 TTS_NATIVE_SAMPLE_RATE = 22_050
-
-
-def _float32_to_int16(data: bytes) -> bytes:
-    f32 = np.frombuffer(data, dtype=np.float32)
-    return np.clip(f32 * 32767.0, -32768, 32767).astype(np.int16).tobytes()
-
-
-def _int16_to_float32(data: bytes) -> bytes:
-    i16 = np.frombuffer(data, dtype=np.int16)
-    return (i16.astype(np.float32) / 32767.0).tobytes()
 
 
 def _hub_pcm_to_mono_16k(pcm_int16: bytes, channels: int, sample_rate: int) -> bytes:
@@ -124,7 +115,7 @@ class XRMediaHubInputTransport(BaseInputTransport):
         if not self._started:
             return
         pcm_int16 = _hub_pcm_to_mono_16k(
-            _float32_to_int16(chunk.data), chunk.channels, chunk.sample_rate,
+            float32_to_int16(chunk.data), chunk.channels, chunk.sample_rate,
         )
         frame = InputAudioRawFrame(
             audio=pcm_int16,
@@ -183,6 +174,10 @@ class XRMediaHubOutputTransport(BaseOutputTransport):
         # StartFrame stashed at start() so per-participant MediaSenders can
         # be created on demand (they need it to .start()).
         self._start_frame: StartFrame | None = None
+
+    @property
+    def target_participant(self) -> str:
+        return self._target_participant
 
     def set_target_participant(self, pid: str) -> None:
         # Retained as a fallback for frames that reach the output with no
@@ -258,8 +253,7 @@ class XRMediaHubOutputTransport(BaseOutputTransport):
         upstream processors (``VoiceGateProcessor``,
         ``StreamingTtsProcessor``) tag outbound audio with
         ``transport_destination = pid`` so the hub knows which
-        participant to send it back to. The two facts together used to
-        drop every TTS / chime frame on the floor.
+        participant to send it back to.
 
         Per-participant routing: each pid has its own ``MediaSender``
         (created on join, or lazily here). The frame keeps its
@@ -296,11 +290,8 @@ class XRMediaHubOutputTransport(BaseOutputTransport):
         no target participant is set — the hub would drop the message
         anyway, so we avoid emitting an unaddressable chunk.
 
-        Note: the pipecat upstream method is ``write_audio_frame``
-        (per-frame, returns bool), NOT ``write_raw_audio_frames`` —
-        the previous implementation overrode a phantom name and pipecat
-        never invoked it, which is why every TTS chunk was silently
-        dropped before reaching the hub.
+        The upstream hook is ``write_audio_frame`` (per-frame, returns
+        bool), NOT ``write_raw_audio_frames``.
         """
         # Address the chunk at the participant whose sender produced it. The
         # per-pid MediaSender stamps ``transport_destination`` onto the frame;
@@ -314,10 +305,10 @@ class XRMediaHubOutputTransport(BaseOutputTransport):
                 )
                 self._missing_target_warned = True
             return False
-        pcm_float32 = _int16_to_float32(frame.audio)
+        pcm_float32 = int16_to_float32(frame.audio)
         num_samples = len(frame.audio) // (2 * frame.num_channels)
         chunk = AudioChunk(
-            pts_us=int(time.time() * 1_000_000),
+            pts_us=time.time_ns() // 1_000,
             sample_rate=frame.sample_rate,
             channels=frame.num_channels,
             samples=num_samples,
@@ -358,7 +349,6 @@ class XRMediaHubTransport(BaseTransport):
 
         self._input  = XRMediaHubInputTransport(self._ep, params, name=self._input_name)
         self._output = XRMediaHubOutputTransport(self._ep, params, name=self._output_name)
-        self._target_participant: str = ""
 
     def input(self) -> XRMediaHubInputTransport:
         return self._input
@@ -375,15 +365,13 @@ class XRMediaHubTransport(BaseTransport):
 
     @property
     def target_participant(self) -> str:
-        return self._target_participant
+        return self._output.target_participant
 
     def set_target_participant(self, pid: str) -> None:
-        self._target_participant = pid
         self._output.set_target_participant(pid)
 
     def cleanup_participant(self, pid: str) -> None:
-        if self._target_participant == pid:
-            self._target_participant = ""
+        if self._output.target_participant == pid:
             self._output.set_target_participant("")
 
     def shutdown(self) -> None:


### PR DESCRIPTION
Repo cleanup batch — xr-ai-pipecat slice (WP-B1/B2/B3/B5, C2/C3/C4, F1-F4). Dead-code deletions grep-confirmed unused; PCM/WAV conversion consolidated into audio.py; pts_us standardized to time_ns()//1_000; docstring history narration stripped. CPU suite + SPDX local. Base main — do not merge (human gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)