### PR TITLE
fix: resolve accepted native Sonar findings

### DIFF
--- a/client-samples/native/StreamKit/Tests/StreamKitTests/LiveKitBackendTests.cpp
+++ b/client-samples/native/StreamKit/Tests/StreamKitTests/LiveKitBackendTests.cpp
@@ -34,7 +34,7 @@ int main() {
 
     streamkit::StreamSession session{
         streamkit::BackendConfiguration{lk}};
-    auto* livekit_backend =
+    const auto* livekit_backend =
         dynamic_cast<streamkit::LiveKitBackend*>(session.GetBackend());
     Expect(livekit_backend != nullptr);
     Expect(!livekit_backend->GetRoom());

--- a/client-samples/native/StreamKit/Tests/StreamKitTests/MappingTests.cpp
+++ b/client-samples/native/StreamKit/Tests/StreamKitTests/MappingTests.cpp
@@ -6,14 +6,14 @@
 #include "streamkit/ConnectionState.h"
 
 int main() {
-    using streamkit::ConnectionState;
+    using enum streamkit::ConnectionState;
     using streamkit::test::Expect;
     using streamkit::test::ExpectEq;
 
-    ExpectEq(ConnectionState::kConnected, ConnectionState::kConnected);
-    Expect(ConnectionState::kDisconnected != ConnectionState::kConnected);
-    Expect(ConnectionState::kConnecting   != ConnectionState::kConnected);
-    Expect(ConnectionState::kReconnecting != ConnectionState::kConnected);
+    ExpectEq(kConnected, kConnected);
+    Expect(kDisconnected != kConnected);
+    Expect(kConnecting   != kConnected);
+    Expect(kReconnecting != kConnected);
 
     return 0;
 }

--- a/client-samples/native/StreamKit/include/streamkit/Config/SessionConfig.h
+++ b/client-samples/native/StreamKit/include/streamkit/Config/SessionConfig.h
@@ -6,6 +6,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <format>
 #include <string>
 
 namespace streamkit {
@@ -26,9 +27,9 @@ struct SessionConfig {
         static std::atomic_uint64_t sequence{0};
         const auto timestamp =
             std::chrono::steady_clock::now().time_since_epoch().count();
-        return SessionConfig{
-            "participant-" + std::to_string(timestamp) + "-" +
-            std::to_string(sequence.fetch_add(1, std::memory_order_relaxed))};
+        return SessionConfig{std::format(
+            "participant-{}-{}", timestamp,
+            sequence.fetch_add(1, std::memory_order_relaxed))};
     }
 };
 

--- a/client-samples/native/StreamKit/src/Backends/LiveKit/LiveKitBackend.cpp
+++ b/client-samples/native/StreamKit/src/Backends/LiveKit/LiveKitBackend.cpp
@@ -21,6 +21,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <format>
 #include <mutex>
 #include <optional>
 #include <stdexcept>
@@ -84,17 +85,18 @@ livekit::VideoBufferType MapPixelFormat(PixelFormat fmt) {
 std::size_t PackedFrameSize(int width, int height, PixelFormat format) {
     const auto pixels =
         static_cast<std::size_t>(width) * static_cast<std::size_t>(height);
+    using enum PixelFormat;
     switch (format) {
-        case PixelFormat::kI420:
-        case PixelFormat::kNV12: {
+        case kI420:
+        case kNV12: {
             const auto chroma_w =
                 (static_cast<std::size_t>(width)  + 1) / 2;
             const auto chroma_h =
                 (static_cast<std::size_t>(height) + 1) / 2;
             return pixels + 2 * chroma_w * chroma_h;
         }
-        case PixelFormat::kRGBA:
-        case PixelFormat::kBGRA:
+        case kRGBA:
+        case kBGRA:
             return pixels * 4;
     }
     return 0;  // unreachable
@@ -182,7 +184,7 @@ void LiveKitBackend::Connect(const SessionConfig& session_config) {
 
     const std::string scheme = config_.secure ? "wss" : "ws";
     const std::string ws_url =
-        scheme + "://" + config_.host + ":" + std::to_string(config_.port);
+        std::format("{}://{}:{}", scheme, config_.host, config_.port);
 
     std::string token;
     if (config_.token.has_value() && !config_.token->empty()) {
@@ -341,12 +343,13 @@ void LiveKitBackend::InjectVideoFrame(std::vector<std::uint8_t>&& data,
     // their padded HAL or GPU readback buffer?" mistake.
     if (const auto expected = PackedFrameSize(width, height, format);
         data.size() != expected) {
-        throw std::invalid_argument(
-            "InjectVideoFrame: buffer size " + std::to_string(data.size()) +
-            " does not match the packed size " + std::to_string(expected) +
+        throw std::invalid_argument(std::format(
+            "InjectVideoFrame: buffer size {}"
+            " does not match the packed size {}"
             " expected for the given dimensions and format. FrameSink "
             "requires tightly packed input - repack padded buffers before "
-            "calling.");
+            "calling.",
+            data.size(), expected));
     }
 
 #if STREAMKIT_HAVE_LIVEKIT
@@ -418,10 +421,10 @@ void LiveKitBackend::InjectAudioFrame(std::span<const std::int16_t> pcm,
             static_cast<std::size_t>(channels) *
             static_cast<std::size_t>(samples_per_channel);
         pcm.size() != expected) {
-        throw std::invalid_argument(
-            "InjectAudioFrame: sample count " + std::to_string(pcm.size()) +
-            " does not match channels * samples_per_channel = " +
-            std::to_string(expected));
+        throw std::invalid_argument(std::format(
+            "InjectAudioFrame: sample count {}"
+            " does not match channels * samples_per_channel = {}",
+            pcm.size(), expected));
     }
 
 #if STREAMKIT_HAVE_LIVEKIT


### PR DESCRIPTION
## Summary

- resolve the seven accepted new-code Sonar findings in native StreamKit code
- use `std::format` for accepted string-concatenation findings
- use `using enum` for accepted enum verbosity findings
- make the LiveKit backend test pointer a pointer-to-const

## Sonar

Accepted issues addressed:

- `cpp:S5350` in `LiveKitBackendTests.cpp`
- `cpp:S6185` in `SessionConfig.h`
- `cpp:S6177` in `LiveKitBackend.cpp`
- `cpp:S6185` in `LiveKitBackend.cpp` URL formatting
- `cpp:S6185` in `LiveKitBackend.cpp` video-frame validation message
- `cpp:S6185` in `LiveKitBackend.cpp` audio-frame validation message
- `cpp:S6177` in `MappingTests.cpp`

## Testing

- `clang++ -std=c++20 -Wall -Wextra` compile of touched StreamKit translation units
- manual compile and run of all six native StreamKit test executables
- manual compile of native sample app
- `git diff --check`
