### PR TITLE
refactor(ai-services): consolidate four vLLM wrappers into xr-ai-vllm

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -103,11 +103,16 @@ xr-ai-vllm  (utils/xr-ai-vllm/)
     based on each YAML's `vllm_backend:` key.  Stays stdlib-only so docker mode
     does not pull vllm/torch/etc. into the wrapper's venv just to manage a
     container.  Imported by the four vllm wrappers and by the orchestrator
-    `--stop` flow.
+    `--stop` flow.  Besides `serve` / `stop_persistent_servers`, exposes the
+    shared wrapper helpers `resolve_model_cache`, `load_config`, `setup_hf_env`,
+    and `gpu_compute_major` (all stdlib-only; pyyaml is imported function-locally
+    inside `load_config` so the `--stop` path stays dependency-free).
 
 xr-ai-vad  (utils/xr-ai-vad/)
     └── numpy >=1.24
-    └── silero-vad >=5.1  (pulls torch + onnxruntime transitively)
+    └── silero-vad >=5.1  (pulls onnxruntime transitively)
+    └── torch >=2.0       (detector.py imports torch directly)
+    └── onnxruntime >=1.17
     Shared per-participant Silero VAD utterance detector for agent workers
     that ingest microphone audio.  Uses the ONNX backend (no GPU required
     at runtime).  Consumes raw int16 PCM bytes and emits int16 PCM utterance
@@ -293,7 +298,7 @@ nemotron3-nano-llm-server  (ai-services/llm/nemotron3_nano/)
     vllm_backend: pip|docker — same dispatch as vlm-server.
 
 nemotron-omni-llm-server  (ai-services/llm/nemotron_omni/)
-    └── vllm >=0.8.0
+    └── vllm >=0.12.0
     └── hf-transfer >=0.1.4
     └── pyyaml >=6.0
     └── xr-ai-logging  [editable: ../../../utils/xr-ai-logging]
@@ -452,7 +457,7 @@ updated in the same commit**.
 | `agent-sdk/` API or types | `AGENTS.md` worker boilerplate, any sample worker that uses the changed API |
 | `server-runtime/` config fields (`LiveKitConnectorConfig`) | `server-runtime/xr_media_hub.yaml` (reference copy), each sample's `xr_media_hub.yaml`, `AGENTS.md` Config section |
 | `utils/xr-ai-launcher/` `Process` / `run_stack` API | `AGENTS.md` orchestrator boilerplate and process model section |
-| `utils/xr-ai-vllm/` API (`serve`, `stop_persistent_servers`) | All four vllm wrappers (`ai-services/vlm-server/`, `ai-services/llm/llama_nemotron/`, `ai-services/llm/nemotron3_nano/`, `ai-services/llm/nemotron_omni/`), `agent-samples/xr-render-demo/main.py` (`_PERSISTENT_SERVERS`) |
+| `utils/xr-ai-vllm/` API (`serve`, `stop_persistent_servers`, `resolve_model_cache`, `load_config`, `setup_hf_env`, `gpu_compute_major`) | All four vllm wrappers (`ai-services/vlm-server/`, `ai-services/llm/llama_nemotron/`, `ai-services/llm/nemotron3_nano/`, `ai-services/llm/nemotron_omni/`), `agent-samples/xr-render-demo/main.py` (`_PERSISTENT_SERVERS`) |
 | `vllm_backend` / `vllm_image` YAML keys | `ai-services/{vlm-server,llm/llama_nemotron,llm/nemotron3_nano,llm/nemotron_omni}/<server>.yaml`, every per-profile copy in `agent-samples/`, `docs/ai-services.md` |
 | Container name used by a vllm wrapper | `_CONTAINER_NAME` in the wrapper's `__main__.py`, `_PERSISTENT_SERVERS` in `agent-samples/xr-render-demo/main.py` |
 | vlm-server model class or supported architectures | `ai-services/vlm-server/vlm_server.yaml` comments |

--- a/ai-services/llm/llama_nemotron/llama_nemotron_llm_server/__main__.py
+++ b/ai-services/llm/llama_nemotron/llama_nemotron_llm_server/__main__.py
@@ -30,16 +30,20 @@ Config keys
     vllm_image:              str    NGC image when vllm_backend=docker
                                     (default: nvcr.io/nvidia/vllm:26.04-py3).
 """
-import argparse
 import os
 import sys
 from pathlib import Path
 
-import yaml
+from loguru import logger
 from xr_ai_logging import setup_logging
-from xr_ai_vllm import DEFAULT_IMAGE, serve
+from xr_ai_vllm import (
+    DEFAULT_IMAGE,
+    load_config,
+    resolve_model_cache,
+    serve,
+    setup_hf_env,
+)
 
-_DEFAULT_MODEL              = "nvidia/Llama-3.1-Nemotron-Nano-8B-v1"
 _DEFAULT_PORT               = 8106
 _DEFAULT_HOST               = "0.0.0.0"
 _DEFAULT_SERVED_NAME        = "llm"
@@ -54,34 +58,16 @@ _DEFAULT_ENABLE_TOOL_CHOICE = True
 _CONTAINER_NAME = "xr-ai-vllm-llama-nemotron-llm-server"
 
 
-def _resolve_model_cache(cfg: dict, yaml_dir: Path) -> Path:
-    raw = cfg.get("model_cache", "../../../models")
-    p = Path(raw)
-    if not p.is_absolute():
-        p = (yaml_dir / p).resolve()
-    p.mkdir(parents=True, exist_ok=True)
-    return p
-
-
 def run() -> None:
-    sys.stdout.reconfigure(line_buffering=True)
-    sys.stderr.reconfigure(line_buffering=True)
-
     setup_logging("llm-llama-nemotron")
 
-    p = argparse.ArgumentParser(add_help=False)
-    p.add_argument("--config",     type=Path, default=None)
-    p.add_argument("--ready-file", type=Path, default=None)
-    ns, _ = p.parse_known_args()
+    cfg, yaml_dir, ready_file = load_config()
 
-    cfg: dict = {}
-    yaml_dir = Path.cwd()
-    if ns.config and ns.config.exists():
-        yaml_dir = ns.config.parent.resolve()
-        with open(ns.config) as f:
-            cfg = yaml.safe_load(f) or {}
+    if not cfg.get("model"):
+        logger.error("'model' is required in config")
+        sys.exit(1)
 
-    model              = cfg.get("model",                _DEFAULT_MODEL)
+    model              = cfg["model"]
     host               = cfg.get("host",                 _DEFAULT_HOST)
     port               = int(cfg.get("port",             _DEFAULT_PORT))
     served_name        = cfg.get("served_model_name",    _DEFAULT_SERVED_NAME)
@@ -95,17 +81,8 @@ def run() -> None:
     backend            = cfg.get("vllm_backend",         "pip")
     image              = cfg.get("vllm_image",           DEFAULT_IMAGE)
 
-    cuda_devices = cfg.get("cuda_visible_devices")
-    if cuda_devices is not None:
-        cuda_devices = str(cuda_devices)
-        os.environ["CUDA_VISIBLE_DEVICES"] = cuda_devices
-
-    model_cache = _resolve_model_cache(cfg, yaml_dir)
-    hf_token = cfg.get("hf_token") or os.environ.get("HF_TOKEN", "")
-    if hf_token:
-        os.environ["HF_TOKEN"] = hf_token
-    os.environ.setdefault("HF_HUB_ENABLE_HF_TRANSFER", "1")
-    os.environ["HF_HOME"] = str(model_cache)
+    model_cache = resolve_model_cache(cfg, yaml_dir, default="../../../models")
+    cuda_devices = setup_hf_env(cfg, model_cache)
 
     extra_serve_args = [
         "--served-model-name", served_name,
@@ -131,9 +108,9 @@ def run() -> None:
         host=host,
         port=port,
         model_cache=model_cache,
-        hf_token=hf_token or None,
+        hf_token=os.environ.get("HF_TOKEN") or None,
         cuda_visible_devices=cuda_devices,
-        ready_file=ns.ready_file,
+        ready_file=ready_file,
     )
 
 

--- a/ai-services/llm/nemotron3_nano/nemotron3_nano_llm_server.yaml
+++ b/ai-services/llm/nemotron3_nano/nemotron3_nano_llm_server.yaml
@@ -25,7 +25,7 @@ hf_token: ""
 model_cache: ../../models
 
 # Pin to a specific GPU (or comma-separated list for multi-GPU).
-# Also controls which GPU _gpu_compute_major() queries for model selection.
+# Also controls which GPU the compute-capability query targets for model selection.
 # Unset to use all GPUs visible to the process.
 # cuda_visible_devices: "0"
 

--- a/ai-services/llm/nemotron3_nano/nemotron3_nano_llm_server/__main__.py
+++ b/ai-services/llm/nemotron3_nano/nemotron3_nano_llm_server/__main__.py
@@ -30,17 +30,20 @@ Config keys
     vllm_image:              str    NGC image when vllm_backend=docker
                                     (default: nvcr.io/nvidia/vllm:26.04-py3).
 """
-import argparse
 import os
-import subprocess
-import sys
 import urllib.request
 from pathlib import Path
 
-import yaml
 from loguru import logger
 from xr_ai_logging import setup_logging
-from xr_ai_vllm import DEFAULT_IMAGE, serve
+from xr_ai_vllm import (
+    DEFAULT_IMAGE,
+    gpu_compute_major,
+    load_config,
+    resolve_model_cache,
+    serve,
+    setup_hf_env,
+)
 
 _MODEL_BLACKWELL  = "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4"
 _MODEL_ADA        = "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8"
@@ -62,32 +65,6 @@ _PARSER_URL_DEFAULT = (
 _CONTAINER_NAME = "xr-ai-vllm-nemotron3-nano-llm-server"
 
 
-def _gpu_compute_major() -> int:
-    try:
-        out = subprocess.check_output(
-            ["nvidia-smi", "--query-gpu=compute_cap", "--format=csv,noheader,nounits"],
-            text=True, stderr=subprocess.DEVNULL,
-        ).strip().splitlines()
-        if out:
-            return int(out[0].split(".")[0])
-    except Exception as exc:
-        logger.warning(
-            "nemotron3_nano: nvidia-smi compute-cap query failed ({}) — "
-            "defaulting to pre-Blackwell model variant",
-            exc,
-        )
-    return 0
-
-
-def _resolve_model_cache(cfg: dict, yaml_dir: Path) -> Path:
-    raw = cfg.get("model_cache", "../../models")
-    p = Path(raw)
-    if not p.is_absolute():
-        p = (yaml_dir / p).resolve()
-    p.mkdir(parents=True, exist_ok=True)
-    return p
-
-
 def _ensure_reasoning_parser(model_cache: Path, url: str) -> Path:
     path = model_cache / _PARSER_FILENAME
     if not path.exists():
@@ -98,30 +75,16 @@ def _ensure_reasoning_parser(model_cache: Path, url: str) -> Path:
 
 
 def run() -> None:
-    sys.stdout.reconfigure(line_buffering=True)
-    sys.stderr.reconfigure(line_buffering=True)
-
     setup_logging("llm-nemotron3-nano")
 
-    p = argparse.ArgumentParser(add_help=False)
-    p.add_argument("--config",     type=Path, default=None)
-    p.add_argument("--ready-file", type=Path, default=None)
-    ns, _ = p.parse_known_args()
+    cfg, yaml_dir, ready_file = load_config()
 
-    cfg: dict = {}
-    yaml_dir = Path.cwd()
-    if ns.config and ns.config.exists():
-        yaml_dir = ns.config.parent.resolve()
-        with open(ns.config) as f:
-            cfg = yaml.safe_load(f) or {}
+    model_cache = resolve_model_cache(cfg, yaml_dir, default="../../models")
+    # setup_hf_env sets CUDA_VISIBLE_DEVICES before gpu_compute_major() so
+    # nvidia-smi queries the right device.
+    cuda_devices = setup_hf_env(cfg, model_cache)
 
-    # Set before _gpu_compute_major() so nvidia-smi queries the right device.
-    cuda_devices = cfg.get("cuda_visible_devices")
-    if cuda_devices is not None:
-        cuda_devices = str(cuda_devices)
-        os.environ["CUDA_VISIBLE_DEVICES"] = cuda_devices
-
-    major = _gpu_compute_major()
+    major = gpu_compute_major()
     if major >= 10:
         model = cfg.get("model_blackwell", _MODEL_BLACKWELL)
         logger.info("Blackwell (SM{}0) → {}", major, model)
@@ -142,22 +105,15 @@ def run() -> None:
     backend       = cfg.get("vllm_backend",        "pip")
     image         = cfg.get("vllm_image",          DEFAULT_IMAGE)
 
-    model_cache = _resolve_model_cache(cfg, yaml_dir)
-    hf_token = cfg.get("hf_token") or os.environ.get("HF_TOKEN", "")
-    if hf_token:
-        os.environ["HF_TOKEN"] = hf_token
-    os.environ.setdefault("HF_HUB_ENABLE_HF_TRANSFER", "1")
-    os.environ["HF_HOME"] = str(model_cache)
-
-    # FlashInfer JIT-compiles CUTLASS MoE kernels on first run via nvcc.
-    # Ensure nvcc is on PATH and cap ninja parallelism so concurrent nvcc
-    # processes don't exhaust RAM on unified-memory machines like DGX Spark.
-    # In docker mode the container ships its own toolchain, but exporting
-    # CUDA_HOME / MAX_JOBS here is harmless.
-    _cuda_bin = Path(os.environ.get("CUDA_HOME", "/usr/local/cuda")) / "bin"
-    if _cuda_bin.exists():
-        os.environ["PATH"] = str(_cuda_bin) + ":" + os.environ.get("PATH", "")
-    os.environ.setdefault("MAX_JOBS", "4")
+    if backend == "pip":
+        # FlashInfer JIT-compiles CUTLASS MoE kernels on first run via nvcc.
+        # Ensure nvcc is on PATH and cap ninja parallelism so concurrent nvcc
+        # processes don't exhaust RAM on unified-memory machines like DGX Spark.
+        # The docker container ships its own toolchain, so this is pip-only.
+        _cuda_bin = Path(os.environ.get("CUDA_HOME", "/usr/local/cuda")) / "bin"
+        if _cuda_bin.exists():
+            os.environ["PATH"] = str(_cuda_bin) + ":" + os.environ.get("PATH", "")
+        os.environ.setdefault("MAX_JOBS", "4")
 
     parser_path = _ensure_reasoning_parser(model_cache, parser_url)
 
@@ -189,9 +145,9 @@ def run() -> None:
         host=host,
         port=port,
         model_cache=model_cache,
-        hf_token=hf_token or None,
+        hf_token=os.environ.get("HF_TOKEN") or None,
         cuda_visible_devices=cuda_devices,
-        ready_file=ns.ready_file,
+        ready_file=ready_file,
     )
 
 

--- a/ai-services/llm/nemotron_omni/nemotron_omni_llm_server/__main__.py
+++ b/ai-services/llm/nemotron_omni/nemotron_omni_llm_server/__main__.py
@@ -38,17 +38,20 @@ Config keys (nemotron_omni_llm_server.yaml)
                                      Nemotron-Omni's hybrid SSM backbone
                                      requires both at model-load time).
 """
-import argparse
 import json
 import os
-import subprocess
-import sys
 from pathlib import Path
 
-import yaml
 from loguru import logger
 from xr_ai_logging import setup_logging
-from xr_ai_vllm import DEFAULT_IMAGE, serve
+from xr_ai_vllm import (
+    DEFAULT_IMAGE,
+    gpu_compute_major,
+    load_config,
+    resolve_model_cache,
+    serve,
+    setup_hf_env,
+)
 
 _MODEL_BLACKWELL = "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4"
 _MODEL_ADA       = "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8"
@@ -69,52 +72,22 @@ _DEFAULT_FRAMES  = 256
 _CONTAINER_NAME = "xr-ai-vllm-nemotron-omni-llm-server"
 
 
-def _gpu_compute_major() -> int:
-    try:
-        out = subprocess.check_output(
-            ["nvidia-smi", "--query-gpu=compute_cap", "--format=csv,noheader,nounits"],
-            text=True, stderr=subprocess.DEVNULL,
-        ).strip().splitlines()
-        if out:
-            return int(out[0].split(".")[0])
-    except Exception:
-        pass
-    return 0
-
-
-def _resolve_model_cache(cfg: dict, yaml_dir: Path) -> Path:
-    raw = cfg.get("model_cache", "../../models")
-    p = Path(raw)
-    if not p.is_absolute():
-        p = (yaml_dir / p).resolve()
-    p.mkdir(parents=True, exist_ok=True)
-    return p
-
-
 def run() -> None:
-    sys.stdout.reconfigure(line_buffering=True)
-    sys.stderr.reconfigure(line_buffering=True)
-
     setup_logging("llm-nemotron-omni")
 
-    p = argparse.ArgumentParser(add_help=False)
-    p.add_argument("--config",     type=Path, default=None)
-    p.add_argument("--ready-file", type=Path, default=None)
-    ns, _ = p.parse_known_args()
+    cfg, yaml_dir, ready_file = load_config()
 
-    cfg: dict = {}
-    yaml_dir = Path.cwd()
-    if ns.config and ns.config.exists():
-        yaml_dir = ns.config.parent.resolve()
-        with open(ns.config) as f:
-            cfg = yaml.safe_load(f) or {}
+    model_cache = resolve_model_cache(cfg, yaml_dir, default="../../models")
+    # setup_hf_env sets CUDA_VISIBLE_DEVICES before gpu_compute_major() so
+    # nvidia-smi queries the right device.
+    cuda_devices = setup_hf_env(cfg, model_cache)
 
     if cfg.get("use_bf16", False):
         model = cfg.get("model_bf16", _MODEL_BF16)
         use_kv_fp8 = False
         logger.info("use_bf16=true → {}", model)
     else:
-        major = _gpu_compute_major()
+        major = gpu_compute_major()
         if major >= 10:
             model = cfg.get("model_blackwell", _MODEL_BLACKWELL)
             use_kv_fp8 = True
@@ -144,18 +117,6 @@ def run() -> None:
     # into the container before `vllm serve` runs. Configurable via YAML
     # for users who want to pin specific versions or add more wheels.
     extra_pip     = cfg.get("extra_pip", ["mamba-ssm", "causal-conv1d"])
-
-    cuda_devices = cfg.get("cuda_visible_devices")
-    if cuda_devices is not None:
-        cuda_devices = str(cuda_devices)
-        os.environ["CUDA_VISIBLE_DEVICES"] = cuda_devices
-
-    model_cache = _resolve_model_cache(cfg, yaml_dir)
-    hf_token = cfg.get("hf_token") or os.environ.get("HF_TOKEN", "")
-    if hf_token:
-        os.environ["HF_TOKEN"] = hf_token
-    os.environ.setdefault("HF_HUB_ENABLE_HF_TRANSFER", "1")
-    os.environ["HF_HOME"] = str(model_cache)
 
     media_io_kwargs = json.dumps({"video": {"fps": video_fps, "num_frames": video_frames}})
 
@@ -189,10 +150,10 @@ def run() -> None:
         host=host,
         port=port,
         model_cache=model_cache,
-        hf_token=hf_token or None,
+        hf_token=os.environ.get("HF_TOKEN") or None,
         cuda_visible_devices=cuda_devices,
         extra_pip=extra_pip,
-        ready_file=ns.ready_file,
+        ready_file=ready_file,
     )
 
 

--- a/ai-services/llm/nemotron_omni/pyproject.toml
+++ b/ai-services/llm/nemotron_omni/pyproject.toml
@@ -10,7 +10,7 @@ name = "nemotron-omni-llm-server"
 version = "0.1.0"
 requires-python = ">=3.11,<3.13"
 dependencies = [
-    "vllm>=0.8.0",
+    "vllm>=0.12.0",
     "pyyaml>=6.0",
     "hf-transfer>=0.1.4",
     "xr-ai-logging",

--- a/ai-services/tts/magpie/magpie_tts_server/__main__.py
+++ b/ai-services/tts/magpie/magpie_tts_server/__main__.py
@@ -108,7 +108,6 @@ class _TtsBackend:
 
 
 def _build_app(cfg: dict, model_cache: Path):
-    import numpy as np
     from fastapi import FastAPI
     from fastapi.responses import Response
     from pydantic import BaseModel

--- a/ai-services/vlm-server/vlm_server/__main__.py
+++ b/ai-services/vlm-server/vlm_server/__main__.py
@@ -36,17 +36,21 @@ Config keys
     vllm_image:              str    NGC image when vllm_backend=docker
                                     (default: nvcr.io/nvidia/vllm:26.04-py3).
 """
-import argparse
 import json
 import os
 import sys
 from pathlib import Path
 
-import yaml
+from loguru import logger
 from xr_ai_logging import setup_logging
-from xr_ai_vllm import DEFAULT_IMAGE, serve
+from xr_ai_vllm import (
+    DEFAULT_IMAGE,
+    load_config,
+    resolve_model_cache,
+    serve,
+    setup_hf_env,
+)
 
-_DEFAULT_MODEL       = "nvidia/Cosmos-Reason1-7B"
 _DEFAULT_PORT        = 8100
 _DEFAULT_HOST        = "0.0.0.0"
 _DEFAULT_SERVED_NAME = "vlm"
@@ -61,34 +65,16 @@ _DEFAULT_MAX_VIDEOS  = 0
 _CONTAINER_NAME = "xr-ai-vllm-vlm-server"
 
 
-def _resolve_model_cache(cfg: dict, yaml_dir: Path) -> Path:
-    raw = cfg.get("model_cache", "../models")
-    p = Path(raw)
-    if not p.is_absolute():
-        p = (yaml_dir / p).resolve()
-    p.mkdir(parents=True, exist_ok=True)
-    return p
-
-
 def run() -> None:
-    sys.stdout.reconfigure(line_buffering=True)
-    sys.stderr.reconfigure(line_buffering=True)
-
     setup_logging("vlm")
 
-    p = argparse.ArgumentParser(add_help=False)
-    p.add_argument("--config",     type=Path, default=None)
-    p.add_argument("--ready-file", type=Path, default=None)
-    ns, _ = p.parse_known_args()
+    cfg, yaml_dir, ready_file = load_config()
 
-    cfg: dict = {}
-    yaml_dir = Path.cwd()
-    if ns.config and ns.config.exists():
-        yaml_dir = ns.config.parent.resolve()
-        with open(ns.config) as f:
-            cfg = yaml.safe_load(f) or {}
+    if not cfg.get("model"):
+        logger.error("'model' is required in config")
+        sys.exit(1)
 
-    model         = cfg.get("model",                _DEFAULT_MODEL)
+    model         = cfg["model"]
     host          = cfg.get("host",                 _DEFAULT_HOST)
     port          = int(cfg.get("port",             _DEFAULT_PORT))
     served_name   = cfg.get("served_model_name",    _DEFAULT_SERVED_NAME)
@@ -102,21 +88,8 @@ def run() -> None:
     backend       = cfg.get("vllm_backend",         "pip")
     image         = cfg.get("vllm_image",           DEFAULT_IMAGE)
 
-    model_cache = _resolve_model_cache(cfg, yaml_dir)
-    hf_token = cfg.get("hf_token") or os.environ.get("HF_TOKEN", "")
-    if hf_token:
-        os.environ["HF_TOKEN"] = hf_token
-    os.environ.setdefault("HF_HUB_ENABLE_HF_TRANSFER", "1")
-    # setdefault so an externally-set HF cache wins over the YAML default.
-    os.environ.setdefault("HF_HOME", str(model_cache))
-    os.environ.setdefault("TRANSFORMERS_CACHE", str(model_cache))
-
-    cuda_devices = cfg.get("cuda_visible_devices")
-    if cuda_devices is not None:
-        cuda_devices = str(cuda_devices)
-        # Pip mode reads it from the env; docker mode forwards it as
-        # NVIDIA_VISIBLE_DEVICES via the nvidia runtime.
-        os.environ["CUDA_VISIBLE_DEVICES"] = cuda_devices
+    model_cache = resolve_model_cache(cfg, yaml_dir, default="../models")
+    cuda_devices = setup_hf_env(cfg, model_cache)
 
     extra_serve_args = [
         "--served-model-name", served_name,
@@ -141,9 +114,9 @@ def run() -> None:
         host=host,
         port=port,
         model_cache=model_cache,
-        hf_token=hf_token or None,
+        hf_token=os.environ.get("HF_TOKEN") or None,
         cuda_visible_devices=cuda_devices,
-        ready_file=ns.ready_file,
+        ready_file=ready_file,
     )
 
 

--- a/utils/xr-ai-vad/pyproject.toml
+++ b/utils/xr-ai-vad/pyproject.toml
@@ -20,6 +20,9 @@ dependencies = [
     "numpy>=1.24",
     "silero-vad>=5.1",
     "onnxruntime>=1.17",
+    # detector.py imports torch directly (silero's __call__ takes a Tensor);
+    # declared explicitly rather than relying on silero-vad to pull it in.
+    "torch>=2.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/utils/xr-ai-vllm/xr_ai_vllm/__init__.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/__init__.py
@@ -47,6 +47,12 @@ import urllib.request
 from pathlib import Path
 
 from . import _docker, _pip
+from ._config import (
+    gpu_compute_major,
+    load_config,
+    resolve_model_cache,
+    setup_hf_env,
+)
 
 log = logging.getLogger(__name__)
 
@@ -122,7 +128,6 @@ def serve(
         )
     elif backend == "docker":
         _docker.run(
-            persistent=persistent,
             image=image,
             container_name=container_name,
             log_prefix=log_prefix,
@@ -226,4 +231,12 @@ def stop_persistent_servers(
         print("  No persistent servers found running.", flush=True)
 
 
-__all__ = ["serve", "stop_persistent_servers", "DEFAULT_IMAGE"]
+__all__ = [
+    "serve",
+    "stop_persistent_servers",
+    "DEFAULT_IMAGE",
+    "resolve_model_cache",
+    "load_config",
+    "setup_hf_env",
+    "gpu_compute_major",
+]

--- a/utils/xr-ai-vllm/xr_ai_vllm/_config.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/_config.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared config/env/GPU helpers for the vLLM-backed service wrappers.
+
+Stdlib-only by contract (see package docstring). ``yaml`` is imported
+function-locally in :func:`load_config` so ``import xr_ai_vllm`` stays
+dependency-free for the orchestrator ``--stop`` path, which declares no
+pyyaml.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+
+def resolve_model_cache(cfg: dict, yaml_dir: Path, *, default: str) -> Path:
+    """Resolve ``model_cache`` (relative to the YAML dir) and ensure it exists."""
+    raw = cfg.get("model_cache", default)
+    p = Path(raw)
+    if not p.is_absolute():
+        p = (yaml_dir / p).resolve()
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def load_config(argv: list[str] | None = None) -> tuple[dict, Path, Path | None]:
+    """Parse ``--config``/``--ready-file`` and load the YAML config.
+
+    Reconfigures stdout/stderr to line-buffered so logs flush under the
+    launcher's piped stdout. Returns ``(cfg, yaml_dir, ready_file)``;
+    ``yaml_dir`` is the config's directory (cwd when no config is given),
+    used as the base for relative paths like ``model_cache``.
+    """
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
+
+    p = argparse.ArgumentParser(add_help=False)
+    p.add_argument("--config", type=Path, default=None)
+    p.add_argument("--ready-file", type=Path, default=None)
+    ns, _ = p.parse_known_args(argv)
+
+    cfg: dict = {}
+    yaml_dir = Path.cwd()
+    if ns.config and ns.config.exists():
+        import yaml
+
+        yaml_dir = ns.config.parent.resolve()
+        with open(ns.config) as f:
+            cfg = yaml.safe_load(f) or {}
+
+    return cfg, yaml_dir, ns.ready_file
+
+
+def setup_hf_env(cfg: dict, model_cache: Path) -> str | None:
+    """Apply the shared HuggingFace / CUDA env block.
+
+    Sets ``CUDA_VISIBLE_DEVICES`` (when configured), ``HF_TOKEN`` (when
+    provided), ``HF_HUB_ENABLE_HF_TRANSFER``, and ``HF_HOME``. ``HF_HOME`` is
+    set via ``setdefault`` so an externally-set HF cache wins over the YAML
+    default. Returns the resolved ``cuda_visible_devices`` string (or ``None``)
+    so callers that run GPU detection can confirm the device filter is applied.
+    """
+    cuda_devices = cfg.get("cuda_visible_devices")
+    if cuda_devices is not None:
+        cuda_devices = str(cuda_devices)
+        # Pip mode reads it from the env; docker mode forwards via --gpus.
+        os.environ["CUDA_VISIBLE_DEVICES"] = cuda_devices
+
+    hf_token = cfg.get("hf_token") or os.environ.get("HF_TOKEN", "")
+    if hf_token:
+        os.environ["HF_TOKEN"] = hf_token
+    os.environ.setdefault("HF_HUB_ENABLE_HF_TRANSFER", "1")
+    os.environ.setdefault("HF_HOME", str(model_cache))
+
+    return cuda_devices
+
+
+def gpu_compute_major() -> int:
+    """Return the GPU's compute-capability major version, or 0 if unknown.
+
+    Reads ``CUDA_VISIBLE_DEVICES`` from the env, so set the device filter
+    before calling. Logs a warning on failure and falls back to 0.
+    """
+    try:
+        out = subprocess.check_output(
+            ["nvidia-smi", "--query-gpu=compute_cap", "--format=csv,noheader,nounits"],
+            text=True, stderr=subprocess.DEVNULL,
+        ).strip().splitlines()
+        if out:
+            return int(out[0].split(".")[0])
+    except Exception as exc:
+        log.warning(
+            "nvidia-smi compute-cap query failed (%s) — "
+            "defaulting to pre-Blackwell model variant", exc,
+        )
+    return 0

--- a/utils/xr-ai-vllm/xr_ai_vllm/_config.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/_config.py
@@ -62,10 +62,19 @@ def setup_hf_env(cfg: dict, model_cache: Path) -> str | None:
     """Apply the shared HuggingFace / CUDA env block.
 
     Sets ``CUDA_VISIBLE_DEVICES`` (when configured), ``HF_TOKEN`` (when
-    provided), ``HF_HUB_ENABLE_HF_TRANSFER``, and ``HF_HOME``. ``HF_HOME`` is
-    set via ``setdefault`` so an externally-set HF cache wins over the YAML
-    default. Returns the resolved ``cuda_visible_devices`` string (or ``None``)
-    so callers that run GPU detection can confirm the device filter is applied.
+    provided), ``HF_HUB_ENABLE_HF_TRANSFER``, ``HF_HOME``, and
+    ``TRANSFORMERS_CACHE``.
+
+    Both ``HF_HOME`` and ``TRANSFORMERS_CACHE`` are set via ``setdefault``, so
+    an externally-set value wins over the YAML default. This intentionally
+    differs from the pre-consolidation per-server code where the LLM wrappers
+    used an unconditional assignment for ``HF_HOME``; callers that need the
+    YAML value to take priority must unset the env var before calling.
+    ``TRANSFORMERS_CACHE`` mirrors ``HF_HOME`` for Transformers <4.36 and
+    third-party libraries that have not yet adopted the ``HF_HOME`` superset.
+
+    Returns the resolved ``cuda_visible_devices`` string (or ``None``) so
+    callers that run GPU detection can confirm the device filter is applied.
     """
     cuda_devices = cfg.get("cuda_visible_devices")
     if cuda_devices is not None:
@@ -78,6 +87,7 @@ def setup_hf_env(cfg: dict, model_cache: Path) -> str | None:
         os.environ["HF_TOKEN"] = hf_token
     os.environ.setdefault("HF_HUB_ENABLE_HF_TRANSFER", "1")
     os.environ.setdefault("HF_HOME", str(model_cache))
+    os.environ.setdefault("TRANSFORMERS_CACHE", str(model_cache))
 
     return cuda_devices
 

--- a/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
@@ -377,7 +377,6 @@ def _append_post_mortem(container_name: str, log_path: Path | None, n: int = 200
 
 def run(
     *,
-    persistent: bool = True,  # accepted for backwards compat; docker always runs foreground
     image: str,
     container_name: str,
     log_prefix: str,


### PR DESCRIPTION
Repo cleanup batch — ai-services + xr-ai-vllm slice (WP-B16-B20, WP-D1-D7). xr-ai-vllm stays stdlib-only; new _config.py provides resolve_model_cache/load_config/setup_hf_env/gpu_compute_major; the four wrappers' run() rewritten on top. **Behavior fix:** HF_HOME unified to setdefault (the three LLM wrappers previously overrode a pre-set value). Required-key validation added. uv.lock is gitignored repo-wide (nothing to commit; resolutions verified). Wrapper run() paths are GPU-verified → flag tests/run_local_gpu_tests.sh for human. Base main — do not merge (human gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)