### PR TITLE
Bound return-audio pacing queue

### DIFF
--- a/server-runtime/xr_media_hub.yaml
+++ b/server-runtime/xr_media_hub.yaml
@@ -41,6 +41,11 @@ web_client_dir:    ../client-samples/web
 # ── Optional: token server (legacy plain-HTTP entry point) ────────────────────
 enable_token_server: true
 
+# ── Return audio pacing ───────────────────────────────────────────────────────
+# Maximum queued TTS audio per participant before oldest queued frames are
+# dropped to keep latency and memory bounded.
+return_audio_max_buffer_s: 3.0
+
 # ── Video recording (NVENC, optional) ─────────────────────────────────────────
 # Requires pynvvideocodec.  Frames are encoded via NVENC and written as
 # H.264 Annex B chunks.  Each chunk starts with an IDR frame and is

--- a/server-runtime/xr_media_hub/transport/livekit/_room_client.py
+++ b/server-runtime/xr_media_hub/transport/livekit/_room_client.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from typing import NamedTuple
 
 import numpy as np
 from livekit import rtc
@@ -38,6 +39,27 @@ def _now_us() -> int:
     return time.time_ns() // 1_000
 
 
+_DEFAULT_RETURN_AUDIO_MAX_BUFFER_S = 3.0
+_RETURN_AUDIO_DROP_LOG_INTERVAL_S = 5.0
+
+
+class _QueuedReturnAudioFrame(NamedTuple):
+    frame: rtc.AudioFrame
+    duration_s: float
+
+
+def _validate_return_audio_max_buffer_s(value: object) -> float:
+    try:
+        max_buffer_s = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"return_audio_max_buffer_s must be a positive number, got {value!r}"
+        ) from exc
+    if max_buffer_s <= 0:
+        raise ValueError(f"return_audio_max_buffer_s must be > 0, got {value!r}")
+    return max_buffer_s
+
+
 class _ReturnAudioPipe:
     """Per-participant pacing pipe for return audio.
 
@@ -50,38 +72,118 @@ class _ReturnAudioPipe:
 
     With it, ``push`` is a non-blocking ``put_nowait`` so the connector
     loop stays responsive; a background task drains the queue into
-    ``capture_frame`` at audio rate; ``flush`` is O(1) and drops both
-    layers instantly.  Only the client's jitter buffer (~100 ms) remains
-    irreducibly outside our control.
+    ``capture_frame`` at audio rate; ``flush`` drops the bounded local
+    backlog and LiveKit queue.  Only the client's jitter buffer (~100 ms)
+    remains irreducibly outside our control.
     """
 
-    def __init__(self, src: rtc.AudioSource) -> None:
-        self._src   = src
-        self._queue: asyncio.Queue[rtc.AudioFrame | None] = asyncio.Queue()
-        self._task  = asyncio.create_task(self._drain(), name="return_audio_pipe")
+    def __init__(
+        self,
+        src: rtc.AudioSource,
+        *,
+        participant_id: str = "unknown",
+        max_buffer_s: float = _DEFAULT_RETURN_AUDIO_MAX_BUFFER_S,
+    ) -> None:
+        self._src = src
+        self._participant_id = participant_id
+        self._max_buffer_s = _validate_return_audio_max_buffer_s(max_buffer_s)
+        self._queued_s = 0.0
+        self._dropped_frames = 0
+        self._dropped_s = 0.0
+        self._last_drop_log_s = 0.0
+        self._queue: asyncio.Queue[_QueuedReturnAudioFrame] = asyncio.Queue()
+        self._task = asyncio.create_task(self._drain(), name="return_audio_pipe")
 
     def push(self, frame: rtc.AudioFrame) -> None:
-        self._queue.put_nowait(frame)
+        duration_s = self._frame_duration_s(frame)
+        dropped_frames = 0
+        dropped_s = 0.0
+        while self._queued_s + duration_s > self._max_buffer_s and not self._queue.empty():
+            dropped = self._queue.get_nowait()
+            self._queue.task_done()
+            self._queued_s = max(0.0, self._queued_s - dropped.duration_s)
+            dropped_frames += 1
+            dropped_s += dropped.duration_s
+
+        self._queue.put_nowait(_QueuedReturnAudioFrame(frame, duration_s))
+        self._queued_s += duration_s
+
+        if dropped_frames:
+            self._dropped_frames += dropped_frames
+            self._dropped_s += dropped_s
+            self._log_drop(dropped_frames, dropped_s)
 
     def flush(self) -> None:
         try:
             while True:
-                self._queue.get_nowait()
+                dropped = self._queue.get_nowait()
+                self._queue.task_done()
+                self._queued_s = max(0.0, self._queued_s - dropped.duration_s)
         except asyncio.QueueEmpty:
             pass
+        self._queued_s = 0.0
         self._src.clear_queue()
+
+    @property
+    def queued_frames(self) -> int:
+        return self._queue.qsize()
+
+    @property
+    def queued_duration_s(self) -> float:
+        return self._queued_s
+
+    @property
+    def dropped_frames(self) -> int:
+        return self._dropped_frames
+
+    @property
+    def dropped_duration_s(self) -> float:
+        return self._dropped_s
+
+    @staticmethod
+    def _frame_duration_s(frame: rtc.AudioFrame) -> float:
+        samples_per_channel = int(getattr(frame, "samples_per_channel"))
+        sample_rate = int(getattr(frame, "sample_rate"))
+        if samples_per_channel <= 0 or sample_rate <= 0:
+            raise ValueError(
+                "return-audio frame must have positive samples_per_channel and sample_rate"
+            )
+        return samples_per_channel / sample_rate
+
+    def _log_drop(self, dropped_frames: int, dropped_s: float) -> None:
+        now_s = time.monotonic()
+        if (
+            self._last_drop_log_s
+            and now_s - self._last_drop_log_s < _RETURN_AUDIO_DROP_LOG_INTERVAL_S
+        ):
+            return
+        self._last_drop_log_s = now_s
+        logger.warning(
+            "Return audio backlog for {!r} exceeded {:.0f} ms; "
+            "dropped {} frame(s) ({:.0f} ms), queued {} frame(s) ({:.0f} ms), "
+            "total dropped {} frame(s) ({:.0f} ms)",
+            self._participant_id,
+            self._max_buffer_s * 1000,
+            dropped_frames,
+            dropped_s * 1000,
+            self.queued_frames,
+            self.queued_duration_s * 1000,
+            self._dropped_frames,
+            self._dropped_s * 1000,
+        )
 
     async def _drain(self) -> None:
         while True:
-            frame = await self._queue.get()
-            if frame is None:
-                return
+            queued = await self._queue.get()
+            self._queued_s = max(0.0, self._queued_s - queued.duration_s)
             try:
-                await self._src.capture_frame(frame)
+                await self._src.capture_frame(queued.frame)
             except asyncio.CancelledError:
                 raise
             except Exception:
                 logger.exception("capture_frame failed")
+            finally:
+                self._queue.task_done()
 
     async def close(self) -> None:
         # Cancel rather than enqueue a sentinel — a bounded queue could drop
@@ -107,6 +209,9 @@ class RoomClient:
         self._cfg  = cfg
         self._ep   = ep
         self._room = rtc.Room()
+        self._return_audio_max_buffer_s = _validate_return_audio_max_buffer_s(
+            cfg.return_audio_max_buffer_s
+        )
         # track SID → streaming task; lets us cancel exactly the right task on unsubscribe.
         self._track_tasks: dict[str, asyncio.Task] = {}
         # Tasks spawned by sync event callbacks; cancelled on disconnect().
@@ -301,7 +406,11 @@ class RoomClient:
         src   = rtc.AudioSource(sample_rate=sample_rate, num_channels=channels)
         track = rtc.LocalAudioTrack.create_audio_track(f"xr-hub-return-{pid}", src)
         pub   = await self._room.local_participant.publish_track(track)
-        pipe  = _ReturnAudioPipe(src)
+        pipe  = _ReturnAudioPipe(
+            src,
+            participant_id=pid,
+            max_buffer_s=self._return_audio_max_buffer_s,
+        )
         logger.info("Return audio track published: pid={!r}  sid={!r}", pid, pub.sid)
         return src, pub, pipe
 

--- a/server-runtime/xr_media_hub/transport/livekit/config.py
+++ b/server-runtime/xr_media_hub/transport/livekit/config.py
@@ -68,6 +68,11 @@ class LiveKitConnectorConfig:
     shm_num_slots:       int = 10
     shm_max_frame_bytes: int = 12_441_600   # 4K NV12
 
+    # ── Return audio pacing ───────────────────────────────────────────────────
+    # Maximum queued TTS audio per participant. When a burst exceeds this,
+    # the LiveKit return-audio pipe drops the oldest queued frames.
+    return_audio_max_buffer_s: float = 3.0
+
     # ── Video recording (NVENC, optional) ─────────────────────────────────────
     # Set video_recording.enabled: true in xr_media_hub.yaml to activate.
     # Frames are encoded via NVENC (pynvvideocodec) and written as H.264

--- a/tests/test_return_audio_pacing.py
+++ b/tests/test_return_audio_pacing.py
@@ -5,13 +5,28 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import MagicMock
 
 import pytest
 
 from xr_media_hub.transport.livekit._room_client import _ReturnAudioPipe
 
 pytestmark = pytest.mark.asyncio
+
+
+class _FakeFrame:
+    def __init__(
+        self,
+        name: str,
+        *,
+        samples_per_channel: int = 480,
+        sample_rate: int = 48_000,
+    ) -> None:
+        self.name = name
+        self.samples_per_channel = samples_per_channel
+        self.sample_rate = sample_rate
+
+    def __repr__(self) -> str:
+        return self.name
 
 
 class _FakeSource:
@@ -35,7 +50,7 @@ async def test_flood_then_flush_drops_unflushed_frames():
     try:
         # Flood 50 frames as fast as possible (no awaits between push calls).
         for i in range(50):
-            pipe.push(MagicMock(name=f"frame_{i}"))
+            pipe.push(_FakeFrame(f"frame_{i}"))
 
         # A few have been captured by now.
         await asyncio.sleep(0.025)
@@ -54,6 +69,8 @@ async def test_flood_then_flush_drops_unflushed_frames():
             f"expected flush to halt drain, before={captured_before_flush} "
             f"after={captured_after_flush}"
         )
+        assert pipe.queued_frames == 0
+        assert pipe.queued_duration_s == 0.0
         assert src.cleared == 1
     finally:
         await pipe.close()
@@ -62,10 +79,34 @@ async def test_flood_then_flush_drops_unflushed_frames():
 async def test_normal_flow_drains_all_frames():
     src  = _FakeSource()
     pipe = _ReturnAudioPipe(src)
-    frames = [MagicMock(name=f"frame_{i}") for i in range(5)]
+    frames = [_FakeFrame(f"frame_{i}") for i in range(5)]
     for f in frames:
         pipe.push(f)
     # Wait for full drain (5 frames * 10 ms + slack).
     await asyncio.sleep(0.15)
     assert src.captured == frames
     await pipe.close()
+
+
+async def test_overflow_drops_oldest_frames_by_audio_duration():
+    src  = _FakeSource()
+    pipe = _ReturnAudioPipe(src, participant_id="alice", max_buffer_s=0.03)
+    frames = [_FakeFrame(f"frame_{i}") for i in range(5)]
+    try:
+        for f in frames:
+            pipe.push(f)
+
+        assert pipe.queued_frames == 3
+        assert pipe.queued_duration_s == pytest.approx(0.03)
+        assert pipe.dropped_frames == 2
+        assert pipe.dropped_duration_s == pytest.approx(0.02)
+
+        await asyncio.sleep(0.06)
+        assert src.captured == frames[2:]
+    finally:
+        await pipe.close()
+
+
+async def test_return_audio_buffer_limit_must_be_positive():
+    with pytest.raises(ValueError, match="return_audio_max_buffer_s must be > 0"):
+        _ReturnAudioPipe(_FakeSource(), max_buffer_s=0)


### PR DESCRIPTION
## Summary
- add a per-participant return-audio backlog cap (`return_audio_max_buffer_s`, default 3 seconds)
- drop the oldest queued audio frames when a TTS burst exceeds the cap, keeping newer audio responsive
- expose queued/dropped frame and duration counters and rate-limit backpressure warnings
- extend pacing tests for overflow, drop-oldest behavior, flush metrics, and invalid buffer limits

## Tests
- `PYTHONPATH=server-runtime:utils/xr-ai-logging uv run --project agent-sdk --with pytest --with pytest-asyncio --with loguru --with numpy --with livekit --with livekit-api --with pyyaml --with fastapi --with 'uvicorn[standard]' --with httpx --with websockets --with cryptography pytest tests/test_return_audio_pacing.py`\n- `uvx ruff check server-runtime/xr_media_hub/transport/livekit/_room_client.py server-runtime/xr_media_hub/transport/livekit/config.py tests/test_return_audio_pacing.py`