### PR TITLE
Fix shared-memory frame size guard

### DIFF
--- a/agent-sdk/xr_ai_agent/_shm.py
+++ b/agent-sdk/xr_ai_agent/_shm.py
@@ -57,6 +57,19 @@ _STATE_READY   = 2
 _STATE_OFFSET = 4
 
 
+def _frame_nbytes(data: bytes | memoryview) -> int:
+    return data.nbytes if isinstance(data, memoryview) else len(data)
+
+
+def _frame_size_error(width: int, height: int, fmt: PixelFormat, n: int, max_frame_bytes: int) -> str:
+    fmt_name = getattr(fmt, "name", str(fmt))
+    return (
+        "frame exceeds shared-memory slot capacity "
+        f"(width={width}, height={height}, format={fmt_name}, "
+        f"bytes={n}, max_frame_bytes={max_frame_bytes})"
+    )
+
+
 class SlotView(NamedTuple):
     """Zero-copy view into one ring-buffer slot's pixel data."""
     data:   memoryview
@@ -113,15 +126,20 @@ class ShmRingBuffer:
         """
         Write frame into the next free slot. Returns slot index.
         Raises RuntimeError if all slots are occupied (back-pressure signal).
+        Raises ValueError if the frame is larger than max_frame_bytes.
         """
+        n       = _frame_nbytes(data)
+        if n > self._max_frame_bytes:
+            raise ValueError(_frame_size_error(width, height, fmt, n, self._max_frame_bytes))
+
+        payload = data.cast("B") if isinstance(data, memoryview) else data
         slot    = self._claim_slot()
         hdr_off = _GH_SIZE + slot * self._slot_stride
         dat_off = hdr_off + _SH_SIZE
-        n       = len(data)
 
         # Mark WRITING so consumer won't touch this slot.
         _SH.pack_into(self._buf, hdr_off, _MAGIC_SLOT, _STATE_WRITING, int(fmt), 0, seq, pts_us, width, height, 0)
-        self._buf[dat_off : dat_off + n] = data
+        self._buf[dat_off : dat_off + n] = payload
         # Mark READY — consumer may read after receiving the ZMQ signal.
         _SH.pack_into(self._buf, hdr_off, _MAGIC_SLOT, _STATE_READY,   int(fmt), 0, seq, pts_us, width, height, n)
 
@@ -138,6 +156,10 @@ class ShmRingBuffer:
         hdr     = _SH.unpack_from(self._buf, hdr_off)
         if hdr[1] != _STATE_READY:
             raise RuntimeError(f"slot {signal.slot} not READY (state={hdr[1]})")
+        if signal.data_sz > self._max_frame_bytes:
+            raise ValueError(
+                _frame_size_error(signal.width, signal.height, signal.fmt, signal.data_sz, self._max_frame_bytes)
+            )
         dat_off = hdr_off + _SH_SIZE
         return SlotView(
             data=self._buf[dat_off : dat_off + signal.data_sz],

--- a/tests/test_shm_ring_buffer.py
+++ b/tests/test_shm_ring_buffer.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import array
+import uuid
+
+import pytest
+from xr_ai_agent._shm import _GH_SIZE, _SH, _SH_SIZE, ShmRingBuffer
+from xr_ai_agent._types import FrameSignal, PixelFormat
+
+
+@pytest.fixture
+def ring():
+    name = f"xr_test_{uuid.uuid4().hex[:10]}"
+    rb = ShmRingBuffer(name=name, num_slots=2, max_frame_bytes=8, create=True)
+    try:
+        yield rb
+    finally:
+        rb.close()
+        rb.unlink()
+
+
+def test_write_frame_rejects_oversized_frame_before_claiming_slot(ring):
+    with pytest.raises(ValueError, match=r"bytes=9, max_frame_bytes=8"):
+        ring.write_frame(
+            b"A" * 9,
+            width=3,
+            height=3,
+            fmt=PixelFormat.RGBA,
+            pts_us=1,
+            seq=1,
+        )
+
+    assert ring._write_pos == 0
+    assert ring.write_frame(b"B" * 8, 2, 2, PixelFormat.RGBA, 2, 2) == 0
+
+
+def test_write_frame_rejects_oversized_frame_without_corrupting_next_slot_header(ring):
+    slot1_hdr_off = _GH_SIZE + ring._slot_stride
+    before = bytes(ring._buf[slot1_hdr_off : slot1_hdr_off + _SH_SIZE])
+
+    with pytest.raises(ValueError, match=r"width=4, height=4, format=RGBA"):
+        ring.write_frame(
+            b"A" * 12,
+            width=4,
+            height=4,
+            fmt=PixelFormat.RGBA,
+            pts_us=1,
+            seq=1,
+        )
+
+    after = bytes(ring._buf[slot1_hdr_off : slot1_hdr_off + _SH_SIZE])
+    assert after == before
+    assert _SH.unpack_from(ring._buf, slot1_hdr_off)[0] == _SH.unpack(before)[0]
+
+
+def test_write_frame_checks_memoryview_byte_size(ring):
+    payload = memoryview(array.array("H", range(5)))
+
+    with pytest.raises(ValueError, match=r"bytes=10, max_frame_bytes=8"):
+        ring.write_frame(
+            payload,
+            width=5,
+            height=1,
+            fmt=PixelFormat.RGB24,
+            pts_us=1,
+            seq=1,
+        )
+
+    assert ring._write_pos == 0
+
+
+def test_read_slot_rejects_signal_larger_than_slot(ring):
+    slot = ring.write_frame(b"A" * 8, 2, 2, PixelFormat.RGBA, 1, 1)
+    signal = FrameSignal(
+        slot=slot,
+        seq=1,
+        pts_us=1,
+        width=2,
+        height=2,
+        fmt=PixelFormat.RGBA,
+        data_sz=9,
+    )
+
+    with pytest.raises(ValueError, match=r"bytes=9, max_frame_bytes=8"):
+        ring.read_slot(signal)


### PR DESCRIPTION
## Summary

Reject frames that exceed a shared-memory slot before claiming or writing to the ring buffer. The error includes the frame dimensions, pixel format, byte count, and configured slot capacity.

This also adds a defensive read-side check for oversized `FrameSignal.data_sz` values, and covers the failure mode with focused regression tests that verify rejected frames do not advance the writer or corrupt the next slot header.

## Validation

- `PYTHONPATH=server-runtime:utils/xr-ai-logging uv run --python 3.12 --project agent-sdk --with pytest --with pytest-asyncio --with loguru pytest tests/test_shm_ring_buffer.py`
- `PYTHONPATH=server-runtime:utils/xr-ai-logging TMPDIR=/tmp uv run --python 3.12 --project agent-sdk --with pytest --with pytest-asyncio --with loguru pytest --basetemp=/tmp/xr-ai-pytest tests/test_participant_events.py`
- `uvx ruff check agent-sdk/xr_ai_agent/_shm.py tests/test_shm_ring_buffer.py`
- `git diff --check`