### PR TITLE
For native clients do not run web client or streaming proxy

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -108,6 +108,11 @@ xr-ai-models  (agent-sdk/xr-ai-models/)
 
 xr-ai-launcher  (utils/xr-ai-launcher/)
     └── (stdlib only — zero runtime deps)
+    `_cloudxr_env` owns the shared CloudXR env helpers (stdlib-only, os + re):
+    `load_cloudxr_env`, plus the single source of truth for native device
+    profiles: `NATIVE_DEVICE_PROFILES`, `is_native_profile(profile)`, and
+    `read_device_profile(yaml_path)` (env-first NV_DEVICE_PROFILE read, regex
+    YAML fallback).
 
 xr-ai-logging  (utils/xr-ai-logging/)
     └── loguru >=0.7
@@ -189,6 +194,8 @@ video-mcp-server  (agent-mcp-servers/video-mcp/)
 cloudxr-runtime  (cloudxr-runtime/)
     └── isaacteleop[cloudxr]
     └── pyyaml
+    └── xr-ai-launcher  [editable: ../utils/xr-ai-launcher] (is_native_profile + read_device_profile)
+    └── xr-ai-logging   [editable: ../utils/xr-ai-logging]
 
 render-mcp-server  (agent-mcp-servers/render-mcp/)
     └── xr-ai-launcher  [editable: ../../utils/xr-ai-launcher] (ManagedProcess + load_cloudxr_env)
@@ -487,7 +494,7 @@ updated in the same commit**.
 | vlm-server model class or supported architectures | `ai-services/vlm-server/vlm_server.yaml` comments |
 | vlm-server YAML config keys (`model`, `model_cache`, …) | `ai-services/vlm-server/vlm_server.yaml`, `agent-samples/simple-vlm-example/vlm_server.yaml` |
 | cloudxr-runtime YAML config keys | `agent-samples/xr-render-demo/cloudxr_runtime.yaml`, `AGENTS.md` CloudXR section |
-| `utils/xr-ai-launcher/xr_ai_launcher/_cloudxr_env.py` API | render-mcp + oxr-mcp `__main__.py` imports, `AGENTS.md` cloudxr-env section |
+| `utils/xr-ai-launcher/xr_ai_launcher/_cloudxr_env.py` API | render-mcp + oxr-mcp + cloudxr-runtime `__main__.py` imports, `agent-samples/xr-render-demo/main.py` (native-profile gate), `AGENTS.md` cloudxr-env section |
 | render-mcp YAML config keys | `agent-mcp-servers/render-mcp/render_mcp.yaml`, sample copies, worker URL constants |
 | oxr-mcp YAML config keys | `agent-mcp-servers/oxr-mcp/oxr_mcp_server.yaml`, sample copies, worker URL constants |
 | Any `pyproject.toml` dependency | `DEPENDENCIES.md` (this file) |

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -493,8 +493,8 @@ updated in the same commit**.
 | Container name used by a vllm wrapper | `_CONTAINER_NAME` in the wrapper's `__main__.py`, `_PERSISTENT_SERVERS` in `agent-samples/xr-render-demo/main.py` |
 | vlm-server model class or supported architectures | `ai-services/vlm-server/vlm_server.yaml` comments |
 | vlm-server YAML config keys (`model`, `model_cache`, …) | `ai-services/vlm-server/vlm_server.yaml`, `agent-samples/simple-vlm-example/vlm_server.yaml` |
-| cloudxr-runtime YAML config keys | `agent-samples/xr-render-demo/cloudxr_runtime.yaml`, `AGENTS.md` CloudXR section |
-| `utils/xr-ai-launcher/xr_ai_launcher/_cloudxr_env.py` API | render-mcp + oxr-mcp + cloudxr-runtime `__main__.py` imports, `agent-samples/xr-render-demo/main.py` (native-profile gate), `AGENTS.md` cloudxr-env section |
+| cloudxr-runtime YAML config keys | `agent-samples/xr-render-demo/yaml/cloudxr_runtime.yaml`, `docs/adding-cloudxr.md` |
+| `utils/xr-ai-launcher/xr_ai_launcher/_cloudxr_env.py` API | render-mcp + oxr-mcp + cloudxr-runtime `__main__.py` imports, `agent-samples/xr-render-demo/main.py` (native-profile gate), `docs/adding-cloudxr.md`, `docs/xr-render-demo.md` (client-type section) |
 | render-mcp YAML config keys | `agent-mcp-servers/render-mcp/render_mcp.yaml`, sample copies, worker URL constants |
 | oxr-mcp YAML config keys | `agent-mcp-servers/oxr-mcp/oxr_mcp_server.yaml`, sample copies, worker URL constants |
 | Any `pyproject.toml` dependency | `DEPENDENCIES.md` (this file) |

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ uv sync
 uv run xr_render_demo
 ```
 
-On first run the orchestrator automatically downloads LOVR v0.18.0 to
+On first run the orchestrator automatically downloads the pinned LOVR version to
 `deps/lovr/` inside the repo and builds the web vendor bundle (requires npm
 and network access). Both steps are skipped on subsequent runs.
 

--- a/agent-mcp-servers/render-mcp/render_mcp.yaml
+++ b/agent-mcp-servers/render-mcp/render_mcp.yaml
@@ -7,9 +7,10 @@
 # Overridable per sample by dropping a render_mcp.yaml next to the sample's
 # orchestrator (the launcher auto-discovers <command>.yaml by convention).
 
-# Path to the LOVR engine binary. Required. If left commented out, render-mcp
-# falls back to $LOVR_BIN. Point this at your existing LOVR build (e.g.
-# ~/hub/lovr/build/bin/lovr); render-mcp does not build or bundle LOVR.
+# Path to the LOVR engine binary. render-mcp needs one from either this key or
+# $LOVR_BIN (this key takes precedence); it exits if neither is set. Point it at
+# your LOVR build (e.g. ~/hub/lovr/build/bin/lovr); render-mcp does not build or
+# bundle LOVR.
 # lovr_bin: /home/you/hub/lovr/build/bin/lovr
 
 # Directory passed to LOVR as the project to run. Resolved relative to this

--- a/agent-samples/xr-render-demo/main.py
+++ b/agent-samples/xr-render-demo/main.py
@@ -25,8 +25,10 @@ How to run (from the repo root or any directory):
     uv run --project agent-samples/xr-render-demo xr_render_demo
 
 On first run the orchestrator auto-downloads LOVR v0.18.0 to deps/lovr/ inside
-the repo and builds the web vendor bundle (requires npm + network). Both steps
-are skipped once the outputs exist.
+the repo and, for WebRTC device profiles, builds the web vendor bundle
+(requires npm + network). Native CloudXR profiles never load the web page, so
+the vendor build is skipped and the hub serves only its signaling endpoints.
+Both steps are skipped once their outputs exist.
 
 To use a custom LOVR build instead of the auto-downloaded one:
     export LOVR_BIN=/path/to/your/lovr      # or set lovr_bin: in render_mcp.yaml
@@ -46,16 +48,26 @@ import urllib.request
 from pathlib import Path
 
 from loguru import logger
-from xr_ai_launcher import Process, ensure_credentials, run_stack
+from xr_ai_launcher import (
+    Process,
+    ensure_credentials,
+    is_native_profile,
+    read_device_profile,
+    run_stack,
+)
 from xr_ai_logging import setup_logging
 
 _BASE = Path(__file__).resolve().parent
 
 _WORKER_CONFIG = "yaml/xr_render_demo_worker.yaml"
+_CLOUDXR_CONFIG = "yaml/cloudxr_runtime.yaml"
 
 # Read the model_backend scalar from the worker YAML without pyyaml — the
 # orchestrator is stdlib-only (mirrors the lovr_bin regex read below).
 _BACKEND_RE = re.compile(r"^\s*model_backend\s*:\s*[\"']?(\w+)[\"']?", re.MULTILINE)
+
+# Must match _config_loader.NO_WEB_CLIENT_ENV.
+_NO_WEB_CLIENT_ENV = "XR_MEDIA_HUB_NO_WEB_CLIENT"
 
 
 def _model_backend() -> str:
@@ -239,7 +251,11 @@ def _ensure_web_vendor() -> None:
 
 def run() -> None:
     setup_logging("orchestrator", namespace="xr-render-demo")
-    _ensure_web_vendor()
+    if is_native_profile(read_device_profile(_BASE / _CLOUDXR_CONFIG)):
+        os.environ[_NO_WEB_CLIENT_ENV] = "1"
+        logger.info("native device profile: web client page disabled, skipping vendor build")
+    else:
+        _ensure_web_vendor()
     _ensure_lovr_bin()
     backend = _model_backend()
     if backend == "nim":

--- a/agent-samples/xr-render-demo/yaml/cloudxr_runtime.yaml
+++ b/agent-samples/xr-render-demo/yaml/cloudxr_runtime.yaml
@@ -14,7 +14,10 @@ cloudxr_install_dir: ~/.cloudxr
 accept_eula: true
 
 # CloudXR env overrides applied before the native service starts.
-# Valid NV_DEVICE_PROFILE values: auto-native | auto-webrtc | apple-vision-pro | ipad-pro | quest3
+# NV_DEVICE_PROFILE selects the client type:
+#   auto-webrtc: WebRTC / web XR clients (default)
+#   auto-native: native iOS / visionOS clients (set this to use the native apps)
+# Device-specific values also accepted: apple-vision-pro | ipad-pro | quest3
 cloudxr_env:
   NV_DEVICE_PROFILE: auto-webrtc
 

--- a/agent-samples/xr-render-demo/yaml/cloudxr_runtime.yaml
+++ b/agent-samples/xr-render-demo/yaml/cloudxr_runtime.yaml
@@ -19,7 +19,7 @@ accept_eula: true
 #   auto-native: native iOS / visionOS clients (set this to use the native apps)
 # Device-specific values also accepted: apple-vision-pro | ipad-pro | quest3
 cloudxr_env:
-  NV_DEVICE_PROFILE: auto-native
+  NV_DEVICE_PROFILE: auto-webrtc
 
 # Physical GPU (nvidia-smi index) the CloudXR compositor pins to. Translated
 # to PCI bus selectors for Vulkan, CUDA, and Mesa, set on this process's

--- a/agent-samples/xr-render-demo/yaml/cloudxr_runtime.yaml
+++ b/agent-samples/xr-render-demo/yaml/cloudxr_runtime.yaml
@@ -19,7 +19,7 @@ accept_eula: true
 #   auto-native: native iOS / visionOS clients (set this to use the native apps)
 # Device-specific values also accepted: apple-vision-pro | ipad-pro | quest3
 cloudxr_env:
-  NV_DEVICE_PROFILE: auto-webrtc
+  NV_DEVICE_PROFILE: auto-native
 
 # Physical GPU (nvidia-smi index) the CloudXR compositor pins to. Translated
 # to PCI bus selectors for Vulkan, CUDA, and Mesa, set on this process's

--- a/cloudxr-runtime/cloudxr_runtime/__main__.py
+++ b/cloudxr-runtime/cloudxr_runtime/__main__.py
@@ -151,8 +151,9 @@ async def _run(
     install_dir = str(Path(cfg.get("cloudxr_install_dir", "~/.cloudxr")).expanduser())
     env_file    = cfg.get("cloudxr_env_config")
 
+    # Environment variables such as NV_DEVICE_PROFILE are respected, with config values used as defaults.
     for key, val in cfg.get("cloudxr_env", {}).items():
-        os.environ[key] = str(val)
+        os.environ.setdefault(key, str(val))
 
     # XR-side GPU pinning. Set on os.environ before EnvConfig.from_args so the
     # multiprocessing.Process that hosts the native CloudXR service inherits

--- a/cloudxr-runtime/cloudxr_runtime/__main__.py
+++ b/cloudxr-runtime/cloudxr_runtime/__main__.py
@@ -36,12 +36,8 @@ from isaacteleop.cloudxr.runtime import (
 )
 from isaacteleop.cloudxr.wss import run as wss_run
 from loguru import logger
+from xr_ai_launcher import is_native_profile, read_device_profile
 from xr_ai_logging import setup_logging
-
-# NV_DEVICE_PROFILE values that use CloudXR's direct native transport.
-# Profiles not listed here (e.g. quest3 — no native CloudXR Android client)
-# connect over WebRTC and go through the WSS proxy.
-_NATIVE_DEVICE_PROFILES = {"auto-native", "apple-vision-pro", "ipad-pro"}
 
 
 async def _wait_with_progress(
@@ -147,7 +143,11 @@ def _append_env_to_file(path: Path, env: dict[str, str]) -> None:
         f.writelines(lines)
 
 
-async def _run(cfg: dict, ready_file: Path | None = None) -> None:
+async def _run(
+    cfg: dict,
+    ready_file: Path | None = None,
+    config_path: Path | None = None,
+) -> None:
     install_dir = str(Path(cfg.get("cloudxr_install_dir", "~/.cloudxr")).expanduser())
     env_file    = cfg.get("cloudxr_env_config")
 
@@ -233,8 +233,8 @@ async def _run(cfg: dict, ready_file: Path | None = None) -> None:
 
         # Native-transport profiles connect directly; only WebRTC profiles need
         # the WSS signaling proxy.
-        profile = os.environ.get("NV_DEVICE_PROFILE", "")
-        if profile in _NATIVE_DEVICE_PROFILES:
+        profile = read_device_profile(config_path)
+        if is_native_profile(profile):
             logger.info("native device profile {}, skipping WSS proxy", profile)
             await stop
         else:
@@ -271,7 +271,7 @@ def run() -> None:
     if our_ns.config:
         cfg = _load_config(our_ns.config)
 
-    asyncio.run(_run(cfg, ready_file=our_ns.ready_file))
+    asyncio.run(_run(cfg, ready_file=our_ns.ready_file, config_path=our_ns.config))
 
 
 if __name__ == "__main__":

--- a/cloudxr-runtime/cloudxr_runtime/__main__.py
+++ b/cloudxr-runtime/cloudxr_runtime/__main__.py
@@ -6,7 +6,7 @@ cloudxr_runtime — launcher for isaacteleop.cloudxr.
 
 Starts the native CloudXR service (libcloudxr.so) in a subprocess, waits for
 it to become ready, then runs isaacteleop's WSS proxy (port 48322) required by
-the auto-webrtc device profile.  auto-native skips the WSS step.
+WebRTC device profiles.  Native device profiles skip the WSS step.
 
 Accepts --config <path>.yaml (auto-passed by xr-ai-launcher).
 """
@@ -37,6 +37,11 @@ from isaacteleop.cloudxr.runtime import (
 from isaacteleop.cloudxr.wss import run as wss_run
 from loguru import logger
 from xr_ai_logging import setup_logging
+
+# NV_DEVICE_PROFILE values that use CloudXR's direct native transport.
+# Profiles not listed here (e.g. quest3 — no native CloudXR Android client)
+# connect over WebRTC and go through the WSS proxy.
+_NATIVE_DEVICE_PROFILES = {"auto-native", "apple-vision-pro", "ipad-pro"}
 
 
 async def _wait_with_progress(
@@ -226,18 +231,25 @@ async def _run(cfg: dict, ready_file: Path | None = None) -> None:
         if ready_file:
             ready_file.touch()
 
-        from datetime import datetime, timezone
-        ts      = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%M%SZ")
-        wss_log = logs_dir / f"wss.{ts}.log"
-        try:
-            await wss_run(log_file_path=wss_log, stop_future=stop)
-        except RuntimeError as exc:
-            logger.error(
-                "CloudXR WSS proxy failed: {}\n"
-                "  If another process owns port 48322, stop it first:\n"
-                "    sudo fuser -k 48322/tcp",
-                exc,
-            )
+        # Native-transport profiles connect directly; only WebRTC profiles need
+        # the WSS signaling proxy.
+        profile = os.environ.get("NV_DEVICE_PROFILE", "")
+        if profile in _NATIVE_DEVICE_PROFILES:
+            logger.info("native device profile {}, skipping WSS proxy", profile)
+            await stop
+        else:
+            from datetime import datetime, timezone
+            ts      = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%M%SZ")
+            wss_log = logs_dir / f"wss.{ts}.log"
+            try:
+                await wss_run(log_file_path=wss_log, stop_future=stop)
+            except RuntimeError as exc:
+                logger.error(
+                    "CloudXR WSS proxy failed: {}\n"
+                    "  If another process owns port 48322, stop it first:\n"
+                    "    sudo fuser -k 48322/tcp",
+                    exc,
+                )
     finally:
         terminate_or_kill_runtime(runtime_proc)
 

--- a/cloudxr-runtime/pyproject.toml
+++ b/cloudxr-runtime/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.11,<3.13"
 dependencies = [
     "isaacteleop[cloudxr]",
     "pyyaml",
+    "xr-ai-launcher",
     "xr-ai-logging",
 ]
 
@@ -19,6 +20,7 @@ dependencies = [
 cloudxr_runtime = "cloudxr_runtime.__main__:run"
 
 [tool.uv.sources]
+xr-ai-launcher = { path = "../utils/xr-ai-launcher", editable = true }
 xr-ai-logging = { path = "../utils/xr-ai-logging", editable = true }
 
 [tool.hatch.build.targets.wheel]

--- a/docs/adding-cloudxr.md
+++ b/docs/adding-cloudxr.md
@@ -33,8 +33,10 @@ cloudxr_install_dir: ~/.cloudxr
 # Written once to <cloudxr_install_dir>/run/eula_accepted; ignored on subsequent runs.
 accept_eula: true
 
-# Device profile — controls transport and XR device defaults.
-# Valid: auto-native | auto-webrtc | apple-vision-pro | ipad-pro | quest3
+# Device profile: selects the client type and XR device defaults.
+#   auto-webrtc: WebRTC / web XR clients (default)
+#   auto-native: native iOS / visionOS clients
+# Device-specific values also accepted: apple-vision-pro | ipad-pro | quest3
 cloudxr_env:
   NV_DEVICE_PROFILE: auto-webrtc
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,14 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-29 — cloudxr_env yaml values default rather than override the environment
+
+cloudxr-runtime applies the `cloudxr_env` block from `cloudxr_runtime.yaml` with
+`os.environ.setdefault`, so the yaml supplies defaults and an explicit
+environment value (e.g. an inlined `NV_DEVICE_PROFILE=auto-native`) overrides it.
+This matches the orchestrator and cloudxr-runtime both resolving the profile
+env-first via `read_device_profile`.
+
 ### 2026-06-26 — Web client page + vendor build are WebRTC-only
 
 The xr-render-demo serves the static web page and runs the npm web-vendor

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,10 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-25 — CloudXR WSS signaling proxy is WebRTC-only
+
+The WSS proxy (port 48322) is started only for WebRTC device profiles.
+
 ### 2026-06-11 — iOS/visionOS: pre-warm the LiveKit recording engine on mic start
 
 `LiveKitBackend.startAudio` now calls

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,24 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-06-26 — Web client page + vendor build are WebRTC-only
+
+The xr-render-demo serves the static web page and runs the npm web-vendor
+build only for WebRTC device profiles. Native CloudXR profiles (`auto-native`,
+`apple-vision-pro`, `ipad-pro`) skip both: the page's "Launch XR" uses the WSS
+proxy that native already skips, so for native it is a dead WebRTC-only UI that
+native clients (the AVP Swift app) never load. Skipping the build drops
+the npm dependency for native-only users.
+
+The orchestrator reads `NV_DEVICE_PROFILE` from `cloudxr_runtime.yaml` (stdlib
+regex, same as the existing `model_backend`/`lovr_bin` reads), gates
+`_ensure_web_vendor()`, and signals the hub via a generic
+`XR_MEDIA_HUB_NO_WEB_CLIENT` env var. The hub stays free of CloudXR-profile
+knowledge: its config loader honors that transport-agnostic var by clearing
+`web_client_dir` (no static mount) while keeping `/token`, `/cert`, and `/rtc`
+live. The native AVP app still fetches its LiveKit token from
+`https://<host>:8080/token`.
+
 ### 2026-06-25 — CloudXR WSS signaling proxy is WebRTC-only
 
 The WSS proxy (port 48322) is started only for WebRTC device profiles.

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -191,7 +191,7 @@ uv sync
 uv run xr_render_demo
 ```
 
-On first run the orchestrator automatically downloads LOVR v0.18.0 to
+On first run the orchestrator automatically downloads the pinned LOVR version to
 `deps/lovr/` inside the repository and builds the web vendor bundle (requires npm
 and network access). Both steps are skipped on subsequent runs.
 

--- a/docs/source/reference/xr-render-demo.md
+++ b/docs/source/reference/xr-render-demo.md
@@ -38,7 +38,8 @@ Before starting the stack, the orchestrator runs two setup steps:
 
 - **Web vendor bundle** — builds the CloudXR + LiveKit ESM bundle via
   `client-samples/web-xr-build/build.sh` (skipped if already present;
-  requires `npm`).
+  requires `npm`). Built only for WebRTC device profiles; native profiles
+  never serve the web page, so the build (and its npm dependency) is skipped.
 - **LOVR binary** — auto-downloads LOVR v0.18.0 AppImage to `deps/lovr/` if
   not present and sets `$LOVR_BIN`. Resolution order: `$LOVR_BIN` env var →
   `lovr_bin:` in `render_mcp.yaml` → cached AppImage → fresh download.

--- a/docs/xr-render-demo.md
+++ b/docs/xr-render-demo.md
@@ -46,14 +46,17 @@ Before starting the stack, the orchestrator runs two setup steps:
 
 ## Selecting the client type (WebRTC vs native)
 
-`NV_DEVICE_PROFILE` in `yaml/cloudxr_runtime.yaml` selects which XR clients can
-connect. The default `auto-webrtc` serves WebRTC / web XR clients. For the
-native iOS / visionOS client apps, change it to `auto-native`:
+`NV_DEVICE_PROFILE` selects which XR clients can connect. For the native iOS /
+visionOS client apps, set it to `auto-native`:
 
-```yaml
-cloudxr_env:
-  NV_DEVICE_PROFILE: auto-native
+```bash
+NV_DEVICE_PROFILE=auto-native uv run ...
 ```
+
+The environment value takes precedence over the yaml, so prefer setting the
+variable. `NV_DEVICE_PROFILE` under `cloudxr_env` in `yaml/cloudxr_runtime.yaml`
+only supplies the default when the variable is unset (currently `auto-webrtc`,
+which serves WebRTC / web XR clients).
 
 For native profiles the hub omits the static web page but keeps `/token`,
 `/cert`, and `/rtc`, so the native AVP app's default token fetch from

--- a/docs/xr-render-demo.md
+++ b/docs/xr-render-demo.md
@@ -38,7 +38,8 @@ Before starting the stack, the orchestrator runs two setup steps:
 
 - **Web vendor bundle** — builds the CloudXR + LiveKit ESM bundle via
   `client-samples/web-xr-build/build.sh` (skipped if already present;
-  requires `npm`).
+  requires `npm`). Built only for WebRTC device profiles; native profiles
+  never serve the web page, so the build (and its npm dependency) is skipped.
 - **LOVR binary** — auto-downloads LOVR v0.18.0 AppImage to `deps/lovr/` if
   not present and sets `$LOVR_BIN`. Resolution order: `$LOVR_BIN` env var →
   `lovr_bin:` in `render_mcp.yaml` → cached AppImage → fresh download.
@@ -53,6 +54,10 @@ native iOS / visionOS client apps, change it to `auto-native`:
 cloudxr_env:
   NV_DEVICE_PROFILE: auto-native
 ```
+
+For native profiles the hub omits the static web page but keeps `/token`,
+`/cert`, and `/rtc`, so the native AVP app's default token fetch from
+`https://<host>:8080/token` keeps working.
 
 ## GPU pinning for the XR side
 

--- a/docs/xr-render-demo.md
+++ b/docs/xr-render-demo.md
@@ -43,6 +43,17 @@ Before starting the stack, the orchestrator runs two setup steps:
   not present and sets `$LOVR_BIN`. Resolution order: `$LOVR_BIN` env var →
   `lovr_bin:` in `render_mcp.yaml` → cached AppImage → fresh download.
 
+## Selecting the client type (WebRTC vs native)
+
+`NV_DEVICE_PROFILE` in `yaml/cloudxr_runtime.yaml` selects which XR clients can
+connect. The default `auto-webrtc` serves WebRTC / web XR clients. For the
+native iOS / visionOS client apps, change it to `auto-native`:
+
+```yaml
+cloudxr_env:
+  NV_DEVICE_PROFILE: auto-native
+```
+
 ## GPU pinning for the XR side
 
 `gpu_index` (int) in `yaml/cloudxr_runtime.yaml` selects the physical GPU

--- a/server-runtime/xr_media_hub/_config_loader.py
+++ b/server-runtime/xr_media_hub/_config_loader.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import argparse
 import dataclasses
+import os
 from pathlib import Path
 
 import yaml
@@ -23,6 +24,13 @@ from loguru import logger
 from xr_media_hub.transport.livekit.config import LiveKitConnectorConfig
 
 DEFAULT_CONFIG_NAME = "xr_media_hub.yaml"
+
+# Clears web_client_dir when set; /token, /cert, /rtc stay up.
+NO_WEB_CLIENT_ENV = "XR_MEDIA_HUB_NO_WEB_CLIENT"
+
+
+def _web_client_disabled() -> bool:
+    return os.environ.get(NO_WEB_CLIENT_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _resolve_path(value: str, base: Path) -> str:
@@ -55,6 +63,9 @@ def load_config() -> LiveKitConnectorConfig:
 
     with config_path.open() as f:
         data: dict = yaml.safe_load(f) or {}
+
+    if _web_client_disabled():
+        data["web_client_dir"] = ""
 
     # Resolve any relative path fields relative to the YAML file's directory.
     for key in ("web_client_dir", "cert_file", "key_file"):

--- a/tests/test_launcher_cloudxr_env.py
+++ b/tests/test_launcher_cloudxr_env.py
@@ -10,7 +10,13 @@ from pathlib import Path
 
 import pytest
 
-from xr_ai_launcher._cloudxr_env import XR_RUNTIME_VAR, load_cloudxr_env
+from xr_ai_launcher._cloudxr_env import (
+    NATIVE_DEVICE_PROFILES,
+    XR_RUNTIME_VAR,
+    is_native_profile,
+    load_cloudxr_env,
+    read_device_profile,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -21,6 +27,7 @@ def _clean_env(monkeypatch):
     monkeypatch.delenv("QUOTED_DOUBLE", raising=False)
     monkeypatch.delenv("QUOTED_SINGLE", raising=False)
     monkeypatch.delenv("NO_EXPORT", raising=False)
+    monkeypatch.delenv("NV_DEVICE_PROFILE", raising=False)
 
 
 def _write_env(tmp_path: Path, content: str) -> Path:
@@ -115,3 +122,56 @@ class TestEdgeCases:
         """)
         load_cloudxr_env(env_file)
         assert os.environ["CLOUDXR_EXTRA"] == "key=value"
+
+
+class TestIsNativeProfile:
+    @pytest.mark.parametrize("profile", sorted(NATIVE_DEVICE_PROFILES))
+    def test_native_profiles(self, profile):
+        assert is_native_profile(profile) is True
+
+    def test_webrtc_profile_is_not_native(self):
+        assert is_native_profile("auto-webrtc") is False
+
+    def test_empty_string_is_not_native(self):
+        assert is_native_profile("") is False
+
+    def test_whitespace_is_stripped(self):
+        assert is_native_profile("  auto-native  ") is True
+
+    def test_case_insensitive(self):
+        assert is_native_profile("Apple-Vision-Pro") is True
+
+
+class TestReadDeviceProfile:
+    def _write_yaml(self, tmp_path: Path, content: str) -> Path:
+        p = tmp_path / "cloudxr_runtime.yaml"
+        p.write_text(textwrap.dedent(content))
+        return p
+
+    def test_env_set_wins_over_yaml(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("NV_DEVICE_PROFILE", "auto-native")
+        yaml_path = self._write_yaml(tmp_path, """\
+            cloudxr_env:
+              NV_DEVICE_PROFILE: auto-webrtc
+        """)
+        assert read_device_profile(yaml_path) == "auto-native"
+
+    def test_env_unset_falls_back_to_yaml(self, tmp_path):
+        yaml_path = self._write_yaml(tmp_path, """\
+            cloudxr_env:
+              NV_DEVICE_PROFILE: "apple-vision-pro"
+        """)
+        assert read_device_profile(yaml_path) == "apple-vision-pro"
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert read_device_profile(tmp_path / "nonexistent.yaml") == ""
+
+    def test_no_match_in_yaml_returns_empty(self, tmp_path):
+        yaml_path = self._write_yaml(tmp_path, """\
+            cloudxr_env:
+              SOMETHING_ELSE: value
+        """)
+        assert read_device_profile(yaml_path) == ""
+
+    def test_falsy_path_returns_empty(self):
+        assert read_device_profile(None) == ""

--- a/utils/xr-ai-launcher/xr_ai_launcher/__init__.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/__init__.py
@@ -26,7 +26,13 @@ Typical usage::
         run_stack(PROCESSES, _BASE)
 """
 
-from ._cloudxr_env import XR_RUNTIME_VAR, load_cloudxr_env
+from ._cloudxr_env import (
+    NATIVE_DEVICE_PROFILES,
+    XR_RUNTIME_VAR,
+    is_native_profile,
+    load_cloudxr_env,
+    read_device_profile,
+)
 from ._credentials import ensure_credentials, load_credentials, warn_if_missing
 from ._gpu import detect_gpu_config
 from ._processes import ManagedProcess
@@ -34,6 +40,7 @@ from ._stack import Parallel, Process, run_stack
 
 __all__ = [
     "XR_RUNTIME_VAR", "load_cloudxr_env",
+    "NATIVE_DEVICE_PROFILES", "is_native_profile", "read_device_profile",
     "ensure_credentials", "load_credentials", "warn_if_missing",
     "detect_gpu_config",
     "ManagedProcess",

--- a/utils/xr-ai-launcher/xr_ai_launcher/_cloudxr_env.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/_cloudxr_env.py
@@ -23,7 +23,41 @@ _EXPORT_RE = re.compile(r"^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$")
 # OpenXR runtime selector written by cloudxr-runtime into cloudxr.env.
 XR_RUNTIME_VAR = "XR_RUNTIME_JSON"
 
-__all__ = ["XR_RUNTIME_VAR", "load_cloudxr_env"]
+# Profiles on CloudXR's direct native transport (skip the WSS proxy).
+NATIVE_DEVICE_PROFILES = frozenset({"auto-native", "apple-vision-pro", "ipad-pro"})
+
+_DEVICE_PROFILE_RE = re.compile(
+    r"^\s*NV_DEVICE_PROFILE\s*:\s*[\"']?([\w-]+)[\"']?", re.MULTILINE
+)
+
+__all__ = [
+    "XR_RUNTIME_VAR",
+    "load_cloudxr_env",
+    "NATIVE_DEVICE_PROFILES",
+    "is_native_profile",
+    "read_device_profile",
+]
+
+
+def is_native_profile(profile: str) -> bool:
+    """True if *profile* names a native-transport CloudXR device profile."""
+    return (profile or "").strip().lower() in NATIVE_DEVICE_PROFILES
+
+
+def read_device_profile(yaml_path) -> str:
+    """Return NV_DEVICE_PROFILE from the environment, or from *yaml_path* when unset."""
+    env_val = os.environ.get("NV_DEVICE_PROFILE")
+    if env_val:
+        return env_val
+    if not yaml_path:
+        return ""
+    try:
+        with open(yaml_path) as f:
+            text = f.read()
+    except OSError:
+        return ""
+    m = _DEVICE_PROFILE_RE.search(text)
+    return m.group(1) if m else ""
 
 
 def load_cloudxr_env(path: Path) -> None:


### PR DESCRIPTION
Server side changes for adding Vision Pro support to the render demo (don't run the web client or proxy which aren't needed for native clients). It does not change the default from webxr.