### PR TITLE
feat(nat): add native text-memory functions and MCP export

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,10 @@ deps/               # Gitignored downloaded binaries (e.g. LOVR AppImage)
 - **Agentic functions are NAT-first and in-process.** Reusable deterministic
   functions live in `xr-ai-nat` as typed NAT function groups. Existing MCP
   servers remain compatibility surfaces while their capabilities migrate.
+- **A process boundary does not imply MCP.** `xr-ai-nat[mcp]` may expose an
+  application's explicit native-function list to MCP-only agents, but native
+  applications invoke the functions directly. Text-memory owns transcript
+  JSONL storage; transcript MCP only republishes that capability.
 - **No API keys or tokens in source files** — use env vars or
   `xr_media_hub.yaml`. See `docs/credentials.md`.
 
@@ -124,6 +128,8 @@ them. They split across SDK packages by what they depend on:
 Typed agent functions live in `xr-ai-nat`. `SpatialMathFunctionsConfig`
 registers deterministic coordinate operations that receive an explicit spatial
 frame; tracking and process boundaries remain outside the math functions.
+`TextMemoryFunctionsConfig` provides persistent timestamped text without a
+network boundary.
 
 The **voice pipeline** lives in `xr-ai-pipecat` (it depends on pipecat):
 

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -109,13 +109,16 @@ xr-ai-models  (agent-sdk/xr-ai-models/)
 xr-ai-nat  (agent-sdk/xr-ai-nat/)
     └── nvidia-nat-core ==1.8.0
     └── pydantic >=2.10
+    └── [mcp] fastmcp >=3.4,<4
     Typed, in-process NeMo Agent Toolkit functions for XR capabilities. The
     ``xr_spatial_math`` function group accepts explicit coordinate frames and
     performs deterministic spatial calculations without OpenXR, model, or MCP
-    dependencies. Each capability module is its own ``nat.plugins`` discovery
-    entry point; there is no package-wide registration aggregator. The pure
-    math core is also used by the transitional Vec and OpenXR MCP compatibility
-    surfaces.
+    dependencies. ``xr_text_memory`` owns persistent per-source JSONL text
+    history. Its optional MCP adapter exports an application's explicit native
+    function list without routing native composition through MCP. Each
+    capability module is its own ``nat.plugins`` discovery entry point; there
+    is no package-wide registration aggregator. The spatial pure math core is
+    also used by the transitional Vec and OpenXR MCP compatibility surfaces.
 
 xr-ai-launcher  (utils/xr-ai-launcher/)
     └── (stdlib only — zero runtime deps)
@@ -169,10 +172,12 @@ xr-media-hub  (server-runtime/)
 
 transcript-mcp-server  (agent-mcp-servers/transcript-mcp/)
     └── uvicorn[standard] >=0.29
-    └── fastmcp >=2.0
     └── pyyaml >=6.0
-    Pure FastMCP — every operation is an MCP tool at /mcp (no REST).
-    Storage: JSONL files per participant in configurable transcripts_dir.
+    └── xr-ai-logging [editable: ../../utils/xr-ai-logging]
+    └── xr-ai-nat[mcp] [editable: ../../agent-sdk/xr-ai-nat]
+    Thin MCP compatibility process at /mcp (no REST). It republishes the four
+    native ``xr_text_memory`` functions under their existing MCP tool names;
+    JSONL storage and source identity handling live in xr-ai-nat.
 
 vlm-mcp-server  (agent-mcp-servers/vlm-mcp/)
     └── uvicorn[standard] >=0.29
@@ -265,7 +270,7 @@ xr-ai-tests  (tests/)
     └── pytest >=8.0
     └── pytest-asyncio >=0.23
     └── numpy >=1.24
-    └── fastmcp >=2.0   (only used by tests marked `gpu`)
+    └── fastmcp >=3.4,<4 (MCP adapter contracts and tests marked `gpu`)
     └── Pillow >=10.0   (only used by tests marked `gpu`)
     └── pyyaml >=6.0    (only used by tests marked `gpu`)
     The unmarked suite is multi-client / multi-agent integration tests over
@@ -273,8 +278,8 @@ xr-ai-tests  (tests/)
     NVENC required. Also covers unit tests for the leaf util packages
     (launcher, logging, vllm), a CI-viable subprocess test for
     CPU-viable subprocess smoke tests for transcript-mcp-server and
-    vec-mcp-server (fastmcp pulled in transitively), native spatial-math
-    function-group tests, and the vlm-mcp /
+    vec-mcp-server (fastmcp pulled in transitively), native spatial-math and
+    text-memory function-group tests, generic NAT-to-MCP adapter tests, and the vlm-mcp /
     render-mcp adapter surfaces (mocked upstreams). oxr-mcp is not
     included: it needs native isaacteleop + a CloudXR runtime, so its
     smoke test self-skips on CPU (see tests/README.md).

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ frames are dropped if it is closed.
 | Launcher | `utils/xr-ai-launcher/` | stdlib-only process manager used by samples |
 | Logging | `utils/xr-ai-logging/` | shared loguru sink + stdlib bridge for every process |
 | Agent functions | `agent-sdk/xr-ai-nat/` | Typed, in-process NAT functions for XR capabilities |
-| Agent interfaces | `agent-mcp-servers/` | MCP adapters for XR data & rendering |
+| Agent interfaces | `agent-mcp-servers/` | MCP compatibility processes for XR data & rendering |
 | Agent demos | `agent-samples/` | End-to-end agent pipelines |
 | Tests | `tests/` | Multi-client / multi-agent integration tests |
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -25,6 +25,7 @@ For the per-package dependency mapping, see [`DEPENDENCIES.md`](DEPENDENCIES.md)
 | `uvicorn`      | 0.29.0   | BSD-3-Clause  | https://github.com/encode/uvicorn |
 | `fastapi`      | 0.111.0  | MIT           | https://github.com/fastapi/fastapi |
 | `httpx`        | 0.27.0   | BSD-3-Clause  | https://github.com/encode/httpx |
+| `fastmcp`      | 3.4.0    | Apache-2.0    | https://github.com/PrefectHQ/fastmcp |
 | `livekit`      | 0.17.0   | Apache-2.0    | https://github.com/livekit/python-sdks |
 | `livekit-api`  | 0.7.0    | Apache-2.0    | https://github.com/livekit/python-sdks |
 | `numpy`        | 1.24.0   | BSD-3-Clause  | https://github.com/numpy/numpy |

--- a/agent-mcp-servers/transcript-mcp/pyproject.toml
+++ b/agent-mcp-servers/transcript-mcp/pyproject.toml
@@ -11,9 +11,9 @@ version = "0.1.0"
 requires-python = ">=3.11,<3.13"
 dependencies = [
     "uvicorn[standard]>=0.29",
-    "fastmcp>=2.0",
     "pyyaml>=6.0",
     "xr-ai-logging",
+    "xr-ai-nat[mcp]",
 ]
 
 [project.scripts]
@@ -21,6 +21,7 @@ transcript_mcp_server = "transcript_mcp_server.__main__:run"
 
 [tool.uv.sources]
 xr-ai-logging = { path = "../../utils/xr-ai-logging", editable = true }
+xr-ai-nat     = { path = "../../agent-sdk/xr-ai-nat", editable = true }
 
 [tool.hatch.build.targets.wheel]
 packages = ["transcript_mcp_server"]

--- a/agent-mcp-servers/transcript-mcp/transcript_mcp_server/__init__.py
+++ b/agent-mcp-servers/transcript-mcp/transcript_mcp_server/__init__.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from .__main__ import TranscriptStore, build_app, build_mcp
+from .__main__ import build_app, build_mcp
 
-__all__ = ["TranscriptStore", "build_app", "build_mcp"]
+__all__ = ["build_app", "build_mcp"]

--- a/agent-mcp-servers/transcript-mcp/transcript_mcp_server/__main__.py
+++ b/agent-mcp-servers/transcript-mcp/transcript_mcp_server/__main__.py
@@ -18,16 +18,15 @@ from nat.builder.workflow_builder import WorkflowBuilder
 from xr_ai_logging import setup_logging
 from xr_ai_nat.adapters.mcp import create_mcp_server
 from xr_ai_nat.functions.text_memory import TextMemoryFunctionsConfig
-from xr_ai_nat.functions.text_memory._store import TextMemoryStore as TranscriptStore
 
 
-async def build_mcp(store: TranscriptStore):
+async def build_mcp(directory: str | Path):
     """Republish the four native text-memory functions under legacy MCP names."""
 
     async with WorkflowBuilder() as builder:
         await builder.add_function_group(
             "text_memory",
-            TextMemoryFunctionsConfig(directory=store.directory),
+            TextMemoryFunctionsConfig(directory=directory),
         )
         group = await builder.get_function_group("text_memory")
         functions = await group.get_all_functions()
@@ -54,10 +53,10 @@ async def build_mcp(store: TranscriptStore):
     )
 
 
-async def build_app(store: TranscriptStore):
+async def build_app(directory: str | Path):
     """Return the ASGI app serving the compatibility transport at `/mcp`."""
 
-    return (await build_mcp(store)).http_app(path="/mcp")
+    return (await build_mcp(directory)).http_app(path="/mcp")
 
 
 def run() -> None:
@@ -82,7 +81,7 @@ def run() -> None:
     port = int(config.get("port", 8200))
 
     async def serve() -> None:
-        app = await build_app(TranscriptStore(directory))
+        app = await build_app(directory)
         uvicorn_config = uvicorn.Config(
             app,
             host=host,

--- a/agent-mcp-servers/transcript-mcp/transcript_mcp_server/__main__.py
+++ b/agent-mcp-servers/transcript-mcp/transcript_mcp_server/__main__.py
@@ -1,335 +1,102 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-Transcript MCP server.
+"""MCP compatibility process for the native text-memory functions."""
 
-Pure FastMCP — every operation is an MCP tool at /mcp. There are no REST
-endpoints. Workers use ``fastmcp.Client`` (or any MCP client) to ingest
-transcripts and query stats.
-
-Source IDs
-──────────
-Every record is keyed by a free-form ``source_id`` string. Sources can be
-real LiveKit participant identities (e.g. ``"alice@home"``,
-``"ipad-pro-1"``), or internal/synthetic names (e.g. ``"agent-vlm"``,
-``"tts"``) — the store doesn't interpret the value, it just keys storage
-by it. Filesystem paths are sanitized internally; the original ``source_id``
-is recovered from a ``.identity`` sidecar so list/query round-trip cleanly.
-
-Tools (FastMCP, mounted at /mcp)
-────────────────────────────────
-  query_transcripts(source_id, start_us, end_us) → list[dict]
-      Return all stored transcript segments for *source_id* whose
-      timestamp falls within [start_us, end_us] (Unix microseconds).
-
-  add_transcript(source_id, timestamp_us, text) → dict
-      Append a transcript segment for *source_id*. Returns
-      ``{"ok": true}`` or ``{"error": ...}`` if *text* is empty.
-
-  list_sources() → list[str]
-      All source IDs that have at least one stored transcript.
-
-  get_transcript_stats(source_id) → dict
-      Summary statistics (count, total_chars, earliest_us, latest_us).
-
-Storage
-───────
-Per-source JSONL alongside a ``.identity`` sidecar holding the raw name:
-
-    <transcripts_dir>/<safe>.jsonl
-    <transcripts_dir>/<safe>.identity
-
-Each JSONL line is ``{"timestamp_us": int, "text": str}``. Files persist
-across server restarts. Distinct ``source_id`` values that map to the
-same ``_safe_name`` get a counter suffix (``alice_home``, ``alice_home_2``…)
-so they don't share storage.
-
-Config (transcript_mcp_server.yaml)
-────────────────────────────────────
-    transcripts_dir: /tmp/xr_transcripts
-    host:            0.0.0.0
-    port:            8200
-"""
 from __future__ import annotations
 
 import argparse
 import asyncio
-import json
 import os
-import pathlib
 import sys
+from pathlib import Path
 
 import uvicorn
 import yaml
-from fastmcp import FastMCP
 from loguru import logger
+from nat.builder.workflow_builder import WorkflowBuilder
 from xr_ai_logging import setup_logging
+from xr_ai_nat.adapters.mcp import create_mcp_server
+from xr_ai_nat.functions.text_memory import TextMemoryFunctionsConfig
+from xr_ai_nat.functions.text_memory._store import TextMemoryStore as TranscriptStore
 
 
-def _safe_name(s: str) -> str:
-    """Filesystem-safe version of *s*."""
-    return "".join(c if c.isalnum() or c in "-_." else "_" for c in s)
+async def build_mcp(store: TranscriptStore):
+    """Republish the four native text-memory functions under legacy MCP names."""
 
-
-# ── storage ───────────────────────────────────────────────────────────────────
-
-class TranscriptStore:
-    """Append-only JSONL storage for timestamped transcript segments.
-
-    Records are keyed by ``source_id`` — any string the caller chooses.
-    Sanitization for filesystem paths is internal; the raw ``source_id``
-    is preserved in a ``.identity`` sidecar.
-    """
-
-    def __init__(self, transcripts_dir: str) -> None:
-        self._dir = pathlib.Path(transcripts_dir)
-        self._dir.mkdir(parents=True, exist_ok=True)
-        # Resolve once at construction so the safe root can't be swapped
-        # for a symlink (TOCTOU) between subsequent _check calls.
-        self._root = self._dir.resolve()
-
-    # ── path resolution ──────────────────────────────────────────────
-
-    def _check(self, path: pathlib.Path) -> pathlib.Path:
-        if not path.resolve().is_relative_to(self._root):
-            raise ValueError(f"Path escapes transcript directory: {path}")
-        return path
-
-    def _resolve_or_create(self, source_id: str) -> pathlib.Path:
-        """Resolve *source_id* to ``<dir>/<stem>.jsonl``, creating the
-        ``.identity`` sidecar on first use. Disambiguates collisions
-        with a counter suffix."""
-        safe   = _safe_name(source_id)
-        suffix = 1
-        while True:
-            stem  = safe if suffix == 1 else f"{safe}_{suffix}"
-            ident = self._dir / f"{stem}.identity"
-            jsonl = self._dir / f"{stem}.jsonl"
-            if not ident.exists() and not jsonl.exists():
-                ident.write_text(source_id, encoding="utf-8")
-                return self._check(jsonl)
-            if ident.exists() and ident.read_text(encoding="utf-8") == source_id:
-                return self._check(jsonl)
-            # Legacy pre-sidecar: jsonl exists, no sidecar, raw == safe.
-            if (
-                not ident.exists() and jsonl.exists()
-                and source_id == safe and suffix == 1
-            ):
-                ident.write_text(source_id, encoding="utf-8")
-                return self._check(jsonl)
-            suffix += 1
-
-    def _resolve_existing(self, source_id: str) -> pathlib.Path | None:
-        """Return the JSONL path for *source_id* if any record has been
-        written for it, else ``None`` — never creates anything."""
-        if not self._dir.exists():
-            return None
-        safe = _safe_name(source_id)
-        # Fast path: canonical name.
-        canonical_jsonl = self._dir / f"{safe}.jsonl"
-        canonical_ident = self._dir / f"{safe}.identity"
-        if canonical_jsonl.exists():
-            if canonical_ident.exists():
-                if canonical_ident.read_text(encoding="utf-8").strip() == source_id.strip():
-                    jsonl = self._check(canonical_jsonl)
-                    return jsonl
-            elif source_id == safe:
-                jsonl = self._check(canonical_jsonl)
-                return jsonl
-        # Slow path: scan sidecars.
-        for ident in sorted(self._dir.glob("*.identity")):
-            if ident.read_text(encoding="utf-8").strip() == source_id.strip():
-                jsonl = self._check(ident.with_suffix(".jsonl"))
-                return jsonl if jsonl.exists() else None
-        return None
-
-    # ── operations ───────────────────────────────────────────────────
-
-    def append(self, source_id: str, timestamp_us: int, text: str) -> None:
-        record = json.dumps({"timestamp_us": timestamp_us, "text": text})
-        with self._resolve_or_create(source_id).open("a") as f:
-            f.write(record + "\n")
-
-    def query(self, source_id: str, start_us: int, end_us: int) -> list[dict]:
-        path = self._resolve_existing(source_id)
-        if path is None:
-            return []
-        results = []
-        skipped = 0
-        with path.open() as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    rec = json.loads(line)
-                    if start_us <= rec["timestamp_us"] <= end_us:
-                        results.append(rec)
-                except (json.JSONDecodeError, KeyError):
-                    skipped += 1
-        if skipped:
-            logger.warning(
-                "transcript-mcp: query  source={!r}  skipped {} corrupt line(s) in {}",
-                source_id, skipped, path,
-            )
-        return results
-
-    def list_sources(self) -> list[str]:
-        """Return raw source IDs (read from ``.identity`` sidecars; falls
-        back to file stem for legacy pre-sidecar files)."""
-        if not self._dir.exists():
-            return []
-        out: list[str] = []
-        seen_stems: set[str] = set()
-        for ident in sorted(self._dir.glob("*.identity")):
-            out.append(ident.read_text(encoding="utf-8"))
-            seen_stems.add(ident.stem)
-        for jsonl in sorted(self._dir.glob("*.jsonl")):
-            if jsonl.stem not in seen_stems:
-                out.append(jsonl.stem)
-        return out
-
-    def stats(self, source_id: str) -> dict | None:
-        path = self._resolve_existing(source_id)
-        if path is None:
-            return None
-        count = earliest = latest = total_chars = 0
-        skipped = 0
-        with path.open() as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    rec = json.loads(line)
-                    ts  = rec["timestamp_us"]
-                    count += 1
-                    total_chars += len(rec.get("text", ""))
-                    if earliest == 0 or ts < earliest:
-                        earliest = ts
-                    if ts > latest:
-                        latest = ts
-                except (json.JSONDecodeError, KeyError):
-                    skipped += 1
-        if skipped:
-            logger.warning(
-                "transcript-mcp: stats  source={!r}  skipped {} corrupt line(s) in {}",
-                source_id, skipped, path,
-            )
-        return {
-            "source_id":   source_id,
-            "count":       count,
-            "total_chars": total_chars,
-            "earliest_us": earliest,
-            "latest_us":   latest,
-        }
-
-
-# ── server ────────────────────────────────────────────────────────────────────
-
-def build_mcp(store: TranscriptStore) -> "FastMCP":
-    """Return a composed FastMCP server with all transcript tools bound to *store*."""
-    mcp = FastMCP("transcript-mcp")
-
-    @mcp.tool()
-    def query_transcripts(
-        source_id: str,
-        start_us:  int,
-        end_us:    int,
-    ) -> list[dict]:
-        """
-        Return transcript segments for *source_id* in the time window
-        [start_us, end_us] (Unix microseconds).
-
-        Each result has keys: timestamp_us (int), text (str).
-        Results are ordered by timestamp_us ascending.
-        """
-        results = store.query(source_id, start_us, end_us)
-        results.sort(key=lambda r: r["timestamp_us"])
-        return results
-
-    @mcp.tool()
-    def add_transcript(source_id: str, timestamp_us: int, text: str) -> dict:
-        """
-        Append a transcript segment for *source_id* at *timestamp_us*
-        (Unix microseconds). ``source_id`` is any string — a real
-        participant identity or an internal source name (e.g. ``"agent-vlm"``).
-
-        Returns ``{"ok": true}`` on success, or an error dict if *text* is empty.
-        """
-        if not text.strip():
-            return {"error": "text must not be empty"}
-        store.append(source_id, timestamp_us, text)
-        logger.debug(
-            "add_transcript  source={!r}  ts={}  {!r}",
-            source_id, timestamp_us, text[:80],
+    async with WorkflowBuilder() as builder:
+        await builder.add_function_group(
+            "text_memory",
+            TextMemoryFunctionsConfig(directory=store.directory),
         )
-        return {"ok": True}
+        group = await builder.get_function_group("text_memory")
+        functions = await group.get_all_functions()
 
-    @mcp.tool()
-    def list_sources() -> list[str]:
-        """Return all source IDs that have at least one stored transcript."""
-        return store.list_sources()
+    exports = [
+        functions["text_memory__query_transcripts"],
+        functions["text_memory__add_transcript"],
+        functions["text_memory__list_sources"],
+        functions["text_memory__get_transcript_stats"],
+    ]
+    aliases = {
+        function.instance_name: function.instance_name.removeprefix("text_memory__")
+        for function in exports
+    }
+    return create_mcp_server(
+        "transcript-mcp",
+        exports,
+        tool_names=aliases,
+        untyped_outputs={
+            "text_memory__add_transcript",
+            "text_memory__query_transcripts",
+            "text_memory__get_transcript_stats",
+        },
+    )
 
-    @mcp.tool()
-    def get_transcript_stats(source_id: str) -> dict:
-        """
-        Return summary statistics for *source_id*'s stored transcripts.
 
-        Keys: source_id, count (utterances), total_chars,
-              earliest_us (Unix µs), latest_us (Unix µs).
-        Returns an error dict if no transcripts exist.
-        """
-        result = store.stats(source_id)
-        if result is None:
-            return {"error": f"No transcripts for {source_id!r}"}
-        return result
+async def build_app(store: TranscriptStore):
+    """Return the ASGI app serving the compatibility transport at `/mcp`."""
 
-    return mcp
-
-
-def build_app(store: TranscriptStore):
-    """Return the ASGI app serving the FastMCP HTTP transport at /mcp."""
-    return build_mcp(store).http_app(path="/mcp")
+    return (await build_mcp(store)).http_app(path="/mcp")
 
 
 def run() -> None:
-    p = argparse.ArgumentParser(add_help=False)
-    p.add_argument("--config",     type=pathlib.Path, default=None)
-    p.add_argument("--ready-file", type=pathlib.Path, default=None)
-    ns, _ = p.parse_known_args()
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--config", type=Path, default=None)
+    parser.add_argument("--ready-file", type=Path, default=None)
+    args, _ = parser.parse_known_args()
 
-    cfg: dict = {}
-    if ns.config and ns.config.exists():
-        with open(ns.config) as f:
-            cfg = yaml.safe_load(f) or {}
+    config: dict = {}
+    if args.config and args.config.exists():
+        with args.config.open() as config_file:
+            config = yaml.safe_load(config_file) or {}
 
     sys.stdout.reconfigure(line_buffering=True)
     sys.stderr.reconfigure(line_buffering=True)
     setup_logging("transcript-mcp")
 
-    _run_dir = os.environ.get("XR_RUN_DIR")
-    _default_transcripts = (
-        str(pathlib.Path(_run_dir) / "transcripts") if _run_dir else "/tmp/xr_transcripts"
-    )
-    transcripts_dir = cfg.get("transcripts_dir") or _default_transcripts
-    host            = cfg.get("host", "0.0.0.0")
-    port            = int(cfg.get("port", 8200))
+    run_dir = os.environ.get("XR_RUN_DIR")
+    default_directory = str(Path(run_dir) / "transcripts") if run_dir else "/tmp/xr_transcripts"
+    directory = config.get("transcripts_dir") or default_directory
+    host = config.get("host", "0.0.0.0")
+    port = int(config.get("port", 8200))
 
-    store = TranscriptStore(transcripts_dir)
-    app   = build_app(store)
-
-    async def _serve() -> None:
-        config = uvicorn.Config(app, host=host, port=port, log_level="warning",
-                                log_config=None)
-        server = uvicorn.Server(config)
-        logger.info("transcript-mcp-server  mcp=/mcp  port={}  dir={}", port, transcripts_dir)
-        if ns.ready_file:
-            ns.ready_file.touch()
+    async def serve() -> None:
+        app = await build_app(TranscriptStore(directory))
+        uvicorn_config = uvicorn.Config(
+            app,
+            host=host,
+            port=port,
+            log_level="warning",
+            log_config=None,
+        )
+        server = uvicorn.Server(uvicorn_config)
+        logger.info("transcript-mcp-server  mcp=/mcp  port={}  dir={}", port, directory)
+        if args.ready_file:
+            args.ready_file.touch()
         await server.serve()
 
-    asyncio.run(_serve())
+    asyncio.run(serve())
 
 
 if __name__ == "__main__":

--- a/agent-sdk/xr-ai-nat/README.md
+++ b/agent-sdk/xr-ai-nat/README.md
@@ -35,3 +35,27 @@ moving, or associating a scene object remains the caller's responsibility.
 
 Install the package in the NAT environment so NAT discovers the spatial-math
 registration directly through its capability-specific `nat.plugins` entry point.
+
+## Text memory
+
+The `xr_text_memory` function group owns persistent, per-source JSONL text
+history:
+
+```yaml
+functions:
+  text_memory:
+    _type: xr_text_memory
+    directory: /tmp/xr-text-memory
+```
+
+It exposes `add_transcript`, `query_transcripts`, `list_sources`, and
+`get_transcript_stats` as native functions. Source identifiers are preserved in
+sidecar files even when their filesystem names require sanitization.
+
+## MCP compatibility
+
+Install `xr-ai-nat[mcp]` and pass an explicit list of native functions to
+`xr_ai_nat.adapters.mcp.create_mcp_server` when an application must serve
+MCP-only agents. The adapter publishes one MCP tool per selected function and
+supports aliases for compatibility names; MCP is not used for in-process NAT
+composition.

--- a/agent-sdk/xr-ai-nat/pyproject.toml
+++ b/agent-sdk/xr-ai-nat/pyproject.toml
@@ -15,8 +15,12 @@ dependencies = [
     "pydantic>=2.10",
 ]
 
+[project.optional-dependencies]
+mcp = ["fastmcp>=3.4,<4"]
+
 [project.entry-points."nat.plugins"]
 xr_ai_nat_spatial_math = "xr_ai_nat.functions.spatial_math.functions"
+xr_ai_nat_text_memory = "xr_ai_nat.functions.text_memory.functions"
 
 [tool.hatch.build.targets.wheel]
 packages = ["xr_ai_nat"]

--- a/agent-sdk/xr-ai-nat/xr_ai_nat/adapters/__init__.py
+++ b/agent-sdk/xr-ai-nat/xr_ai_nat/adapters/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Optional transport and framework adapters for native XR functions."""
+
+__all__: list[str] = []

--- a/agent-sdk/xr-ai-nat/xr_ai_nat/adapters/mcp.py
+++ b/agent-sdk/xr-ai-nat/xr_ai_nat/adapters/mcp.py
@@ -10,10 +10,9 @@ from typing import Any, get_args, get_origin
 
 from fastmcp import FastMCP
 from fastmcp.exceptions import ValidationError as FastMCPValidationError
-from fastmcp.tools import Tool
-from fastmcp.tools.base import ToolResult
+from fastmcp.tools import FunctionTool
 from nat.plugin_api import Function
-from pydantic import PrivateAttr, TypeAdapter, ValidationError
+from pydantic import TypeAdapter, ValidationError
 
 
 def _wrapped_schema(schema: dict[str, Any]) -> dict[str, Any]:
@@ -46,37 +45,34 @@ def _output_schema(function: Function, *, untyped: bool) -> dict[str, Any]:
     return _wrapped_schema(schema)
 
 
-class _NatFunctionTool(Tool):
-    _function: Function = PrivateAttr()
+def _function_tool(
+    function: Function,
+    *,
+    name: str | None = None,
+    untyped_output: bool = False,
+) -> FunctionTool:
+    if not function.has_single_output:
+        raise TypeError("MCP exports require a NAT function with a single-response path")
 
-    def __init__(
-        self,
-        function: Function,
-        *,
-        name: str | None = None,
-        untyped_output: bool = False,
-    ) -> None:
-        if not function.has_single_output:
-            raise TypeError("MCP exports require a NAT function with a single-response path")
-        super().__init__(
-            name=name or function.instance_name,
-            description=function.description or "",
-            parameters=function.input_schema.model_json_schema(mode="validation"),
-            output_schema=_output_schema(function, untyped=untyped_output),
-        )
-        self._function = function
-
-    async def run(self, arguments: dict[str, Any]) -> ToolResult:
+    async def invoke(**arguments: Any) -> Any:
         try:
-            request = self._function.input_schema.model_validate(arguments)
+            request = function.input_schema.model_validate(arguments)
         except ValidationError as exc:
             raise FastMCPValidationError(str(exc)) from exc
-        result = await self._function.ainvoke(request)
-        serialized = TypeAdapter(self._function.single_output_type).dump_python(
+        result = await function.ainvoke(request)
+        return TypeAdapter(function.single_output_type).dump_python(
             result,
             mode="json",
         )
-        return self.convert_result(serialized)
+
+    return FunctionTool(
+        name=name or function.instance_name,
+        description=function.description or "",
+        parameters=function.input_schema.model_json_schema(mode="validation"),
+        output_schema=_output_schema(function, untyped=untyped_output),
+        fn=invoke,
+        run_in_thread=False,
+    )
 
 
 def create_mcp_server(
@@ -102,7 +98,7 @@ def create_mcp_server(
     server = FastMCP(name, strict_input_validation=True, mask_error_details=True)
     for function, tool_name in zip(functions, names, strict=True):
         server.add_tool(
-            _NatFunctionTool(
+            _function_tool(
                 function,
                 name=tool_name,
                 untyped_output=function.instance_name in untyped,

--- a/agent-sdk/xr-ai-nat/xr_ai_nat/adapters/mcp.py
+++ b/agent-sdk/xr-ai-nat/xr_ai_nat/adapters/mcp.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Expose an explicit set of native NAT functions to MCP-only agents."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, get_args, get_origin
+
+from fastmcp import FastMCP
+from fastmcp.exceptions import ValidationError as FastMCPValidationError
+from fastmcp.tools import Tool
+from fastmcp.tools.base import ToolResult
+from nat.plugin_api import Function
+from pydantic import PrivateAttr, TypeAdapter, ValidationError
+
+
+def _wrapped_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    definitions = schema.pop("$defs", None)
+    wrapped = {
+        "type": "object",
+        "properties": {"result": schema},
+        "required": ["result"],
+        "x-fastmcp-wrap-result": True,
+    }
+    if definitions:
+        wrapped["$defs"] = definitions
+    return wrapped
+
+
+def _output_schema(function: Function, *, untyped: bool) -> dict[str, Any]:
+    if untyped:
+        output_type = function.single_output_type
+        if get_origin(output_type) is list:
+            item_type = get_args(output_type)[0]
+            item_schema = TypeAdapter(item_type).json_schema(mode="serialization")
+            if item_schema.get("type") == "object":
+                item_schema = {"type": "object", "additionalProperties": True}
+            return _wrapped_schema({"type": "array", "items": item_schema})
+        return {"type": "object", "additionalProperties": True}
+
+    schema = TypeAdapter(function.single_output_type).json_schema(mode="serialization")
+    if schema.get("type") == "object":
+        return schema
+    return _wrapped_schema(schema)
+
+
+class _NatFunctionTool(Tool):
+    _function: Function = PrivateAttr()
+
+    def __init__(
+        self,
+        function: Function,
+        *,
+        name: str | None = None,
+        untyped_output: bool = False,
+    ) -> None:
+        if not function.has_single_output:
+            raise TypeError("MCP exports require a NAT function with a single-response path")
+        super().__init__(
+            name=name or function.instance_name,
+            description=function.description or "",
+            parameters=function.input_schema.model_json_schema(mode="validation"),
+            output_schema=_output_schema(function, untyped=untyped_output),
+        )
+        self._function = function
+
+    async def run(self, arguments: dict[str, Any]) -> ToolResult:
+        try:
+            request = self._function.input_schema.model_validate(arguments)
+        except ValidationError as exc:
+            raise FastMCPValidationError(str(exc)) from exc
+        result = await self._function.ainvoke(request)
+        serialized = TypeAdapter(self._function.single_output_type).dump_python(
+            result,
+            mode="json",
+        )
+        return self.convert_result(serialized)
+
+
+def create_mcp_server(
+    name: str,
+    functions: Sequence[Function],
+    *,
+    tool_names: Mapping[str, str] | None = None,
+    untyped_outputs: set[str] | None = None,
+) -> FastMCP:
+    """Publish one ordinary MCP tool per explicitly selected NAT function."""
+
+    aliases = dict(tool_names or {})
+    function_names = {function.instance_name for function in functions}
+    if unknown := set(aliases) - function_names:
+        raise ValueError(f"MCP aliases reference unknown functions: {sorted(unknown)}")
+    names = [aliases.get(function.instance_name, function.instance_name) for function in functions]
+    if len(names) != len(set(names)):
+        raise ValueError("MCP tool names must be unique")
+    untyped = set(untyped_outputs or ())
+    if unknown := untyped - function_names:
+        raise ValueError(f"Untyped MCP outputs reference unknown functions: {sorted(unknown)}")
+
+    server = FastMCP(name, strict_input_validation=True, mask_error_details=True)
+    for function, tool_name in zip(functions, names, strict=True):
+        server.add_tool(
+            _NatFunctionTool(
+                function,
+                name=tool_name,
+                untyped_output=function.instance_name in untyped,
+            )
+        )
+    return server
+
+
+__all__ = ["create_mcp_server"]

--- a/agent-sdk/xr-ai-nat/xr_ai_nat/functions/text_memory/__init__.py
+++ b/agent-sdk/xr-ai-nat/xr_ai_nat/functions/text_memory/__init__.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public text-memory function group and result schemas."""
+
+from .functions import TextMemoryFunctionsConfig
+from .schemas import OperationResult, TextMemoryError, TranscriptSegment, TranscriptStats
+
+__all__ = [
+    "OperationResult",
+    "TextMemoryError",
+    "TextMemoryFunctionsConfig",
+    "TranscriptSegment",
+    "TranscriptStats",
+]

--- a/agent-sdk/xr-ai-nat/xr_ai_nat/functions/text_memory/_store.py
+++ b/agent-sdk/xr-ai-nat/xr_ai_nat/functions/text_memory/_store.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Append-only JSONL storage owned by the text-memory capability."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from threading import Lock
+
+from .schemas import TranscriptSegment, TranscriptStats
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _safe_name(source_id: str) -> str:
+    return "".join(character if character.isalnum() or character in "-_." else "_" for character in source_id)
+
+
+class TextMemoryStore:
+    """Persistent timestamped text keyed by an arbitrary source identifier."""
+
+    def __init__(self, directory: str | Path) -> None:
+        self.directory = Path(directory)
+        self.directory.mkdir(parents=True, exist_ok=True)
+        self._root = self.directory.resolve()
+        self._lock = Lock()
+
+    def _check(self, path: Path) -> Path:
+        resolved = path.resolve()
+        if not resolved.is_relative_to(self._root):
+            raise ValueError(f"Path escapes text-memory directory: {path}")
+        return resolved
+
+    def _resolve_or_create(self, source_id: str) -> Path:
+        safe = _safe_name(source_id)
+        suffix = 1
+        while True:
+            stem = safe if suffix == 1 else f"{safe}_{suffix}"
+            identity = self.directory / f"{stem}.identity"
+            data = self.directory / f"{stem}.jsonl"
+            if not identity.exists() and not data.exists():
+                identity.write_text(source_id, encoding="utf-8")
+                return self._check(data)
+            if identity.exists() and identity.read_text(encoding="utf-8") == source_id:
+                return self._check(data)
+            if not identity.exists() and data.exists() and source_id == safe and suffix == 1:
+                identity.write_text(source_id, encoding="utf-8")
+                return self._check(data)
+            suffix += 1
+
+    def _resolve_existing(self, source_id: str) -> Path | None:
+        safe = _safe_name(source_id)
+        canonical_data = self.directory / f"{safe}.jsonl"
+        canonical_identity = self.directory / f"{safe}.identity"
+        if canonical_data.exists():
+            if canonical_identity.exists():
+                if canonical_identity.read_text(encoding="utf-8").strip() == source_id.strip():
+                    return self._check(canonical_data)
+            elif source_id == safe:
+                return self._check(canonical_data)
+        for identity in sorted(self.directory.glob("*.identity")):
+            if identity.read_text(encoding="utf-8").strip() == source_id.strip():
+                data = self._check(identity.with_suffix(".jsonl"))
+                return data if data.exists() else None
+        return None
+
+    def append(self, source_id: str, timestamp_us: int, text: str) -> None:
+        record = json.dumps({"timestamp_us": timestamp_us, "text": text})
+        with self._lock, self._resolve_or_create(source_id).open("a", encoding="utf-8") as output:
+            output.write(record + "\n")
+
+    def query(self, source_id: str, start_us: int, end_us: int) -> list[TranscriptSegment]:
+        with self._lock:
+            path = self._resolve_existing(source_id)
+            if path is None:
+                return []
+            lines = path.read_text(encoding="utf-8").splitlines()
+
+        segments: list[TranscriptSegment] = []
+        skipped = 0
+        for line in lines:
+            if not line.strip():
+                continue
+            try:
+                segment = TranscriptSegment.model_validate_json(line)
+            except ValueError:
+                skipped += 1
+                continue
+            if start_us <= segment.timestamp_us <= end_us:
+                segments.append(segment)
+        if skipped:
+            _LOGGER.warning("Skipped %d corrupt text-memory lines in %s", skipped, path)
+        return sorted(segments, key=lambda segment: segment.timestamp_us)
+
+    def list_sources(self) -> list[str]:
+        with self._lock:
+            sources: list[str] = []
+            identified: set[str] = set()
+            for identity in sorted(self.directory.glob("*.identity")):
+                sources.append(identity.read_text(encoding="utf-8"))
+                identified.add(identity.stem)
+            for data in sorted(self.directory.glob("*.jsonl")):
+                if data.stem not in identified:
+                    sources.append(data.stem)
+        return sources
+
+    def stats(self, source_id: str) -> TranscriptStats | None:
+        with self._lock:
+            path = self._resolve_existing(source_id)
+        if path is None:
+            return None
+        segments = self.query(source_id, 0, 9_223_372_036_854_775_807)
+        if not segments:
+            return TranscriptStats(
+                source_id=source_id,
+                count=0,
+                total_chars=0,
+                earliest_us=0,
+                latest_us=0,
+            )
+        return TranscriptStats(
+            source_id=source_id,
+            count=len(segments),
+            total_chars=sum(len(segment.text) for segment in segments),
+            earliest_us=segments[0].timestamp_us,
+            latest_us=segments[-1].timestamp_us,
+        )

--- a/agent-sdk/xr-ai-nat/xr_ai_nat/functions/text_memory/functions.py
+++ b/agent-sdk/xr-ai-nat/xr_ai_nat/functions/text_memory/functions.py
@@ -15,6 +15,8 @@ from .schemas import OperationResult, TextMemoryError, TranscriptSegment, Transc
 
 
 class _EmptyInput(BaseModel):
+    """Explicit empty request keeps the zero-argument function's schema object-shaped."""
+
     pass
 
 

--- a/agent-sdk/xr-ai-nat/xr_ai_nat/functions/text_memory/functions.py
+++ b/agent-sdk/xr-ai-nat/xr_ai_nat/functions/text_memory/functions.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Native NAT functions for persistent timestamped text."""
+
+import asyncio
+from pathlib import Path
+from typing import Annotated
+
+from nat.plugin_api import Builder, FunctionGroup, FunctionGroupBaseConfig, register_function_group
+from pydantic import BaseModel, Field
+
+from ._store import TextMemoryStore
+from .schemas import OperationResult, TextMemoryError, TranscriptSegment, TranscriptStats
+
+
+class _EmptyInput(BaseModel):
+    pass
+
+
+class TextMemoryFunctionsConfig(FunctionGroupBaseConfig, name="xr_text_memory"):
+    """Configure text-memory functions over one persistent directory."""
+
+    directory: str | Path
+
+
+def _function_group(config: TextMemoryFunctionsConfig, store: TextMemoryStore) -> FunctionGroup:
+    group = FunctionGroup(config=config)
+
+    async def add_transcript(
+        source_id: Annotated[str, Field(description="Participant or internal source identifier.")],
+        timestamp_us: Annotated[int, Field(description="Unix timestamp in microseconds.")],
+        text: str,
+    ) -> OperationResult | TextMemoryError:
+        if not text.strip():
+            return TextMemoryError(error="text must not be empty")
+        await asyncio.to_thread(store.append, source_id, timestamp_us, text)
+        return OperationResult()
+
+    group.add_function(
+        "add_transcript",
+        add_transcript,
+        description="Persist one timestamped text segment for a source.",
+    )
+
+    async def query_transcripts(
+        source_id: Annotated[str, Field(description="Participant or internal source identifier.")],
+        start_us: Annotated[int, Field(description="Inclusive window start in Unix microseconds.")],
+        end_us: Annotated[int, Field(description="Inclusive window end in Unix microseconds.")],
+    ) -> list[TranscriptSegment]:
+        return await asyncio.to_thread(store.query, source_id, start_us, end_us)
+
+    group.add_function(
+        "query_transcripts",
+        query_transcripts,
+        description="Return ordered text segments for one source and inclusive time window.",
+    )
+
+    async def list_sources(request: _EmptyInput) -> list[str]:
+        del request
+        return await asyncio.to_thread(store.list_sources)
+
+    group.add_function(
+        "list_sources",
+        list_sources,
+        description="List source identifiers that have persistent text memory.",
+    )
+
+    async def get_transcript_stats(source_id: str) -> TranscriptStats | TextMemoryError:
+        result = await asyncio.to_thread(store.stats, source_id)
+        if result is None:
+            return TextMemoryError(error=f"No transcripts for {source_id!r}")
+        return result
+
+    group.add_function(
+        "get_transcript_stats",
+        get_transcript_stats,
+        description="Return count, character, and time-range statistics for one source.",
+    )
+
+    return group
+
+
+@register_function_group(config_type=TextMemoryFunctionsConfig)
+async def text_memory_functions(config: TextMemoryFunctionsConfig, _builder: Builder):
+    yield _function_group(config, TextMemoryStore(config.directory))
+
+
+__all__ = ["TextMemoryFunctionsConfig"]

--- a/agent-sdk/xr-ai-nat/xr_ai_nat/functions/text_memory/schemas.py
+++ b/agent-sdk/xr-ai-nat/xr_ai_nat/functions/text_memory/schemas.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed values returned by text-memory functions."""
+
+from pydantic import BaseModel
+
+
+class OperationResult(BaseModel):
+    """Confirmation that a text-memory write completed."""
+
+    ok: bool = True
+
+
+class TextMemoryError(BaseModel):
+    """A query error represented as data for agent and MCP callers."""
+
+    error: str
+
+
+class TranscriptSegment(BaseModel):
+    """One timestamped text segment."""
+
+    timestamp_us: int
+    text: str
+
+
+class TranscriptStats(BaseModel):
+    """Summary statistics for one text source."""
+
+    source_id: str
+    count: int
+    total_chars: int
+    earliest_us: int
+    latest_us: int
+
+
+__all__ = ["OperationResult", "TextMemoryError", "TranscriptSegment", "TranscriptStats"]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,14 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-07-17 — Text history becomes native with optional MCP export
+
+The `xr_text_memory` NAT function group now owns persistent transcript JSONL
+storage. Transcript MCP republishes an explicit selection of those functions
+under its existing tool names through the generic `xr-ai-nat[mcp]` adapter.
+Native agents invoke text memory in-process; the MCP process exists only for
+agents that require that protocol.
+
 ### 2026-07-17 — Spatial calculations become native NAT functions
 
 `agent-sdk/xr-ai-nat` introduces an `xr_spatial_math` NAT function group whose

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "pytest-asyncio>=0.23",
     "numpy>=1.24",
     # GPU/MCP test deps — only exercised by tests marked `gpu`.
-    "fastmcp>=2.0",
+    "fastmcp>=3.4,<4",
     "Pillow>=10.0",
     "pyyaml>=6.0",
 ]

--- a/tests/test_text_memory_functions.py
+++ b/tests/test_text_memory_functions.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU-only tests for native text memory and its generic MCP adapter."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+import pytest
+from fastmcp import Client as McpClient
+from nat.builder.workflow_builder import WorkflowBuilder
+from xr_ai_nat.adapters.mcp import create_mcp_server
+from xr_ai_nat.functions.text_memory import TextMemoryError, TextMemoryFunctionsConfig
+
+
+@asynccontextmanager
+async def _functions(directory):
+    async with WorkflowBuilder() as builder:
+        await builder.add_function_group(
+            "text_memory",
+            TextMemoryFunctionsConfig(directory=directory),
+        )
+        group = await builder.get_function_group("text_memory")
+        yield await group.get_all_functions()
+
+
+async def test_text_memory_functions_persist_query_and_summarize(tmp_path) -> None:
+    async with _functions(tmp_path) as functions:
+        assert set(functions) == {
+            "text_memory__add_transcript",
+            "text_memory__get_transcript_stats",
+            "text_memory__list_sources",
+            "text_memory__query_transcripts",
+        }
+        add = functions["text_memory__add_transcript"]
+        query = functions["text_memory__query_transcripts"]
+        sources = functions["text_memory__list_sources"]
+        stats = functions["text_memory__get_transcript_stats"]
+        assert sources.input_schema.model_json_schema()["properties"] == {}
+
+        await add.ainvoke({"source_id": "alice@home", "timestamp_us": 20, "text": "later"})
+        await add.ainvoke({"source_id": "alice@home", "timestamp_us": 10, "text": "first"})
+
+        segments = await query.ainvoke(
+            {"source_id": "alice@home", "start_us": 0, "end_us": 20}
+        )
+        source_ids = await sources.ainvoke({})
+        summary = await stats.ainvoke({"source_id": "alice@home"})
+        missing = await stats.ainvoke({"source_id": "missing"})
+    assert [segment.text for segment in segments] == ["first", "later"]
+    assert source_ids == ["alice@home"]
+    assert summary.model_dump() == {
+        "source_id": "alice@home",
+        "count": 2,
+        "total_chars": 10,
+        "earliest_us": 10,
+        "latest_us": 20,
+    }
+    assert isinstance(missing, TextMemoryError)
+    assert (tmp_path / "alice_home.identity").read_text() == "alice@home"
+
+
+async def test_generic_mcp_adapter_preserves_list_and_object_results(tmp_path) -> None:
+    async with _functions(tmp_path) as functions:
+        exports = [
+            functions["text_memory__add_transcript"],
+            functions["text_memory__query_transcripts"],
+        ]
+        server = create_mcp_server(
+            "text-memory-test",
+            exports,
+            tool_names={
+                "text_memory__add_transcript": "add_transcript",
+                "text_memory__query_transcripts": "query_transcripts",
+            },
+        )
+        async with McpClient(server) as client:
+            tools = {tool.name: tool for tool in await client.list_tools()}
+            added = await client.call_tool(
+                "add_transcript",
+                {"source_id": "agent", "timestamp_us": 100, "text": "remember this"},
+            )
+            queried = await client.call_tool(
+                "query_transcripts",
+                {"source_id": "agent", "start_us": 0, "end_us": 200},
+            )
+    assert set(tools) == {"add_transcript", "query_transcripts"}
+    assert set(tools["add_transcript"].inputSchema["properties"]) == {
+        "source_id",
+        "timestamp_us",
+        "text",
+    }
+    assert added.structured_content == {"result": {"ok": True}}
+    assert queried.structured_content == {
+        "result": [{"timestamp_us": 100, "text": "remember this"}]
+    }
+
+
+async def test_text_memory_disambiguates_sanitized_source_names(tmp_path) -> None:
+    async with _functions(tmp_path) as functions:
+        add = functions["text_memory__add_transcript"]
+        query = functions["text_memory__query_transcripts"]
+        await add.ainvoke({"source_id": "room/a", "timestamp_us": 1, "text": "slash"})
+        await add.ainvoke({"source_id": "room?a", "timestamp_us": 2, "text": "question"})
+        slash = await query.ainvoke({"source_id": "room/a", "start_us": 0, "end_us": 10})
+        question = await query.ainvoke(
+            {"source_id": "room?a", "start_us": 0, "end_us": 10}
+        )
+
+    assert [segment.text for segment in slash] == ["slash"]
+    assert [segment.text for segment in question] == ["question"]
+    assert (tmp_path / "room_a.identity").read_text() == "room/a"
+    assert (tmp_path / "room_a_2.identity").read_text() == "room?a"
+
+
+async def test_mcp_adapter_rejects_ambiguous_or_unknown_names(tmp_path) -> None:
+    async with _functions(tmp_path) as functions:
+        add = functions["text_memory__add_transcript"]
+        with pytest.raises(ValueError, match="unique"):
+            create_mcp_server("duplicate", [add, add])
+        with pytest.raises(ValueError, match="unknown functions"):
+            create_mcp_server("unknown", [add], tool_names={"missing": "add"})
+        with pytest.raises(ValueError, match="unknown functions"):
+            create_mcp_server("unknown", [add], untyped_outputs={"missing"})

--- a/tests/test_text_memory_functions.py
+++ b/tests/test_text_memory_functions.py
@@ -10,6 +10,7 @@ from contextlib import asynccontextmanager
 import pytest
 from fastmcp import Client as McpClient
 from nat.builder.workflow_builder import WorkflowBuilder
+from transcript_mcp_server.__main__ import build_mcp
 from xr_ai_nat.adapters.mcp import create_mcp_server
 from xr_ai_nat.functions.text_memory import TextMemoryError, TextMemoryFunctionsConfig
 
@@ -92,6 +93,25 @@ async def test_generic_mcp_adapter_preserves_list_and_object_results(tmp_path) -
         "text",
     }
     assert added.structured_content == {"result": {"ok": True}}
+    assert queried.structured_content == {
+        "result": [{"timestamp_us": 100, "text": "remember this"}]
+    }
+
+
+async def test_transcript_mcp_functions_survive_builder_teardown(tmp_path) -> None:
+    server = await build_mcp(tmp_path)
+
+    async with McpClient(server) as client:
+        added = await client.call_tool(
+            "add_transcript",
+            {"source_id": "agent", "timestamp_us": 100, "text": "remember this"},
+        )
+        queried = await client.call_tool(
+            "query_transcripts",
+            {"source_id": "agent", "start_us": 0, "end_us": 200},
+        )
+
+    assert added.structured_content == {"ok": True}
     assert queried.structured_content == {
         "result": [{"timestamp_us": 100, "text": "remember this"}]
     }


### PR DESCRIPTION
## Stack

P01 of 3. This PR is stacked on #285 and targets `migration/00-native-spatial-math`.

- P00: #285 — native spatial-math functions
- **P01:** native text-memory functions and MCP export
- P02: native vision functions

Review this PR as the incremental diff from P00. Its base will move to `main` after #285 merges.

## What changed

- Adds a direct text-memory `nat.plugins` entry point alongside spatial math instead of extending a central registration module.

- Adds the `xr_text_memory` NAT function group for persistent timestamped text history.
- Moves transcript JSONL storage, source identity handling, querying, and statistics into the native function implementation.
- Adds a generic `create_mcp_server()` adapter that exports an explicit list of NAT functions as typed MCP tools.
- Rebuilds transcript MCP as a thin compatibility process over the native functions while retaining its existing public tool names and response contracts.
- Adds direct text-memory and generic NAT-to-MCP adapter tests.

## Why

Transcript persistence is repository-native capability logic, not an MCP-specific implementation. NAT applications should invoke it directly in process. MCP remains an optional compatibility boundary for non-NAT consumers and should only republish selected native functions.

## Compatibility and impact

- Existing transcript MCP tool names, JSONL data, source naming, and FastMCP response behavior are preserved.
- The adapter exports only functions explicitly selected by an application.
- No existing sample is migrated or removed in this PR.
- P00 remains independently usable and reviewable.

## Validation

- Full CPU presubmit on Python 3.11: 441 passed, 1 skipped, 37 GPU-only deselected.
- Full CPU presubmit on Python 3.12: 441 passed, 1 skipped, 37 GPU-only deselected.
- Existing transcript MCP end-to-end test passed.
- Existing Vec MCP regression test passed.
- Native text-memory and generic adapter tests passed.
- Ruff, SPDX, DCO, dependency resolution, compilation, and diff checks passed.