### PR TITLE
feat(nat): add native spatial-math functions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,11 +13,12 @@ historical decisions in `docs/changelog.md`.
 ```
 client-samples/     # Platform clients (Android, iOS/visionOS, Web)
 server-runtime/     # XR-Media-Hub core + LiveKit transport
-agent-sdk/          # Four packages:
+agent-sdk/          # Five packages:
                     #   xr-ai-agent        — IPC client library (pyzmq + msgpack only)
                     #   xr-ai-models       — LLM/VLM/STT/TTS service protocols + OpenAI-compat clients
                     #   xr-ai-capabilities — framework-agnostic reusable agent features (VisionModule)
                     #   xr-ai-pipecat      — optional Pipecat transport bridge (heavier deps)
+                    #   xr-ai-nat          — typed, in-process NAT functions for XR capabilities
 utils/              # Shared infra: launcher, logging, vad, vllm, voicegate
 cloudxr-runtime/    # Shared CloudXR OpenXR runtime + WSS proxy (opt-in)
 ai-services/        # OpenAI-compatible inference servers (VLM, STT, TTS, LLM)
@@ -51,7 +52,9 @@ deps/               # Gitignored downloaded binaries (e.g. LOVR AppImage)
   OpenAI-compatible HTTP.
 - **Workers never import from `server-runtime` or `xr_ai_launcher`.** Only
   `xr_ai_agent` + `xr_ai_models` + task-specific libs (numpy, torch, …).
-- **MCP servers are the agent's only interface to XR data and rendering.**
+- **Agentic functions are NAT-first and in-process.** Reusable deterministic
+  functions live in `xr-ai-nat` as typed NAT function groups. Existing MCP
+  servers remain compatibility surfaces while their capabilities migrate.
 - **No API keys or tokens in source files** — use env vars or
   `xr_media_hub.yaml`. See `docs/credentials.md`.
 
@@ -86,7 +89,8 @@ mechanically:
 
 **Worker code rules** (apply to every sample worker):
 
-- Only import from `xr_ai_agent` for IPC types.
+- Import IPC types from `xr_ai_agent`; native agent functions come from
+  `xr_ai_nat`.
 - `_HUB_PUB` / `_HUB_PUSH` are module-level constants, not magic strings.
 - Wire `SIGINT` and `SIGTERM` to `agent.shutdown()`; wrap `await agent.run()`
   in `try/finally` calling `shutdown()`.
@@ -115,7 +119,11 @@ Reference implementation: `agent-samples/simple-vlm-example/`.
 ## Agent sample architecture: reusable modules
 
 Samples must **reuse** the shared building blocks rather than re-implement
-them. They split across two SDK packages by what they depend on:
+them. They split across SDK packages by what they depend on:
+
+Typed agent functions live in `xr-ai-nat`. `SpatialMathFunctionsConfig`
+registers deterministic coordinate operations that receive an explicit spatial
+frame; tracking and process boundaries remain outside the math functions.
 
 The **voice pipeline** lives in `xr-ai-pipecat` (it depends on pipecat):
 

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -106,6 +106,15 @@ xr-ai-models  (agent-sdk/xr-ai-models/)
     protocols or callers.  Workers depend on this instead of rolling their
     own httpx wrappers.
 
+xr-ai-nat  (agent-sdk/xr-ai-nat/)
+    └── nvidia-nat-core ==1.8.0
+    └── pydantic >=2.10
+    Typed, in-process NeMo Agent Toolkit functions for XR capabilities. The
+    ``xr_spatial_math`` function group accepts explicit coordinate frames and
+    performs deterministic spatial calculations without OpenXR, model, or MCP
+    dependencies. Its pure math core is also used by the transitional Vec and
+    OpenXR MCP compatibility surfaces.
+
 xr-ai-launcher  (utils/xr-ai-launcher/)
     └── (stdlib only — zero runtime deps)
     `_cloudxr_env` owns the shared CloudXR env helpers (stdlib-only, os + re):
@@ -215,8 +224,11 @@ oxr-mcp-server  (agent-mcp-servers/oxr-mcp/)
     └── pyyaml >=6.0
     └── uvicorn[standard] >=0.29
     └── fastmcp >=2.0
+    └── xr-ai-nat [editable: ../../agent-sdk/xr-ai-nat]
     Pure FastMCP at /mcp. Reads pose from CloudXR via a second (headless)
     OpenXR session; runs alongside LOVR's rendering session.
+    Pose acquisition remains here while coordinate calculations delegate to
+    the shared native spatial-math core.
     cloudxr-runtime must start before oxr-mcp (serial launch order).
 
 vec-mcp-server  (agent-mcp-servers/vec-mcp/)
@@ -224,14 +236,18 @@ vec-mcp-server  (agent-mcp-servers/vec-mcp/)
     └── fastmcp >=2.0
     └── pyyaml >=6.0
     └── xr-ai-logging  [editable: ../../utils/xr-ai-logging]
+    └── xr-ai-nat      [editable: ../../agent-sdk/xr-ai-nat]
     Pure FastMCP at /mcp. Deterministic spatial-math primitives
     (between_anchors, world_offset, along_direction, scale_value).
-    Offloads vector arithmetic from the LLM.
+    Preserves the existing MCP tool names while delegating coordinate
+    calculations to the shared native spatial-math core. ``scale_value``
+    remains compatibility-only and is not part of the native function group.
 
 xr-ai-tests  (tests/)
     └── xr-ai-agent             [editable: ../agent-sdk]
     └── xr-ai-capabilities      [editable: ../agent-sdk/xr-ai-capabilities]
     └── xr-ai-models            [editable: ../agent-sdk/xr-ai-models]
+    └── xr-ai-nat               [editable: ../agent-sdk/xr-ai-nat]
     └── xr-ai-pipecat           [editable: ../agent-sdk/xr-ai-pipecat]
     └── xr-media-hub            [editable: ../server-runtime]    (pulls in livekit, livekit-api for the wss /rtc proxy + room-client tests)
     └── xr-ai-launcher          [editable: ../utils/xr-ai-launcher]
@@ -255,7 +271,8 @@ xr-ai-tests  (tests/)
     NVENC required. Also covers unit tests for the leaf util packages
     (launcher, logging, vllm), a CI-viable subprocess test for
     CPU-viable subprocess smoke tests for transcript-mcp-server and
-    vec-mcp-server (fastmcp pulled in transitively), and the vlm-mcp /
+    vec-mcp-server (fastmcp pulled in transitively), native spatial-math
+    function-group tests, and the vlm-mcp /
     render-mcp adapter surfaces (mocked upstreams). oxr-mcp is not
     included: it needs native isaacteleop + a CloudXR runtime, so its
     smoke test self-skips on CPU (see tests/README.md).
@@ -524,6 +541,9 @@ updated in the same commit**.
   vendor SDKs (no `openai`, no `anthropic`, no `litellm`). All in-tree
   backends speak OpenAI-compatible HTTP; vendor adapters arrive as new
   `kind`s in Phase B if/when needed.
+- `agent-sdk/xr-ai-nat/` — NAT framework dependencies plus only the smallest
+  capability-specific dependencies. Spatial math remains CPU-only and has no
+  tracking, service, model, or MCP dependency.
 - Agent workers — `xr-ai-agent` + `xr-ai-models` + task-specific libs (numpy,
   torch, etc.). Must never import from `xr-media-hub` or `xr-ai-launcher`.
 - New external deps require a note here explaining why they were added.

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -112,8 +112,10 @@ xr-ai-nat  (agent-sdk/xr-ai-nat/)
     Typed, in-process NeMo Agent Toolkit functions for XR capabilities. The
     ``xr_spatial_math`` function group accepts explicit coordinate frames and
     performs deterministic spatial calculations without OpenXR, model, or MCP
-    dependencies. Its pure math core is also used by the transitional Vec and
-    OpenXR MCP compatibility surfaces.
+    dependencies. Each capability module is its own ``nat.plugins`` discovery
+    entry point; there is no package-wide registration aggregator. The pure
+    math core is also used by the transitional Vec and OpenXR MCP compatibility
+    surfaces.
 
 xr-ai-launcher  (utils/xr-ai-launcher/)
     └── (stdlib only — zero runtime deps)

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ frames are dropped if it is closed.
 | Server runtime | `server-runtime/` | XR-Media-Hub + LiveKit internal transport |
 | Launcher | `utils/xr-ai-launcher/` | stdlib-only process manager used by samples |
 | Logging | `utils/xr-ai-logging/` | shared loguru sink + stdlib bridge for every process |
+| Agent functions | `agent-sdk/xr-ai-nat/` | Typed, in-process NAT functions for XR capabilities |
 | Agent interfaces | `agent-mcp-servers/` | MCP adapters for XR data & rendering |
 | Agent demos | `agent-samples/` | End-to-end agent pipelines |
 | Tests | `tests/` | Multi-client / multi-agent integration tests |

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -28,6 +28,8 @@ For the per-package dependency mapping, see [`DEPENDENCIES.md`](DEPENDENCIES.md)
 | `livekit`      | 0.17.0   | Apache-2.0    | https://github.com/livekit/python-sdks |
 | `livekit-api`  | 0.7.0    | Apache-2.0    | https://github.com/livekit/python-sdks |
 | `numpy`        | 1.24.0   | BSD-3-Clause  | https://github.com/numpy/numpy |
+| `nvidia-nat-core` | 1.8.0 | Apache-2.0    | https://github.com/NVIDIA/NeMo-Agent-Toolkit |
+| `pydantic`     | 2.10.0   | MIT           | https://github.com/pydantic/pydantic |
 | `websockets`   | 12.0     | BSD-3-Clause  | https://github.com/python-websockets/websockets |
 
 ## Swift (iOS / visionOS client)

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -29,7 +29,7 @@ For the per-package dependency mapping, see [`DEPENDENCIES.md`](DEPENDENCIES.md)
 | `livekit-api`  | 0.7.0    | Apache-2.0    | https://github.com/livekit/python-sdks |
 | `numpy`        | 1.24.0   | BSD-3-Clause  | https://github.com/numpy/numpy |
 | `nvidia-nat-core` | 1.8.0 | Apache-2.0    | https://github.com/NVIDIA/NeMo-Agent-Toolkit |
-| `pydantic`     | 2.10.0   | MIT           | https://github.com/pydantic/pydantic |
+| `pydantic`     | >=2.10   | MIT           | https://github.com/pydantic/pydantic |
 | `websockets`   | 12.0     | BSD-3-Clause  | https://github.com/python-websockets/websockets |
 
 ## Swift (iOS / visionOS client)

--- a/agent-mcp-servers/oxr-mcp/oxr_mcp_server/__main__.py
+++ b/agent-mcp-servers/oxr-mcp/oxr_mcp_server/__main__.py
@@ -315,10 +315,12 @@ def build_mcp(source: PoseSource) -> FastMCP:
 
         Use for: "in front of me", "where I'm looking", "ahead of me".
 
-        Returns {x, y, z} world-space position, or {error: "pose unavailable"} if
-        tracking is not yet established — in that case do not use any position
-        values; retry after a short delay.
+        Returns {x, y, z} world-space position. A negative distance returns an
+        error; unavailable tracking returns {error: "pose unavailable"}. In
+        either case, do not use position values; retry after a short delay.
         """
+        if distance < 0:
+            return {"error": "distance must be non-negative; flip the direction instead"}
         pose = await asyncio.get_running_loop().run_in_executor(None, source.get_pose)
         if not pose.get("is_valid"):
             return {"error": "pose unavailable"}

--- a/agent-mcp-servers/oxr-mcp/oxr_mcp_server/__main__.py
+++ b/agent-mcp-servers/oxr-mcp/oxr_mcp_server/__main__.py
@@ -77,6 +77,8 @@ import isaacteleop.oxr as oxr
 
 from xr_ai_launcher import load_cloudxr_env
 from xr_ai_logging import setup_logging
+from xr_ai_nat.functions.spatial_math import SpatialFrame, Vector3
+from xr_ai_nat.functions.spatial_math import _math as spatial_math
 
 _DEFAULT_YAML = Path(__file__).resolve().parent.parent / "oxr_mcp_server.yaml"
 
@@ -278,6 +280,14 @@ class PoseSource:
 
 # ── MCP tool surface ──────────────────────────────────────────────────────────
 
+def _spatial_frame(pose: dict) -> SpatialFrame:
+    return SpatialFrame(
+        origin=Vector3.model_validate(pose["position"]),
+        forward=Vector3.model_validate(pose["forward"]),
+        right=Vector3.model_validate(pose["right"]),
+        up=Vector3.model_validate(pose["up"]),
+    )
+
 def build_mcp(source: PoseSource) -> FastMCP:
     mcp = FastMCP("oxr-mcp")
 
@@ -312,31 +322,7 @@ def build_mcp(source: PoseSource) -> FastMCP:
         pose = await asyncio.get_running_loop().run_in_executor(None, source.get_pose)
         if not pose.get("is_valid"):
             return {"error": "pose unavailable"}
-        p = pose["position"]
-        f = pose["forward"]
-        return {
-            "x": round(p["x"] + f["x"] * distance, 3),
-            "y": round(p["y"] + f["y"] * distance, 3),
-            "z": round(p["z"] + f["z"] * distance, 3),
-        }
-
-    def _ground_basis(pose: dict) -> tuple[tuple[float, float], tuple[float, float]]:
-        """Return ((fx, fz), (rx, rz)): pose.forward / pose.right projected onto
-        the y=0 plane and renormalised."""
-        f, r = pose["forward"], pose["right"]
-        fx, fz = f["x"], f["z"]
-        mag = math.sqrt(fx * fx + fz * fz)
-        if mag < 1e-6:
-            rx0, rz0 = r["x"], r["z"]
-            mag2 = math.sqrt(rx0 * rx0 + rz0 * rz0)
-            if mag2 < 1e-6:
-                fx, fz = 0.0, -1.0
-            else:
-                rx0, rz0 = rx0 / mag2, rz0 / mag2
-                fx, fz = rz0, -rx0
-        else:
-            fx, fz = fx / mag, fz / mag
-        return (fx, fz), (-fz, fx)
+        return spatial_math.position_in_gaze(_spatial_frame(pose), distance)
 
     @mcp.tool()
     async def position_relative(
@@ -385,15 +371,18 @@ def build_mcp(source: PoseSource) -> FastMCP:
         if not pose.get("is_valid"):
             return {"error": "pose unavailable"}
         p = pose["position"]
-        ox = p["x"] if origin_x is None else origin_x
-        oy = p["y"] if origin_y is None else origin_y
-        oz = p["z"] if origin_z is None else origin_z
-        (fx, fz), (rx, rz) = _ground_basis(pose)
-        return {
-            "x": round(ox + fx*forward + rx*right,        3),
-            "y": round(oy + up,                            3),
-            "z": round(oz + fz*forward + rz*right,        3),
-        }
+        origin = Vector3(
+            x=p["x"] if origin_x is None else origin_x,
+            y=p["y"] if origin_y is None else origin_y,
+            z=p["z"] if origin_z is None else origin_z,
+        )
+        return spatial_math.displace_object(
+            _spatial_frame(pose),
+            position=origin,
+            forward=forward,
+            right=right,
+            up=up,
+        )
 
     @mcp.tool()
     async def place_user_relative(
@@ -431,26 +420,11 @@ def build_mcp(source: PoseSource) -> FastMCP:
         pose = await asyncio.get_running_loop().run_in_executor(None, source.get_pose)
         if not pose.get("is_valid"):
             return {"error": "pose unavailable"}
-        p = pose["position"]
-        (fx, fz), (rx, rz) = _ground_basis(pose)
-        dx = dy = dz = 0.0
-        if direction == "front":
-            dx, dz = fx * distance, fz * distance
-        elif direction == "back":
-            dx, dz = -fx * distance, -fz * distance
-        elif direction == "right":
-            dx, dz = rx * distance, rz * distance
-        elif direction == "left":
-            dx, dz = -rx * distance, -rz * distance
-        elif direction == "above":
-            dy = distance
-        elif direction == "below":
-            dy = -distance
-        return {
-            "x": round(p["x"] + dx, 3),
-            "y": round(p["y"] + dy, 3),
-            "z": round(p["z"] + dz, 3),
-        }
+        return spatial_math.place_user_relative(
+            _spatial_frame(pose),
+            direction=direction,
+            distance=distance,
+        )
 
     @mcp.tool()
     async def place_object_relative(
@@ -508,29 +482,19 @@ def build_mcp(source: PoseSource) -> FastMCP:
             pose = await asyncio.get_running_loop().run_in_executor(None, source.get_pose)
             if not pose.get("is_valid"):
                 return {"error": "pose unavailable"}
-            (fx, fz), (rx, rz) = _ground_basis(pose)
         else:
-            fx = fz = rx = rz = 0.0
-        dx = dy = dz = 0.0
-        if direction == "front":
-            dx, dz = -fx * distance, -fz * distance
-        elif direction == "back":
-            dx, dz = fx * distance, fz * distance
-        elif direction == "right":
-            dx, dz = rx * distance, rz * distance
-        elif direction == "left":
-            dx, dz = -rx * distance, -rz * distance
-        elif direction == "next_to":
-            dx, dz = rx * distance, rz * distance
-        elif direction == "above":
-            dy = distance
-        elif direction == "below":
-            dy = -distance
-        return {
-            "x": round(origin_x + dx, 3),
-            "y": round(origin_y + dy, 3),
-            "z": round(origin_z + dz, 3),
-        }
+            pose = {
+                "position": {"x": 0.0, "y": 0.0, "z": 0.0},
+                "forward": {"x": 0.0, "y": 0.0, "z": -1.0},
+                "right": {"x": 1.0, "y": 0.0, "z": 0.0},
+                "up": {"x": 0.0, "y": 1.0, "z": 0.0},
+            }
+        return spatial_math.place_object_relative(
+            _spatial_frame(pose),
+            anchor=Vector3(x=origin_x, y=origin_y, z=origin_z),
+            direction="right" if direction == "next_to" else direction,
+            distance=distance,
+        )
 
     @mcp.tool()
     async def displace_object(
@@ -571,12 +535,13 @@ def build_mcp(source: PoseSource) -> FastMCP:
         pose = await asyncio.get_running_loop().run_in_executor(None, source.get_pose)
         if not pose.get("is_valid"):
             return {"error": "pose unavailable"}
-        (fx, fz), (rx, rz) = _ground_basis(pose)
-        return {
-            "x": round(current_x + fx * forward + rx * right, 3),
-            "y": round(current_y + up,                        3),
-            "z": round(current_z + fz * forward + rz * right, 3),
-        }
+        return spatial_math.displace_object(
+            _spatial_frame(pose),
+            position=Vector3(x=current_x, y=current_y, z=current_z),
+            forward=forward,
+            right=right,
+            up=up,
+        )
 
     @mcp.tool()
     async def place_inside_by_id(
@@ -596,12 +561,10 @@ def build_mcp(source: PoseSource) -> FastMCP:
         verbatim:
             update_primitive(obj_id=ret.obj_id, x=ret.x, y=ret.y, z=ret.z)
         """
-        return {
-            "obj_id": movee_id,
-            "x":      round(container_x, 3),
-            "y":      round(container_y, 3),
-            "z":      round(container_z, 3),
-        }
+        return spatial_math.place_in_container(
+            movee_id,
+            Vector3(x=container_x, y=container_y, z=container_z),
+        )
 
     @mcp.tool()
     async def displace_objects(
@@ -636,16 +599,17 @@ def build_mcp(source: PoseSource) -> FastMCP:
         pose = await asyncio.get_running_loop().run_in_executor(None, source.get_pose)
         if not pose.get("is_valid"):
             return {"error": "pose unavailable"}
-        (fx, fz), (rx, rz) = _ground_basis(pose)
+        frame = _spatial_frame(pose)
         items = []
         for i in range(n):
-            cx, cy, cz = current_xs[i], current_ys[i], current_zs[i]
-            items.append({
-                "obj_id": object_ids[i],
-                "x": round(cx + fx * forward + rx * right, 3),
-                "y": round(cy + up,                         3),
-                "z": round(cz + fz * forward + rz * right, 3),
-            })
+            position = spatial_math.displace_object(
+                frame,
+                position=Vector3(x=current_xs[i], y=current_ys[i], z=current_zs[i]),
+                forward=forward,
+                right=right,
+                up=up,
+            )
+            items.append({"obj_id": object_ids[i], **position})
         return {"items": items}
 
     @mcp.tool()

--- a/agent-mcp-servers/oxr-mcp/oxr_mcp_server/__main__.py
+++ b/agent-mcp-servers/oxr-mcp/oxr_mcp_server/__main__.py
@@ -322,7 +322,7 @@ def build_mcp(source: PoseSource) -> FastMCP:
         pose = await asyncio.get_running_loop().run_in_executor(None, source.get_pose)
         if not pose.get("is_valid"):
             return {"error": "pose unavailable"}
-        return spatial_math.position_in_gaze(_spatial_frame(pose), distance)
+        return spatial_math.compute_gaze_target(_spatial_frame(pose), distance)
 
     @mcp.tool()
     async def position_relative(
@@ -376,12 +376,12 @@ def build_mcp(source: PoseSource) -> FastMCP:
             y=p["y"] if origin_y is None else origin_y,
             z=p["z"] if origin_z is None else origin_z,
         )
-        return spatial_math.displace_object(
+        return spatial_math.offset_position_in_user_frame(
             _spatial_frame(pose),
-            position=origin,
-            forward=forward,
-            right=right,
-            up=up,
+            start_position=origin,
+            forward_meters=forward,
+            right_meters=right,
+            up_meters=up,
         )
 
     @mcp.tool()
@@ -420,10 +420,10 @@ def build_mcp(source: PoseSource) -> FastMCP:
         pose = await asyncio.get_running_loop().run_in_executor(None, source.get_pose)
         if not pose.get("is_valid"):
             return {"error": "pose unavailable"}
-        return spatial_math.place_user_relative(
+        return spatial_math.compute_user_relative_position(
             _spatial_frame(pose),
-            direction=direction,
-            distance=distance,
+            direction_from_user=direction,
+            distance_meters=distance,
         )
 
     @mcp.tool()
@@ -489,11 +489,20 @@ def build_mcp(source: PoseSource) -> FastMCP:
                 "right": {"x": 1.0, "y": 0.0, "z": 0.0},
                 "up": {"x": 0.0, "y": 1.0, "z": 0.0},
             }
-        return spatial_math.place_object_relative(
+        relations = {
+            "front": "toward_user",
+            "back": "away_from_user",
+            "left": "left_of",
+            "right": "right_of",
+            "above": "above",
+            "below": "below",
+            "next_to": "right_of",
+        }
+        return spatial_math.compute_position_relative_to_anchor(
             _spatial_frame(pose),
-            anchor=Vector3(x=origin_x, y=origin_y, z=origin_z),
-            direction="right" if direction == "next_to" else direction,
-            distance=distance,
+            anchor_position=Vector3(x=origin_x, y=origin_y, z=origin_z),
+            relation_to_anchor=relations[direction],
+            distance_meters=distance,
         )
 
     @mcp.tool()
@@ -535,12 +544,12 @@ def build_mcp(source: PoseSource) -> FastMCP:
         pose = await asyncio.get_running_loop().run_in_executor(None, source.get_pose)
         if not pose.get("is_valid"):
             return {"error": "pose unavailable"}
-        return spatial_math.displace_object(
+        return spatial_math.offset_position_in_user_frame(
             _spatial_frame(pose),
-            position=Vector3(x=current_x, y=current_y, z=current_z),
-            forward=forward,
-            right=right,
-            up=up,
+            start_position=Vector3(x=current_x, y=current_y, z=current_z),
+            forward_meters=forward,
+            right_meters=right,
+            up_meters=up,
         )
 
     @mcp.tool()
@@ -561,10 +570,12 @@ def build_mcp(source: PoseSource) -> FastMCP:
         verbatim:
             update_primitive(obj_id=ret.obj_id, x=ret.x, y=ret.y, z=ret.z)
         """
-        return spatial_math.place_in_container(
-            movee_id,
-            Vector3(x=container_x, y=container_y, z=container_z),
-        )
+        return {
+            "obj_id": movee_id,
+            "x": round(container_x, 3),
+            "y": round(container_y, 3),
+            "z": round(container_z, 3),
+        }
 
     @mcp.tool()
     async def displace_objects(
@@ -602,12 +613,12 @@ def build_mcp(source: PoseSource) -> FastMCP:
         frame = _spatial_frame(pose)
         items = []
         for i in range(n):
-            position = spatial_math.displace_object(
+            position = spatial_math.offset_position_in_user_frame(
                 frame,
-                position=Vector3(x=current_xs[i], y=current_ys[i], z=current_zs[i]),
-                forward=forward,
-                right=right,
-                up=up,
+                start_position=Vector3(x=current_xs[i], y=current_ys[i], z=current_zs[i]),
+                forward_meters=forward,
+                right_meters=right,
+                up_meters=up,
             )
             items.append({"obj_id": object_ids[i], **position})
         return {"items": items}

--- a/agent-mcp-servers/oxr-mcp/pyproject.toml
+++ b/agent-mcp-servers/oxr-mcp/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.11,<3.13"
 dependencies = [
     "xr-ai-launcher",
     "xr-ai-logging",
+    "xr-ai-nat",
     "pyyaml>=6.0",
     "uvicorn[standard]>=0.29",
     "fastmcp>=2.0",
@@ -24,6 +25,7 @@ dependencies = [
 [tool.uv.sources]
 xr-ai-launcher = { path = "../../utils/xr-ai-launcher", editable = true }
 xr-ai-logging  = { path = "../../utils/xr-ai-logging", editable = true }
+xr-ai-nat      = { path = "../../agent-sdk/xr-ai-nat", editable = true }
 
 [project.scripts]
 oxr_mcp_server = "oxr_mcp_server.__main__:run"

--- a/agent-mcp-servers/vec-mcp/pyproject.toml
+++ b/agent-mcp-servers/vec-mcp/pyproject.toml
@@ -14,10 +14,12 @@ dependencies = [
     "fastmcp>=2.0",
     "pyyaml>=6.0",
     "xr-ai-logging",
+    "xr-ai-nat",
 ]
 
 [tool.uv.sources]
 xr-ai-logging = { path = "../../utils/xr-ai-logging", editable = true }
+xr-ai-nat     = { path = "../../agent-sdk/xr-ai-nat", editable = true }
 
 [project.scripts]
 vec_mcp_server = "vec_mcp_server.__main__:run"

--- a/agent-mcp-servers/vec-mcp/vec_mcp_server/__main__.py
+++ b/agent-mcp-servers/vec-mcp/vec_mcp_server/__main__.py
@@ -88,7 +88,7 @@ def build_mcp() -> FastMCP:
         Returns {x, y, z} — the midpoint. Feed straight into
         add_primitive or update_primitive.
         """
-        return spatial_math.midpoint(
+        return spatial_math.compute_midpoint(
             Vector3(x=a_x, y=a_y, z=a_z),
             Vector3(x=b_x, y=b_y, z=b_z),
         )
@@ -111,9 +111,9 @@ def build_mcp() -> FastMCP:
         """
         return spatial_math.world_offset(
             Vector3(x=origin_x, y=origin_y, z=origin_z),
-            dx=dx,
-            dy=dy,
-            dz=dz,
+            x_meters=dx,
+            y_meters=dy,
+            z_meters=dz,
         )
 
     @mcp.tool()
@@ -131,11 +131,11 @@ def build_mcp() -> FastMCP:
         Returns {x, y, z}, or {error} if origin and target coincide.
         """
         try:
-            return spatial_math.move_relative_to(
+            return spatial_math.compute_position_toward_or_away_from_reference(
                 Vector3(x=origin_x, y=origin_y, z=origin_z),
                 Vector3(x=target_x, y=target_y, z=target_z),
-                direction="toward" if distance >= 0 else "away",
-                distance=abs(distance),
+                movement_direction="toward" if distance >= 0 else "away",
+                distance_meters=abs(distance),
             )
         except ValueError:
             return {"error": "origin and target coincide"}

--- a/agent-mcp-servers/vec-mcp/vec_mcp_server/__main__.py
+++ b/agent-mcp-servers/vec-mcp/vec_mcp_server/__main__.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import math
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -40,6 +39,8 @@ import yaml
 from fastmcp import FastMCP
 from loguru import logger
 from xr_ai_logging import setup_logging
+from xr_ai_nat.functions.spatial_math import Vector3
+from xr_ai_nat.functions.spatial_math import _math as spatial_math
 
 _DEFAULT_YAML = Path(__file__).resolve().parent.parent / "vec_mcp_server.yaml"
 
@@ -66,9 +67,6 @@ def _build_config(raw: dict) -> Config:
 
 # ── Tool surface ──────────────────────────────────────────────────────────────
 
-def _round3(x: float, y: float, z: float) -> dict:
-    return {"x": round(x, 3), "y": round(y, 3), "z": round(z, 3)}
-
 
 def build_mcp() -> FastMCP:
     mcp = FastMCP("vec-mcp")
@@ -90,7 +88,10 @@ def build_mcp() -> FastMCP:
         Returns {x, y, z} — the midpoint. Feed straight into
         add_primitive or update_primitive.
         """
-        return _round3((a_x + b_x) / 2, (a_y + b_y) / 2, (a_z + b_z) / 2)
+        return spatial_math.midpoint(
+            Vector3(x=a_x, y=a_y, z=a_z),
+            Vector3(x=b_x, y=b_y, z=b_z),
+        )
 
     @mcp.tool()
     async def world_offset(
@@ -108,7 +109,12 @@ def build_mcp() -> FastMCP:
         Example: sphere at (0, 1.5, -1.5), "30 cm above" →
             world_offset(0, 1.5, -1.5, dy=0.3) → (0, 1.8, -1.5).
         """
-        return _round3(origin_x + dx, origin_y + dy, origin_z + dz)
+        return spatial_math.world_offset(
+            Vector3(x=origin_x, y=origin_y, z=origin_z),
+            dx=dx,
+            dy=dy,
+            dz=dz,
+        )
 
     @mcp.tool()
     async def along_direction(
@@ -124,16 +130,15 @@ def build_mcp() -> FastMCP:
 
         Returns {x, y, z}, or {error} if origin and target coincide.
         """
-        vx, vy, vz = target_x - origin_x, target_y - origin_y, target_z - origin_z
-        mag = math.sqrt(vx * vx + vy * vy + vz * vz)
-        if mag < 1e-9:
+        try:
+            return spatial_math.move_relative_to(
+                Vector3(x=origin_x, y=origin_y, z=origin_z),
+                Vector3(x=target_x, y=target_y, z=target_z),
+                direction="toward" if distance >= 0 else "away",
+                distance=abs(distance),
+            )
+        except ValueError:
             return {"error": "origin and target coincide"}
-        ux, uy, uz = vx / mag, vy / mag, vz / mag
-        return _round3(
-            origin_x + ux * distance,
-            origin_y + uy * distance,
-            origin_z + uz * distance,
-        )
 
     @mcp.tool()
     async def scale_value(current: float, factor: float) -> dict:

--- a/agent-sdk/xr-ai-nat/README.md
+++ b/agent-sdk/xr-ai-nat/README.md
@@ -1,0 +1,35 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# XR AI functions for NeMo Agent Toolkit
+
+`xr-ai-nat` provides typed, in-process XR functions for NVIDIA NeMo Agent
+Toolkit (NAT). Applications compose these functions directly; process-backed
+or MCP compatibility adapters remain separate boundaries.
+
+## Spatial math
+
+The `xr_spatial_math` function group contains deterministic coordinate
+operations. Callers supply an explicit `SpatialFrame`, so the functions do not
+depend on OpenXR, a tracking service, or an MCP server.
+
+```yaml
+functions:
+  spatial_math:
+    _type: xr_spatial_math
+```
+
+The group exposes:
+
+- `spatial_math__position_in_gaze`
+- `spatial_math__place_user_relative`
+- `spatial_math__place_object_relative`
+- `spatial_math__displace_object`
+- `spatial_math__move_relative_to`
+- `spatial_math__midpoint`
+- `spatial_math__place_in_container`
+
+Install the package in the NAT environment so its `nat.plugins` entry point is
+discovered automatically.

--- a/agent-sdk/xr-ai-nat/README.md
+++ b/agent-sdk/xr-ai-nat/README.md
@@ -23,13 +23,15 @@ functions:
 
 The group exposes:
 
-- `spatial_math__position_in_gaze`
-- `spatial_math__place_user_relative`
-- `spatial_math__place_object_relative`
-- `spatial_math__displace_object`
-- `spatial_math__move_relative_to`
-- `spatial_math__midpoint`
-- `spatial_math__place_in_container`
+- `spatial_math__compute_gaze_target(user_frame, distance_meters)`
+- `spatial_math__compute_user_relative_position(user_frame, direction_from_user, distance_meters)`
+- `spatial_math__compute_position_relative_to_anchor(user_frame, anchor_position, relation_to_anchor, distance_meters)`
+- `spatial_math__offset_position_in_user_frame(user_frame, start_position, forward_meters, right_meters, up_meters)`
+- `spatial_math__compute_position_toward_or_away_from_reference(start_position, reference_position, movement_direction, distance_meters)`
+- `spatial_math__compute_midpoint(first_position, second_position)`
+
+Every operation returns a `Vector3` and only calculates coordinates. Creating,
+moving, or associating a scene object remains the caller's responsibility.
 
 Install the package in the NAT environment so its `nat.plugins` entry point is
 discovered automatically.

--- a/agent-sdk/xr-ai-nat/README.md
+++ b/agent-sdk/xr-ai-nat/README.md
@@ -33,5 +33,5 @@ The group exposes:
 Every operation returns a `Vector3` and only calculates coordinates. Creating,
 moving, or associating a scene object remains the caller's responsibility.
 
-Install the package in the NAT environment so its `nat.plugins` entry point is
-discovered automatically.
+Install the package in the NAT environment so NAT discovers the spatial-math
+registration directly through its capability-specific `nat.plugins` entry point.

--- a/agent-sdk/xr-ai-nat/pyproject.toml
+++ b/agent-sdk/xr-ai-nat/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 ]
 
 [project.entry-points."nat.plugins"]
-xr_ai_nat = "xr_ai_nat.plugin"
+xr_ai_nat_spatial_math = "xr_ai_nat.functions.spatial_math.functions"
 
 [tool.hatch.build.targets.wheel]
 packages = ["xr_ai_nat"]

--- a/agent-sdk/xr-ai-nat/pyproject.toml
+++ b/agent-sdk/xr-ai-nat/pyproject.toml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "xr-ai-nat"
+version = "0.1.0"
+description = "NVIDIA NeMo Agent Toolkit functions for XR AI."
+requires-python = ">=3.11,<3.13"
+dependencies = [
+    "nvidia-nat-core==1.8.0",
+    "pydantic>=2.10",
+]
+
+[project.entry-points."nat.plugins"]
+xr_ai_nat = "xr_ai_nat.plugin"
+
+[tool.hatch.build.targets.wheel]
+packages = ["xr_ai_nat"]

--- a/agent-sdk/xr-ai-nat/xr_ai_nat/__init__.py
+++ b/agent-sdk/xr-ai-nat/xr_ai_nat/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NAT-native XR functions."""
+
+__all__: list[str] = []

--- a/agent-sdk/xr-ai-nat/xr_ai_nat/functions/__init__.py
+++ b/agent-sdk/xr-ai-nat/xr_ai_nat/functions/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NAT function namespaces supplied by XR AI."""
+
+__all__: list[str] = []

--- a/agent-sdk/xr-ai-nat/xr_ai_nat/functions/spatial_math/__init__.py
+++ b/agent-sdk/xr-ai-nat/xr_ai_nat/functions/spatial_math/__init__.py
@@ -1,14 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Public spatial-math function group and value schemas."""
+"""Public spatial-math function group and coordinate schemas."""
 
 from .functions import SpatialMathFunctionsConfig
-from .schemas import ObjectPositionResult, PositionResult, SpatialFrame, Vector3
+from .schemas import SpatialFrame, Vector3
 
 __all__ = [
-    "ObjectPositionResult",
-    "PositionResult",
     "SpatialFrame",
     "SpatialMathFunctionsConfig",
     "Vector3",

--- a/agent-sdk/xr-ai-nat/xr_ai_nat/functions/spatial_math/__init__.py
+++ b/agent-sdk/xr-ai-nat/xr_ai_nat/functions/spatial_math/__init__.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public spatial-math function group and value schemas."""
+
+from .functions import SpatialMathFunctionsConfig
+from .schemas import ObjectPositionResult, PositionResult, SpatialFrame, Vector3
+
+__all__ = [
+    "ObjectPositionResult",
+    "PositionResult",
+    "SpatialFrame",
+    "SpatialMathFunctionsConfig",
+    "Vector3",
+]

--- a/agent-sdk/xr-ai-nat/xr_ai_nat/functions/spatial_math/_math.py
+++ b/agent-sdk/xr-ai-nat/xr_ai_nat/functions/spatial_math/_math.py
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pure calculations shared by native functions and compatibility adapters."""
+
+from __future__ import annotations
+
+import math
+from typing import Literal
+
+from .schemas import SpatialFrame, Vector3
+
+
+def _position(x: float, y: float, z: float) -> dict[str, float]:
+    return {"x": round(x, 3), "y": round(y, 3), "z": round(z, 3)}
+
+
+def _require_distance(distance: float) -> None:
+    if distance < 0:
+        raise ValueError("distance must be non-negative; flip the direction instead")
+
+
+def _ground_basis(frame: SpatialFrame) -> tuple[tuple[float, float], tuple[float, float]]:
+    fx, fz = frame.forward.x, frame.forward.z
+    magnitude = math.hypot(fx, fz)
+    if magnitude < 1e-6:
+        rx, rz = frame.right.x, frame.right.z
+        right_magnitude = math.hypot(rx, rz)
+        if right_magnitude < 1e-6:
+            fx, fz = 0.0, -1.0
+        else:
+            fx, fz = rz / right_magnitude, -rx / right_magnitude
+    else:
+        fx, fz = fx / magnitude, fz / magnitude
+    return (fx, fz), (-fz, fx)
+
+
+def offset(
+    frame: SpatialFrame,
+    origin: Vector3,
+    *,
+    forward: float = 0.0,
+    right: float = 0.0,
+    up: float = 0.0,
+) -> dict[str, float]:
+    """Apply a gravity-aligned frame-relative offset to an origin."""
+
+    (fx, fz), (rx, rz) = _ground_basis(frame)
+    return _position(
+        origin.x + fx * forward + rx * right,
+        origin.y + up,
+        origin.z + fz * forward + rz * right,
+    )
+
+
+def world_offset(
+    origin: Vector3,
+    *,
+    dx: float = 0.0,
+    dy: float = 0.0,
+    dz: float = 0.0,
+) -> dict[str, float]:
+    """Apply a world-axis offset used by the legacy Vec MCP surface."""
+
+    return _position(origin.x + dx, origin.y + dy, origin.z + dz)
+
+
+def position_in_gaze(frame: SpatialFrame, distance: float = 1.5) -> dict[str, float]:
+    """Return a point along the frame's full forward vector."""
+
+    return _position(
+        frame.origin.x + frame.forward.x * distance,
+        frame.origin.y + frame.forward.y * distance,
+        frame.origin.z + frame.forward.z * distance,
+    )
+
+
+def place_user_relative(
+    frame: SpatialFrame,
+    direction: Literal["front", "back", "left", "right", "above", "below"],
+    distance: float = 1.5,
+) -> dict[str, float]:
+    """Place a point in a named gravity-aligned direction from the frame origin."""
+
+    _require_distance(distance)
+    offsets = {
+        "front": (distance, 0.0, 0.0),
+        "back": (-distance, 0.0, 0.0),
+        "left": (0.0, -distance, 0.0),
+        "right": (0.0, distance, 0.0),
+        "above": (0.0, 0.0, distance),
+        "below": (0.0, 0.0, -distance),
+    }
+    forward, right, up = offsets[direction]
+    return offset(frame, frame.origin, forward=forward, right=right, up=up)
+
+
+def place_object_relative(
+    frame: SpatialFrame,
+    *,
+    anchor: Vector3,
+    direction: Literal["front", "back", "left", "right", "above", "below"],
+    distance: float = 0.3,
+) -> dict[str, float]:
+    """Place a point in a named gravity-aligned direction from an object anchor."""
+
+    _require_distance(distance)
+    offsets = {
+        "front": (-distance, 0.0, 0.0),
+        "back": (distance, 0.0, 0.0),
+        "left": (0.0, -distance, 0.0),
+        "right": (0.0, distance, 0.0),
+        "above": (0.0, 0.0, distance),
+        "below": (0.0, 0.0, -distance),
+    }
+    forward, right, up = offsets[direction]
+    return offset(frame, anchor, forward=forward, right=right, up=up)
+
+
+def displace_object(
+    frame: SpatialFrame,
+    *,
+    position: Vector3,
+    forward: float = 0.0,
+    right: float = 0.0,
+    up: float = 0.0,
+) -> dict[str, float]:
+    """Move a position by a signed frame-relative delta."""
+
+    return offset(frame, position, forward=forward, right=right, up=up)
+
+
+def move_relative_to(
+    position: Vector3,
+    reference: Vector3,
+    *,
+    direction: Literal["toward", "away"],
+    distance: float = 0.5,
+) -> dict[str, float]:
+    """Move a position toward or away from a reference by an exact distance."""
+
+    _require_distance(distance)
+    dx = reference.x - position.x
+    dy = reference.y - position.y
+    dz = reference.z - position.z
+    magnitude = math.sqrt(dx * dx + dy * dy + dz * dz)
+    if magnitude < 1e-9:
+        raise ValueError("position and reference coincide")
+    scale = (1.0 if direction == "toward" else -1.0) * distance / magnitude
+    return _position(
+        position.x + dx * scale,
+        position.y + dy * scale,
+        position.z + dz * scale,
+    )
+
+
+def midpoint(first: Vector3, second: Vector3) -> dict[str, float]:
+    """Return the midpoint between two world positions."""
+
+    return _position(
+        (first.x + second.x) / 2,
+        (first.y + second.y) / 2,
+        (first.z + second.z) / 2,
+    )
+
+
+def place_in_container(obj_id: str, container: Vector3) -> dict[str, float | str]:
+    """Pair an object id with a container's center position."""
+
+    return {"obj_id": obj_id, **_position(container.x, container.y, container.z)}

--- a/agent-sdk/xr-ai-nat/xr_ai_nat/functions/spatial_math/_math.py
+++ b/agent-sdk/xr-ai-nat/xr_ai_nat/functions/spatial_math/_math.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Pure calculations shared by native functions and compatibility adapters."""
+"""Pure coordinate calculations shared by native functions and compatibility adapters."""
 
 from __future__ import annotations
 
@@ -15,156 +15,181 @@ def _position(x: float, y: float, z: float) -> dict[str, float]:
     return {"x": round(x, 3), "y": round(y, 3), "z": round(z, 3)}
 
 
-def _require_distance(distance: float) -> None:
-    if distance < 0:
-        raise ValueError("distance must be non-negative; flip the direction instead")
+def _require_non_negative_distance(distance_meters: float) -> None:
+    if distance_meters < 0:
+        raise ValueError("distance_meters must be non-negative; choose the opposite direction instead")
 
 
-def _ground_basis(frame: SpatialFrame) -> tuple[tuple[float, float], tuple[float, float]]:
-    fx, fz = frame.forward.x, frame.forward.z
-    magnitude = math.hypot(fx, fz)
+def _horizontal_user_axes(
+    user_frame: SpatialFrame,
+) -> tuple[tuple[float, float], tuple[float, float]]:
+    """Return normalized forward and right axes projected onto the ground plane."""
+    forward_x, forward_z = user_frame.forward.x, user_frame.forward.z
+    magnitude = math.sqrt(forward_x * forward_x + forward_z * forward_z)
     if magnitude < 1e-6:
-        rx, rz = frame.right.x, frame.right.z
-        right_magnitude = math.hypot(rx, rz)
+        right_x, right_z = user_frame.right.x, user_frame.right.z
+        right_magnitude = math.sqrt(right_x * right_x + right_z * right_z)
         if right_magnitude < 1e-6:
-            fx, fz = 0.0, -1.0
+            forward_x, forward_z = 0.0, -1.0
         else:
-            fx, fz = rz / right_magnitude, -rx / right_magnitude
+            forward_x, forward_z = right_z / right_magnitude, -right_x / right_magnitude
     else:
-        fx, fz = fx / magnitude, fz / magnitude
-    return (fx, fz), (-fz, fx)
+        forward_x, forward_z = forward_x / magnitude, forward_z / magnitude
+    return (forward_x, forward_z), (-forward_z, forward_x)
 
 
-def offset(
-    frame: SpatialFrame,
-    origin: Vector3,
+def _offset_in_user_frame(
+    user_frame: SpatialFrame,
+    start_position: Vector3,
     *,
-    forward: float = 0.0,
-    right: float = 0.0,
-    up: float = 0.0,
+    forward_meters: float = 0.0,
+    right_meters: float = 0.0,
+    up_meters: float = 0.0,
 ) -> dict[str, float]:
-    """Apply a gravity-aligned frame-relative offset to an origin."""
-
-    (fx, fz), (rx, rz) = _ground_basis(frame)
+    (forward_x, forward_z), (right_x, right_z) = _horizontal_user_axes(user_frame)
     return _position(
-        origin.x + fx * forward + rx * right,
-        origin.y + up,
-        origin.z + fz * forward + rz * right,
+        start_position.x + forward_x * forward_meters + right_x * right_meters,
+        start_position.y + up_meters,
+        start_position.z + forward_z * forward_meters + right_z * right_meters,
+    )
+
+
+def compute_gaze_target(
+    user_frame: SpatialFrame,
+    distance_meters: float = 1.5,
+) -> dict[str, float]:
+    """Compute a world position along the user's full three-dimensional gaze ray."""
+    _require_non_negative_distance(distance_meters)
+    return _position(
+        user_frame.origin.x + user_frame.forward.x * distance_meters,
+        user_frame.origin.y + user_frame.forward.y * distance_meters,
+        user_frame.origin.z + user_frame.forward.z * distance_meters,
+    )
+
+
+def compute_user_relative_position(
+    user_frame: SpatialFrame,
+    direction_from_user: Literal["front", "back", "left", "right", "above", "below"],
+    distance_meters: float = 1.5,
+) -> dict[str, float]:
+    """Compute a gravity-aligned position in a named direction from the user."""
+    _require_non_negative_distance(distance_meters)
+    offsets = {
+        "front": (distance_meters, 0.0, 0.0),
+        "back": (-distance_meters, 0.0, 0.0),
+        "left": (0.0, -distance_meters, 0.0),
+        "right": (0.0, distance_meters, 0.0),
+        "above": (0.0, 0.0, distance_meters),
+        "below": (0.0, 0.0, -distance_meters),
+    }
+    forward_meters, right_meters, up_meters = offsets[direction_from_user]
+    return _offset_in_user_frame(
+        user_frame,
+        user_frame.origin,
+        forward_meters=forward_meters,
+        right_meters=right_meters,
+        up_meters=up_meters,
+    )
+
+
+def compute_position_relative_to_anchor(
+    user_frame: SpatialFrame,
+    *,
+    anchor_position: Vector3,
+    relation_to_anchor: Literal[
+        "toward_user",
+        "away_from_user",
+        "left_of",
+        "right_of",
+        "above",
+        "below",
+    ],
+    distance_meters: float = 0.3,
+) -> dict[str, float]:
+    """Compute a position relative to an anchor using the user's horizontal axes."""
+    _require_non_negative_distance(distance_meters)
+    offsets = {
+        "toward_user": (-distance_meters, 0.0, 0.0),
+        "away_from_user": (distance_meters, 0.0, 0.0),
+        "left_of": (0.0, -distance_meters, 0.0),
+        "right_of": (0.0, distance_meters, 0.0),
+        "above": (0.0, 0.0, distance_meters),
+        "below": (0.0, 0.0, -distance_meters),
+    }
+    forward_meters, right_meters, up_meters = offsets[relation_to_anchor]
+    return _offset_in_user_frame(
+        user_frame,
+        anchor_position,
+        forward_meters=forward_meters,
+        right_meters=right_meters,
+        up_meters=up_meters,
+    )
+
+
+def offset_position_in_user_frame(
+    user_frame: SpatialFrame,
+    *,
+    start_position: Vector3,
+    forward_meters: float = 0.0,
+    right_meters: float = 0.0,
+    up_meters: float = 0.0,
+) -> dict[str, float]:
+    """Offset a world position along the user's forward, right, and up axes."""
+    return _offset_in_user_frame(
+        user_frame,
+        start_position,
+        forward_meters=forward_meters,
+        right_meters=right_meters,
+        up_meters=up_meters,
+    )
+
+
+def compute_position_toward_or_away_from_reference(
+    start_position: Vector3,
+    reference_position: Vector3,
+    *,
+    movement_direction: Literal["toward", "away"],
+    distance_meters: float = 0.5,
+) -> dict[str, float]:
+    """Compute a position moved toward or away from a reference by an exact distance."""
+    _require_non_negative_distance(distance_meters)
+    delta_x = reference_position.x - start_position.x
+    delta_y = reference_position.y - start_position.y
+    delta_z = reference_position.z - start_position.z
+    magnitude = math.sqrt(delta_x * delta_x + delta_y * delta_y + delta_z * delta_z)
+    if magnitude < 1e-9:
+        raise ValueError("start_position and reference_position coincide")
+    sign = 1.0 if movement_direction == "toward" else -1.0
+    scale = sign * distance_meters / magnitude
+    return _position(
+        start_position.x + delta_x * scale,
+        start_position.y + delta_y * scale,
+        start_position.z + delta_z * scale,
+    )
+
+
+def compute_midpoint(
+    first_position: Vector3,
+    second_position: Vector3,
+) -> dict[str, float]:
+    """Compute the world-space midpoint between two positions."""
+    return _position(
+        (first_position.x + second_position.x) / 2,
+        (first_position.y + second_position.y) / 2,
+        (first_position.z + second_position.z) / 2,
     )
 
 
 def world_offset(
-    origin: Vector3,
+    start_position: Vector3,
     *,
-    dx: float = 0.0,
-    dy: float = 0.0,
-    dz: float = 0.0,
+    x_meters: float = 0.0,
+    y_meters: float = 0.0,
+    z_meters: float = 0.0,
 ) -> dict[str, float]:
-    """Apply a world-axis offset used by the legacy Vec MCP surface."""
-
-    return _position(origin.x + dx, origin.y + dy, origin.z + dz)
-
-
-def position_in_gaze(frame: SpatialFrame, distance: float = 1.5) -> dict[str, float]:
-    """Return a point along the frame's full forward vector."""
-
+    """Apply world-axis offsets for the legacy Vec MCP compatibility surface."""
     return _position(
-        frame.origin.x + frame.forward.x * distance,
-        frame.origin.y + frame.forward.y * distance,
-        frame.origin.z + frame.forward.z * distance,
+        start_position.x + x_meters,
+        start_position.y + y_meters,
+        start_position.z + z_meters,
     )
-
-
-def place_user_relative(
-    frame: SpatialFrame,
-    direction: Literal["front", "back", "left", "right", "above", "below"],
-    distance: float = 1.5,
-) -> dict[str, float]:
-    """Place a point in a named gravity-aligned direction from the frame origin."""
-
-    _require_distance(distance)
-    offsets = {
-        "front": (distance, 0.0, 0.0),
-        "back": (-distance, 0.0, 0.0),
-        "left": (0.0, -distance, 0.0),
-        "right": (0.0, distance, 0.0),
-        "above": (0.0, 0.0, distance),
-        "below": (0.0, 0.0, -distance),
-    }
-    forward, right, up = offsets[direction]
-    return offset(frame, frame.origin, forward=forward, right=right, up=up)
-
-
-def place_object_relative(
-    frame: SpatialFrame,
-    *,
-    anchor: Vector3,
-    direction: Literal["front", "back", "left", "right", "above", "below"],
-    distance: float = 0.3,
-) -> dict[str, float]:
-    """Place a point in a named gravity-aligned direction from an object anchor."""
-
-    _require_distance(distance)
-    offsets = {
-        "front": (-distance, 0.0, 0.0),
-        "back": (distance, 0.0, 0.0),
-        "left": (0.0, -distance, 0.0),
-        "right": (0.0, distance, 0.0),
-        "above": (0.0, 0.0, distance),
-        "below": (0.0, 0.0, -distance),
-    }
-    forward, right, up = offsets[direction]
-    return offset(frame, anchor, forward=forward, right=right, up=up)
-
-
-def displace_object(
-    frame: SpatialFrame,
-    *,
-    position: Vector3,
-    forward: float = 0.0,
-    right: float = 0.0,
-    up: float = 0.0,
-) -> dict[str, float]:
-    """Move a position by a signed frame-relative delta."""
-
-    return offset(frame, position, forward=forward, right=right, up=up)
-
-
-def move_relative_to(
-    position: Vector3,
-    reference: Vector3,
-    *,
-    direction: Literal["toward", "away"],
-    distance: float = 0.5,
-) -> dict[str, float]:
-    """Move a position toward or away from a reference by an exact distance."""
-
-    _require_distance(distance)
-    dx = reference.x - position.x
-    dy = reference.y - position.y
-    dz = reference.z - position.z
-    magnitude = math.sqrt(dx * dx + dy * dy + dz * dz)
-    if magnitude < 1e-9:
-        raise ValueError("position and reference coincide")
-    scale = (1.0 if direction == "toward" else -1.0) * distance / magnitude
-    return _position(
-        position.x + dx * scale,
-        position.y + dy * scale,
-        position.z + dz * scale,
-    )
-
-
-def midpoint(first: Vector3, second: Vector3) -> dict[str, float]:
-    """Return the midpoint between two world positions."""
-
-    return _position(
-        (first.x + second.x) / 2,
-        (first.y + second.y) / 2,
-        (first.z + second.z) / 2,
-    )
-
-
-def place_in_container(obj_id: str, container: Vector3) -> dict[str, float | str]:
-    """Pair an object id with a container's center position."""
-
-    return {"obj_id": obj_id, **_position(container.x, container.y, container.z)}

--- a/agent-sdk/xr-ai-nat/xr_ai_nat/functions/spatial_math/functions.py
+++ b/agent-sdk/xr-ai-nat/xr_ai_nat/functions/spatial_math/functions.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Typed NAT functions for deterministic XR spatial calculations."""
+"""Model-facing NAT functions for pure, framework-neutral coordinate calculations."""
 
 import json
 from typing import Annotated, Literal
@@ -9,11 +9,12 @@ from typing import Annotated, Literal
 from nat.plugin_api import Builder, FunctionGroup, FunctionGroupBaseConfig, register_function_group
 from pydantic import BeforeValidator, Field
 
-from . import _math
-from .schemas import ObjectPositionResult, PositionResult, SpatialFrame, Vector3
+from . import _math as spatial_math
+from .schemas import SpatialFrame, Vector3
 
 
 def _decode_json(value: object) -> object:
+    # LangChain may present a typed tool result as text before the model reuses it.
     if isinstance(value, str):
         try:
             return json.loads(value)
@@ -22,141 +23,205 @@ def _decode_json(value: object) -> object:
     return value
 
 
-_Frame = Annotated[
+_UserFrameArgument = Annotated[
     SpatialFrame,
     BeforeValidator(_decode_json),
-    Field(description="Coordinate frame returned by an XR tracking function."),
+    Field(
+        description=("Current user coordinate frame returned by an XR tracking function, copied as one JSON object.")
+    ),
 ]
-_Position = Annotated[
+_WorldPositionArgument = Annotated[
     Vector3,
     BeforeValidator(_decode_json),
-    Field(description="A complete world position represented as one {x, y, z} object."),
+    Field(
+        description=(
+            "Complete world position copied as one {x, y, z} object from scene state or a previous spatial-math result."
+        )
+    ),
 ]
-_Distance = Annotated[float, Field(ge=0, description="Non-negative distance in metres.")]
 
 
 class SpatialMathFunctionsConfig(FunctionGroupBaseConfig, name="xr_spatial_math"):
-    """Configure pure spatial functions over caller-supplied coordinates."""
+    """Configure pure coordinate calculations over caller-supplied positions and frames."""
 
 
 @register_function_group(config_type=SpatialMathFunctionsConfig)
 async def spatial_math_functions(config: SpatialMathFunctionsConfig, _builder: Builder):
+    """Build calculations that return coordinates but never mutate scene objects."""
+
     group = FunctionGroup(config=config)
 
-    async def position_in_gaze(frame: _Frame, distance: _Distance = 1.5) -> PositionResult:
-        return PositionResult.model_validate(_math.position_in_gaze(frame, distance))
+    async def compute_gaze_target(
+        user_frame: _UserFrameArgument,
+        distance_meters: Annotated[
+            float,
+            Field(ge=0, description="Non-negative distance along the full 3D gaze ray, in metres."),
+        ] = 1.5,
+    ) -> Vector3:
+        return Vector3.model_validate(spatial_math.compute_gaze_target(user_frame, distance_meters))
 
     group.add_function(
-        "position_in_gaze",
-        position_in_gaze,
-        description="Return a position along the user's full 3D gaze direction.",
-    )
-
-    async def place_user_relative(
-        frame: _Frame,
-        direction: Literal["front", "back", "left", "right", "above", "below"],
-        distance: _Distance = 1.5,
-    ) -> PositionResult:
-        return PositionResult.model_validate(
-            _math.place_user_relative(frame, direction=direction, distance=distance)
-        )
-
-    group.add_function(
-        "place_user_relative",
-        place_user_relative,
+        "compute_gaze_target",
+        compute_gaze_target,
         description=(
-            "Return a gravity-aligned position in a named direction from the user. "
-            "Use only when the user is the spatial anchor."
+            "Compute a world position along the user's full 3D gaze ray. "
+            "Use only for explicit gaze language such as 'where I am looking'. "
+            "This function calculates coordinates and does not create or move a scene object."
         ),
     )
 
-    async def place_object_relative(
-        frame: _Frame,
-        anchor: _Position,
-        direction: Annotated[
+    async def compute_user_relative_position(
+        user_frame: _UserFrameArgument,
+        direction_from_user: Annotated[
             Literal["front", "back", "left", "right", "above", "below"],
-            Field(description="Direction from the object anchor; front points toward the user."),
+            Field(description="Named direction whose anchor is the user."),
         ],
-        distance: _Distance = 0.3,
-    ) -> PositionResult:
-        return PositionResult.model_validate(
-            _math.place_object_relative(
-                frame,
-                anchor=anchor,
-                direction=direction,
-                distance=distance,
+        distance_meters: Annotated[
+            float,
+            Field(ge=0, description="Non-negative distance from the user, in metres."),
+        ] = 1.5,
+    ) -> Vector3:
+        return Vector3.model_validate(
+            spatial_math.compute_user_relative_position(
+                user_frame,
+                direction_from_user,
+                distance_meters,
             )
         )
 
     group.add_function(
-        "place_object_relative",
-        place_object_relative,
-        description="Return a gravity-aligned position relative to a scene-object anchor.",
+        "compute_user_relative_position",
+        compute_user_relative_position,
+        description=(
+            "Compute a gravity-aligned world position relative to the user, for requests such as "
+            "'in front of me' or 'to my left'. The user is always the anchor. This function "
+            "calculates coordinates and does not create or move a scene object."
+        ),
     )
 
-    async def displace_object(
-        frame: _Frame,
-        position: _Position,
-        forward: Annotated[float, Field(description="Signed user-forward offset in metres.")] = 0.0,
-        right: Annotated[float, Field(description="Signed user-right offset in metres.")] = 0.0,
-        up: Annotated[float, Field(description="Signed world-up offset in metres.")] = 0.0,
-    ) -> PositionResult:
-        return PositionResult.model_validate(
-            _math.displace_object(
-                frame,
-                position=position,
-                forward=forward,
-                right=right,
-                up=up,
+    async def compute_position_relative_to_anchor(
+        user_frame: _UserFrameArgument,
+        anchor_position: _WorldPositionArgument,
+        relation_to_anchor: Annotated[
+            Literal[
+                "toward_user",
+                "away_from_user",
+                "left_of",
+                "right_of",
+                "above",
+                "below",
+            ],
+            Field(
+                description=(
+                    "Requested relation to the anchor. Horizontal relations use the user's view: "
+                    "toward_user, away_from_user, left_of, or right_of."
+                )
+            ),
+        ],
+        distance_meters: Annotated[
+            float,
+            Field(ge=0, description="Non-negative distance from the anchor, in metres."),
+        ] = 0.3,
+    ) -> Vector3:
+        return Vector3.model_validate(
+            spatial_math.compute_position_relative_to_anchor(
+                user_frame,
+                anchor_position=anchor_position,
+                relation_to_anchor=relation_to_anchor,
+                distance_meters=distance_meters,
             )
         )
 
     group.add_function(
-        "displace_object",
-        displace_object,
-        description="Offset an existing world position in the user's gravity-aligned frame.",
+        "compute_position_relative_to_anchor",
+        compute_position_relative_to_anchor,
+        description=(
+            "Compute a world position relative to a named scene-object anchor. Pass the anchor's "
+            "complete position and describe the relation explicitly as toward/away from the user, "
+            "left/right of the anchor, above, or below. This function calculates coordinates and "
+            "does not mutate either object."
+        ),
     )
 
-    async def move_relative_to(
-        position: _Position,
-        reference: _Position,
-        direction: Literal["toward", "away"],
-        distance: _Distance = 0.5,
-    ) -> PositionResult:
-        return PositionResult.model_validate(
-            _math.move_relative_to(
-                position,
-                reference,
-                direction=direction,
-                distance=distance,
+    async def offset_position_in_user_frame(
+        user_frame: _UserFrameArgument,
+        start_position: _WorldPositionArgument,
+        forward_meters: Annotated[
+            float,
+            Field(description="Signed offset along user-forward, in metres; negative means backward."),
+        ] = 0.0,
+        right_meters: Annotated[
+            float,
+            Field(description="Signed offset along user-right, in metres; negative means left."),
+        ] = 0.0,
+        up_meters: Annotated[
+            float,
+            Field(description="Signed world-up offset, in metres; negative means down."),
+        ] = 0.0,
+    ) -> Vector3:
+        return Vector3.model_validate(
+            spatial_math.offset_position_in_user_frame(
+                user_frame,
+                start_position=start_position,
+                forward_meters=forward_meters,
+                right_meters=right_meters,
+                up_meters=up_meters,
             )
         )
 
     group.add_function(
-        "move_relative_to",
-        move_relative_to,
-        description="Move one position toward or away from a reference by an exact distance.",
+        "offset_position_in_user_frame",
+        offset_position_in_user_frame,
+        description=(
+            "Compute a new world position by applying signed forward, right, and up offsets to an "
+            "existing position in the user's coordinate frame. This function only returns the new "
+            "coordinates; update the scene separately."
+        ),
     )
 
-    async def midpoint(first: _Position, second: _Position) -> PositionResult:
-        return PositionResult.model_validate(_math.midpoint(first, second))
+    async def compute_position_toward_or_away_from_reference(
+        start_position: _WorldPositionArgument,
+        reference_position: _WorldPositionArgument,
+        movement_direction: Annotated[
+            Literal["toward", "away"],
+            Field(description="Whether the result moves toward or away from the reference position."),
+        ],
+        distance_meters: Annotated[
+            float,
+            Field(ge=0, description="Non-negative travel distance, in metres."),
+        ] = 0.5,
+    ) -> Vector3:
+        return Vector3.model_validate(
+            spatial_math.compute_position_toward_or_away_from_reference(
+                start_position,
+                reference_position,
+                movement_direction=movement_direction,
+                distance_meters=distance_meters,
+            )
+        )
 
     group.add_function(
-        "midpoint",
-        midpoint,
-        description="Return the world-space midpoint between two positions.",
+        "compute_position_toward_or_away_from_reference",
+        compute_position_toward_or_away_from_reference,
+        description=(
+            "Compute where a starting position ends after moving an exact distance toward or away "
+            "from a named reference position. No user frame is involved and no scene object is mutated."
+        ),
     )
 
-    async def place_in_container(
-        obj_id: Annotated[str, Field(description="ID of the object being placed inside.")],
-        container: _Position,
-    ) -> ObjectPositionResult:
-        return ObjectPositionResult.model_validate(_math.place_in_container(obj_id, container))
+    async def compute_midpoint(
+        first_position: _WorldPositionArgument,
+        second_position: _WorldPositionArgument,
+    ) -> Vector3:
+        return Vector3.model_validate(spatial_math.compute_midpoint(first_position, second_position))
 
     group.add_function(
-        "place_in_container",
-        place_in_container,
-        description="Pair an object ID with the center position of its container.",
+        "compute_midpoint",
+        compute_midpoint,
+        description=(
+            "Compute the world-space midpoint between two complete positions. "
+            "This function only returns coordinates and does not move either object."
+        ),
     )
 
     yield group

--- a/agent-sdk/xr-ai-nat/xr_ai_nat/functions/spatial_math/functions.py
+++ b/agent-sdk/xr-ai-nat/xr_ai_nat/functions/spatial_math/functions.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed NAT functions for deterministic XR spatial calculations."""
+
+import json
+from typing import Annotated, Literal
+
+from nat.plugin_api import Builder, FunctionGroup, FunctionGroupBaseConfig, register_function_group
+from pydantic import BeforeValidator, Field
+
+from . import _math
+from .schemas import ObjectPositionResult, PositionResult, SpatialFrame, Vector3
+
+
+def _decode_json(value: object) -> object:
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return value
+    return value
+
+
+_Frame = Annotated[
+    SpatialFrame,
+    BeforeValidator(_decode_json),
+    Field(description="Coordinate frame returned by an XR tracking function."),
+]
+_Position = Annotated[
+    Vector3,
+    BeforeValidator(_decode_json),
+    Field(description="A complete world position represented as one {x, y, z} object."),
+]
+_Distance = Annotated[float, Field(ge=0, description="Non-negative distance in metres.")]
+
+
+class SpatialMathFunctionsConfig(FunctionGroupBaseConfig, name="xr_spatial_math"):
+    """Configure pure spatial functions over caller-supplied coordinates."""
+
+
+@register_function_group(config_type=SpatialMathFunctionsConfig)
+async def spatial_math_functions(config: SpatialMathFunctionsConfig, _builder: Builder):
+    group = FunctionGroup(config=config)
+
+    async def position_in_gaze(frame: _Frame, distance: _Distance = 1.5) -> PositionResult:
+        return PositionResult.model_validate(_math.position_in_gaze(frame, distance))
+
+    group.add_function(
+        "position_in_gaze",
+        position_in_gaze,
+        description="Return a position along the user's full 3D gaze direction.",
+    )
+
+    async def place_user_relative(
+        frame: _Frame,
+        direction: Literal["front", "back", "left", "right", "above", "below"],
+        distance: _Distance = 1.5,
+    ) -> PositionResult:
+        return PositionResult.model_validate(
+            _math.place_user_relative(frame, direction=direction, distance=distance)
+        )
+
+    group.add_function(
+        "place_user_relative",
+        place_user_relative,
+        description=(
+            "Return a gravity-aligned position in a named direction from the user. "
+            "Use only when the user is the spatial anchor."
+        ),
+    )
+
+    async def place_object_relative(
+        frame: _Frame,
+        anchor: _Position,
+        direction: Annotated[
+            Literal["front", "back", "left", "right", "above", "below"],
+            Field(description="Direction from the object anchor; front points toward the user."),
+        ],
+        distance: _Distance = 0.3,
+    ) -> PositionResult:
+        return PositionResult.model_validate(
+            _math.place_object_relative(
+                frame,
+                anchor=anchor,
+                direction=direction,
+                distance=distance,
+            )
+        )
+
+    group.add_function(
+        "place_object_relative",
+        place_object_relative,
+        description="Return a gravity-aligned position relative to a scene-object anchor.",
+    )
+
+    async def displace_object(
+        frame: _Frame,
+        position: _Position,
+        forward: Annotated[float, Field(description="Signed user-forward offset in metres.")] = 0.0,
+        right: Annotated[float, Field(description="Signed user-right offset in metres.")] = 0.0,
+        up: Annotated[float, Field(description="Signed world-up offset in metres.")] = 0.0,
+    ) -> PositionResult:
+        return PositionResult.model_validate(
+            _math.displace_object(
+                frame,
+                position=position,
+                forward=forward,
+                right=right,
+                up=up,
+            )
+        )
+
+    group.add_function(
+        "displace_object",
+        displace_object,
+        description="Offset an existing world position in the user's gravity-aligned frame.",
+    )
+
+    async def move_relative_to(
+        position: _Position,
+        reference: _Position,
+        direction: Literal["toward", "away"],
+        distance: _Distance = 0.5,
+    ) -> PositionResult:
+        return PositionResult.model_validate(
+            _math.move_relative_to(
+                position,
+                reference,
+                direction=direction,
+                distance=distance,
+            )
+        )
+
+    group.add_function(
+        "move_relative_to",
+        move_relative_to,
+        description="Move one position toward or away from a reference by an exact distance.",
+    )
+
+    async def midpoint(first: _Position, second: _Position) -> PositionResult:
+        return PositionResult.model_validate(_math.midpoint(first, second))
+
+    group.add_function(
+        "midpoint",
+        midpoint,
+        description="Return the world-space midpoint between two positions.",
+    )
+
+    async def place_in_container(
+        obj_id: Annotated[str, Field(description="ID of the object being placed inside.")],
+        container: _Position,
+    ) -> ObjectPositionResult:
+        return ObjectPositionResult.model_validate(_math.place_in_container(obj_id, container))
+
+    group.add_function(
+        "place_in_container",
+        place_in_container,
+        description="Pair an object ID with the center position of its container.",
+    )
+
+    yield group
+
+
+__all__ = ["SpatialMathFunctionsConfig"]

--- a/agent-sdk/xr-ai-nat/xr_ai_nat/functions/spatial_math/schemas.py
+++ b/agent-sdk/xr-ai-nat/xr_ai_nat/functions/spatial_math/schemas.py
@@ -31,14 +31,4 @@ class SpatialFrame(_StructuredValue):
     up: Vector3
 
 
-class PositionResult(Vector3):
-    """A resolved world-space position."""
-
-
-class ObjectPositionResult(PositionResult):
-    """A resolved position paired with the object that should move."""
-
-    obj_id: str
-
-
-__all__ = ["ObjectPositionResult", "PositionResult", "SpatialFrame", "Vector3"]
+__all__ = ["SpatialFrame", "Vector3"]

--- a/agent-sdk/xr-ai-nat/xr_ai_nat/functions/spatial_math/schemas.py
+++ b/agent-sdk/xr-ai-nat/xr_ai_nat/functions/spatial_math/schemas.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Transport-neutral values used by spatial-math functions."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class _StructuredValue(BaseModel):
+    def __str__(self) -> str:
+        # Text-only agent bridges call str(); JSON keeps the value reusable as a typed tool input.
+        return self.model_dump_json()
+
+
+class Vector3(_StructuredValue):
+    """A position or direction in three-dimensional space."""
+
+    x: float
+    y: float
+    z: float
+
+
+class SpatialFrame(_StructuredValue):
+    """An origin and orthogonal directions supplied by a tracking capability."""
+
+    origin: Vector3
+    forward: Vector3
+    right: Vector3
+    up: Vector3
+
+
+class PositionResult(Vector3):
+    """A resolved world-space position."""
+
+
+class ObjectPositionResult(PositionResult):
+    """A resolved position paired with the object that should move."""
+
+    obj_id: str
+
+
+__all__ = ["ObjectPositionResult", "PositionResult", "SpatialFrame", "Vector3"]

--- a/agent-sdk/xr-ai-nat/xr_ai_nat/plugin.py
+++ b/agent-sdk/xr-ai-nat/xr_ai_nat/plugin.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Register XR AI function groups with NeMo Agent Toolkit."""
+
+from .functions.spatial_math.functions import spatial_math_functions as _spatial_math_functions  # noqa: F401
+
+__all__: list[str] = []

--- a/agent-sdk/xr-ai-nat/xr_ai_nat/plugin.py
+++ b/agent-sdk/xr-ai-nat/xr_ai_nat/plugin.py
@@ -1,8 +1,0 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
-
-"""Register XR AI function groups with NeMo Agent Toolkit."""
-
-from .functions.spatial_math.functions import spatial_math_functions as _spatial_math_functions  # noqa: F401
-
-__all__: list[str] = []

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,7 +16,10 @@ inputs include an explicit spatial frame. This keeps deterministic coordinate
 math in-process and independent of tracking or transport. Vec MCP and the
 spatial tools in OpenXR MCP retain their existing commands and schemas, but now
 delegate to the same pure math core; they are compatibility boundaries rather
-than owners of the capability.
+than owners of the capability. Native function names use calculation verbs,
+identify anchors and reference frames explicitly, and include `_meters` on
+distance arguments. The six operations all return `Vector3`; containment and
+scene mutation remain application responsibilities rather than spatial math.
 
 ### 2026-07-02 — Apple client: CloudXR streaming (visionOS-only)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,8 @@ than owners of the capability. Native function names use calculation verbs,
 identify anchors and reference frames explicitly, and include `_meters` on
 distance arguments. The six operations all return `Vector3`; containment and
 scene mutation remain application responsibilities rather than spatial math.
+Each capability module is also its own NAT plugin entry point, avoiding a
+package-wide import aggregator as more native capabilities are added.
 
 ### 2026-07-02 — Apple client: CloudXR streaming (visionOS-only)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,15 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-07-17 — Spatial calculations become native NAT functions
+
+`agent-sdk/xr-ai-nat` introduces an `xr_spatial_math` NAT function group whose
+inputs include an explicit spatial frame. This keeps deterministic coordinate
+math in-process and independent of tracking or transport. Vec MCP and the
+spatial tools in OpenXR MCP retain their existing commands and schemas, but now
+delegate to the same pure math core; they are compatibility boundaries rather
+than owners of the capability.
+
 ### 2026-07-02 — Apple client: CloudXR streaming (visionOS-only)
 
 `client-samples/ios-visionos/` runs CloudXR as a second transport alongside its

--- a/docs/source/components/mcp-servers.md
+++ b/docs/source/components/mcp-servers.md
@@ -140,8 +140,8 @@ the LLM never has to apply signs to user-frame axes:
 - `get_head_pose()` — LLM-friendly pose with derived spatial vectors (no raw
   quaternions): `is_valid`, `position`, `forward`, `right`, `up`, `yaw_deg`,
   `pitch_deg`, `ts`.
-- `position_ahead(distance)` — world position `distance` metres along the user's
-  gaze.
+- `position_ahead(distance)` — world position a non-negative `distance` metres
+  along the user's gaze; invalid negative distances return an error.
 - `position_relative(forward, right, up, origin_x?, origin_y?, origin_z?)` —
   convert user-frame offsets to a world-space position (origin defaults to the
   head).

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "xr-ai-agent",
     "xr-ai-capabilities",
     "xr-ai-models",
+    "xr-ai-nat",
     "xr-ai-pipecat",
     "xr-media-hub",
     "xr-ai-launcher",
@@ -42,6 +43,7 @@ dependencies = [
 xr-ai-agent           = { path = "../agent-sdk",                        editable = true }
 xr-ai-capabilities    = { path = "../agent-sdk/xr-ai-capabilities",     editable = true }
 xr-ai-models          = { path = "../agent-sdk/xr-ai-models",           editable = true }
+xr-ai-nat             = { path = "../agent-sdk/xr-ai-nat",              editable = true }
 xr-ai-pipecat         = { path = "../agent-sdk/xr-ai-pipecat",          editable = true }
 xr-media-hub          = { path = "../server-runtime",                   editable = true }
 xr-ai-launcher        = { path = "../utils/xr-ai-launcher",             editable = true }

--- a/tests/test_oxr_mcp.py
+++ b/tests/test_oxr_mcp.py
@@ -23,7 +23,27 @@ pytest.importorskip(
            "not CPU-viable. See tests/README.md.",
 )
 
+build_mcp = pytest.importorskip(
+    "oxr_mcp_server.__main__",
+    reason="oxr-mcp is exercised only on a GPU host with its native dependencies installed",
+).build_mcp
+
 pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+
+class _NeverCalledPoseSource:
+    def get_pose(self) -> dict:
+        raise AssertionError("negative distances must be rejected before reading a pose")
+
+
+async def test_position_ahead_rejects_negative_distance() -> None:
+    result = await build_mcp(_NeverCalledPoseSource()).call_tool(
+        "position_ahead", {"distance": -1.0}
+    )
+
+    assert result.structured_content == {
+        "error": "distance must be non-negative; flip the direction instead"
+    }
 
 
 @pytest.mark.skip(reason="oxr-mcp smoke test requires a GPU host with CloudXR — see tests/README.md")

--- a/tests/test_spatial_math_functions.py
+++ b/tests/test_spatial_math_functions.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU-only tests for the native spatial-math function group."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from nat.builder.workflow_builder import WorkflowBuilder
+from xr_ai_nat.functions.spatial_math import SpatialFrame, SpatialMathFunctionsConfig, Vector3
+
+_FRAME = SpatialFrame(
+    origin=Vector3(x=1.0, y=1.5, z=2.0),
+    forward=Vector3(x=0.0, y=0.0, z=-1.0),
+    right=Vector3(x=1.0, y=0.0, z=0.0),
+    up=Vector3(x=0.0, y=1.0, z=0.0),
+)
+
+
+@pytest.mark.asyncio
+async def test_spatial_math_group_exposes_minimal_task_shaped_functions() -> None:
+    async with WorkflowBuilder() as builder:
+        await builder.add_function_group("spatial_math", SpatialMathFunctionsConfig())
+        group = await builder.get_function_group("spatial_math")
+        functions = await group.get_all_functions()
+
+    assert set(functions) == {
+        "spatial_math__displace_object",
+        "spatial_math__midpoint",
+        "spatial_math__move_relative_to",
+        "spatial_math__place_in_container",
+        "spatial_math__place_object_relative",
+        "spatial_math__place_user_relative",
+        "spatial_math__position_in_gaze",
+    }
+
+
+@pytest.mark.asyncio
+async def test_spatial_math_functions_accept_structured_and_serialized_values() -> None:
+    frame = _FRAME.model_dump()
+    async with WorkflowBuilder() as builder:
+        await builder.add_function_group("spatial_math", SpatialMathFunctionsConfig())
+        group = await builder.get_function_group("spatial_math")
+        functions = await group.get_all_functions()
+
+        gaze = await functions["spatial_math__position_in_gaze"].ainvoke(
+            {"frame": json.dumps(frame), "distance": 2.0}
+        )
+        user_relative = await functions["spatial_math__place_user_relative"].ainvoke(
+            {"frame": frame, "direction": "front", "distance": 1.5}
+        )
+        object_relative = await functions["spatial_math__place_object_relative"].ainvoke(
+            {
+                "frame": frame,
+                "anchor": {"x": 1.0, "y": 1.5, "z": 0.5},
+                "direction": "right",
+                "distance": 0.3,
+            }
+        )
+        displaced = await functions["spatial_math__displace_object"].ainvoke(
+            {
+                "frame": frame,
+                "position": {"x": 4.0, "y": 1.0, "z": 5.0},
+                "forward": 2.0,
+                "up": 0.2,
+            }
+        )
+        moved = await functions["spatial_math__move_relative_to"].ainvoke(
+            {
+                "position": {"x": -1.0, "y": 1.0, "z": -2.0},
+                "reference": {"x": 1.0, "y": 1.0, "z": -2.0},
+                "direction": "toward",
+                "distance": 0.4,
+            }
+        )
+        midpoint = await functions["spatial_math__midpoint"].ainvoke(
+            {
+                "first": {"x": -1.0, "y": 1.0, "z": -2.0},
+                "second": {"x": 3.0, "y": 2.0, "z": 0.0},
+            }
+        )
+        contained = await functions["spatial_math__place_in_container"].ainvoke(
+            {"obj_id": "sphere-0", "container": {"x": 0.4, "y": 1.2, "z": -1.7}}
+        )
+
+    assert gaze.model_dump() == {"x": 1.0, "y": 1.5, "z": 0.0}
+    assert user_relative.model_dump() == {"x": 1.0, "y": 1.5, "z": 0.5}
+    assert object_relative.model_dump() == {"x": 1.3, "y": 1.5, "z": 0.5}
+    assert displaced.model_dump() == {"x": 4.0, "y": 1.2, "z": 3.0}
+    assert moved.model_dump() == {"x": -0.6, "y": 1.0, "z": -2.0}
+    assert midpoint.model_dump() == {"x": 1.0, "y": 1.5, "z": -1.0}
+    assert contained.model_dump() == {
+        "x": 0.4,
+        "y": 1.2,
+        "z": -1.7,
+        "obj_id": "sphere-0",
+    }
+
+
+@pytest.mark.asyncio
+async def test_spatial_math_schema_rejects_negative_named_distance() -> None:
+    async with WorkflowBuilder() as builder:
+        await builder.add_function_group("spatial_math", SpatialMathFunctionsConfig())
+        group = await builder.get_function_group("spatial_math")
+        functions = await group.get_all_functions()
+
+        with pytest.raises(ValueError):
+            await functions["spatial_math__place_user_relative"].ainvoke(
+                {"frame": _FRAME.model_dump(), "direction": "front", "distance": -1.0}
+            )

--- a/tests/test_spatial_math_functions.py
+++ b/tests/test_spatial_math_functions.py
@@ -20,21 +20,53 @@ _FRAME = SpatialFrame(
 
 
 @pytest.mark.asyncio
-async def test_spatial_math_group_exposes_minimal_task_shaped_functions() -> None:
+async def test_spatial_math_group_exposes_explicit_coordinate_calculations() -> None:
     async with WorkflowBuilder() as builder:
         await builder.add_function_group("spatial_math", SpatialMathFunctionsConfig())
         group = await builder.get_function_group("spatial_math")
         functions = await group.get_all_functions()
 
     assert set(functions) == {
-        "spatial_math__displace_object",
-        "spatial_math__midpoint",
-        "spatial_math__move_relative_to",
-        "spatial_math__place_in_container",
-        "spatial_math__place_object_relative",
-        "spatial_math__place_user_relative",
-        "spatial_math__position_in_gaze",
+        "spatial_math__compute_gaze_target",
+        "spatial_math__compute_midpoint",
+        "spatial_math__compute_position_relative_to_anchor",
+        "spatial_math__compute_position_toward_or_away_from_reference",
+        "spatial_math__compute_user_relative_position",
+        "spatial_math__offset_position_in_user_frame",
     }
+
+    expected_inputs = {
+        "spatial_math__compute_gaze_target": {"user_frame", "distance_meters"},
+        "spatial_math__compute_user_relative_position": {
+            "user_frame",
+            "direction_from_user",
+            "distance_meters",
+        },
+        "spatial_math__compute_position_relative_to_anchor": {
+            "user_frame",
+            "anchor_position",
+            "relation_to_anchor",
+            "distance_meters",
+        },
+        "spatial_math__offset_position_in_user_frame": {
+            "user_frame",
+            "start_position",
+            "forward_meters",
+            "right_meters",
+            "up_meters",
+        },
+        "spatial_math__compute_position_toward_or_away_from_reference": {
+            "start_position",
+            "reference_position",
+            "movement_direction",
+            "distance_meters",
+        },
+        "spatial_math__compute_midpoint": {"first_position", "second_position"},
+    }
+    for name, function in functions.items():
+        properties = function.input_schema.model_json_schema()["properties"]
+        assert set(properties) == expected_inputs[name]
+        assert all(value.get("description") for value in properties.values())
 
 
 @pytest.mark.asyncio
@@ -45,44 +77,45 @@ async def test_spatial_math_functions_accept_structured_and_serialized_values() 
         group = await builder.get_function_group("spatial_math")
         functions = await group.get_all_functions()
 
-        gaze = await functions["spatial_math__position_in_gaze"].ainvoke(
-            {"frame": json.dumps(frame), "distance": 2.0}
+        gaze = await functions["spatial_math__compute_gaze_target"].ainvoke(
+            {"user_frame": json.dumps(frame), "distance_meters": 2.0}
         )
-        user_relative = await functions["spatial_math__place_user_relative"].ainvoke(
-            {"frame": frame, "direction": "front", "distance": 1.5}
-        )
-        object_relative = await functions["spatial_math__place_object_relative"].ainvoke(
+        user_relative = await functions["spatial_math__compute_user_relative_position"].ainvoke(
             {
-                "frame": frame,
-                "anchor": {"x": 1.0, "y": 1.5, "z": 0.5},
-                "direction": "right",
-                "distance": 0.3,
+                "user_frame": frame,
+                "direction_from_user": "front",
+                "distance_meters": 1.5,
             }
         )
-        displaced = await functions["spatial_math__displace_object"].ainvoke(
+        object_relative = await functions["spatial_math__compute_position_relative_to_anchor"].ainvoke(
             {
-                "frame": frame,
-                "position": {"x": 4.0, "y": 1.0, "z": 5.0},
-                "forward": 2.0,
-                "up": 0.2,
+                "user_frame": frame,
+                "anchor_position": {"x": 1.0, "y": 1.5, "z": 0.5},
+                "relation_to_anchor": "right_of",
+                "distance_meters": 0.3,
             }
         )
-        moved = await functions["spatial_math__move_relative_to"].ainvoke(
+        displaced = await functions["spatial_math__offset_position_in_user_frame"].ainvoke(
             {
-                "position": {"x": -1.0, "y": 1.0, "z": -2.0},
-                "reference": {"x": 1.0, "y": 1.0, "z": -2.0},
-                "direction": "toward",
-                "distance": 0.4,
+                "user_frame": frame,
+                "start_position": {"x": 4.0, "y": 1.0, "z": 5.0},
+                "forward_meters": 2.0,
+                "up_meters": 0.2,
             }
         )
-        midpoint = await functions["spatial_math__midpoint"].ainvoke(
+        moved = await functions["spatial_math__compute_position_toward_or_away_from_reference"].ainvoke(
             {
-                "first": {"x": -1.0, "y": 1.0, "z": -2.0},
-                "second": {"x": 3.0, "y": 2.0, "z": 0.0},
+                "start_position": {"x": -1.0, "y": 1.0, "z": -2.0},
+                "reference_position": {"x": 1.0, "y": 1.0, "z": -2.0},
+                "movement_direction": "toward",
+                "distance_meters": 0.4,
             }
         )
-        contained = await functions["spatial_math__place_in_container"].ainvoke(
-            {"obj_id": "sphere-0", "container": {"x": 0.4, "y": 1.2, "z": -1.7}}
+        midpoint = await functions["spatial_math__compute_midpoint"].ainvoke(
+            {
+                "first_position": {"x": -1.0, "y": 1.0, "z": -2.0},
+                "second_position": {"x": 3.0, "y": 2.0, "z": 0.0},
+            }
         )
 
     assert gaze.model_dump() == {"x": 1.0, "y": 1.5, "z": 0.0}
@@ -91,11 +124,25 @@ async def test_spatial_math_functions_accept_structured_and_serialized_values() 
     assert displaced.model_dump() == {"x": 4.0, "y": 1.2, "z": 3.0}
     assert moved.model_dump() == {"x": -0.6, "y": 1.0, "z": -2.0}
     assert midpoint.model_dump() == {"x": 1.0, "y": 1.5, "z": -1.0}
-    assert contained.model_dump() == {
-        "x": 0.4,
-        "y": 1.2,
-        "z": -1.7,
-        "obj_id": "sphere-0",
+
+
+@pytest.mark.asyncio
+async def test_anchor_relation_schema_names_the_reference_frame() -> None:
+    async with WorkflowBuilder() as builder:
+        await builder.add_function_group("spatial_math", SpatialMathFunctionsConfig())
+        group = await builder.get_function_group("spatial_math")
+        functions = await group.get_all_functions()
+
+    relation = functions[
+        "spatial_math__compute_position_relative_to_anchor"
+    ].input_schema.model_json_schema()["properties"]["relation_to_anchor"]
+    assert set(relation["enum"]) == {
+        "toward_user",
+        "away_from_user",
+        "left_of",
+        "right_of",
+        "above",
+        "below",
     }
 
 
@@ -107,6 +154,10 @@ async def test_spatial_math_schema_rejects_negative_named_distance() -> None:
         functions = await group.get_all_functions()
 
         with pytest.raises(ValueError):
-            await functions["spatial_math__place_user_relative"].ainvoke(
-                {"frame": _FRAME.model_dump(), "direction": "front", "distance": -1.0}
+            await functions["spatial_math__compute_user_relative_position"].ainvoke(
+                {
+                    "user_frame": _FRAME.model_dump(),
+                    "direction_from_user": "front",
+                    "distance_meters": -1.0,
+                }
             )


### PR DESCRIPTION
## Stack

P00 of 3. This is the base PR and targets `main`.

- **P00:** native spatial-math functions
- P01: native text-memory functions and MCP export
- P02: native vision functions

## What changed

- Registers spatial math directly through its capability-owned `nat.plugins` entry point; there is no package-wide registration module.

- Adds the `xr-ai-nat` package and registers an `xr_spatial_math` NAT function group.
- Exposes six typed coordinate calculations with explicit anchors, reference frames, and metre-based argument names:
  - `compute_gaze_target`
  - `compute_user_relative_position`
  - `compute_position_relative_to_anchor`
  - `offset_position_in_user_frame`
  - `compute_position_toward_or_away_from_reference`
  - `compute_midpoint`
- Every native operation returns `Vector3` and never creates, moves, or associates a scene object.
- Shares the pure spatial implementation with the transitional Vec and OpenXR MCP compatibility surfaces.
- Removes duplicate position-result schemas and keeps containment with the application-level compatibility adapter.
- Adds generated-schema and behavior tests and updates dependency, notice, and public architecture documentation.

## Why

Spatial calculations are in-process deterministic functionality. They should be directly composable as NAT functions instead of requiring an MCP process boundary. Tracking and OpenXR pose acquisition remain separate concerns and pass explicit frames into the math functions.

Calculation-oriented names also prevent an agent from mistaking coordinate helpers for scene mutations. Inputs name whether the user, an object, or another position is the anchor, and distance arguments state their units.

## Compatibility and impact

- Existing Vec MCP tool names and behavior are preserved.
- Existing OpenXR MCP tool names and pose ownership are preserved.
- No sample is migrated or removed in this PR.
- This establishes the bottom-up native function layer used by the following PRs.

## Validation

- Full local CPU presubmit on Python 3.12: 436 passed, 1 skipped, 37 GPU-only deselected.
- Focused native spatial-math and Vec MCP tests: 5 passed.
- Strict Sphinx documentation build passed.
- Ruff, SPDX, DCO, compilation, and diff checks passed.
- GitHub Actions passes on Python 3.11 and Python 3.12, including strict docs, lock verification, SPDX, Ruff, DCO, and CodeQL.