### PR TITLE
fix(cloudxr): start runtime with spawn context

### DIFF
--- a/services/cloudxr-runtime/cloudxr_runtime/__main__.py
+++ b/services/cloudxr-runtime/cloudxr_runtime/__main__.py
@@ -62,6 +62,12 @@ async def _wait_with_progress(
     return False
 
 
+def _start_runtime_process() -> multiprocessing.Process:
+    runtime_proc = multiprocessing.get_context("spawn").Process(target=runtime_run)
+    runtime_proc.start()
+    return runtime_proc
+
+
 def _load_config(path: Path) -> dict:
     with open(path) as f:
         return yaml.safe_load(f) or {}
@@ -155,8 +161,7 @@ async def _run(
         os.environ.setdefault(key, str(val))
 
     # XR-side GPU pinning. Set on os.environ before EnvConfig.from_args so the
-    # multiprocessing.Process that hosts the native CloudXR service inherits
-    # the three selectors via fork.
+    # process that hosts the native CloudXR service inherits the three selectors.
     pinning: dict[str, str] | None = None
     gpu_idx = cfg.get("gpu_index")
     if gpu_idx is None:
@@ -192,8 +197,7 @@ async def _run(
     for sig in (signal.SIGINT, signal.SIGTERM):
         loop.add_signal_handler(sig, _on_signal)
 
-    runtime_proc = multiprocessing.Process(target=runtime_run)
-    runtime_proc.start()
+    runtime_proc = _start_runtime_process()
 
     cxr_ver = runtime_version()
     logger.info("Isaac Teleop {}  CloudXR {}", isaacteleop_version, cxr_ver)

--- a/tests/test_cloudxr_runtime_process.py
+++ b/tests/test_cloudxr_runtime_process.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for cloudxr_runtime process launch behavior."""
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+
+
+def _install_cloudxr_runtime_fakes(monkeypatch):
+    isaacteleop = types.ModuleType("isaacteleop")
+    isaacteleop.__version__ = "test"
+
+    cloudxr_pkg = types.ModuleType("isaacteleop.cloudxr")
+
+    env_config = types.ModuleType("isaacteleop.cloudxr.env_config")
+
+    class EnvConfig:
+        @classmethod
+        def from_args(cls, *_args, **_kwargs):
+            return cls()
+
+    env_config.EnvConfig = EnvConfig
+    env_config.get_env_config = lambda: types.SimpleNamespace(openxr_run_dir=lambda: "/tmp")
+
+    runtime = types.ModuleType("isaacteleop.cloudxr.runtime")
+
+    def runtime_run():
+        return None
+
+    runtime.run = runtime_run
+    runtime.check_eula = lambda *args, **kwargs: None
+    runtime.latest_runtime_log = lambda: None
+    runtime.runtime_version = lambda: "test"
+    runtime.terminate_or_kill_runtime = lambda _proc: None
+    runtime.wait_for_runtime_ready = lambda *args, **kwargs: True
+
+    wss = types.ModuleType("isaacteleop.cloudxr.wss")
+    wss.run = lambda *args, **kwargs: None
+
+    yaml = types.ModuleType("yaml")
+    yaml.safe_load = lambda _stream: {}
+
+    loguru = types.ModuleType("loguru")
+    loguru.logger = types.SimpleNamespace(
+        debug=lambda *_args, **_kwargs: None,
+        error=lambda *_args, **_kwargs: None,
+        info=lambda *_args, **_kwargs: None,
+        warning=lambda *_args, **_kwargs: None,
+    )
+
+    xr_ai_logging = types.ModuleType("xr_ai_logging")
+    xr_ai_logging.setup_logging = lambda *_args, **_kwargs: None
+
+    xr_ai_launcher = types.ModuleType("xr_ai_launcher")
+    xr_ai_launcher.is_native_profile = lambda _profile: False
+    xr_ai_launcher.read_device_profile = lambda _path: "web"
+
+    monkeypatch.setitem(sys.modules, "isaacteleop", isaacteleop)
+    monkeypatch.setitem(sys.modules, "isaacteleop.cloudxr", cloudxr_pkg)
+    monkeypatch.setitem(sys.modules, "isaacteleop.cloudxr.env_config", env_config)
+    monkeypatch.setitem(sys.modules, "isaacteleop.cloudxr.runtime", runtime)
+    monkeypatch.setitem(sys.modules, "isaacteleop.cloudxr.wss", wss)
+    monkeypatch.setitem(sys.modules, "yaml", yaml)
+    monkeypatch.setitem(sys.modules, "loguru", loguru)
+    monkeypatch.setitem(sys.modules, "xr_ai_launcher", xr_ai_launcher)
+    monkeypatch.setitem(sys.modules, "xr_ai_logging", xr_ai_logging)
+
+
+def _import_cloudxr_runtime(monkeypatch):
+    _install_cloudxr_runtime_fakes(monkeypatch)
+    package_dir = Path(__file__).resolve().parents[1] / "services" / "cloudxr-runtime"
+    monkeypatch.syspath_prepend(str(package_dir))
+    sys.modules.pop("cloudxr_runtime.__main__", None)
+    sys.modules.pop("cloudxr_runtime", None)
+    return importlib.import_module("cloudxr_runtime.__main__")
+
+
+def test_start_runtime_process_uses_spawn_context(monkeypatch):
+    module = _import_cloudxr_runtime(monkeypatch)
+    requested_contexts = []
+    started_targets = []
+
+    class FakeProcess:
+        def __init__(self, target):
+            self.target = target
+
+        def start(self):
+            started_targets.append(self.target)
+
+    class FakeContext:
+        def Process(self, target):  # pylint: disable=invalid-name
+            return FakeProcess(target)
+
+    def fake_get_context(method):
+        requested_contexts.append(method)
+        return FakeContext()
+
+    monkeypatch.setattr(module.multiprocessing, "get_context", fake_get_context)
+
+    try:
+        proc = module._start_runtime_process()
+
+        assert requested_contexts == ["spawn"]
+        assert started_targets == [module.runtime_run]
+        assert proc.target is module.runtime_run
+    finally:
+        sys.modules.pop("cloudxr_runtime.__main__", None)
+        sys.modules.pop("cloudxr_runtime", None)


### PR DESCRIPTION
## Summary

- start the native CloudXR runtime process from an explicit `spawn` multiprocessing context instead of the platform-default fork context
- preserve the existing `multiprocessing.Process` handle contract used by readiness polling and `terminate_or_kill_runtime`
- add a focused unit test that stubs native CloudXR imports and verifies the spawn context
- document the process-model decision in the architecture changelog

## Rationale

Issue #40 calls out that the current `multiprocessing.Process(target=runtime_run)` path can fork from inside an already-running asyncio event loop. Using `spawn` starts the runtime in a fresh interpreter, avoiding inherited asyncio lock and signal-handler state while keeping the current readiness and cleanup APIs intact.

Fixes #40

## Validation

Refreshed onto current `NVIDIA/xr-ai@6de6ca73cec931c5833fe7c418fb30e1df5b4172`; GitHub reports `behind_by: 0`, `ahead_by: 1`.

- `pytest -q tests/test_cloudxr_runtime_process.py tests/test_cloudxr_service_layout.py` — 4 passed
- Ruff 0.15.16 on both changed Python files — passed
- repository SPDX checker on source, test, and changelog — passed
- signed-off commit / DCO — present
- `git diff --check upstream/main...HEAD` — passed

The unit test imports the runtime from its current `services/cloudxr-runtime` location and replaces the platform-specific Isaac Teleop modules with fakes, so this process-launch contract is verified without requiring CloudXR hardware.