### PR TITLE
fix(deps): bump stale version floors across pyproject.toml files

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -49,11 +49,11 @@ xr-ai-pipecat  (agent-sdk/xr-ai-pipecat/)
     └── xr-ai-models    [editable: ../xr-ai-models]
     └── xr-ai-vad       [editable: ../../utils/xr-ai-vad]
     └── xr-ai-voicegate [editable: ../../utils/xr-ai-voicegate]
-    └── pipecat-ai >=0.0.46
+    └── pipecat-ai >=1.0
     └── numpy >=1.24
     └── scipy >=1.11
     └── httpx >=0.27
-    └── fastmcp >=0.4
+    └── fastmcp >=2.0
     Unified Pipecat voice pipeline. Owns the transport bridge to
     ProcessorEndpoint (ZMQ IPC) plus the four library FrameProcessors —
     VadSttProcessor, VoiceGateProcessor, BrainProcessor, StreamingTtsProcessor —
@@ -124,8 +124,8 @@ xr-ai-vad  (utils/xr-ai-vad/)
 xr-media-hub  (server-runtime/)
     └── xr-ai-agent  [editable: ../agent-sdk]
     └── pyzmq >=27.0
-    └── livekit >=0.17
-    └── livekit-api >=0.7
+    └── livekit >=1.0
+    └── livekit-api >=1.0
     └── fastapi >=0.111
     └── uvicorn[standard] >=0.29
     └── httpx >=0.27
@@ -137,14 +137,14 @@ xr-media-hub  (server-runtime/)
 
 transcript-mcp-server  (agent-mcp-servers/transcript-mcp/)
     └── uvicorn[standard] >=0.29
-    └── fastmcp >=0.4
+    └── fastmcp >=2.0
     └── pyyaml >=6.0
     Pure FastMCP — every operation is an MCP tool at /mcp (no REST).
     Storage: JSONL files per participant in configurable transcripts_dir.
 
 vlm-mcp-server  (agent-mcp-servers/vlm-mcp/)
     └── uvicorn[standard] >=0.29
-    └── fastmcp >=0.4
+    └── fastmcp >=2.0
     └── pyyaml >=6.0
     └── Pillow >=10.0
     └── httpx >=0.27   (imported directly to catch httpx.HTTPError from xr-ai-models)
@@ -157,7 +157,7 @@ vlm-mcp-server  (agent-mcp-servers/vlm-mcp/)
 
 video-mcp-server  (agent-mcp-servers/video-mcp/)
     └── uvicorn[standard] >=0.29
-    └── fastmcp >=0.4
+    └── fastmcp >=2.0
     └── pyyaml >=6.0
     └── xr-ai-agent  [editable: ../../agent-sdk]
     └── PyNvVideoCodec >=1.0
@@ -180,7 +180,7 @@ render-mcp-server  (agent-mcp-servers/render-mcp/)
     └── msgpack >=1.0      (wire format for LOVR ops)
     └── pyyaml >=6.0
     └── uvicorn[standard] >=0.29
-    └── fastmcp >=0.4
+    └── fastmcp >=2.0
     Pure FastMCP at /mcp → LOVR (msgpack/ZMQ); no REST routes.
     Spawns LOVR (the OpenXR rendering app) on the first start_xr call.
     cloudxr-runtime must start before render-mcp (serial launch order);
@@ -191,14 +191,14 @@ oxr-mcp-server  (agent-mcp-servers/oxr-mcp/)
     └── isaacteleop                                (headless OpenXR + HeadTracker)
     └── pyyaml >=6.0
     └── uvicorn[standard] >=0.29
-    └── fastmcp >=0.4
+    └── fastmcp >=2.0
     Pure FastMCP at /mcp. Reads pose from CloudXR via a second (headless)
     OpenXR session; runs alongside LOVR's rendering session.
     cloudxr-runtime must start before oxr-mcp (serial launch order).
 
 vec-mcp-server  (agent-mcp-servers/vec-mcp/)
     └── uvicorn[standard] >=0.29
-    └── fastmcp >=0.4
+    └── fastmcp >=2.0
     └── pyyaml >=6.0
     └── xr-ai-logging  [editable: ../../utils/xr-ai-logging]
     Pure FastMCP at /mcp. Deterministic spatial-math primitives
@@ -223,7 +223,7 @@ xr-ai-tests  (tests/)
     └── pytest >=8.0
     └── pytest-asyncio >=0.23
     └── numpy >=1.24
-    └── fastmcp >=0.4   (only used by tests marked `gpu`)
+    └── fastmcp >=2.0   (only used by tests marked `gpu`)
     └── Pillow >=10.0   (only used by tests marked `gpu`)
     └── pyyaml >=6.0    (only used by tests marked `gpu`)
     The unmarked suite is multi-client / multi-agent integration tests over
@@ -437,7 +437,7 @@ forwarding.
 | Sub-project | Package | Internal deps | External deps |
 |---|---|---|---|
 | Orchestrator | `xr-render-demo` | `xr-ai-launcher`, `xr-ai-logging` | loguru >=0.7 |
-| Worker | `xr-render-demo-worker` | `xr-ai-agent`, `xr-ai-models` [editable], `xr-ai-pipecat` [editable], `xr-ai-voicegate` [editable], `xr-ai-logging` [editable] | numpy >=1.24, Pillow >=10.0, fastmcp >=0.4, pyyaml >=6.0, pipecat-ai >=0.0.46 (silero-vad pulled in via xr-ai-pipecat → xr-ai-vad). Pillow + numpy drive `pixels.py` (live-frame → PIL → JPEG data URL) for the `look_at_current_frame` perception tool. |
+| Worker | `xr-render-demo-worker` | `xr-ai-agent`, `xr-ai-models` [editable], `xr-ai-pipecat` [editable], `xr-ai-voicegate` [editable], `xr-ai-logging` [editable] | numpy >=1.24, Pillow >=10.0, fastmcp >=2.0, pyyaml >=6.0, pipecat-ai >=1.0 (silero-vad pulled in via xr-ai-pipecat → xr-ai-vad). Pillow + numpy drive `pixels.py` (live-frame → PIL → JPEG data URL) for the `look_at_current_frame` perception tool. |
 
 Model endpoints (llm, agent_llm, stt, tts, vlm) are declared in
 `yaml/models.yaml` and loaded via `xr-ai-models` `load_models_config` /

--- a/agent-mcp-servers/oxr-mcp/pyproject.toml
+++ b/agent-mcp-servers/oxr-mcp/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "xr-ai-logging",
     "pyyaml>=6.0",
     "uvicorn[standard]>=0.29",
-    "fastmcp>=0.4",
+    "fastmcp>=2.0",
     # Headless OpenXR session + HeadTracker. Lives in the same wheel as the
     # cloudxr-runtime launcher; we pin it explicitly here so this package
     # builds standalone.

--- a/agent-mcp-servers/render-mcp/pyproject.toml
+++ b/agent-mcp-servers/render-mcp/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "xr-ai-logging",
     "pyyaml>=6.0",
     "uvicorn[standard]>=0.29",
-    "fastmcp>=0.4",
+    "fastmcp>=2.0",
     # render-mcp → LOVR uses ZMQ PUSH/PULL with msgpack-encoded {op, ...} frames.
     "pyzmq>=27.0",
     "msgpack>=1.0",

--- a/agent-mcp-servers/transcript-mcp/pyproject.toml
+++ b/agent-mcp-servers/transcript-mcp/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.1.0"
 requires-python = ">=3.11,<3.13"
 dependencies = [
     "uvicorn[standard]>=0.29",
-    "fastmcp>=0.4",
+    "fastmcp>=2.0",
     "pyyaml>=6.0",
     "xr-ai-logging",
 ]

--- a/agent-mcp-servers/vec-mcp/pyproject.toml
+++ b/agent-mcp-servers/vec-mcp/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.1.0"
 requires-python = ">=3.11,<3.13"
 dependencies = [
     "uvicorn[standard]>=0.29",
-    "fastmcp>=0.4",
+    "fastmcp>=2.0",
     "pyyaml>=6.0",
     "xr-ai-logging",
 ]

--- a/agent-mcp-servers/video-mcp/pyproject.toml
+++ b/agent-mcp-servers/video-mcp/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.1.0"
 requires-python = ">=3.11,<3.13"
 dependencies = [
     "uvicorn[standard]>=0.29",
-    "fastmcp>=0.4",
+    "fastmcp>=2.0",
     "pyyaml>=6.0",
     # Frame querying — connects to the hub via IPC and decodes H.264 chunks.
     "xr-ai-agent",

--- a/agent-mcp-servers/vlm-mcp/pyproject.toml
+++ b/agent-mcp-servers/vlm-mcp/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.1.0"
 requires-python = ">=3.11,<3.13"
 dependencies = [
     "uvicorn[standard]>=0.29",
-    "fastmcp>=0.4",
+    "fastmcp>=2.0",
     "pyyaml>=6.0",
     "Pillow>=10.0",
     # Imported directly to catch httpx.HTTPError from xr-ai-models' transport.

--- a/agent-samples/xr-render-demo/worker/pyproject.toml
+++ b/agent-samples/xr-render-demo/worker/pyproject.toml
@@ -18,8 +18,8 @@ dependencies = [
     "numpy>=1.24",
     "Pillow>=10.0",
     "pyyaml>=6.0",
-    "fastmcp>=0.4",
-    "pipecat-ai>=0.0.46",
+    "fastmcp>=2.0",
+    "pipecat-ai>=1.0",
 ]
 
 [tool.uv.sources]

--- a/agent-sdk/xr-ai-pipecat/pyproject.toml
+++ b/agent-sdk/xr-ai-pipecat/pyproject.toml
@@ -15,11 +15,11 @@ dependencies = [
     "xr-ai-models",
     "xr-ai-vad",
     "xr-ai-voicegate",
-    "pipecat-ai>=0.0.46",
+    "pipecat-ai>=1.0",
     "numpy>=1.24",
     "scipy>=1.11",
     "httpx>=0.27",
-    "fastmcp>=0.4",
+    "fastmcp>=2.0",
 ]
 
 [tool.uv.sources]

--- a/server-runtime/pyproject.toml
+++ b/server-runtime/pyproject.toml
@@ -17,8 +17,8 @@ dependencies = [
     # IPC layer — server side uses ZMQ directly (connector + hub)
     "pyzmq>=27.0",
     # LiveKit transport
-    "livekit>=0.17",
-    "livekit-api>=0.7",
+    "livekit>=1.0",
+    "livekit-api>=1.0",
     # Token server
     "fastapi>=0.111",
     "uvicorn[standard]>=0.29",

--- a/server-runtime/xr_media_hub/transport/livekit/_docker.py
+++ b/server-runtime/xr_media_hub/transport/livekit/_docker.py
@@ -60,6 +60,7 @@ _OUTPUT_CAPTURE_BYTES = 4096  # how much subprocess output to retain for diagnos
 _BANNER = "━" * 56
 
 _CONTAINER_NAME = "xr-ai-livekit-server"
+_LIVEKIT_IMAGE = "livekit/livekit-server:v1.8.2"
 
 
 class LiveKitDocker:
@@ -95,7 +96,7 @@ class LiveKitDocker:
                 "--name", _CONTAINER_NAME,
                 "--network", "host",
                 "-v", f"{cfg_path}:/etc/livekit.yaml:ro",
-                "livekit/livekit-server:latest",
+                _LIVEKIT_IMAGE,
                 "--config", "/etc/livekit.yaml",
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,

--- a/server-runtime/xr_media_hub/transport/livekit/_docker.py
+++ b/server-runtime/xr_media_hub/transport/livekit/_docker.py
@@ -60,7 +60,6 @@ _OUTPUT_CAPTURE_BYTES = 4096  # how much subprocess output to retain for diagnos
 _BANNER = "━" * 56
 
 _CONTAINER_NAME = "xr-ai-livekit-server"
-_LIVEKIT_IMAGE = "livekit/livekit-server:v1.8.2"
 
 
 class LiveKitDocker:
@@ -96,7 +95,7 @@ class LiveKitDocker:
                 "--name", _CONTAINER_NAME,
                 "--network", "host",
                 "-v", f"{cfg_path}:/etc/livekit.yaml:ro",
-                _LIVEKIT_IMAGE,
+                "livekit/livekit-server:latest",
                 "--config", "/etc/livekit.yaml",
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "pytest-asyncio>=0.23",
     "numpy>=1.24",
     # GPU/MCP test deps — only exercised by tests marked `gpu`.
-    "fastmcp>=0.4",
+    "fastmcp>=2.0",
     "Pillow>=10.0",
     "pyyaml>=6.0",
 ]


### PR DESCRIPTION
Bumps minimum version floors that had fallen well behind the locked versions, risking installation of incompatible old releases.

> **Note:** The LiveKit Docker image pin is intentionally excluded — that work is handled in PR #258 by the original contributor.

## Changes

| Package | Old floor | New floor | Locked at |
|---|---|---|---|
| `livekit` | `>=0.17` | `>=1.0` | `1.1.9` |
| `livekit-api` | `>=0.7` | `>=1.0` | `1.1.0` |
| `pipecat-ai` | `>=0.0.46` | `>=1.0` | `1.3.0` |
| `fastmcp` | `>=0.4` | `>=2.0` | `3.4.0` |

The `livekit` and `pipecat-ai` floors allow installing versions with known breaking API changes vs what the codebase uses. The `fastmcp` floor allows 0.x/1.x which have incompatible MCP transport APIs (StreamableHTTP arrived in 2.x). All bumps remain flexible lower bounds, not pins.

Files updated: `server-runtime/pyproject.toml`, `agent-sdk/xr-ai-pipecat/pyproject.toml`, `agent-samples/xr-render-demo/worker/pyproject.toml`, all 6 MCP server pyproject.toml files, `tests/pyproject.toml`, `DEPENDENCIES.md`.

## Verification
- SPDX: OK, ruff: clean, `pytest -q -k "not gpu"`: 407 passed