### PR TITLE
fix(tests): drop unused extra_pip from omni gpu xfail (~16min → ~15s)

### DIFF
--- a/tests/test_gpu_llm_servers.py
+++ b/tests/test_gpu_llm_servers.py
@@ -360,8 +360,14 @@ async def test_nemotron3_nano_persistent(tmp_path: Path) -> None:
 # break this suite on the day the fix lands.
 @pytest.mark.xfail(
     reason="vLLM 0.19.0 in nvcr.io/nvidia/vllm:26.04-py3 does not register "
-           "the NemotronH_Nano_Omni_Reasoning_V3 architecture; remove xfail "
-           "after bumping DEFAULT_IMAGE to a tag whose vLLM has it.",
+           "the NemotronH_Nano_Omni_Reasoning_V3 architecture, so startup "
+           "fails in create_model_config (config.json arch check) — before "
+           "any model code loads. The test config below sets extra_pip=[] so "
+           "this guaranteed failure no longer pays the ~16 min mamba-ssm / "
+           "causal-conv1d CUDA-kernel compile it never reaches. When vLLM "
+           "registers the arch, the failure mode shifts to a mamba_ssm "
+           "ImportError at model load — that's the signal to restore extra_pip "
+           "(and bump DEFAULT_IMAGE) and run this for real.",
     strict=False,
 )
 async def test_nemotron_omni_multimodal(tmp_path: Path) -> None:
@@ -390,6 +396,11 @@ async def test_nemotron_omni_multimodal(tmp_path: Path) -> None:
         "video_num_frames":       8,
         # docker backend: nvcc + flashinfer are pre-built in the NGC image.
         "vllm_backend":           "docker",
+        # This test xfails at the vLLM arch check (see the xfail reason),
+        # which runs before any model code imports mamba_ssm. Skip the
+        # default mamba-ssm/causal-conv1d source build — it's a ~16 min
+        # CUDA-kernel compile this guaranteed failure never reaches.
+        "extra_pip":              [],
     }
     cfg_yaml = tmp_path / "nemotron_omni_llm_server.yaml"
     cfg_yaml.write_text(yaml.safe_dump(cfg))


### PR DESCRIPTION
## Problem

`test_nemotron_omni_multimodal` appeared to hang — each run sat with no output for ~16 minutes before resolving.

It's an intentional `xfail`: vLLM 0.19.0 in `nvcr.io/nvidia/vllm:26.04-py3` does not register the `NemotronH_Nano_Omni_Reasoning_V3` architecture, so startup fails in `create_model_config` (the `config.json` arch check):

```
pydantic_core.ValidationError: Model architectures ['NemotronH_Nano_Omni_Reasoning_V3'] are not supported for now.
```

The test had no `extra_pip` of its own, so it inherited the server default `["mamba-ssm", "causal-conv1d"]`. The docker backend builds those from source (`pip install --no-build-isolation`) **on every run** — the container is removed on stop, so nothing is reused. That CUDA-kernel compile is the time sink:

- container launch **01:49:01** → vLLM's first banner line **02:05:34** in the container log = **~16.5 min** of pre-vLLM container setup, then the arch error fires instantly.

It's entirely wasted work: the arch check fails in `create_model_config`, **before** any model code imports `mamba_ssm` (which only happens at model load). The kernels are never reached.

## Fix

Set `extra_pip: []` in the **test** config (test-scoped; product default unchanged). `hf_transfer` still installs — it's gated separately (`_docker.py:96 if extra_pip:`). The guaranteed xfail now resolves in ~15s.

The `xfail` `reason=` is updated to document the failure-mode shift: once vLLM registers the arch, startup proceeds to model load and fails on a missing `mamba_ssm` import instead — the signal to restore `extra_pip`, bump `DEFAULT_IMAGE`, and run the test for real.

## Verification

On a free L40S with the NGC image already cached:

- Before: ~16 min per run (kernel compile), then XFAIL.
- After: `1 xfailed in 15.13s`.

XFAIL semantics preserved; no behavior change for `llama`/`nemotron3` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)