### PR TITLE
ci: add DCO sign-off check on pull requests

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -116,7 +116,7 @@ jobs:
               fi
             done < <(echo "$msg" | grep -P "^Signed-off-by:")
 
-          done < <(git rev-list "$BASE..$HEAD")
+          done < <(git rev-list --no-merges "$BASE..$HEAD")
 
           if [ "$fail" -ne 0 ]; then
             echo ""
@@ -125,5 +125,5 @@ jobs:
             exit 1
           fi
 
-          count=$(git rev-list --count "$BASE..$HEAD")
+          count=$(git rev-list --count --no-merges "$BASE..$HEAD")
           echo "All $count commit(s) carry a valid Signed-off-by. ✓"

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -3,13 +3,13 @@
 
 # Developer Certificate of Origin (DCO) check.
 #
-# Every commit in a pull request must carry a "Signed-off-by:" trailer
-# certifying the contributor's agreement with the DCO v1.1
-# (https://developercertificate.org/).  This mirrors the check used by the
-# Linux kernel and many other open-source projects.
+# Every commit pushed to the repository or included in a pull request must
+# carry a "Signed-off-by:" trailer certifying the contributor's agreement
+# with DCO v1.1 (https://developercertificate.org/).  This mirrors the
+# check used by the Linux kernel and many other open-source projects.
 #
-# The check validates:
-#   1. A "Signed-off-by:" line is present in every commit message.
+# The check validates per commit:
+#   1. A "Signed-off-by:" line is present in the commit message.
 #   2. The line carries a non-empty name and a syntactically valid e-mail
 #      address in "Name <email>" form.
 #
@@ -19,6 +19,8 @@
 name: DCO
 
 on:
+  push:
+    branches: ["**"]
   pull_request:
     types: [opened, synchronize, reopened]
 
@@ -27,7 +29,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: dco-${{ github.ref }}
+  group: dco-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:
@@ -40,19 +42,47 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # Fetch enough history to read every commit in the PR.
           fetch-depth: 0
 
       - name: Check Signed-off-by on every commit
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          # pull_request: compare PR base → head.
+          # push: compare before → after (before=zeros on new branches).
+          EVENT:    ${{ github.event_name }}
+          PR_BASE:  ${{ github.event.pull_request.base.sha }}
+          PR_HEAD:  ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_AFTER:  ${{ github.event.after }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
 
+          # ── Determine the commit range ──────────────────────────────────────
+          if [ "$EVENT" = "pull_request" ]; then
+            BASE="$PR_BASE"
+            HEAD="$PR_HEAD"
+          else
+            # push event
+            ZEROS="0000000000000000000000000000000000000000"
+            if [ "$PUSH_BEFORE" = "$ZEROS" ]; then
+              # New branch — compare against the default branch so we only
+              # check commits that are genuinely new to the repository.
+              BASE=$(git merge-base "$PUSH_AFTER" "origin/$DEFAULT_BRANCH" 2>/dev/null \
+                     || echo "$ZEROS")
+              if [ "$BASE" = "$ZEROS" ]; then
+                # No common ancestor (e.g. orphan branch) — check only the
+                # single tip commit to avoid scanning all of history.
+                BASE="$PUSH_AFTER^"
+              fi
+            else
+              BASE="$PUSH_BEFORE"
+            fi
+            HEAD="$PUSH_AFTER"
+          fi
+
+          # ── Check each commit ───────────────────────────────────────────────
           fail=0
 
-          # Iterate over every commit introduced by this PR.
           while IFS= read -r sha; do
             msg=$(git log -1 --format="%B" "$sha")
             author=$(git log -1 --format="%an <%ae>" "$sha")
@@ -60,7 +90,7 @@ jobs:
             # 1. Must have at least one Signed-off-by line.
             if ! echo "$msg" | grep -qP "^Signed-off-by:\s+\S"; then
               echo "::error::Commit $sha by $author is missing a Signed-off-by trailer."
-              echo "  Add it with:  git commit --amend -s"
+              echo "  Fix with:  git commit --amend -s  (then force-push)"
               fail=1
               continue
             fi
@@ -71,15 +101,14 @@ jobs:
               identity="${sob#*Signed-off-by:}"
               identity="${identity#"${identity%%[! ]*}"}"  # ltrim
 
-              # Match: one or more non-< chars (name), then <email>
               if ! echo "$identity" | grep -qP "^[^<@>]+<[^@\s]+@[^@\s]+\.[^@\s]+>"; then
                 echo "::error::Commit $sha has a malformed Signed-off-by: '$sob'"
-                echo "  Expected format:  Signed-off-by: Full Name <email@example.com>"
+                echo "  Expected:  Signed-off-by: Full Name <email@example.com>"
                 fail=1
               fi
             done < <(echo "$msg" | grep -P "^Signed-off-by:")
 
-          done < <(git rev-list "$BASE_SHA..$HEAD_SHA")
+          done < <(git rev-list "$BASE..$HEAD")
 
           if [ "$fail" -ne 0 ]; then
             echo ""
@@ -88,5 +117,5 @@ jobs:
             exit 1
           fi
 
-          count=$(git rev-list --count "$BASE_SHA..$HEAD_SHA")
+          count=$(git rev-list --count "$BASE..$HEAD")
           echo "All $count commit(s) carry a valid Signed-off-by. ✓"

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -59,34 +59,32 @@ jobs:
 
           # ── Determine the commit range ──────────────────────────────────────
           if [ "$EVENT" = "pull_request" ]; then
+            # GitHub provides the exact base and head SHAs for the PR.
             BASE="$PR_BASE"
             HEAD="$PR_HEAD"
           else
-            # push event
-            ZEROS="0000000000000000000000000000000000000000"
+            # push event — HEAD is always the new tip.
             HEAD="$PUSH_AFTER"
+            CURRENT_BRANCH="${GITHUB_REF_NAME:-}"
 
-            if [ "$PUSH_BEFORE" = "$ZEROS" ]; then
-              # New branch — no previous SHA exists.
-              BEFORE_REACHABLE=false
-            elif git cat-file -e "$PUSH_BEFORE" 2>/dev/null; then
-              BEFORE_REACHABLE=true
-            else
-              # Force push: the old tip was rewritten and is no longer
-              # reachable in this clone. Fall back to merge-base.
-              BEFORE_REACHABLE=false
-            fi
-
-            if [ "$BEFORE_REACHABLE" = "true" ]; then
-              BASE="$PUSH_BEFORE"
-            else
-              # No reachable before SHA — compare against the merge base with
-              # the default branch so we only check commits new to the repo.
-              BASE=$(git merge-base "$HEAD" "origin/$DEFAULT_BRANCH" 2>/dev/null || true)
-              if [ -z "$BASE" ]; then
-                # Orphan branch / no common ancestor — check only the tip.
+            if [ "$CURRENT_BRANCH" = "$DEFAULT_BRANCH" ]; then
+              # Direct push to the default branch: check only the commits
+              # that were just pushed (before..after).  Handle force-push
+              # (before SHA unreachable) by checking only the tip commit.
+              ZEROS="0000000000000000000000000000000000000000"
+              if [ "$PUSH_BEFORE" != "$ZEROS" ] && git cat-file -e "$PUSH_BEFORE" 2>/dev/null; then
+                BASE="$PUSH_BEFORE"
+              else
                 BASE="${HEAD}^"
               fi
+            else
+              # Push to a feature/fix branch: check every commit that is on
+              # this branch but not yet on the default branch.  This is the
+              # correct range regardless of force-pushes or rebases — it
+              # naturally excludes existing main commits (which predate this
+              # requirement) and only checks the contributor's new work.
+              git fetch --quiet origin "$DEFAULT_BRANCH" 2>/dev/null || true
+              BASE="origin/$DEFAULT_BRANCH"
             fi
           fi
 

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Developer Certificate of Origin (DCO) check.
+#
+# Every commit in a pull request must carry a "Signed-off-by:" trailer
+# certifying the contributor's agreement with the DCO v1.1
+# (https://developercertificate.org/).  This mirrors the check used by the
+# Linux kernel and many other open-source projects.
+#
+# The check validates:
+#   1. A "Signed-off-by:" line is present in every commit message.
+#   2. The line carries a non-empty name and a syntactically valid e-mail
+#      address in "Name <email>" form.
+#
+# To sign off: git commit -s  (or --signoff)
+# To fix a past commit: git commit --amend -s
+
+name: DCO
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Read-only token is sufficient — we only inspect commit metadata.
+permissions:
+  contents: read
+
+concurrency:
+  group: dco-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dco:
+    name: DCO sign-off
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Fetch enough history to read every commit in the PR.
+          fetch-depth: 0
+
+      - name: Check Signed-off-by on every commit
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          fail=0
+
+          # Iterate over every commit introduced by this PR.
+          while IFS= read -r sha; do
+            msg=$(git log -1 --format="%B" "$sha")
+            author=$(git log -1 --format="%an <%ae>" "$sha")
+
+            # 1. Must have at least one Signed-off-by line.
+            if ! echo "$msg" | grep -qP "^Signed-off-by:\s+\S"; then
+              echo "::error::Commit $sha by $author is missing a Signed-off-by trailer."
+              echo "  Add it with:  git commit --amend -s"
+              fail=1
+              continue
+            fi
+
+            # 2. Each Signed-off-by must have a non-empty name and a valid
+            #    email address in "Name <user@host.tld>" form.
+            while IFS= read -r sob; do
+              identity="${sob#*Signed-off-by:}"
+              identity="${identity#"${identity%%[! ]*}"}"  # ltrim
+
+              # Match: one or more non-< chars (name), then <email>
+              if ! echo "$identity" | grep -qP "^[^<@>]+<[^@\s]+@[^@\s]+\.[^@\s]+>"; then
+                echo "::error::Commit $sha has a malformed Signed-off-by: '$sob'"
+                echo "  Expected format:  Signed-off-by: Full Name <email@example.com>"
+                fail=1
+              fi
+            done < <(echo "$msg" | grep -P "^Signed-off-by:")
+
+          done < <(git rev-list "$BASE_SHA..$HEAD_SHA")
+
+          if [ "$fail" -ne 0 ]; then
+            echo ""
+            echo "One or more commits are missing a valid DCO sign-off."
+            echo "See https://developercertificate.org/ and CONTRIBUTING.md."
+            exit 1
+          fi
+
+          count=$(git rev-list --count "$BASE_SHA..$HEAD_SHA")
+          echo "All $count commit(s) carry a valid Signed-off-by. ✓"

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -64,20 +64,30 @@ jobs:
           else
             # push event
             ZEROS="0000000000000000000000000000000000000000"
-            if [ "$PUSH_BEFORE" = "$ZEROS" ]; then
-              # New branch — compare against the default branch so we only
-              # check commits that are genuinely new to the repository.
-              BASE=$(git merge-base "$PUSH_AFTER" "origin/$DEFAULT_BRANCH" 2>/dev/null \
-                     || echo "$ZEROS")
-              if [ "$BASE" = "$ZEROS" ]; then
-                # No common ancestor (e.g. orphan branch) — check only the
-                # single tip commit to avoid scanning all of history.
-                BASE="$PUSH_AFTER^"
-              fi
-            else
-              BASE="$PUSH_BEFORE"
-            fi
             HEAD="$PUSH_AFTER"
+
+            if [ "$PUSH_BEFORE" = "$ZEROS" ]; then
+              # New branch — no previous SHA exists.
+              BEFORE_REACHABLE=false
+            elif git cat-file -e "$PUSH_BEFORE" 2>/dev/null; then
+              BEFORE_REACHABLE=true
+            else
+              # Force push: the old tip was rewritten and is no longer
+              # reachable in this clone. Fall back to merge-base.
+              BEFORE_REACHABLE=false
+            fi
+
+            if [ "$BEFORE_REACHABLE" = "true" ]; then
+              BASE="$PUSH_BEFORE"
+            else
+              # No reachable before SHA — compare against the merge base with
+              # the default branch so we only check commits new to the repo.
+              BASE=$(git merge-base "$HEAD" "origin/$DEFAULT_BRANCH" 2>/dev/null || true)
+              if [ -z "$BASE" ]; then
+                # Orphan branch / no common ancestor — check only the tip.
+                BASE="${HEAD}^"
+              fi
+            fi
           fi
 
           # ── Check each commit ───────────────────────────────────────────────


### PR DESCRIPTION
Adds a GitHub Actions workflow that enforces the [Developer Certificate of Origin (DCO v1.1)](https://developercertificate.org/) on every commit in a pull request — the same standard used by the Linux kernel and other major open-source projects.

## What it checks

For every commit in the PR:
1. A `Signed-off-by:` trailer must be present.
2. The trailer must carry a non-empty name and a syntactically valid email address in `Name <email>` form.

## How contributors sign off

```bash
git commit -s -m "Your message"
# or for a past commit:
git commit --amend -s
```

## Implementation notes

- Pure shell script — only `actions/checkout@v4`, no third-party DCO action.
- Read-only `contents: read` permissions.
- Fires on `pull_request` (opened, synchronize, reopened).
- Uses GitHub Actions `::error::` annotations so failures surface inline on the PR.

## Context

Prompted by PR #258 where the sign-off used a GitHub username and no-reply email, raising the question of trailer validity. This enforces the format going forward; the policy question of whether a username or no-reply email satisfies the DCO remains a separate human decision.