### PR TITLE
feat(agent-sdk): add MCPToolset + AgentCapability to xr-ai-capabilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,11 +150,12 @@ has no pipeline-framework dependency. Keep new reusable agent building blocks in
 `xr-ai-capabilities` — `xr-ai-pipecat` must not become a catch-all.
 Planned structural follow-ups (own PRs):
 
-1. **`MCPToolset`.** `RenderSceneProcessor` still takes one `McpClient` per MCP
-   server and routes via a hardcoded `_execute_tool` switch — adding a server
-   means a new arg + frozenset + branch, reusable by nothing. Replace it with a
-   toolset that pairs a client with the tool names it owns, so a brain accepts a
-   list and auto-routes:
+1. **`MCPToolset` + `AgentCapability`** — shipped in `agent-sdk/xr-ai-capabilities`.
+   `MCPToolset` pairs any MCP client with the tool names it owns (`tools=None` =
+   catch-all); `route_tool` / `collect_tool_defs` replace the per-sample frozenset
+   switch.  `AgentCapability` is the ABC for brain-local tools (no MCP hop);
+   `VisionModule` implements it.  Next: refactor `BrainProcessor` (M2) and
+   `xr-render-demo` (M3) to consume these building blocks.
 
    ```python
    brain = AgentBrain(
@@ -204,6 +205,22 @@ Hard rules (also in `DEPENDENCIES.md`):
 - Agent workers import only from `xr_ai_agent` + `xr_ai_models` (and task-specific libs).
 - Agent workers must never import from `xr_media_hub` or `xr_ai_launcher`.
 - Don't add abstractions until needed by two concrete use-cases.
+
+## DCO sign-off
+
+Every commit must carry a `Signed-off-by` trailer certifying agreement with
+[DCO v1.1](https://developercertificate.org/). CI enforces this on every push
+and PR — commits without it fail the `DCO sign-off` check.
+
+```
+Signed-off-by: Full Name <email@example.com>
+```
+
+Add automatically with `git commit -s` (or `--signoff`).  To fix a commit that
+already landed: `git commit --amend -s` then force-push the branch.
+
+**Agents / automated tooling:** include the committing user's `Signed-off-by`
+in every commit message, in addition to any `Co-Authored-By` lines.
 
 ## License headers
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,6 +278,7 @@ Read these on demand when the topic comes up:
 
 | File | When to read |
 |---|---|
+| `docs/agent-pipeline.md` | The pipecat voice pipeline internals — processor chain, frame types, `BrainProcessor` hooks, `AgentCapability` vs `MCPToolset`, `VisionModule` |
 | `docs/architecture.md` | Working across module boundaries; understanding hub ↔ transport ↔ agent boundaries; the same-origin wss:// signaling proxy in front of LiveKit |
 | `docs/process-model.md` | Touching `utils/xr-ai-launcher/`, orchestrators, ready-files, or adding a managed process type |
 | `docs/credentials.md` | Code that needs `HF_TOKEN` / `NGC_API_KEY` |

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -74,11 +74,20 @@ xr-ai-capabilities  (agent-sdk/xr-ai-capabilities/)
     sample architecture"). A capability talks to the hub through a
     ``ProcessorEndpoint`` and depends only on the core SDK — NOT on pipecat or
     any pipeline framework — so both pipecat and non-pipecat agents can compose
-    it. Hosts ``pixels`` (frame → PIL → JPEG; numpy + Pillow) and ``vision``
-    (VisionModule — live-camera VLM Q&A with camera-on-demand, exposing ``ask``
-    for streaming TTS and ``perceive`` for agentic tool loops), so vision
-    samples no longer copy that code per-worker. A pipecat brain wires it up by
-    passing ``transport.endpoint``.
+    it.
+
+    Building blocks:
+    - ``pixels`` — frame → PIL → JPEG encoding (numpy + Pillow)
+    - ``VisionModule`` (``vision``) — live-camera VLM Q&A with camera-on-demand;
+      exposes ``ask`` (streaming TTS) and ``perceive`` (agentic tool loops);
+      implements ``AgentCapability`` and registers a ``look_at_current_frame``
+      brain-local tool
+    - ``AgentCapability`` (``capability``) — ABC for brain-local tools that run
+      inline (no MCP server hop); exposes ``as_tool_defs()`` and ``execute()``
+    - ``MCPToolset`` (``toolset``) — pairs any MCP client (duck-typed via
+      ``McpClientProtocol``) with the set of tool names it owns; ``tools=None``
+      is the catch-all; ``route_tool`` finds the right toolset for a tool name;
+      ``collect_tool_defs`` queries all clients and returns ``ToolDef`` objects
 
 xr-ai-voicegate  (utils/xr-ai-voicegate/)
     └── numpy >=1.24

--- a/agent-sdk/xr-ai-capabilities/xr_ai_capabilities/__init__.py
+++ b/agent-sdk/xr-ai-capabilities/xr_ai_capabilities/__init__.py
@@ -5,16 +5,34 @@
 
 Capabilities are self-contained features an agent brain can compose — they talk
 to the hub through a ``ProcessorEndpoint`` and depend only on the core SDK
-(``xr-ai-agent`` / ``xr-ai-models``), not on any voice/pipeline framework. The
-first capability is :class:`VisionModule` (live-camera VLM question answering);
-more (teacher-demo, agent-monitor) will follow here.
+(``xr-ai-agent`` / ``xr-ai-models``), not on any voice/pipeline framework.
+
+Building blocks:
+
+* :class:`VisionModule` — live-camera VLM question answering
+* :class:`AgentCapability` — ABC for brain-local tools
+* :class:`MCPToolset` — pairs an MCP client with the tool names it owns
+* :func:`route_tool` — finds the right toolset for a given tool name
+* :func:`collect_tool_defs` — queries all toolsets and returns :class:`~xr_ai_models.ToolDef` objects
 """
+from .capability import AgentCapability
 from .pixels import encode_image, frame_to_pil
-from .vision import VisionModule, VisionUnavailable
+from .toolset import McpClientProtocol, MCPToolset, collect_tool_defs, route_tool
+from .vision import VISION_TOOL_NAME, VisionModule, VisionUnavailable
 
 __all__ = [
+    # Capability interface
+    "AgentCapability",
+    # MCP toolset routing
+    "MCPToolset",
+    "McpClientProtocol",
+    "collect_tool_defs",
+    "route_tool",
+    # Vision capability
+    "VISION_TOOL_NAME",
     "VisionModule",
     "VisionUnavailable",
+    # Image encoding helpers
     "encode_image",
     "frame_to_pil",
 ]

--- a/agent-sdk/xr-ai-capabilities/xr_ai_capabilities/capability.py
+++ b/agent-sdk/xr-ai-capabilities/xr_ai_capabilities/capability.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Framework-agnostic agent capability interface.
+
+An :class:`AgentCapability` is a self-contained feature that an agent brain can
+compose.  It exposes one or more *brain-local* tools (tools that the brain
+executes inline rather than by calling an external MCP server) and implements
+their execution logic.
+
+The canonical example is :class:`~xr_ai_capabilities.VisionModule`: it exposes
+a ``look_at_current_frame`` tool that turns the camera on, grabs a live frame,
+and runs the VLM — without going through any MCP server.
+
+Capability vs. :class:`~xr_ai_capabilities.MCPToolset`:
+
+* ``MCPToolset`` — a remote MCP server; tool calls cross a network boundary.
+* ``AgentCapability`` — local code in the brain process; no network hop.
+
+A brain collects tool defs from both and merges them before sending the tool
+list to the LLM.  When a tool call arrives, the brain checks capabilities first
+(by name) and falls back to the MCP toolset router for everything else.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from xr_ai_models import ToolDef
+
+
+class AgentCapability(ABC):
+    """Base class for brain-local agent capabilities.
+
+    Subclass and implement :meth:`as_tool_defs` and :meth:`execute`.
+    """
+
+    @abstractmethod
+    def as_tool_defs(self) -> list[ToolDef]:
+        """Return the tool definitions this capability contributes to the LLM's
+        tool list.  Called once per session setup; the result is merged with the
+        definitions from all registered MCP toolsets.
+        """
+
+    @abstractmethod
+    async def execute(
+        self,
+        name: str,
+        args: dict,
+        pid: str,
+        *,
+        onset_pts_us: int = 0,
+        end_pts_us: int = 0,
+    ) -> dict:
+        """Execute a tool call and return the result as a plain dict.
+
+        Parameters
+        ----------
+        name:
+            The tool name (must be one this capability owns).
+        args:
+            The arguments from the LLM tool call.
+        pid:
+            The participant ID for the current turn.
+        onset_pts_us / end_pts_us:
+            Speech-window timestamps (Unix µs) from the utterance that triggered
+            this turn.  Zero when not available (e.g. text input).  Capabilities
+            that do time-anchored lookups (live-frame VLM, head-pose) use these
+            to pick the frame / pose from when the user was speaking rather than
+            from when the LLM started processing.
+        """

--- a/agent-sdk/xr-ai-capabilities/xr_ai_capabilities/toolset.py
+++ b/agent-sdk/xr-ai-capabilities/xr_ai_capabilities/toolset.py
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""MCP tool-set routing for agent brains.
+
+``MCPToolset`` pairs an MCP client with the set of tool names it owns.  A list
+of toolsets replaces the per-sample hardcoded ``frozenset`` + ``if tool in
+_X_TOOLS`` dispatch pattern: a brain accepts a ``list[MCPToolset]`` and routes
+tool calls automatically with :func:`route_tool`.
+
+Usage::
+
+    brain = MyBrain(
+        toolsets=[
+            MCPToolset(oxr,    _OXR_TOOLS),    # explicit claim
+            MCPToolset(vec,    _VEC_TOOLS),
+            MCPToolset(render),                # catch-all (tools=None)
+        ],
+    )
+
+    # in the agentic loop:
+    toolset = route_tool(brain.toolsets, tool_name)
+    result  = await toolset.call_tool(tool_name, args)
+
+``collect_tool_defs`` queries each client once and converts the results to the
+``ToolDef`` objects that :class:`~xr_ai_models.LLMService` understands.
+
+Neither class imports FastMCP — the client is typed by the
+:class:`McpClientProtocol` structural protocol, so any object that has
+``list_tools`` and ``call_tool`` methods satisfies it.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+from loguru import logger
+from xr_ai_models import ToolDef
+
+
+@runtime_checkable
+class McpClientProtocol(Protocol):
+    """Structural protocol for any MCP client.
+
+    Satisfied by ``fastmcp.Client`` (and any compatible implementation)
+    without importing FastMCP as a hard dependency.
+    """
+
+    async def list_tools(self) -> list[Any]: ...
+
+    async def call_tool(
+        self, name: str, arguments: dict[str, Any] | None = None,
+    ) -> Any: ...
+
+
+@dataclass
+class MCPToolset:
+    """An MCP client paired with the tool names it owns.
+
+    Parameters
+    ----------
+    client:
+        Any MCP client satisfying :class:`McpClientProtocol`.
+    tools:
+        The set of tool names this client serves.  ``None`` means
+        *catch-all*: this toolset answers any tool not claimed by an
+        earlier entry in the list.  Put the catch-all last.
+    """
+
+    client: McpClientProtocol
+    tools: frozenset[str] | None = field(default=None)
+
+    async def call_tool(
+        self, name: str, args: dict[str, Any],
+    ) -> dict[str, Any] | list[Any] | None:
+        """Call ``name`` on the underlying MCP client and unwrap the result.
+
+        FastMCP wraps results in an object with a ``data`` or
+        ``structured_content`` attribute.  This unwraps either form so callers
+        get a plain Python object without depending on FastMCP directly.
+        """
+        res = await self.client.call_tool(name, args)
+        if hasattr(res, "data") and res.data is not None:
+            return res.data
+        return getattr(res, "structured_content", None)
+
+
+def route_tool(
+    toolsets: list[MCPToolset], name: str,
+) -> MCPToolset | None:
+    """Return the toolset that owns ``name``.
+
+    Searches ``toolsets`` in order.  The first entry whose ``tools`` set
+    contains ``name`` wins.  A catch-all entry (``tools=None``) is
+    returned if no explicit owner is found.  Returns ``None`` when
+    ``toolsets`` is empty or no entry matches.
+    """
+    catch_all: MCPToolset | None = None
+    for ts in toolsets:
+        if ts.tools is None:
+            catch_all = ts
+        elif name in ts.tools:
+            return ts
+    return catch_all
+
+
+async def collect_tool_defs(
+    toolsets: list[MCPToolset],
+    *,
+    exclude: frozenset[str] = frozenset(),
+) -> list[ToolDef]:
+    """Query every toolset client and return the union as :class:`ToolDef` objects.
+
+    Parameters
+    ----------
+    toolsets:
+        Toolsets to query.  Discovery errors on any single client are
+        logged as warnings and skipped (the rest still succeed).
+    exclude:
+        Tool names to omit — typically worker-managed tools that should
+        not appear in the model's tool list (e.g. ``{"start_xr"}``).
+
+    Tool ordering follows the toolset order, then the server's own order
+    within each toolset.  Duplicates (same name from multiple clients)
+    are silently deduplicated: the first occurrence wins.
+    """
+    result: list[ToolDef] = []
+    seen: set[str] = set()
+
+    for ts in toolsets:
+        try:
+            mcp_tools = await ts.client.list_tools()
+        except Exception as exc:
+            logger.warning("tool discovery failed: {}", exc)
+            continue
+
+        for t in mcp_tools:
+            name: str = t.name
+            if name in exclude or name in seen:
+                continue
+            # Respect explicit ownership: skip tools not in this toolset's set.
+            if ts.tools is not None and name not in ts.tools:
+                continue
+            seen.add(name)
+            schema = (
+                getattr(t, "inputSchema", None)
+                or {"type": "object", "properties": {}}
+            )
+            result.append(ToolDef(
+                name=name,
+                description=(t.description or "").strip(),
+                parameters=schema,
+            ))
+
+    return result

--- a/agent-sdk/xr-ai-capabilities/xr_ai_capabilities/vision.py
+++ b/agent-sdk/xr-ai-capabilities/xr_ai_capabilities/vision.py
@@ -24,6 +24,11 @@ The module is framework-agnostic: it talks to the hub through a
 ``ProcessorEndpoint`` (subscribing to ``FrameSignal`` events, fetching frames,
 and setting agent status) and has no dependency on pipecat. A pipecat brain
 passes ``transport.endpoint``; a non-pipecat agent passes its own endpoint.
+
+``VisionModule`` also implements :class:`~xr_ai_capabilities.AgentCapability`
+so it can be registered with a brain's capability list.  It exposes a single
+brain-local tool — :data:`VISION_TOOL_NAME` — that agentic-loop brains can
+include in their LLM tool list.
 """
 from __future__ import annotations
 
@@ -33,9 +38,31 @@ from typing import AsyncIterator
 
 from loguru import logger
 from xr_ai_agent import FrameSignal, ProcessorEndpoint
-from xr_ai_models import VLMService
+from xr_ai_models import ToolDef, VLMService
 
+from .capability import AgentCapability
 from .pixels import encode_image, frame_to_pil
+
+#: Canonical name of the brain-local perception tool exposed by VisionModule.
+VISION_TOOL_NAME = "look_at_current_frame"
+
+_DEFAULT_TOOL_DESCRIPTION = (
+    "Look at the user's LIVE camera feed right now and answer a question "
+    "about the real world — what they are holding, pointing at, or looking "
+    "at; a real-world colour, shape, text, or object. Use this whenever the "
+    "answer requires observing the physical world."
+)
+
+_VISION_TOOL_PARAMETERS: dict = {
+    "type": "object",
+    "properties": {
+        "question": {
+            "type": "string",
+            "description": "The question to answer about what the camera sees.",
+        },
+    },
+    "required": ["question"],
+}
 
 
 def _now_us() -> int:
@@ -48,8 +75,12 @@ class VisionUnavailable(Exception):
     The message is a short, user-facing sentence suitable to speak."""
 
 
-class VisionModule:
+class VisionModule(AgentCapability):
     """Live-camera VLM question answering.
+
+    Implements :class:`~xr_ai_capabilities.AgentCapability` so it can be
+    registered with a brain's capability list.  The exposed tool is
+    :data:`VISION_TOOL_NAME` (``look_at_current_frame``).
 
     Camera streaming is always-on — this module does not send camera control
     messages.  It waits up to ``frame_timeout_s`` for a fresh frame to arrive
@@ -65,6 +96,11 @@ class VisionModule:
         A ``VLMService`` (its ``stream`` is used for token-by-token answers).
     system_prompt:
         Default system prompt for the VLM (overridable per ``ask``).
+    tool_description:
+        Override the LLM-visible description of the ``look_at_current_frame``
+        tool.  Useful when the brain operates in a domain-specific context
+        (e.g. spatial XR) and needs a more tailored hint.  Defaults to
+        :data:`_DEFAULT_TOOL_DESCRIPTION`.
     frame_max_age_s:
         Maximum age of a cached frame signal before it is considered stale.
     frame_timeout_s:
@@ -78,12 +114,14 @@ class VisionModule:
         vlm: VLMService,
         *,
         system_prompt: str = "",
+        tool_description: str = _DEFAULT_TOOL_DESCRIPTION,
         frame_max_age_s: float = 2.0,
         frame_timeout_s: float = 5.0,
     ) -> None:
         self._endpoint = endpoint
         self._vlm = vlm
         self._system_prompt = system_prompt
+        self._tool_description = tool_description
         self._frame_max_age_us = int(frame_max_age_s * 1_000_000)
         self._frame_timeout_s  = frame_timeout_s
 
@@ -100,6 +138,38 @@ class VisionModule:
         """Drop all per-participant state (call from ``on_participant_left``)."""
         self._latest = {k: v for k, v in self._latest.items() if k[0] != pid}
         self._frame_events.pop(pid, None)
+
+    # ── AgentCapability interface ───────────────────────────────────────────────
+
+    def as_tool_defs(self) -> list[ToolDef]:
+        """Return the ``look_at_current_frame`` tool definition."""
+        return [ToolDef(
+            name=VISION_TOOL_NAME,
+            description=self._tool_description,
+            parameters=_VISION_TOOL_PARAMETERS,
+        )]
+
+    async def execute(
+        self,
+        name: str,
+        args: dict,
+        pid: str,
+        *,
+        onset_pts_us: int = 0,
+        end_pts_us: int = 0,
+    ) -> dict:
+        """Execute the ``look_at_current_frame`` tool.
+
+        Returns ``{"answer": <text>}`` on success or ``{"spoken": <message>}``
+        when vision is unavailable (so callers can surface it to the user
+        instead of feeding an error back to the model).
+        """
+        question = str(args.get("question") or "").strip()
+        try:
+            answer = await self.perceive(pid, question)
+            return {"answer": answer}
+        except VisionUnavailable as exc:
+            return {"spoken": str(exc)}
 
     # ── frame tracking ─────────────────────────────────────────────────────────
 

--- a/docs/agent-pipeline.md
+++ b/docs/agent-pipeline.md
@@ -1,0 +1,234 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Agent pipeline
+
+The unified voice pipeline (`xr-ai-pipecat`) assembles a chain of pipecat
+`FrameProcessor`s.  Read this when writing a new agent brain, adding a
+capability or MCP toolset, or debugging frame-level behavior.
+
+For system-level topology (hub, IPC, LiveKit) see `docs/architecture.md`.
+For adding a new sample from scratch see `docs/adding-a-sample.md`.
+
+---
+
+## Pipeline shape
+
+```
+XRMediaHubInputTransport
+        │  InputAudioRawFrame (transport_source = pid)
+        ▼
+VadSttProcessor
+        │  UserStartedSpeakingFrame (transport_source = pid)
+        │  UserStoppedSpeakingFrame (transport_source = pid)
+        │  TranscriptionFrame       (user_id = pid, transport_source = pid)
+        │  InterruptionFrame        (transport_source = pid)  ← early STOP probe only
+        ▼
+VoiceGateProcessor
+        │  GatedQueryFrame  (participant_id, text, fresh_match, pts_us)
+        │  InterruptionFrame (transport_source = pid)         ← gate's STOP handler
+        │  TextFrame        ("Okay, I will stop.", transport_destination = pid)
+        ▼
+BrainProcessor  (subclass)
+        │  TextFrame        (transport_destination = pid)     ← one per yielded chunk
+        │  BrainResponseEndFrame (pid, text, pts_us)          ← end of turn
+        ▼
+StreamingTtsProcessor
+        │  OutputAudioRawFrame (transport_destination = pid)
+        ▼
+XRMediaHubOutputTransport
+        │  AudioChunk → hub → client
+```
+
+`make_voice_pipeline()` assembles this chain and returns a ready-to-run
+`PipelineWorker`.  Pass a `BrainProcessor` subclass; configure VAD knobs
+via `VadConfig` and gate behavior via `VoiceGateConfig`.
+
+---
+
+## Processor contracts
+
+### `XRMediaHubInputTransport`
+
+Receives `AudioChunk` and `FrameSignal` from the hub over ZMQ and converts
+them to pipecat frames.  Sets `transport_source = participant_id` on every
+`InputAudioRawFrame` so downstream processors can route by speaker.
+
+### `VadSttProcessor`
+
+One `VadDetector` per participant (keyed by `transport_source`).  Emits:
+
+- `UserStartedSpeakingFrame` — when VAD accumulates ≥ `min_speech` seconds.
+  `transport_source` is set to the speaker's pid.
+- `UserStoppedSpeakingFrame` — at utterance end.  `transport_source` = pid.
+- `TranscriptionFrame` — STT result.  `user_id` and `transport_source` both
+  carry the pid.
+- `InterruptionFrame` — only from the early STOP probe (a fast-path that runs
+  STT on the partial buffer after `stop_probe_after_s`).  `transport_source` =
+  pid so the brain cancels only that speaker's task.
+
+### `VoiceGateProcessor`
+
+Feeds each `TranscriptionFrame` into a per-pid `VoiceGate` state machine.
+Emits one of:
+
+| Event | Frame emitted |
+|---|---|
+| Magic phrase + query | `GatedQueryFrame(participant_id, text, fresh_match=True, pts_us)` |
+| Follow-up window open | `GatedQueryFrame(participant_id, text, fresh_match=False, pts_us)` |
+| "Stop" detected | `InterruptionFrame(transport_source=pid)` + `TextFrame(stop ack)` |
+| Magic phrase only | nothing (opens follow-up window) |
+| Neither | nothing |
+
+`UserStartedSpeakingFrame` passes through unconditionally — the gate does not
+check its state before forwarding it.  `on_user_started_speaking` therefore
+fires on every VAD onset, including utterances that the gate will ultimately
+drop.
+
+### `BrainProcessor`
+
+Base class for all agent brains.  Owns:
+
+- **Per-pid in-flight task** — at most one `handle_query` coroutine running
+  per participant; a new `GatedQueryFrame` cancels the prior task.
+- **`InterruptionFrame` handling** — cancels the task for the pid in
+  `frame.transport_source`; falls back to cancelling all tasks when no pid is
+  set (global interrupt).
+- **Hook dispatch** — `on_user_started_speaking(pid)`, `on_query_superseded(pid)`,
+  `on_participant_joined(pid)`, `on_participant_left(pid)`.
+
+**Subclass contract:** implement `handle_query(pid, text, fresh_match)` and
+return either a string or an `AsyncIterator[str]`.  Each yielded chunk becomes
+a `TextFrame` routed to `pid`.
+
+```python
+class MyBrain(BrainProcessor):
+    async def handle_query(self, pid, text, fresh_match):
+        return await self._vlm.ask(...)            # single string
+        # or:
+        return self._vision.ask(pid, text)         # AsyncIterator[str]
+```
+
+### `StreamingTtsProcessor`
+
+Consumes `TextFrame`s, calls the TTS service, and emits
+`OutputAudioRawFrame`s.  Echoes the completed turn text on the
+`agent.response` data channel once the `BrainResponseEndFrame` arrives.
+Also observes TTS WAVs from the voice gate chime.
+
+### `XRMediaHubOutputTransport`
+
+Converts `OutputAudioRawFrame`s back to `AudioChunk`s and sends them to the
+hub, addressed to the participant in `frame.transport_destination`.
+
+---
+
+## Frame types (`xr_ai_pipecat.frames`)
+
+| Frame | Fields | Who emits | Who consumes |
+|---|---|---|---|
+| `GatedQueryFrame` | `participant_id`, `text`, `fresh_match`, `pts_us` | `VoiceGateProcessor` | `BrainProcessor` |
+| `BrainResponseEndFrame` | `pid`, `text`, `pts_us` | `BrainProcessor` | `StreamingTtsProcessor` |
+| `ParticipantJoinedFrame` | `participant_id` | `XRMediaHubInputTransport` | `VoiceGateProcessor`, `BrainProcessor` |
+| `ParticipantLeftFrame` | `participant_id` | `XRMediaHubInputTransport` | `VadSttProcessor`, `VoiceGateProcessor`, `BrainProcessor` |
+
+Pipecat's built-in frames (`UserStartedSpeakingFrame`, `UserStoppedSpeakingFrame`,
+`InterruptionFrame`, `TranscriptionFrame`, `TextFrame`, `InputAudioRawFrame`,
+`OutputAudioRawFrame`) are used directly.  `transport_source` and
+`transport_destination` on the pipecat base `Frame` carry the participant id;
+our processors always set these on the frames they emit.
+
+---
+
+## Brain building blocks (`xr-ai-capabilities`)
+
+Two composable abstractions let a brain expose tools to an LLM without
+hard-coding routing logic.
+
+### `AgentCapability`
+
+A **brain-local** tool — executes inside the agent process, no network hop.
+Implement two methods:
+
+```python
+class MyCapability(AgentCapability):
+    def as_tool_defs(self) -> list[ToolDef]:
+        return [ToolDef(name="my_tool", description="...", parameters={...})]
+
+    async def execute(self, name, args, pid, *, onset_pts_us=0, end_pts_us=0) -> dict:
+        ...
+```
+
+`VisionModule` is the canonical example: it exposes `look_at_current_frame`
+and handles camera access, frame fetch, and VLM call entirely in-process.
+
+### `MCPToolset`
+
+A **remote** tool server reachable via FastMCP.  Pairs a client with the
+tool names it owns:
+
+```python
+MCPToolset(oxr_client, frozenset({"get_head_pose", "position_ahead", ...}))
+MCPToolset(render_client)   # tools=None → catch-all
+```
+
+`route_tool(toolsets, name)` returns the first toolset whose set contains
+`name`, or the catch-all.  `collect_tool_defs(toolsets)` queries all clients
+once and returns `ToolDef` objects for the LLM's tool list.
+
+### Wiring them into a brain
+
+```python
+brain = MyBrain(
+    toolsets=[
+        MCPToolset(oxr,    _OXR_TOOLS),
+        MCPToolset(render),               # catch-all
+    ],
+    capabilities=[
+        VisionModule(transport.endpoint, vlm),
+    ],
+)
+```
+
+`BrainProcessor` (M2, planned) will route tool calls automatically: checks
+capabilities first (by name), then `route_tool` for MCP servers.  Until then,
+subclasses call `route_tool` / `capability.execute` directly in their
+`handle_query` implementation.
+
+---
+
+## `VisionModule`
+
+`VisionModule` implements `AgentCapability` and exposes one brain-local tool:
+
+| Tool | Constant | What it does |
+|---|---|---|
+| `look_at_current_frame` | `VISION_TOOL_NAME` | Fetches the latest live frame and runs VLM Q&A inline |
+
+Camera streaming is always-on; `VisionModule` never sends `startCamera` /
+`stopCamera`.  It waits up to `frame_timeout_s` for a fresh frame and raises
+`VisionUnavailable` if none arrives.
+
+Two call styles over the same frame-acquisition path:
+
+- `ask(pid, query)` — `AsyncIterator[str]` for TTS streaming.
+- `perceive(pid, query)` — `str` for agentic tool loops; raises
+  `VisionUnavailable` on failure.
+- `execute(name, args, pid)` — `AgentCapability` interface; wraps `perceive`,
+  returns `{"answer": text}` or `{"spoken": message}`.
+
+---
+
+## Adding a new brain
+
+1. Subclass `BrainProcessor`.
+2. Implement `handle_query(pid, text, fresh_match)`.
+3. Use `MCPToolset` + `collect_tool_defs` to wire MCP servers.
+4. Use `VisionModule` (or a custom `AgentCapability`) for brain-local tools.
+5. Pass to `make_voice_pipeline(transport, stt, tts, brain, vad_cfg, voice_gate_cfg)`.
+
+See `agent-samples/simple-vlm-example/worker/agent.py` (minimal VLM brain)
+and `agent-samples/xr-render-demo/worker/processors.py` (full agentic loop
+with MCP tool calling).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,33 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-29 — MCPToolset + AgentCapability in xr-ai-capabilities (M1)
+
+Added two foundation building blocks to `agent-sdk/xr-ai-capabilities`:
+
+**`MCPToolset`** (`toolset.py`) pairs any MCP client with the set of tool names it
+owns.  `tools=None` is the catch-all (owns any tool not claimed by an earlier
+entry).  `route_tool(toolsets, name)` finds the right toolset for a given name;
+`collect_tool_defs(toolsets)` queries all clients via `list_tools()` and
+returns `ToolDef` objects.  The client type is duck-typed via
+`McpClientProtocol` (a `runtime_checkable` Protocol), so `fastmcp.Client`
+satisfies it without importing FastMCP into `xr-ai-capabilities`.
+
+**`AgentCapability`** (`capability.py`) is the ABC for brain-local tools — tools
+that run inline in the brain process rather than calling an external MCP server.
+It exposes `as_tool_defs()` and `execute(name, args, pid, *, onset_pts_us,
+end_pts_us)`.  The timing params are 0-defaulted for forward-compat with the
+timing integration track.
+
+**`VisionModule`** now implements `AgentCapability`.  It exposes the canonical
+`look_at_current_frame` tool (`VISION_TOOL_NAME`) via `as_tool_defs()` and
+executes it via `execute()` (wrapping `perceive()`).  A `tool_description`
+constructor param lets samples override the LLM-visible description.
+
+These replace the per-sample hardcoded frozenset + `if tool in _X_TOOLS` switch.
+Follow-up PRs: M2 (`BrainProcessor` accepts `toolsets`/`capabilities`), M3
+(refactor `xr-render-demo` + wire T4 timing).
+
 ### 2026-06-11 — iOS/visionOS: pre-warm the LiveKit recording engine on mic start
 
 `LiveKitBackend.startAudio` now calls


### PR DESCRIPTION
## Summary

- Adds `MCPToolset` (`toolset.py`): pairs any MCP client with the tool names it owns; `route_tool` / `collect_tool_defs` replace the per-sample hardcoded frozenset + if-chain dispatch
- Adds `AgentCapability` (`capability.py`): ABC for brain-local tools (no MCP hop); exposes `as_tool_defs()` and `execute()` with forward-compat timing params
- `VisionModule` now implements `AgentCapability`: registers `look_at_current_frame` via `as_tool_defs()`, executes via `execute()`; adds `tool_description` constructor param for sample-specific LLM hints

No new external dependencies — `xr-ai-capabilities/pyproject.toml` unchanged.

## Context

This is **M1** of the modular agent architecture (AGENTS.md follow-up #1). It unblocks:
- **M2** — `BrainProcessor` accepts `toolsets` + `capabilities` lists (can start now)
- **M3+T4** — refactor `xr-render-demo` to use `MCPToolset` + wire speech-timing

The timing params (`onset_pts_us`, `end_pts_us`) on `AgentCapability.execute()` are 0-defaulted for forward-compat with the T-track (timing integration), where `VisionModule` will gain `perceive_at()` for time-anchored frame lookup.

## Test plan

- [ ] `uv run python -c "from xr_ai_capabilities import AgentCapability, MCPToolset, route_tool, collect_tool_defs, VISION_TOOL_NAME, VisionModule; print('OK')"` passes in `agent-sdk/xr-ai-capabilities/`
- [ ] `issubclass(VisionModule, AgentCapability)` is `True`
- [ ] `route_tool([], 'any')` returns `None`
- [ ] Existing `simple-vlm-example` and `xr-render-demo` still run unchanged (no API breakage — VisionModule constructor is backward-compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)