### PR TITLE
ci: switch to correct runner tags for SonarQube jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,9 @@ stages:
 build-sonar:
   stage: build-sonar
   tags:
-    - type/docker
+    - linux
+    - x86_64
+    - gpu
 
   cache:
     policy: pull-push
@@ -36,7 +38,9 @@ build-sonar:
 sonarqube-vulnerability-report:
   stage: sonarqube-vulnerability-report
   tags:
-    - type/docker
+    - linux
+    - x86_64
+    - gpu
 
   script:
     - 'curl -u "${SONAR_TOKEN}:" "${SONAR_HOST_URL}/api/issues/gitlab_sast_export?projectKey=SW-Cloud_XR_XR-AI_xr-ai&branch=${CI_COMMIT_BRANCH}&pullRequest=${CI_MERGE_REQUEST_IID}" -o gl-sast-sonar-report.json'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,6 @@ build-sonar:
   tags:
     - linux
     - x86_64
-    - gpu
 
   cache:
     policy: pull-push
@@ -40,7 +39,6 @@ sonarqube-vulnerability-report:
   tags:
     - linux
     - x86_64
-    - gpu
 
   script:
     - 'curl -u "${SONAR_TOKEN}:" "${SONAR_HOST_URL}/api/issues/gitlab_sast_export?projectKey=SW-Cloud_XR_XR-AI_xr-ai&branch=${CI_COMMIT_BRANCH}&pullRequest=${CI_MERGE_REQUEST_IID}" -o gl-sast-sonar-report.json'


### PR DESCRIPTION
## Summary

- Replaces the `type/docker` runner tag on both `build-sonar` and `sonarqube-vulnerability-report` jobs with `linux` / `x86_64` / `gpu`
- Routes SonarQube scans to the internal GitLab runner via the mirrored repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)