### PR TITLE
refactor(xr-ai-capabilities): unify vision on a canonical stream

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,12 +132,12 @@ features that talk to the hub through a `ProcessorEndpoint` and depend only on
 the core SDK (no pipecat), so both pipecat and non-pipecat agents can compose
 them:
 
-- **Live-camera vision Q&A** — `VisionModule` (frame tracking,
-  camera-on-demand, the VLM call). `perceive(pid, q)` returns a **string**
-  answer (raising `VisionUnavailable` on failure) over one frame-acquisition
-  path; the caller owns status-badge and streaming concerns. `pixels` is its
-  frame → JPEG codec. A pipecat brain constructs it with
-  `VisionModule(transport.endpoint, vlm)`.
+- **Live-camera vision Q&A** — `VisionModule` (live-frame acquisition and the
+  VLM call). `stream(pid, q)` yields answer chunks for latency-sensitive voice
+  pipelines; `perceive(pid, q)` collects that same stream into a string for
+  tool loops. Both raise `VisionUnavailable` on failure, and the caller owns
+  status-badge concerns. `pixels` is its frame → JPEG codec. A pipecat brain
+  constructs it with `VisionModule(transport.endpoint, vlm)`.
 
 A new vision sample's brain therefore reduces to thin glue over `VisionModule`;
 a voice sample gets the wake word from config alone.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,11 +133,11 @@ the core SDK (no pipecat), so both pipecat and non-pipecat agents can compose
 them:
 
 - **Live-camera vision Q&A** — `VisionModule` (frame tracking,
-  camera-on-demand, the VLM call). Two call styles over one
-  frame-acquisition path: `ask(pid, q)` **streams** tokens (for TTS) and
-  `perceive(pid, q)` returns a **string** (for agentic tool loops, raising
-  `VisionUnavailable`). `pixels` is its frame → JPEG codec. A pipecat brain
-  constructs it with `VisionModule(transport.endpoint, vlm)`.
+  camera-on-demand, the VLM call). `perceive(pid, q)` returns a **string**
+  answer (raising `VisionUnavailable` on failure) over one frame-acquisition
+  path; the caller owns status-badge and streaming concerns. `pixels` is its
+  frame → JPEG codec. A pipecat brain constructs it with
+  `VisionModule(transport.endpoint, vlm)`.
 
 A new vision sample's brain therefore reduces to thin glue over `VisionModule`;
 a voice sample gets the wake word from config alone.

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -75,10 +75,10 @@ xr-ai-capabilities  (agent-sdk/xr-ai-capabilities/)
     ``ProcessorEndpoint`` and depends only on the core SDK — NOT on pipecat or
     any pipeline framework — so both pipecat and non-pipecat agents can compose
     it. Hosts ``pixels`` (frame → PIL → JPEG; numpy + Pillow) and ``vision``
-    (VisionModule — live-camera VLM Q&A with camera-on-demand, exposing ``ask``
-    for streaming TTS and ``perceive`` for agentic tool loops), so vision
-    samples no longer copy that code per-worker. A pipecat brain wires it up by
-    passing ``transport.endpoint``.
+    (VisionModule — live-camera VLM Q&A with camera-on-demand, exposing
+    ``perceive`` for a string answer), so vision samples no longer copy that
+    code per-worker. A pipecat brain wires it up by passing
+    ``transport.endpoint``.
 
 xr-ai-voicegate  (utils/xr-ai-voicegate/)
     └── numpy >=1.24

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -75,9 +75,9 @@ xr-ai-capabilities  (agent-sdk/xr-ai-capabilities/)
     ``ProcessorEndpoint`` and depends only on the core SDK — NOT on pipecat or
     any pipeline framework — so both pipecat and non-pipecat agents can compose
     it. Hosts ``pixels`` (frame → PIL → JPEG; numpy + Pillow) and ``vision``
-    (VisionModule — live-camera VLM Q&A with camera-on-demand, exposing
-    ``perceive`` for a string answer), so vision samples no longer copy that
-    code per-worker. A pipecat brain wires it up by passing
+    (VisionModule — live-camera VLM Q&A exposing a canonical token stream plus
+    ``perceive`` to collect it into a string), so vision samples no longer copy
+    that code per-worker. A pipecat brain wires it up by passing
     ``transport.endpoint``.
 
 xr-ai-voicegate  (utils/xr-ai-voicegate/)

--- a/agent-samples/simple-vlm-example/worker/agent.py
+++ b/agent-samples/simple-vlm-example/worker/agent.py
@@ -5,20 +5,18 @@
 SimpleVlmBrain — vision Q&A on the unified pipecat pipeline.
 
 Behaviour is identical to the original sample; the difference is that the
-live-camera machinery (frame tracking, camera-on-demand, the streaming VLM
-call) is no longer re-implemented here — it lives in the shared, reusable
+live-camera machinery (frame tracking, camera-on-demand, the VLM call) is no
+longer re-implemented here — it lives in the shared, reusable
 :class:`xr_ai_capabilities.VisionModule`. This brain is thin glue: it routes a query
 to the module, owns the data-channel side path, and interrupts on supersede.
 """
 from __future__ import annotations
 
-from typing import AsyncIterator
-
 from loguru import logger
 from pipecat.frames.frames import InterruptionFrame
 from xr_ai_agent import DataMessage
 from xr_ai_models import VLMService
-from xr_ai_capabilities import VisionModule
+from xr_ai_capabilities import VisionModule, VisionUnavailable
 from xr_ai_pipecat import BrainProcessor, GatedQueryFrame
 from xr_ai_pipecat.transport import XRMediaHubTransport
 
@@ -83,9 +81,15 @@ class SimpleVlmBrain(BrainProcessor):
 
     async def handle_query(
         self, pid: str, text: str, fresh_match: bool,
-    ) -> AsyncIterator[str]:
-        # Return (not yield) the async iterator — the base awaits then iterates.
-        return self._vision.ask(pid, text)
+    ) -> str:
+        # Status badge is this brain's responsibility — perceive() stays out of it.
+        await self._transport.endpoint.set_status("processing", pid)
+        try:
+            return await self._vision.perceive(pid, text)
+        except VisionUnavailable as exc:
+            return str(exc)
+        finally:
+            await self._transport.endpoint.set_status("idle", pid)
 
     async def on_user_started_speaking(self, pid: str) -> None:
         pass

--- a/agent-samples/simple-vlm-example/worker/agent.py
+++ b/agent-samples/simple-vlm-example/worker/agent.py
@@ -12,6 +12,8 @@ to the module, owns the data-channel side path, and interrupts on supersede.
 """
 from __future__ import annotations
 
+from typing import AsyncIterator
+
 from loguru import logger
 from pipecat.frames.frames import InterruptionFrame
 from xr_ai_agent import DataMessage
@@ -81,13 +83,17 @@ class SimpleVlmBrain(BrainProcessor):
 
     async def handle_query(
         self, pid: str, text: str, fresh_match: bool,
-    ) -> str:
-        # Status badge is this brain's responsibility — perceive() stays out of it.
+    ) -> AsyncIterator[str]:
+        return self._stream_answer(pid, text)
+
+    async def _stream_answer(self, pid: str, text: str) -> AsyncIterator[str]:
+        # Status spans iteration because VLM failures can arrive after some chunks.
         await self._transport.endpoint.set_status("processing", pid)
         try:
-            return await self._vision.perceive(pid, text)
+            async for chunk in self._vision.stream(pid, text):
+                yield chunk
         except VisionUnavailable as exc:
-            return str(exc)
+            yield str(exc)
         finally:
             await self._transport.endpoint.set_status("idle", pid)
 

--- a/agent-sdk/xr-ai-capabilities/xr_ai_capabilities/vision.py
+++ b/agent-sdk/xr-ai-capabilities/xr_ai_capabilities/vision.py
@@ -9,14 +9,17 @@ that each used to re-implement it. It owns:
 
   * frame tracking — the latest ``FrameSignal`` per participant, with a
     wall-clock freshness check;
-  * the VLM call — fetch the freshest frame, encode it, and return the answer
-    as a string.
+  * the VLM call — fetch the freshest frame, encode it, and stream the answer.
+
+Callers that need a completed value use ``perceive()``, which collects that
+same stream into a string.
 
 Camera streaming is always-on (the client streams continuously); this module
 never sends ``startCamera`` / ``stopCamera`` control messages.
 
-A brain builds a ``VisionModule`` when it has a VLM service to back it, and calls
-``perceive`` for any "what do you see"-style query, getting back a string answer.
+A brain builds a ``VisionModule`` when it has a VLM service to back it. Voice
+pipelines use ``stream`` so sentence-batched TTS can start before generation
+finishes; tool loops use ``perceive`` when they need a completed string.
 
 The module is framework-agnostic: it talks to the hub through a
 ``ProcessorEndpoint`` (subscribing to ``FrameSignal`` events and fetching frames)
@@ -27,6 +30,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from typing import AsyncIterator
 
 from loguru import logger
 from xr_ai_agent import FrameSignal, ProcessorEndpoint
@@ -59,7 +63,7 @@ class VisionModule:
         subscribes to frame signals and fetches frames on demand.
         A pipecat brain passes ``transport.endpoint``.
     vlm:
-        A ``VLMService`` (its ``ask_image`` is used to answer).
+        A ``VLMService`` (its token stream is used to answer).
     system_prompt:
         Default system prompt for the VLM (overridable per call).
     frame_max_age_s:
@@ -167,10 +171,10 @@ class VisionModule:
 
     # ── the VLM call ────────────────────────────────────────────────────────────
 
-    async def perceive(
+    async def stream(
         self, pid: str, query: str, *, system_prompt: str | None = None,
-    ) -> str:
-        """Acquire a fresh frame and return the VLM answer as a **string**.
+    ) -> AsyncIterator[str]:
+        """Acquire a fresh frame and stream VLM answer chunks.
 
         Raises :class:`VisionUnavailable` (with a speakable message) on no
         frame, VLM error, or an empty answer.
@@ -181,16 +185,30 @@ class VisionModule:
         """
         t0 = time.monotonic()
         image_url = await self._acquire_image_url(pid)   # raises VisionUnavailable
+        has_content = False
         try:
-            resp = await self._vlm.ask_image(
+            async for chunk in self._vlm.stream(
                 image_url, query, system_prompt=system_prompt or self._system_prompt,
-            )
+            ):
+                if chunk.strip():
+                    has_content = True
+                yield chunk
         except Exception as exc:
             logger.error("vlm-server error: {}", exc)
             raise VisionUnavailable("VLM server unavailable — please retry.") from exc
         finally:
             logger.info("vision call pid={!r} elapsed={:.2f}s", pid, time.monotonic() - t0)
-        answer = (resp.content or "").strip()
-        if not answer:
+        if not has_content:
             raise VisionUnavailable("I couldn't make out anything in the view.")
-        return answer
+
+    async def perceive(
+        self, pid: str, query: str, *, system_prompt: str | None = None,
+    ) -> str:
+        """Collect the canonical VLM stream and return a completed string."""
+        chunks = [
+            chunk
+            async for chunk in self.stream(
+                pid, query, system_prompt=system_prompt,
+            )
+        ]
+        return "".join(chunks).strip()

--- a/agent-sdk/xr-ai-capabilities/xr_ai_capabilities/vision.py
+++ b/agent-sdk/xr-ai-capabilities/xr_ai_capabilities/vision.py
@@ -9,27 +9,24 @@ that each used to re-implement it. It owns:
 
   * frame tracking — the latest ``FrameSignal`` per participant, with a
     wall-clock freshness check;
-  * the VLM call — fetch the freshest frame, encode it, and stream answer
-    tokens for downstream sentence-batched TTS (or text output).
+  * the VLM call — fetch the freshest frame, encode it, and return the answer
+    as a string.
 
 Camera streaming is always-on (the client streams continuously); this module
 never sends ``startCamera`` / ``stopCamera`` control messages.
 
-A brain builds a ``VisionModule`` when it has a VLM service to back it, and uses
-it for any "what do you see"-style query. It exposes two call styles: ``ask``
-(streams tokens, for TTS) and ``perceive`` (returns a string, for agentic tool
-loops); both share one frame-acquisition path.
+A brain builds a ``VisionModule`` when it has a VLM service to back it, and calls
+``perceive`` for any "what do you see"-style query, getting back a string answer.
 
 The module is framework-agnostic: it talks to the hub through a
-``ProcessorEndpoint`` (subscribing to ``FrameSignal`` events, fetching frames,
-and setting agent status) and has no dependency on pipecat. A pipecat brain
-passes ``transport.endpoint``; a non-pipecat agent passes its own endpoint.
+``ProcessorEndpoint`` (subscribing to ``FrameSignal`` events and fetching frames)
+and has no dependency on pipecat. A pipecat brain passes ``transport.endpoint``;
+a non-pipecat agent passes its own endpoint.
 """
 from __future__ import annotations
 
 import asyncio
 import time
-from typing import AsyncIterator
 
 from loguru import logger
 from xr_ai_agent import FrameSignal, ProcessorEndpoint
@@ -59,12 +56,12 @@ class VisionModule:
     ----------
     endpoint:
         The ``ProcessorEndpoint`` to talk to the hub through; the module
-        subscribes to frame signals, fetches frames, and sets agent status.
+        subscribes to frame signals and fetches frames on demand.
         A pipecat brain passes ``transport.endpoint``.
     vlm:
-        A ``VLMService`` (its ``stream`` is used for token-by-token answers).
+        A ``VLMService`` (its ``ask_image`` is used to answer).
     system_prompt:
-        Default system prompt for the VLM (overridable per ``ask``).
+        Default system prompt for the VLM (overridable per call).
     frame_max_age_s:
         Maximum age of a cached frame signal before it is considered stale.
     frame_timeout_s:
@@ -168,53 +165,19 @@ class VisionModule:
         logger.info("vision  pid={!r}  {}x{}", pid, frame.width, frame.height)
         return image_url
 
-    # ── the VLM call: streaming (ask) and one-shot (perceive) ──────────────────
-
-    async def ask(
-        self, pid: str, query: str, *, system_prompt: str | None = None,
-    ) -> AsyncIterator[str]:
-        """Acquire a fresh frame and **stream** VLM answer tokens (for TTS).
-
-        On a failure the user should hear, yields a single canned line and
-        returns — downstream TTS / text output handles it like any answer.
-
-        Status contract: ``ask`` drives the agent-status badge — it sets
-        ``"processing"`` for the duration of the VLM stream and ``"idle"``
-        after. (``perceive`` deliberately does *not*; see its note.)
-        """
-        t0 = time.monotonic()
-        try:
-            image_url = await self._acquire_image_url(pid)
-        except VisionUnavailable as exc:
-            yield str(exc)
-            return
-        await self._endpoint.set_status("processing", pid)
-        try:
-            async for token in self._vlm.stream(
-                image_url, query, system_prompt=system_prompt or self._system_prompt,
-            ):
-                yield token
-        except Exception as exc:
-            logger.error("vlm-server error: {}", exc)
-            yield "VLM server unavailable — please retry."
-            return
-        finally:
-            await self._endpoint.set_status("idle", pid)
-            logger.info("vision call pid={!r} elapsed={:.2f}s", pid, time.monotonic() - t0)
+    # ── the VLM call ────────────────────────────────────────────────────────────
 
     async def perceive(
         self, pid: str, query: str, *, system_prompt: str | None = None,
     ) -> str:
-        """Acquire a fresh frame and return the VLM answer as a **string**
-        (one-shot). Use this from an agentic tool loop that needs a value to feed
-        back to the LLM rather than a token stream for TTS.
+        """Acquire a fresh frame and return the VLM answer as a **string**.
 
         Raises :class:`VisionUnavailable` (with a speakable message) on no
         frame, VLM error, or an empty answer.
 
-        Status contract: unlike ``ask``, ``perceive`` does **not** touch the
-        agent-status badge — the calling agentic loop owns its own status (it
-        is typically mid-turn doing other work), so this method stays out of it.
+        Does not touch the agent-status badge — the caller owns its own status
+        (it is typically mid-turn doing other work), so this method stays out
+        of it.
         """
         t0 = time.monotonic()
         image_url = await self._acquire_image_url(pid)   # raises VisionUnavailable

--- a/tests/test_vision_module.py
+++ b/tests/test_vision_module.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Streaming and materialization tests for ``VisionModule``."""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from pathlib import Path
+
+import pytest
+from xr_ai_capabilities import VisionModule, VisionUnavailable
+
+_AGENT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "agent-samples"
+    / "simple-vlm-example"
+    / "worker"
+    / "agent.py"
+)
+_AGENT_SPEC = importlib.util.spec_from_file_location("simple_vlm_agent", _AGENT_PATH)
+assert _AGENT_SPEC is not None and _AGENT_SPEC.loader is not None
+_AGENT_MODULE = importlib.util.module_from_spec(_AGENT_SPEC)
+_AGENT_SPEC.loader.exec_module(_AGENT_MODULE)
+SimpleVlmBrain = _AGENT_MODULE.SimpleVlmBrain
+
+
+class _Endpoint:
+    pass
+
+
+class _ControlledVlm:
+    def __init__(self) -> None:
+        self.release = asyncio.Event()
+
+    async def stream(self, image, question, *, system_prompt="", **kwargs):
+        yield "First sentence."
+        await self.release.wait()
+        yield " Second sentence."
+
+    async def ask_image(self, *args, **kwargs):
+        raise AssertionError("VisionModule must materialize the canonical stream")
+
+
+async def _vision(vlm) -> VisionModule:
+    vision = VisionModule(_Endpoint(), vlm)  # type: ignore[arg-type]
+
+    async def acquire(pid: str) -> str:
+        return "data:image/jpeg;base64,stub"
+
+    vision._acquire_image_url = acquire  # type: ignore[method-assign]
+    return vision
+
+
+async def test_stream_delivers_first_chunk_before_generation_finishes() -> None:
+    vlm = _ControlledVlm()
+    vision = await _vision(vlm)
+    stream = vision.stream("pid-1", "What do you see?")
+
+    assert await anext(stream) == "First sentence."
+
+    second = asyncio.create_task(anext(stream))
+    await asyncio.sleep(0)
+    assert not second.done()
+
+    vlm.release.set()
+    assert await second == " Second sentence."
+    with pytest.raises(StopAsyncIteration):
+        await anext(stream)
+
+
+async def test_perceive_collects_the_canonical_stream() -> None:
+    vlm = _ControlledVlm()
+    vlm.release.set()
+    vision = await _vision(vlm)
+
+    answer = await vision.perceive("pid-1", "What do you see?")
+
+    assert answer == "First sentence. Second sentence."
+
+
+class _EmptyVlm:
+    async def stream(self, image, question, *, system_prompt="", **kwargs):
+        yield "  "
+
+
+async def test_empty_stream_raises_speakable_error() -> None:
+    vision = await _vision(_EmptyVlm())
+
+    with pytest.raises(VisionUnavailable, match="couldn't make out"):
+        await vision.perceive("pid-1", "What do you see?")
+
+
+class _StatusEndpoint:
+    def __init__(self) -> None:
+        self.statuses: list[tuple[str, str]] = []
+
+    async def set_status(self, status: str, pid: str) -> None:
+        self.statuses.append((status, pid))
+
+
+class _Transport:
+    def __init__(self, endpoint: _StatusEndpoint) -> None:
+        self.endpoint = endpoint
+
+
+async def test_simple_vlm_status_spans_stream_iteration() -> None:
+    endpoint = _StatusEndpoint()
+    vision = _ControlledVlm()
+    brain = object.__new__(SimpleVlmBrain)
+    brain._transport = _Transport(endpoint)
+    brain._vision = vision
+    stream = brain._stream_answer("pid-1", "What do you see?")
+
+    assert endpoint.statuses == []
+    assert await anext(stream) == "First sentence."
+    assert endpoint.statuses == [("processing", "pid-1")]
+
+    second = asyncio.create_task(anext(stream))
+    await asyncio.sleep(0)
+    assert endpoint.statuses == [("processing", "pid-1")]
+
+    vision.release.set()
+    assert await second == " Second sentence."
+    with pytest.raises(StopAsyncIteration):
+        await anext(stream)
+    assert endpoint.statuses == [("processing", "pid-1"), ("idle", "pid-1")]

--- a/tests/test_xr_render_demo_wire.py
+++ b/tests/test_xr_render_demo_wire.py
@@ -608,20 +608,18 @@ class _CaptureTransportWithEndpoint(_CaptureTransport):
 
 
 class _FakeVLM:
-    """VLMService double — records the ask_image call and returns a canned
-    ChatResponse so we can assert the perception path reached the VLM."""
+    """VLMService double that records the canonical streaming call."""
 
     def __init__(self, answer: str = "It's a red mug.") -> None:
         self.answer = answer
         self.calls: list[tuple[str, str]] = []
 
-    async def ask_image(self, image, question, *, system_prompt: str = "",
-                        **_kw) -> ChatResponse:
+    async def stream(self, image, question, *, system_prompt: str = "", **_kw):
         self.calls.append((image, question))
-        return ChatResponse(
-            content=self.answer, reasoning=None, tool_calls=None,
-            finish_reason="stop", raw={},
-        )
+        yield self.answer
+
+    async def ask_image(self, *args, **kwargs) -> ChatResponse:
+        raise AssertionError("VisionModule must materialize the canonical stream")
 
     async def close(self) -> None:
         pass


### PR DESCRIPTION
## Summary

- Remove the special-purpose `VisionModule.ask()` wrapper while preserving streaming response latency.
- Make `VisionModule.stream(pid, query)` the canonical VLM implementation. The simple VLM voice sample consumes this stream directly, so sentence-batched TTS can begin before generation completes.
- Keep `perceive(pid, query)` as a small materializer over that same stream for agentic tool loops that require a completed string.
- Keep status-badge and speakable-error ownership in the simple VLM brain; status now spans the full stream lifetime, including cancellation and late stream failures.
- Add regression coverage proving the first chunk is delivered before generation finishes, `perceive()` uses the canonical stream, empty responses remain speakable errors, and status remains `processing` until stream exhaustion.

This leaves one VLM inference path with two explicit consumption contracts: streaming for latency-sensitive voice and materialized text for tool loops.

## Test plan

- [x] Ruff clean on all changed Python files
- [x] Affected voice/VLM/render suite: 93 passed
- [x] Pre-commit SPDX and DCO checks passed
- [ ] Manual simple-vlm voice smoke test not run in this environment
