### PR TITLE
ci: fix nightly notify job skipped when pytest fails

### DIFF
--- a/.github/workflows/nightly-xr-ai-test.yml
+++ b/.github/workflows/nightly-xr-ai-test.yml
@@ -302,8 +302,12 @@ jobs:
     # timeout-minutes hit concludes as `cancelled`, not `failure`, so
     # failure() alone would silently skip the alert on the most important
     # case. Skip on PRs — those are pre-merge dry-runs, not the nightly.
+    #
+    # always() is required here: without it GitHub skips this job entirely
+    # when a needs job fails, before ever evaluating the if expression.
     if: >-
-      (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
+      always()
+      && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
       && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
## Summary

- GitHub Actions skips a dependent job when any `needs` job fails, without evaluating the `if` expression — **unless** `always()` appears in the condition.
- The `notify` job's `if` checked `contains(needs.*.result, 'failure')` but lacked `always()`, so it was silently skipped every time `pytest` failed (the exact case it was meant to catch).
- Fix: prepend `always() &&` so GitHub evaluates the full expression instead of skipping the job outright.


🤖 Generated with [Claude Code](https://claude.com/claude-code)