### PR TITLE
chore: add pre-commit hooks (ruff, SPDX, DCO) and CI guidelines

### DIFF
--- a/.github/scripts/check_dco.sh
+++ b/.github/scripts/check_dco.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# commit-msg hook: verify a Signed-off-by trailer is present.
+# pre-commit passes the commit message file path as $1.
+
+set -euo pipefail
+
+msg_file="${1:?commit message file path required}"
+
+if grep -qP "^Signed-off-by:\s+\S+.*<[^@\s]+@[^@\s]+>" "$msg_file"; then
+    exit 0
+fi
+
+echo ""
+echo "ERROR: Commit is missing a DCO Signed-off-by trailer."
+echo ""
+echo "  Fix: git commit --amend -s"
+echo ""
+echo "  Or add to your git config so every commit signs off automatically:"
+echo "    git config --global alias.c 'commit -s'"
+echo ""
+echo "  See https://developercertificate.org/ and AGENTS.md § DCO sign-off."
+echo ""
+exit 1

--- a/.github/scripts/check_dco.sh
+++ b/.github/scripts/check_dco.sh
@@ -7,7 +7,12 @@
 
 set -euo pipefail
 
-msg_file="${1:?commit message file path required}"
+if [ -n "${1:-}" ]; then
+    msg_file="$1"
+else
+    git_dir=$(git rev-parse --git-dir 2>/dev/null) || git_dir=".git"
+    msg_file="${git_dir}/COMMIT_EDITMSG"
+fi
 
 if grep -qP "^Signed-off-by:\s+\S+.*<[^@\s]+@[^@\s]+>" "$msg_file"; then
     exit 0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,21 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Run `pre-commit install` once after cloning to enable these hooks.
-# See AGENTS.md § License headers for the exact SPDX text and the
-# language-by-language comment-syntax mapping the hook enforces.
+# One-time setup after cloning:
+#   uv tool install pre-commit        # install pre-commit itself (once per machine)
+#   pre-commit install                 # wire the pre-commit stage hooks
+#   pre-commit install --hook-type commit-msg   # wire the DCO commit-msg hook
+#
+# See AGENTS.md § DCO sign-off and § License headers.
 
 repos:
+  # ── Ruff lint (matches CI: ruff.toml at repo root, version pinned to CI) ──
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.16
+    hooks:
+      - id: ruff
+        args: [--fix]
+
   - repo: local
     hooks:
       - id: check-spdx-headers
@@ -39,3 +49,14 @@ repos:
             | gradlew(\.bat)?
             | gradle/wrapper/gradle-wrapper\.properties
           )$
+
+      - id: dco-sign-off
+        name: DCO sign-off
+        description: >
+          Every commit must carry a Signed-off-by trailer (DCO v1.1).
+          Fails if the trailer is absent; fix with `git commit --amend -s`.
+        entry: bash .github/scripts/check_dco.sh
+        language: system
+        stages: [commit-msg]
+        always_run: true
+        pass_filenames: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,3 +13,12 @@ Update it in the same commit — not as a follow-up.
 
 Sub-repos may have their own `CLAUDE.md` with module-specific context — read
 those before working inside them.
+
+Before committing any Python changes, run:
+
+```
+uv tool run ruff check --fix <changed_files>
+```
+
+Every commit must have `Signed-off-by: Devdeep Ray <devdeepr@nvidia.com>` — use
+`git commit -s`. See the DCO section in `AGENTS.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,5 +20,14 @@ Before committing any Python changes, run:
 uv tool run ruff check --fix <changed_files>
 ```
 
-Every commit must have `Signed-off-by: Devdeep Ray <devdeepr@nvidia.com>` — use
-`git commit -s`. See the DCO section in `AGENTS.md`.
+Every commit must have a `Signed-off-by` trailer — use `git commit -s`.
+See the DCO section in `AGENTS.md`.
+
+After pushing to a PR branch, a PR is not done until CI is green:
+
+```
+gh pr checks <number>
+```
+
+Run this after every push. Fix any failures before reporting the PR as ready.
+Only Python files need ruff. Only commits need DCO. CI catches both.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,32 @@ Skip files that can't carry comments or aren't ours to license: `LICENSE`,
 Xcode-managed files (`*.pbxproj`, `*.xcworkspacedata`), and third-party Gradle
 wrapper files (`gradlew`, `gradlew.bat`, `gradle/wrapper/gradle-wrapper.properties`).
 
+## Pre-commit hooks
+
+The repo ships a `.pre-commit-config.yaml` that runs the same checks as CI
+locally before each commit. Set it up once after cloning:
+
+```bash
+# Install pre-commit itself (once per machine)
+uv tool install pre-commit
+
+# Wire the hooks (once per clone)
+pre-commit install                          # pre-commit stage (ruff, SPDX)
+pre-commit install --hook-type commit-msg  # commit-msg stage (DCO)
+```
+
+After that:
+
+- **Ruff** auto-fixes import order and lint errors on every `git commit`.
+  If it changes files, re-stage and commit again.
+- **SPDX header** auto-inserts the license header on new files; same
+  re-stage-and-commit flow.
+- **DCO** blocks the commit if `Signed-off-by` is missing.
+  Fix with `git commit --amend -s`.
+
+Always use `git commit -s` (or `--signoff`) so the DCO hook never fires.
+See [Signing Your Work](#signing-your-work) for the full DCO context.
+
 ## CI
 
 GitHub Actions runs the IPC + multi-client / multi-agent suite under `tests/`


### PR DESCRIPTION
## Summary

- `CLAUDE.md`: run ruff before committing; use `git commit -s` for DCO
- `.pre-commit-config.yaml`: add ruff hook (v0.15.16, matches CI) and DCO commit-msg hook
- `.github/scripts/check_dco.sh`: fails if `Signed-off-by` trailer absent; falls back to `COMMIT_EDITMSG` when `$1` not passed by pre-commit
- `CONTRIBUTING.md`: new "Pre-commit hooks" section with one-time setup commands
- `CLAUDE.md`: add rule — run `gh pr checks` after every push, PR not done until all green

## Setup (once per clone)

```bash
uv tool install pre-commit
pre-commit install
pre-commit install --hook-type commit-msg
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)