### PR TITLE
fix(ipc): drop stale ring on failed re-registration

### DIFF
--- a/services/xr-media-hub/xr_media_hub/ipc/_hub.py
+++ b/services/xr-media-hub/xr_media_hub/ipc/_hub.py
@@ -461,7 +461,7 @@ class HubEndpoint:
     def _handle_registration(self, reg: ConnectorRegistration) -> None:
         if reg.connector_id in self._ring_registry:
             logger.warning("Connector {} re-registered — replacing ring buffer", reg.connector_id)
-            old_ring = self._ring_registry[reg.connector_id]
+            old_ring = self._ring_registry.pop(reg.connector_id)
             # Drop any frames still held in the old ring BEFORE closing it.
             # A live SlotView keeps a sliced memoryview exported into the ring's
             # mmap; closing with that outstanding makes ShmRingBuffer.close()'s

--- a/tests/test_participant_events.py
+++ b/tests/test_participant_events.py
@@ -11,8 +11,9 @@ from __future__ import annotations
 import asyncio
 
 import pytest
+import xr_media_hub.ipc._hub as hub_module
 
-from xr_ai_hub import ParticipantEvent, PixelFormat
+from xr_ai_hub import ConnectorRegistration, ParticipantEvent, PixelFormat
 
 pytestmark = pytest.mark.asyncio
 
@@ -160,3 +161,30 @@ async def test_connector_reregistration_releases_held_slots(hub, make_connector,
     )
     await settle()
     assert ("alice", "cam") in hub._latest_slots
+
+
+async def test_connector_reregistration_open_failure_drops_stale_ring(monkeypatch):
+    """Regression for #209: a failed SHM reopen during connector
+    re-registration must not leave the just-closed old ring in the registry."""
+
+    class CloseTrackingRing:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    def fail_open(*, name: str, create: bool):
+        raise RuntimeError(f"cannot open {name} create={create}")
+
+    hub = hub_module.HubEndpoint.__new__(hub_module.HubEndpoint)
+    old_ring = CloseTrackingRing()
+    hub._latest_slots = {}
+    hub._ring_registry = {}
+    hub._ring_registry["conn"] = old_ring
+    monkeypatch.setattr(hub_module, "ShmRingBuffer", fail_open)
+
+    hub._handle_registration(ConnectorRegistration(connector_id="conn", shm_name="missing"))
+
+    assert old_ring.closed is True
+    assert "conn" not in hub._ring_registry


### PR DESCRIPTION
## Summary

- remove the stale connector ring entry before closing the old ring during re-registration
- leave the connector without a registered ring if opening the replacement shared-memory segment fails, instead of retaining a closed ring in `_ring_registry`
- add a regression test for the failed-reopen path that does not depend on an IPC socket fixture

Fixes #209.

## Validation

Rebased onto current `NVIDIA/xr-ai@37822349729f9c67f492f9aac29b7eeb803d1dd9` on 2026-08-09. The only conflict was the upstream SDK rename from `xr_ai_agent` to `xr_ai_hub`; the refreshed test uses the current package.

- focused failed-reopen regression: 1 passed
- complete `tests/test_participant_events.py`: 5 passed
  - run with a short `TMPDIR` on macOS to stay below the Unix-domain socket path limit
- Ruff 0.15.16 on both changed Python files: passed
- repository SPDX checker on both changed files: passed
- DCO sign-off present
- `git diff --check upstream/main...HEAD`: passed
