### PR TITLE
fix(vision): remove camera-on-demand re-introduced by PR #266

### DIFF
--- a/agent-samples/simple-vlm-example/worker/agent.py
+++ b/agent-samples/simple-vlm-example/worker/agent.py
@@ -57,11 +57,10 @@ class SimpleVlmBrain(BrainProcessor):
         *,
         transport: XRMediaHubTransport,
         vlm: VLMService,
-        default_prompt:      str   = "Describe what you see.",
-        system_prompt:       str   = DEFAULT_SYSTEM_PROMPT,
-        frame_max_age_s:     float = 2.0,
-        camera_on_timeout_s: float = 15.0,
-        camera_grace_s:      float = 5.0,
+        default_prompt:  str   = "Describe what you see.",
+        system_prompt:   str   = DEFAULT_SYSTEM_PROMPT,
+        frame_max_age_s: float = 2.0,
+        frame_timeout_s: float = 5.0,
     ) -> None:
         super().__init__()
         self._transport = transport
@@ -70,10 +69,9 @@ class SimpleVlmBrain(BrainProcessor):
         # All the live-camera machinery lives in the shared module.
         self._vision = VisionModule(
             transport.endpoint, vlm,
-            system_prompt       = system_prompt,
-            frame_max_age_s     = frame_max_age_s,
-            camera_on_timeout_s = camera_on_timeout_s,
-            camera_grace_s      = camera_grace_s,
+            system_prompt   = system_prompt,
+            frame_max_age_s = frame_max_age_s,
+            frame_timeout_s = frame_timeout_s,
         )
         self._vision.register()
 
@@ -90,8 +88,7 @@ class SimpleVlmBrain(BrainProcessor):
         return self._vision.ask(pid, text)
 
     async def on_user_started_speaking(self, pid: str) -> None:
-        # Speculative camera warmup at the leading edge of speech.
-        await self._vision.warmup(pid)
+        pass
 
     async def on_query_superseded(self, pid: str) -> None:
         # Vision Q&A turns are short; cut the previous answer's audio so the new

--- a/agent-samples/simple-vlm-example/worker/simple_vlm_example_worker.py
+++ b/agent-samples/simple-vlm-example/worker/simple_vlm_example_worker.py
@@ -31,9 +31,8 @@ Config (simple_vlm_example_worker.yaml — auto-passed by the launcher)
     voice_gate_yaml:       yaml/voice_gate.yaml  # path to voice-gate config
     default_prompt:        "Describe what you see."
     system_prompt:               <multiline string>   # role/style guidance
-    frame_max_age_s:            2.0   # frames older than this trigger startCamera
-    camera_on_timeout_s:       15.0   # wait for a fresh frame after startCamera
-    camera_grace_s:             5.0   # keep camera on after a query
+    frame_max_age_s:            2.0   # frames older than this are considered stale
+    frame_timeout_s:            5.0   # wait for a fresh frame before giving up
     silero_threshold:           0.5   # Silero speech probability gate (0..1)
     silence_duration:           0.4   # seconds of silence ending an utterance
     min_speech:                 0.1   # min seconds of speech before STT fires
@@ -103,9 +102,8 @@ async def main(
         vlm                 = vlm,
         default_prompt      = cfg.get("default_prompt", "Describe what you see."),
         system_prompt       = cfg.get("system_prompt",  DEFAULT_SYSTEM_PROMPT),
-        frame_max_age_s     = float(cfg.get("frame_max_age_s",      2.0)),
-        camera_on_timeout_s = float(cfg.get("camera_on_timeout_s", 15.0)),
-        camera_grace_s      = float(cfg.get("camera_grace_s",       5.0)),
+        frame_max_age_s = float(cfg.get("frame_max_age_s", 2.0)),
+        frame_timeout_s = float(cfg.get("frame_timeout_s", 5.0)),
     )
 
     # make_voice_pipeline returns (pipeline, task); only the task is run.

--- a/agent-samples/simple-vlm-example/yaml/simple_vlm_example_worker.yaml
+++ b/agent-samples/simple-vlm-example/yaml/simple_vlm_example_worker.yaml
@@ -50,10 +50,9 @@ system_prompt: |
     talking, just acknowledge briefly with something like "Okay, I will
     stop." and say nothing else.
 
-# Camera on demand — tune timing for your network/device combination.
-frame_max_age_s:      5.0   # frame older than this is considered stale; agent requests camera
-camera_on_timeout_s: 30.0   # give up waiting for a fresh frame after this many seconds
-camera_grace_s:       5.0   # keep camera on this long after a query (avoids restart on follow-ups)
+# Frame freshness — tune if the agent sees stale frames.
+frame_max_age_s: 5.0   # frame older than this is considered stale
+frame_timeout_s: 5.0   # give up waiting for a fresh frame after this many seconds
 
 # Voice Activity Detection — Silero VAD (ONNX backend).
 # Tune if STT triggers too early or misses speech.

--- a/agent-samples/xr-render-demo/worker/processors.py
+++ b/agent-samples/xr-render-demo/worker/processors.py
@@ -205,9 +205,8 @@ class RenderSceneProcessor(BrainProcessor):
         llm:         LLMService,
         agent_llm:   LLMService,
         vlm_service: VLMService | None = None,
-        frame_max_age_s:     float = 2.0,
-        camera_on_timeout_s: float = 15.0,
-        camera_grace_s:      float = 5.0,
+        frame_max_age_s: float = 2.0,
+        frame_timeout_s: float = 5.0,
     ):
         super().__init__()
         self._transport      = transport
@@ -252,17 +251,16 @@ class RenderSceneProcessor(BrainProcessor):
         self._pending_notices: dict[str, list[str]] = {}
 
         # ── live-frame perception (look_at_current_frame) ────────────────────
-        # The reusable VisionModule owns frame tracking, camera-on-demand, and
-        # the VLM call — shared with simple-vlm-example. Built only when a VLM
-        # service is wired (None in unit tests / no-camera deployments).
+        # VisionModule owns frame tracking and the VLM call — shared with
+        # simple-vlm-example. Built only when a VLM service is wired
+        # (None in unit tests / no-camera deployments).
         self._vision: VisionModule | None = None
         if vlm_service is not None:
             self._vision = VisionModule(
                 transport.endpoint, vlm_service,
-                system_prompt       = _PERCEPTION_SYSTEM_PROMPT,
-                frame_max_age_s     = frame_max_age_s,
-                camera_on_timeout_s = camera_on_timeout_s,
-                camera_grace_s      = camera_grace_s,
+                system_prompt   = _PERCEPTION_SYSTEM_PROMPT,
+                frame_max_age_s = frame_max_age_s,
+                frame_timeout_s = frame_timeout_s,
             )
             # FrameSignal events aren't pipecat frames, so the module subscribes
             # on the endpoint directly. Guard the unit-test transport double.

--- a/agent-sdk/xr-ai-capabilities/xr_ai_capabilities/vision.py
+++ b/agent-sdk/xr-ai-capabilities/xr_ai_capabilities/vision.py
@@ -9,33 +9,30 @@ that each used to re-implement it. It owns:
 
   * frame tracking — the latest ``FrameSignal`` per participant, with a
     wall-clock freshness check;
-  * camera-on-demand — ``startCamera`` / ``stopCamera`` on the ``clientControl``
-    topic, a speculative warmup on the leading edge of speech, and a grace
-    timer that keeps the camera on across rapid follow-ups;
-  * the VLM streaming call — fetch the freshest frame, encode it, and stream
-    answer tokens for downstream sentence-batched TTS (or text output).
+  * the VLM call — fetch the freshest frame, encode it, and stream answer
+    tokens for downstream sentence-batched TTS (or text output).
+
+Camera streaming is always-on (the client streams continuously); this module
+never sends ``startCamera`` / ``stopCamera`` control messages.
 
 A brain builds a ``VisionModule`` when it has a VLM service to back it, and uses
 it for any "what do you see"-style query. It exposes two call styles: ``ask``
 (streams tokens, for TTS) and ``perceive`` (returns a string, for agentic tool
-loops); both share one frame-acquisition + camera-on-demand path.
+loops); both share one frame-acquisition path.
 
 The module is framework-agnostic: it talks to the hub through a
 ``ProcessorEndpoint`` (subscribing to ``FrameSignal`` events, fetching frames,
-sending ``clientControl`` data, and setting agent status) and has no dependency
-on pipecat. A pipecat brain passes ``transport.endpoint``; a non-pipecat agent
-passes its own endpoint.
+and setting agent status) and has no dependency on pipecat. A pipecat brain
+passes ``transport.endpoint``; a non-pipecat agent passes its own endpoint.
 """
 from __future__ import annotations
 
 import asyncio
-import contextlib
-import json
 import time
 from typing import AsyncIterator
 
 from loguru import logger
-from xr_ai_agent import DataMessage, FrameSignal, ProcessorEndpoint
+from xr_ai_agent import FrameSignal, ProcessorEndpoint
 from xr_ai_models import VLMService
 
 from .pixels import encode_image, frame_to_pil
@@ -47,27 +44,32 @@ def _now_us() -> int:
 
 class VisionUnavailable(Exception):
     """Raised by :meth:`VisionModule.perceive` when a live frame can't be turned
-    into a VLM answer (no camera frame, frame fetch failed, or the VLM errored).
+    into a VLM answer (no frame available, frame fetch failed, or VLM errored).
     The message is a short, user-facing sentence suitable to speak."""
 
 
 class VisionModule:
-    """Live-camera VLM question answering, with camera-on-demand.
+    """Live-camera VLM question answering.
+
+    Camera streaming is always-on — this module does not send camera control
+    messages.  It waits up to ``frame_timeout_s`` for a fresh frame to arrive
+    before raising :class:`VisionUnavailable`.
 
     Parameters
     ----------
     endpoint:
         The ``ProcessorEndpoint`` to talk to the hub through; the module
-        subscribes to frame signals, fetches frames, sends ``clientControl``
-        messages, and sets agent status on it. A pipecat brain passes
-        ``transport.endpoint``.
+        subscribes to frame signals, fetches frames, and sets agent status.
+        A pipecat brain passes ``transport.endpoint``.
     vlm:
         A ``VLMService`` (its ``stream`` is used for token-by-token answers).
     system_prompt:
         Default system prompt for the VLM (overridable per ``ask``).
-    frame_max_age_s / camera_on_timeout_s / camera_grace_s:
-        Freshness threshold, how long to wait for a fresh frame after
-        ``startCamera``, and how long to keep the camera on after a query.
+    frame_max_age_s:
+        Maximum age of a cached frame signal before it is considered stale.
+    frame_timeout_s:
+        How long to wait for a fresh frame before raising
+        :class:`VisionUnavailable`.
     """
 
     def __init__(
@@ -77,21 +79,16 @@ class VisionModule:
         *,
         system_prompt: str = "",
         frame_max_age_s: float = 2.0,
-        camera_on_timeout_s: float = 15.0,
-        camera_grace_s: float = 5.0,
+        frame_timeout_s: float = 5.0,
     ) -> None:
         self._endpoint = endpoint
         self._vlm = vlm
         self._system_prompt = system_prompt
-        self._frame_max_age_us  = int(frame_max_age_s * 1_000_000)
-        self._camera_on_timeout = camera_on_timeout_s
-        self._camera_grace_s    = camera_grace_s
+        self._frame_max_age_us = int(frame_max_age_s * 1_000_000)
+        self._frame_timeout_s  = frame_timeout_s
 
         self._latest: dict[tuple[str, str], FrameSignal] = {}
         self._frame_events: dict[str, asyncio.Event] = {}
-        self._camera_on: dict[str, bool] = {}
-        self._camera_held: set[str] = set()
-        self._camera_off_timers: dict[str, asyncio.Task] = {}
 
     # ── lifecycle ──────────────────────────────────────────────────────────────
 
@@ -99,26 +96,10 @@ class VisionModule:
         """Subscribe to the endpoint's frame signals. Call once at setup."""
         self._endpoint.on_frame(self._on_frame)
 
-    async def warmup(self, pid: str) -> None:
-        """Speculative camera-on at the leading edge of speech, so the frame is
-        usually ready by the time the query reaches the VLM."""
-        old = self._camera_off_timers.pop(pid, None)
-        if old and not old.done():
-            old.cancel()
-        try:
-            await self._ensure_camera_on(pid)
-        except Exception:
-            logger.exception("camera warmup failed pid={!r}", pid)
-
     def release(self, pid: str) -> None:
         """Drop all per-participant state (call from ``on_participant_left``)."""
         self._latest = {k: v for k, v in self._latest.items() if k[0] != pid}
         self._frame_events.pop(pid, None)
-        self._camera_on.pop(pid, None)
-        self._camera_held.discard(pid)
-        timer = self._camera_off_timers.pop(pid, None)
-        if timer and not timer.done():
-            timer.cancel()
 
     # ── frame tracking ─────────────────────────────────────────────────────────
 
@@ -144,13 +125,11 @@ class VisionModule:
     def _is_fresh(self, sig: FrameSignal) -> bool:
         return _now_us() - sig.pts_us < self._frame_max_age_us
 
-    async def _wait_for_camera_frame(self, pid: str, timeout: float) -> FrameSignal | None:
-        """Wait up to ``timeout`` for a fresh ``FrameSignal``. Only fresh
-        signals are accepted — a stale one from a stopped track would make
-        ``request_frame`` deliver an 8x8 placeholder."""
+    async def _wait_for_frame(self, pid: str) -> FrameSignal | None:
+        """Wait up to ``frame_timeout_s`` for a fresh ``FrameSignal``."""
         ev = self._frame_events.setdefault(pid, asyncio.Event())
         loop = asyncio.get_running_loop()
-        deadline = loop.time() + timeout
+        deadline = loop.time() + self._frame_timeout_s
         ev.clear()
         sig = self._latest_signal(pid)
         if sig is not None and self._is_fresh(sig):
@@ -169,82 +148,16 @@ class VisionModule:
                 return sig
             ev.clear()
 
-    # ── camera on demand ───────────────────────────────────────────────────────
-
-    async def _client_control(self, pid: str, action: str) -> None:
-        await self._endpoint.send_return_data(DataMessage(
-            participant_id = pid,
-            topic          = "clientControl",
-            pts_us         = _now_us(),
-            data           = json.dumps({"action": action}).encode(),
-        ))
-
-    async def _ensure_camera_on(self, pid: str) -> None:
-        """Send ``startCamera`` once (idempotent); claim the flag before the
-        first await so concurrent callers can't double-send."""
-        if self._camera_on.get(pid, False):
-            return
-        self._camera_on[pid] = True
-        try:
-            logger.info("camera.on → pid={!r}", pid)
-            await self._client_control(pid, "startCamera")
-        except Exception:
-            self._camera_on[pid] = False
-            raise
-
-    def _schedule_camera_off(self, pid: str) -> None:
-        old = self._camera_off_timers.pop(pid, None)
-        if old and not old.done():
-            old.cancel()
-
-        async def _off() -> None:
-            try:
-                await asyncio.sleep(self._camera_grace_s)
-                if pid not in self._camera_held:
-                    self._camera_on[pid] = False
-                    await self._client_control(pid, "stopCamera")
-            except asyncio.CancelledError:
-                # Expected: a newer query cancels this grace timer before it
-                # fires (see the cancel above), keeping the camera on. Nothing
-                # to do — the timer simply doesn't stop the camera.
-                pass
-
-        self._camera_off_timers[pid] = asyncio.create_task(_off())
-
-    @contextlib.asynccontextmanager
-    async def _camera_session(self, pid: str):
-        """Bracket one query's camera use: cancel any pending stop and mark the
-        participant held on entry; release the hold + reschedule stop on exit.
-
-        Shared by ``ask`` and ``perceive`` (their identical preamble/teardown).
-        Logs per-call elapsed time so VLM latency stays visible in the logs even
-        though the SDK emits no sample-level task banner.
-        """
-        old = self._camera_off_timers.pop(pid, None)
-        if old and not old.done():
-            old.cancel()
-        self._camera_held.add(pid)
-        t0 = time.monotonic()
-        try:
-            yield
-        finally:
-            self._camera_held.discard(pid)
-            self._schedule_camera_off(pid)
-            logger.info("vision call pid={!r} elapsed={:.2f}s",
-                        pid, time.monotonic() - t0)
-
-    # ── frame acquisition (shared by ask + perceive) ───────────────────────────
+    # ── frame acquisition ──────────────────────────────────────────────────────
 
     async def _acquire_image_url(self, pid: str) -> str:
-        """Ensure the camera is on, wait for a fresh frame, fetch + encode it to
-        a JPEG data URL. Raises :class:`VisionUnavailable` if no usable frame."""
+        """Wait for a fresh frame, fetch and encode it to a JPEG data URL.
+        Raises :class:`VisionUnavailable` if no usable frame arrives in time."""
         sig = self._latest_signal(pid)
         if not (sig and self._is_fresh(sig)):
-            await self._ensure_camera_on(pid)
-            sig = await self._wait_for_camera_frame(pid, self._camera_on_timeout)
+            sig = await self._wait_for_frame(pid)
             if sig is None:
-                self._camera_on[pid] = False
-                raise VisionUnavailable("Camera unavailable, please try again.")
+                raise VisionUnavailable("No camera frame available — please try again.")
         frame = await self._endpoint.request_frame(sig)
         if frame is None:
             raise VisionUnavailable("Frame data unavailable — please retry.")
@@ -255,7 +168,7 @@ class VisionModule:
         logger.info("vision  pid={!r}  {}x{}", pid, frame.width, frame.height)
         return image_url
 
-    # ── the VLM call: streaming (ask) and one-shot (perceive) ───────────────────
+    # ── the VLM call: streaming (ask) and one-shot (perceive) ──────────────────
 
     async def ask(
         self, pid: str, query: str, *, system_prompt: str | None = None,
@@ -269,24 +182,25 @@ class VisionModule:
         ``"processing"`` for the duration of the VLM stream and ``"idle"``
         after. (``perceive`` deliberately does *not*; see its note.)
         """
-        async with self._camera_session(pid):
-            try:
-                image_url = await self._acquire_image_url(pid)
-            except VisionUnavailable as exc:
-                yield str(exc)
-                return
-            await self._endpoint.set_status("processing", pid)
-            try:
-                async for token in self._vlm.stream(
-                    image_url, query, system_prompt=system_prompt or self._system_prompt,
-                ):
-                    yield token
-            except Exception as exc:
-                logger.error("vlm-server error: {}", exc)
-                yield "VLM server unavailable — please retry."
-                return
-            finally:
-                await self._endpoint.set_status("idle", pid)
+        t0 = time.monotonic()
+        try:
+            image_url = await self._acquire_image_url(pid)
+        except VisionUnavailable as exc:
+            yield str(exc)
+            return
+        await self._endpoint.set_status("processing", pid)
+        try:
+            async for token in self._vlm.stream(
+                image_url, query, system_prompt=system_prompt or self._system_prompt,
+            ):
+                yield token
+        except Exception as exc:
+            logger.error("vlm-server error: {}", exc)
+            yield "VLM server unavailable — please retry."
+            return
+        finally:
+            await self._endpoint.set_status("idle", pid)
+            logger.info("vision call pid={!r} elapsed={:.2f}s", pid, time.monotonic() - t0)
 
     async def perceive(
         self, pid: str, query: str, *, system_prompt: str | None = None,
@@ -296,22 +210,24 @@ class VisionModule:
         back to the LLM rather than a token stream for TTS.
 
         Raises :class:`VisionUnavailable` (with a speakable message) on no
-        camera/frame, VLM error, or an empty answer.
+        frame, VLM error, or an empty answer.
 
         Status contract: unlike ``ask``, ``perceive`` does **not** touch the
         agent-status badge — the calling agentic loop owns its own status (it
         is typically mid-turn doing other work), so this method stays out of it.
         """
-        async with self._camera_session(pid):
-            image_url = await self._acquire_image_url(pid)   # raises VisionUnavailable
-            try:
-                resp = await self._vlm.ask_image(
-                    image_url, query, system_prompt=system_prompt or self._system_prompt,
-                )
-            except Exception as exc:
-                logger.error("vlm-server error: {}", exc)
-                raise VisionUnavailable("VLM server unavailable — please retry.") from exc
-            answer = (resp.content or "").strip()
-            if not answer:
-                raise VisionUnavailable("I couldn't make out anything in the view.")
-            return answer
+        t0 = time.monotonic()
+        image_url = await self._acquire_image_url(pid)   # raises VisionUnavailable
+        try:
+            resp = await self._vlm.ask_image(
+                image_url, query, system_prompt=system_prompt or self._system_prompt,
+            )
+        except Exception as exc:
+            logger.error("vlm-server error: {}", exc)
+            raise VisionUnavailable("VLM server unavailable — please retry.") from exc
+        finally:
+            logger.info("vision call pid={!r} elapsed={:.2f}s", pid, time.monotonic() - t0)
+        answer = (resp.content or "").strip()
+        if not answer:
+            raise VisionUnavailable("I couldn't make out anything in the view.")
+        return answer

--- a/tests/test_xr_render_demo_wire.py
+++ b/tests/test_xr_render_demo_wire.py
@@ -758,8 +758,8 @@ async def test_perception_no_frame_yields_graceful_message() -> None:
 
     # Graceful spoken message, not a hang or a generic "Done." fallback.
     assert answer == _proc._NO_FRAME_MSG
-    # The camera WAS turned on (startCamera sent) before giving up.
+    # Camera is always-on streaming — no startCamera/stopCamera messages sent.
     controls = [m for m in transport.sent if m.topic == "clientControl"]
-    assert any(b'"startCamera"' in m.data for m in controls)
+    assert not any(b'"startCamera"' in m.data for m in controls)
     # VLM was never reached — there was no frame to ask about.
     assert vlm.calls == []

--- a/tests/test_xr_render_demo_wire.py
+++ b/tests/test_xr_render_demo_wire.py
@@ -661,9 +661,8 @@ def _make_perception_brain(transport, vlm: _FakeVLM):
         llm         = None,
         agent_llm   = None,
         vlm_service = vlm,
-        frame_max_age_s     = 60.0,   # generous so the seeded frame stays fresh
-        camera_on_timeout_s = 0.2,    # short — the no-frame test must not hang
-        camera_grace_s      = 0.05,
+        frame_max_age_s = 60.0,   # generous so the seeded frame stays fresh
+        frame_timeout_s = 0.2,    # short — the no-frame test must not hang
     )
 
 
@@ -724,7 +723,7 @@ async def test_perception_no_frame_yields_graceful_message() -> None:
     vlm = _FakeVLM()
     brain = _make_perception_brain(transport, vlm)
 
-    # No frame seeded → _wait_for_camera_frame times out (camera_on_timeout=0.2s).
+    # No frame seeded → _wait_for_frame times out (frame_timeout=0.2s).
     # Stub the MCP prefetch (None clients) and script the agent LLM to emit a
     # single look_at_current_frame tool call.
     async def _fake_call_mcp(_client, tool, _args, *, silent=False):


### PR DESCRIPTION
## Summary

PR #180 intentionally removed always-on-demand camera control (`startCamera`/`stopCamera`) in favour of always-on streaming. PR #266 accidentally re-introduced it by extracting `VisionModule` from `xr-render-demo`, which still had the code.

- **`VisionModule`**: remove `warmup()`, `_ensure_camera_on()`, `_schedule_camera_off()`, `_camera_session()`, `_client_control()`; remove `_camera_on`/`_camera_held`/`_camera_off_timers` state; replace `camera_on_timeout_s`/`camera_grace_s` constructor params with `frame_timeout_s`
- **`simple-vlm-example`**: drop `warmup()` call from `on_user_started_speaking`, update constructor args and YAML config keys
- **`xr-render-demo`**: update `VisionModule` constructor args

Camera is now always-on streaming; `VisionModule` simply waits up to `frame_timeout_s` for a fresh frame.

## Test plan

- [x] `simple-vlm-example` runs without error; VLM answers use live frames
- [x] `xr-render-demo` `look_at_current_frame` tool still works
- [x] No `startCamera`/`stopCamera` messages sent to clients during a session
- [x] `VisionModule` raises `VisionUnavailable` if no frame arrives within `frame_timeout_s`

🤖 Generated with [Claude Code](https://claude.com/claude-code)