### PR TITLE
feat(semantic-slam): scaffold ai-services module + third-party notices

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -30,6 +30,76 @@ For the per-package dependency mapping, see [`DEPENDENCIES.md`](DEPENDENCIES.md)
 | `numpy`        | 1.24.0   | BSD-3-Clause  | https://github.com/numpy/numpy |
 | `websockets`   | 12.0     | BSD-3-Clause  | https://github.com/python-websockets/websockets |
 
+## Python — `ai-services/semantic-slam`
+
+Used by `ai-services/semantic-slam/`. Pinned versions from `uv.lock` in
+[`semantic-slam-server`](https://github.com/nvddr/semantic-slam-server).
+
+### PyPI packages
+
+| Package              | Version          | License            | Upstream |
+|---                   |---               |---                 |---|
+| `torch`              | 2.0.1+cu118      | BSD-3-Clause       | https://github.com/pytorch/pytorch |
+| `torchvision`        | 0.15.2+cu118     | BSD-3-Clause       | https://github.com/pytorch/vision |
+| `numpy`              | 1.26.4           | BSD-3-Clause       | https://github.com/numpy/numpy |
+| `opencv-python`      | 4.10.0.84        | Apache-2.0         | https://github.com/opencv/opencv-python |
+| `Pillow`             | 12.2.0           | HPND               | https://github.com/python-pillow/Pillow |
+| `grpcio`             | 1.81.0           | Apache-2.0         | https://github.com/grpc/grpc |
+| `grpcio-tools`       | 1.81.0           | Apache-2.0         | https://github.com/grpc/grpc |
+| `supervision`        | 0.28.0           | MIT                | https://github.com/roboflow/supervision |
+| `pynvvideocodec`     | 2.1.0            | MIT                | https://github.com/NVIDIA/PyNvVideoCodec |
+| `distinctipy`        | 1.3.4            | MIT                | https://github.com/alan-turing-institute/distinctipy |
+| `open-clip-torch`    | 3.3.0            | MIT                | https://github.com/mlfoundations/open_clip |
+| `transformers`       | 4.25.1           | Apache-2.0         | https://github.com/huggingface/transformers |
+| `openai`             | 2.41.0           | Apache-2.0         | https://github.com/openai/openai-python |
+| `hydra-core`         | 1.3.2            | MIT                | https://github.com/facebookresearch/hydra |
+| `omegaconf`          | 2.3.0            | BSD-3-Clause       | https://github.com/omry/omegaconf |
+| `wandb`              | 0.27.2           | MIT                | https://github.com/wandb/wandb |
+| `h5py`               | 3.16.0           | BSD-3-Clause       | https://github.com/h5py/h5py |
+| `tyro`               | 1.0.13           | MIT                | https://github.com/brentyi/tyro |
+| `tqdm`               | 4.68.2           | MIT / MPL-2.0      | https://github.com/tqdm/tqdm |
+| `matplotlib`         | 3.10.9           | PSF / BSD-style    | https://github.com/matplotlib/matplotlib |
+| `scikit-learn`       | 1.7.2            | BSD-3-Clause       | https://github.com/scikit-learn/scikit-learn |
+| `scipy`              | 1.14.1           | BSD-3-Clause       | https://github.com/scipy/scipy |
+| `imageio`            | 2.37.3           | BSD-2-Clause       | https://github.com/imageio/imageio |
+| `kornia`             | 0.7.3            | Apache-2.0         | https://github.com/kornia/kornia |
+| `natsort`            | 8.4.0            | MIT                | https://github.com/SethMMorton/natsort |
+| `open3d`             | 0.19.0           | MIT                | https://github.com/isl-org/Open3D |
+| `faiss-cpu`          | 1.14.2           | MIT                | https://github.com/facebookresearch/faiss |
+| `ftfy`               | 6.3.1            | Apache-2.0         | https://github.com/rspeer/python-ftfy |
+| `fairscale`          | 0.4.13           | BSD-3-Clause       | https://github.com/facebookresearch/fairscale |
+| `addict`             | 2.4.0            | MIT                | https://github.com/mewwts/addict |
+| `pyyaml`             | 6.0.3            | MIT                | https://github.com/yaml/pyyaml |
+| `fvcore`             | 0.1.5            | Apache-2.0         | https://github.com/facebookresearch/fvcore |
+| `iopath`             | 0.1.10           | MIT                | https://github.com/facebookresearch/iopath |
+| `timm`               | 1.0.27           | Apache-2.0         | https://github.com/huggingface/pytorch-image-models |
+| `yapf`               | 0.43.0           | Apache-2.0         | https://github.com/google/yapf |
+| `pycocotools`        | 2.0.11           | BSD-2-Clause       | https://github.com/cocodataset/cocoapi |
+
+### Git-installed model components
+
+| Project                  | License     | Upstream |
+|---                       |---          |---|
+| GroundingDINO            | Apache-2.0  | https://github.com/IDEA-Research/GroundingDINO |
+| Segment Anything (SAM)   | Apache-2.0  | https://github.com/facebookresearch/segment-anything |
+| MobileSAM                | Apache-2.0  | https://github.com/ChaoningZhang/MobileSAM |
+| sam-hq / LightHQSAM      | Apache-2.0  | https://github.com/SysCV/sam-hq |
+| EfficientSAM             | Apache-2.0  | https://github.com/yformer/EfficientSAM |
+| recognize-anything (RAM) | Apache-2.0  | https://github.com/xinyu1205/recognize-anything |
+| gradslam (conceptfusion) | MIT         | https://github.com/gradslam/gradslam |
+| chamferdist              | MIT         | https://github.com/krrish94/chamferdist |
+| pytorch3d                | BSD-3-Clause | https://github.com/facebookresearch/pytorch3d |
+
+### NVIDIA proprietary runtime SDKs (runtime-only, not redistributed)
+
+| SDK                    | Purpose |
+|---                     |---|
+| CUDA Toolkit           | GPU compute runtime |
+| cuDNN                  | Deep-learning primitives |
+| NCCL                   | Multi-GPU collectives |
+| TensorRT               | Inference optimizer (optional CLIP path) |
+| NVIDIA Video Codec SDK | Hardware H.264/H.265 decode (via `pynvvideocodec`) |
+
 ## Swift (iOS / visionOS client)
 
 Used by `client-samples/ios-visionos/`. Resolved via Swift Package Manager.
@@ -47,8 +117,12 @@ The full text of each SPDX license identifier referenced above is available at:
 
 - **Apache-2.0**: https://www.apache.org/licenses/LICENSE-2.0 — also bundled
   with this repository as [`LICENSE`](LICENSE).
+- **BSD-2-Clause**: https://opensource.org/license/bsd-2-clause
 - **BSD-3-Clause**: https://opensource.org/license/bsd-3-clause
+- **HPND**: https://opensource.org/license/historical-permission-notice-and-disclaimer (Pillow / PIL)
 - **MIT**: https://opensource.org/license/mit
+- **MPL-2.0**: https://www.mozilla.org/en-US/MPL/2.0/ (tqdm dual-license)
+- **PSF**: https://docs.python.org/3/license.html (matplotlib)
 
 Each upstream project repository linked above includes its own canonical
 license file (typically `LICENSE`, `LICENSE.txt`, or `COPYING`).

--- a/ai-services/semantic-slam/pyproject.toml
+++ b/ai-services/semantic-slam/pyproject.toml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "semantic-slam"
+version = "0.1.0"
+requires-python = ">=3.10,<3.12"
+# TODO: populate dependencies when code is migrated from semantic-slam-server
+
+[tool.hatch.build.targets.wheel]
+packages = ["semantic_slam"]

--- a/ai-services/semantic-slam/semantic_slam.yaml
+++ b/ai-services/semantic-slam/semantic_slam.yaml
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# semantic-slam — Semantic SLAM service configuration.
+# TODO: populate when code is migrated from semantic-slam-server.

--- a/ai-services/semantic-slam/semantic_slam/__init__.py
+++ b/ai-services/semantic-slam/semantic_slam/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
## Summary

- Adds `ai-services/semantic-slam/` skeleton matching the module layout used by `vlm-server`, `stt-server`, etc.
- Updates `THIRD_PARTY_NOTICES.md` with a complete inventory of `semantic-slam`'s third-party dependencies before any code lands

No production code migrated yet — this is the structural + licensing groundwork.

## Directory structure

```
ai-services/semantic-slam/
  pyproject.toml          ← stub; deps populated when code migrates
  semantic_slam/
    __init__.py
  semantic_slam.yaml      ← stub config
```

## THIRD_PARTY_NOTICES.md additions

New section **`## Python — ai-services/semantic-slam`** with:
- 36 PyPI packages (pinned versions from `semantic-slam-server` `uv.lock`, licenses verified via PyPI JSON API)
- 9 git-installed model components (GroundingDINO, SAM variants, RAM, gradslam, chamferdist, pytorch3d)
- NVIDIA proprietary runtime SDKs table (CUDA, cuDNN, NCCL, TensorRT, NVVS)
- New SPDX identifiers added to license texts section: HPND, BSD-2-Clause, MPL-2.0, PSF

## Test plan

- [ ] `ai-services/semantic-slam/` directory present and matches module layout convention
- [ ] `THIRD_PARTY_NOTICES.md` renders correctly on GitHub
- [ ] All license identifiers in the new section are covered in the **License texts** footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)