### PR TITLE
fix: address Sonar findings in check_dco.sh and android-build.yml

### DIFF
--- a/.github/scripts/check_dco.sh
+++ b/.github/scripts/check_dco.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-if [ -n "${1:-}" ]; then
+if [[ -n "${1:-}" ]]; then
     msg_file="$1"
 else
     git_dir=$(git rev-parse --git-dir 2>/dev/null) || git_dir=".git"
@@ -18,14 +18,14 @@ if grep -qP "^Signed-off-by:\s+\S+.*<[^@\s]+@[^@\s]+>" "$msg_file"; then
     exit 0
 fi
 
-echo ""
-echo "ERROR: Commit is missing a DCO Signed-off-by trailer."
-echo ""
-echo "  Fix: git commit --amend -s"
-echo ""
-echo "  Or add to your git config so every commit signs off automatically:"
-echo "    git config --global alias.c 'commit -s'"
-echo ""
-echo "  See https://developercertificate.org/ and AGENTS.md § DCO sign-off."
-echo ""
+echo "" >&2
+echo "ERROR: Commit is missing a DCO Signed-off-by trailer." >&2
+echo "" >&2
+echo "  Fix: git commit --amend -s" >&2
+echo "" >&2
+echo "  Or add to your git config so every commit signs off automatically:" >&2
+echo "    git config --global alias.c 'commit -s'" >&2
+echo "" >&2
+echo "  See https://developercertificate.org/ and AGENTS.md § DCO sign-off." >&2
+echo "" >&2
 exit 1

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -42,7 +42,7 @@ jobs:
           java-version: '17'
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947 # v4
 
       - name: Build debug APK
         run: ./gradlew assembleDebug


### PR DESCRIPTION
## Summary

Fixes three Sonar findings flagged on the `SW-Cloud_XR_XR-AI_xr-ai` project:

- **shelldre:S7688** (MAJOR) — `check_dco.sh:10`: replace `[ -n ... ]` with `[[ -n ... ]]` for safer conditional
- **shelldre:S7677** (MAJOR) — `check_dco.sh:22–30`: redirect all error-path `echo` lines to stderr (`>&2`)
- **Security hotspot** (LOW) — `android-build.yml:45`: pin `gradle/actions/setup-gradle@v4` to full commit SHA `48b5f213c81028ace310571dc5ec0fbbca0b2947`

## Test plan

- [x] CI passes on this PR (lint, DCO, android-build workflows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)