### PR TITLE
fix(vllm): launch GPU containers via nvidia runtime, not legacy --gpus

### DIFF
--- a/ai-services/vlm-server/vlm_server/__main__.py
+++ b/ai-services/vlm-server/vlm_server/__main__.py
@@ -114,7 +114,8 @@ def run() -> None:
     cuda_devices = cfg.get("cuda_visible_devices")
     if cuda_devices is not None:
         cuda_devices = str(cuda_devices)
-        # Pip mode reads it from the env; docker mode forwards via --gpus.
+        # Pip mode reads it from the env; docker mode forwards it as
+        # NVIDIA_VISIBLE_DEVICES via the nvidia runtime.
         os.environ["CUDA_VISIBLE_DEVICES"] = cuda_devices
 
     extra_serve_args = [

--- a/docs/ai-services.md
+++ b/docs/ai-services.md
@@ -253,9 +253,11 @@ Existing `~/.docker/config.json` entries take priority and are not overwritten.
 
 ### docker mode — runtime details
 
-- Container is launched with `--network host --ipc host --gpus …` (matches
-  the existing LiveKit container precedent and gives vLLM the shared-memory
-  region its workers expect).
+- Container is launched with `--network host --ipc host --runtime nvidia`
+  (forwarding `NVIDIA_VISIBLE_DEVICES`). The nvidia runtime is used instead of
+  the legacy `--gpus` flag so the launch works under both legacy and CDI
+  container-toolkit modes; `--ipc host` gives vLLM the shared-memory region
+  its workers expect.
 - The host `model_cache` is bind-mounted at the same path inside the
   container and `HF_HOME` is set to it, so weights cached by pip mode are
   reused by docker mode and vice versa.

--- a/tests/test_vllm_docker.py
+++ b/tests/test_vllm_docker.py
@@ -104,17 +104,22 @@ class TestBuildRunArgv:
         assert "--network" in argv
         assert argv[argv.index("--network") + 1] == "host"
 
-    def test_gpus_all_when_no_cuda_filter(self, tmp_path):
+    def test_nvidia_runtime_all_gpus_when_no_cuda_filter(self, tmp_path):
+        # nvidia runtime (not legacy --gpus) so the launch works under both
+        # legacy and CDI toolkit modes; "all" requests every GPU.
         argv = build_run_argv(**self._base_kwargs(tmp_path))
-        assert "--gpus" in argv
-        assert argv[argv.index("--gpus") + 1] == "all"
+        assert "--gpus" not in argv
+        assert argv[argv.index("--runtime") + 1] == "nvidia"
+        env_flags = [argv[i + 1] for i, a in enumerate(argv) if a == "-e"]
+        assert "NVIDIA_VISIBLE_DEVICES=all" in env_flags
 
     def test_cuda_visible_devices_applied(self, tmp_path):
         kwargs = self._base_kwargs(tmp_path)
         kwargs["cuda_visible_devices"] = "0,1"
         argv = build_run_argv(**kwargs)
-        assert "--gpus" in argv
-        assert argv[argv.index("--gpus") + 1] == "device=0,1"
+        assert argv[argv.index("--runtime") + 1] == "nvidia"
+        env_flags = [argv[i + 1] for i, a in enumerate(argv) if a == "-e"]
+        assert "NVIDIA_VISIBLE_DEVICES=0,1" in env_flags
 
     def test_hf_token_in_env(self, tmp_path):
         argv = build_run_argv(**self._base_kwargs(tmp_path))

--- a/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
@@ -71,10 +71,19 @@ def build_run_argv(
     # shared memory namespace.
     argv += ["--ipc", "host"]
 
-    if cuda_visible_devices:
-        argv += ["--gpus", f"device={cuda_visible_devices}"]
-    else:
-        argv += ["--gpus", "all"]
+    # Request GPUs via the nvidia runtime, not the legacy `--gpus` hook.
+    # Under nvidia-container-toolkit `mode = "auto"`, `--gpus` is rejected
+    # whenever the toolkit auto-detects CDI mode (the prestart hook refuses
+    # with "use --runtime=nvidia instead"), so it fails non-deterministically
+    # across hosts. The nvidia runtime injects devices itself and works under
+    # both legacy and CDI modes — don't depend on a host's mutable toolkit
+    # mode. NVIDIA_VISIBLE_DEVICES takes the same comma list as
+    # CUDA_VISIBLE_DEVICES, or "all".
+    argv += ["--runtime", "nvidia"]
+    argv += ["-e", f"NVIDIA_VISIBLE_DEVICES={cuda_visible_devices or 'all'}"]
+    # The NGC image sets compute,utility,video, but set it explicitly so a
+    # non-NGC image (or one with a narrower default) still gets CUDA compute.
+    argv += ["-e", "NVIDIA_DRIVER_CAPABILITIES=compute,utility"]
 
     env_vars: dict[str, str] = {
         "HF_HOME": str(model_cache),


### PR DESCRIPTION
## Problem

The docker backend requested GPUs with `--gpus`, which routes through the legacy NVIDIA prestart hook. Under `nvidia-container-toolkit` `mode = "auto"`, that hook is **rejected whenever the toolkit auto-detects CDI mode**:

```
docker: Error response from daemon: ... error running prestart hook #0: ... Using requested mode 'cdi'
invoking the NVIDIA Container Runtime Hook directly (e.g. specifying the docker --gpus flag) is not
supported. Please use the NVIDIA Container Runtime (e.g. specify the --runtime=nvidia flag) instead
```

Auto-detection is per-invocation (it tips to CDI when a CDI spec is present, e.g. `/var/run/cdi/nvidia.yaml`), so vLLM launches fail **non-deterministically across hosts** — `test_llama_nemotron_tool_call`, `test_nemotron3_nano_persistent`, and `test_vlm_server_chat_completions_smoke` all died this way on the nightly GPU runner. The root issue is that our launcher depends on a *mutable host toolkit setting we don't control*.

## Fix

Request GPUs via `--runtime nvidia` + `NVIDIA_VISIBLE_DEVICES` instead of `--gpus`. The nvidia runtime injects devices itself and works under **both legacy and CDI** toolkit modes, so the launch no longer depends on how a given host auto-detects. This is also what the daemon's own error message recommends, and is the original (pre-`--gpus`) way to run GPU containers. Also sets `NVIDIA_DRIVER_CAPABILITIES=compute,utility` explicitly so non-NGC images still get CUDA compute.

`build_run_argv` is the single GPU-container launch path in the repo (every LLM/VLM server routes through it), so this one change covers all three failing tests. Swept for other launch mechanisms (compose device reservations, other `docker run` calls) — none exist.

## Verification

On an RTX 6000 Ada host, a container launched with the generated flags reports CUDA compute available:
```
$ docker run --rm --runtime nvidia -e NVIDIA_VISIBLE_DEVICES=0 \
    -e NVIDIA_DRIVER_CAPABILITIES=compute,utility --network host --ipc host \
    --entrypoint python3 nvcr.io/nvidia/vllm:26.04-py3 \
    -c "import torch; print(torch.cuda.is_available(), torch.cuda.device_count())"
True 1
```
- `tests/test_vllm_docker.py` updated to assert the new argv; 26 passed.

## Also

- Updated the now-stale `--gpus` comment in `vlm_server/__main__.py` and the runtime-details note in `docs/ai-services.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)