### PR TITLE
fix(simple-vlm-example): offload blocking JPEG encode; dedup health wait

### DIFF
--- a/agent-samples/simple-vlm-example/worker/agent.py
+++ b/agent-samples/simple-vlm-example/worker/agent.py
@@ -34,7 +34,6 @@ import json
 import time
 from typing import AsyncIterator
 
-import httpx
 from loguru import logger
 from pipecat.frames.frames import InterruptionFrame
 from xr_ai_agent import DataMessage, FrameSignal
@@ -384,7 +383,10 @@ class SimpleVlmBrain(BrainProcessor):
                 yield "Frame data unavailable — please retry."
                 return
 
-            image_url = encode_image(frame_to_pil(frame))
+            loop = asyncio.get_running_loop()
+            image_url = await loop.run_in_executor(
+                None, lambda: encode_image(frame_to_pil(frame)),
+            )
             logger.info(
                 "vlm  pid={!r}  {}x{}  query={!r}",
                 pid, frame.width, frame.height, query[:60],
@@ -397,7 +399,7 @@ class SimpleVlmBrain(BrainProcessor):
                         image_url, query, system_prompt=self._system_prompt,
                     ):
                         yield token
-                except httpx.HTTPError as exc:
+                except Exception as exc:
                     logger.error("vlm-server error: {}", exc)
                     yield "VLM server unavailable — please retry."
                     return

--- a/agent-samples/simple-vlm-example/worker/simple_vlm_example_worker.py
+++ b/agent-samples/simple-vlm-example/worker/simple_vlm_example_worker.py
@@ -51,6 +51,7 @@ from pipecat.pipeline.runner import PipelineRunner
 from xr_ai_logging import setup_logging
 from xr_ai_models import load_models_config, make_stt, make_tts, make_vlm
 from xr_ai_pipecat import VadConfig, make_voice_pipeline
+from xr_ai_pipecat.services import wait_for_services
 from xr_ai_pipecat.transport import XRMediaHubTransport
 from xr_ai_voicegate import load_voice_gate_config
 
@@ -87,7 +88,7 @@ async def main(
     vlm = make_vlm(models_cfg, "vlm")
     tts = make_tts(models_cfg, "tts")
 
-    await _wait_for_health(stt=stt, vlm=vlm, tts=tts)
+    await wait_for_services({"stt": stt.health, "vlm": vlm.health, "tts": tts.health})
 
     if ready_file:
         ready_file.touch()
@@ -155,28 +156,6 @@ async def main(
             except Exception:
                 logger.opt(exception=True).warning("service close failed")
     logger.info("simple-vlm-example stopped")
-
-
-async def _wait_for_health(**services: object) -> None:
-    """Block until every service's health endpoint reports healthy."""
-    pending: dict[str, object] = dict(services)
-    while pending:
-        results = await asyncio.gather(
-            *(svc.health() for svc in pending.values()),  # type: ignore[attr-defined]
-            return_exceptions=True,
-        )
-        still_waiting = {
-            name: svc
-            for (name, svc), ok in zip(pending.items(), results)
-            if not (isinstance(ok, bool) and ok)
-        }
-        for name in pending:
-            if name not in still_waiting:
-                logger.info("{} ready", name)
-        pending = still_waiting
-        if pending:
-            logger.info("still waiting for: {}", ", ".join(sorted(pending)))
-            await asyncio.sleep(5.0)
 
 
 def run() -> None:


### PR DESCRIPTION
Repo cleanup batch — simple-vlm-example slice (WP-A5/B14/H1). A5 wraps the blocking PIL/NumPy encode in run_in_executor; B14 drops the httpx coupling; H1 reuses xr_ai_pipecat.services.wait_for_services. CPU suite + SPDX local. Base main — do not merge (human gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)