### PR TITLE
fix(pipecat): set transport_source=pid on InterruptionFrame; cancel per-pid

### DIFF
--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/brain.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/brain.py
@@ -172,10 +172,17 @@ class BrainProcessor(FrameProcessor):
             return
 
         if isinstance(frame, InterruptionFrame):
-            if self._inflight:
-                for pid in list(self._inflight):
-                    logger.info("brain cancel pid={!r} reason=interruption", pid)
-            self._cancel_all_inflight()
+            pid = frame.transport_source
+            if pid:
+                # Cancel only the participant who triggered the interruption.
+                logger.info("brain cancel pid={!r} reason=interruption", pid)
+                self._cancel_pid(pid)
+            else:
+                # No pid on frame — global interrupt (legacy / unknown source).
+                if self._inflight:
+                    for p in list(self._inflight):
+                        logger.info("brain cancel pid={!r} reason=interruption", p)
+                self._cancel_all_inflight()
             await self.push_frame(frame, direction)
             return
 

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/vad_stt.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/vad_stt.py
@@ -323,7 +323,9 @@ class VadSttProcessor(FrameProcessor):
         # canned ack. UserStoppedSpeakingFrame tails as a hint to
         # downstream turn-state consumers that the partial-audio turn
         # has ended.
-        await self.push_frame(InterruptionFrame())
+        f = InterruptionFrame()
+        f.transport_source = pid
+        await self.push_frame(f)
         tf = TranscriptionFrame(
             text      = text,
             user_id   = pid,

--- a/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/voice_gate.py
+++ b/agent-sdk/xr-ai-pipecat/xr_ai_pipecat/processors/voice_gate.py
@@ -140,7 +140,9 @@ class VoiceGateProcessor(FrameProcessor):
 
     async def _on_gate_stop(self, pid: str) -> None:
         logger.info("stop ack emit pid={!r}", pid)
-        await self.push_frame(InterruptionFrame())
+        f = InterruptionFrame()
+        f.transport_source = pid
+        await self.push_frame(f)
         ack = TextFrame(text=_STOP_ACK_TEXT)
         ack.transport_destination = pid
         await self.push_frame(ack)


### PR DESCRIPTION
## Summary

**Bug:** `InterruptionFrame` was emitted without a participant identity from both `VadSttProcessor` (early stop probe) and `VoiceGateProcessor` (`_on_gate_stop`). `BrainProcessor` called `_cancel_all_inflight()` on every `InterruptionFrame`, cancelling **every participant's** in-flight query — not just the one who said "stop".

In a two-participant session, participant B saying "stop" silently cancelled participant A's response.

**Changes:**
- `vad_stt.py`: set `f.transport_source = pid` on the `InterruptionFrame` from the early stop probe
- `voice_gate.py`: set `f.transport_source = pid` on the `InterruptionFrame` from `_on_gate_stop`
- `brain.py`: when `frame.transport_source` is set, cancel only that pid's task; fall back to `_cancel_all_inflight()` only when source is absent (global interrupt or third-party processor)

## Test plan
- [ ] Participant A has in-flight query; participant B says "stop" → A's query continues, B's is cancelled
- [ ] Single-participant "stop" → still cancels correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)