### PR TITLE
feat(nat): add native vision functions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,10 @@ deps/               # Gitignored downloaded binaries (e.g. LOVR AppImage)
   application's explicit native-function list to MCP-only agents, but native
   applications invoke the functions directly. Text-memory owns transcript
   JSONL storage; transcript MCP only republishes that capability.
+- **Image acquisition and vision reasoning stay separate.** The native vision
+  function accepts an acquired image path and calls a `VLMService` from
+  `xr-ai-models`; it does not own hub, participant, recording, or MCP state.
+  VLM MCP republishes this function only for MCP clients.
 - **No API keys or tokens in source files** — use env vars or
   `xr_media_hub.yaml`. See `docs/credentials.md`.
 
@@ -129,7 +133,9 @@ Typed agent functions live in `xr-ai-nat`. `SpatialMathFunctionsConfig`
 registers deterministic coordinate operations that receive an explicit spatial
 frame; tracking and process boundaries remain outside the math functions.
 `TextMemoryFunctionsConfig` provides persistent timestamped text without a
-network boundary.
+network boundary. `VisionFunctionsConfig` adds image-question answering over an
+injected `xr-ai-models` VLM while leaving frame acquisition to its own
+capability.
 
 The **voice pipeline** lives in `xr-ai-pipecat` (it depends on pipecat):
 

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -110,6 +110,7 @@ xr-ai-nat  (agent-sdk/xr-ai-nat/)
     └── nvidia-nat-core ==1.8.0
     └── pydantic >=2.10
     └── [mcp] fastmcp >=3.4,<4
+    └── [vision] httpx >=0.27, Pillow >=10.0, xr-ai-models [editable: ../xr-ai-models]
     Typed, in-process NeMo Agent Toolkit functions for XR capabilities. The
     ``xr_spatial_math`` function group accepts explicit coordinate frames and
     performs deterministic spatial calculations without OpenXR, model, or MCP
@@ -119,6 +120,8 @@ xr-ai-nat  (agent-sdk/xr-ai-nat/)
     capability module is its own ``nat.plugins`` discovery entry point; there
     is no package-wide registration aggregator. The spatial pure math core is
     also used by the transitional Vec and OpenXR MCP compatibility surfaces.
+    ``xr_vision`` normalizes an acquired local image and calls an injected
+    xr-ai-models VLM; it does not acquire frames itself.
 
 xr-ai-launcher  (utils/xr-ai-launcher/)
     └── (stdlib only — zero runtime deps)
@@ -181,16 +184,14 @@ transcript-mcp-server  (agent-mcp-servers/transcript-mcp/)
 
 vlm-mcp-server  (agent-mcp-servers/vlm-mcp/)
     └── uvicorn[standard] >=0.29
-    └── fastmcp >=2.0
     └── pyyaml >=6.0
-    └── Pillow >=10.0
-    └── httpx >=0.27   (imported directly to catch httpx.HTTPError from xr-ai-models)
     └── xr-ai-logging  [editable: ../../utils/xr-ai-logging]
     └── xr-ai-models   [editable: ../../agent-sdk/xr-ai-models]
-    Pure FastMCP — one tool at /mcp (no REST). Reads a local image file,
-    encodes it as a JPEG data URL, and calls vlm-server via xr-ai-models
-    ``OpenAICompatVLM``. Back-compat: legacy ``vlm_server:`` URL key is
-    still accepted with a deprecation warning.
+    └── xr-ai-nat[mcp,vision] [editable: ../../agent-sdk/xr-ai-nat]
+    Thin MCP compatibility process with one tool at /mcp (no REST). It
+    republishes ``vision__ask_image`` under the existing ``ask_image`` name.
+    Image normalization and the VLM call live in the native vision function;
+    the legacy ``vlm_server:`` URL key remains accepted with a warning.
 
 video-mcp-server  (agent-mcp-servers/video-mcp/)
     └── uvicorn[standard] >=0.29
@@ -279,7 +280,8 @@ xr-ai-tests  (tests/)
     (launcher, logging, vllm), a CI-viable subprocess test for
     CPU-viable subprocess smoke tests for transcript-mcp-server and
     vec-mcp-server (fastmcp pulled in transitively), native spatial-math and
-    text-memory function-group tests, generic NAT-to-MCP adapter tests, and the vlm-mcp /
+    text-memory and vision function-group tests, generic NAT-to-MCP adapter
+    tests, and the vlm-mcp /
     render-mcp adapter surfaces (mocked upstreams). oxr-mcp is not
     included: it needs native isaacteleop + a CloudXR runtime, so its
     smoke test self-skips on CPU (see tests/README.md).

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -30,6 +30,7 @@ For the per-package dependency mapping, see [`DEPENDENCIES.md`](DEPENDENCIES.md)
 | `livekit-api`  | 0.7.0    | Apache-2.0    | https://github.com/livekit/python-sdks |
 | `numpy`        | 1.24.0   | BSD-3-Clause  | https://github.com/numpy/numpy |
 | `nvidia-nat-core` | 1.8.0 | Apache-2.0    | https://github.com/NVIDIA/NeMo-Agent-Toolkit |
+| `Pillow`       | 10.0.0   | HPND          | https://github.com/python-pillow/Pillow |
 | `pydantic`     | >=2.10   | MIT           | https://github.com/pydantic/pydantic |
 | `websockets`   | 12.0     | BSD-3-Clause  | https://github.com/python-websockets/websockets |
 
@@ -51,6 +52,7 @@ The full text of each SPDX license identifier referenced above is available at:
 - **Apache-2.0**: https://www.apache.org/licenses/LICENSE-2.0 — also bundled
   with this repository as [`LICENSE`](LICENSE).
 - **BSD-3-Clause**: https://opensource.org/license/bsd-3-clause
+- **HPND**: https://opensource.org/license/historical-ntu-disclaimer
 - **MIT**: https://opensource.org/license/mit
 
 Each upstream project repository linked above includes its own canonical

--- a/agent-mcp-servers/vlm-mcp/pyproject.toml
+++ b/agent-mcp-servers/vlm-mcp/pyproject.toml
@@ -11,13 +11,10 @@ version = "0.1.0"
 requires-python = ">=3.11,<3.13"
 dependencies = [
     "uvicorn[standard]>=0.29",
-    "fastmcp>=2.0",
     "pyyaml>=6.0",
-    "Pillow>=10.0",
-    # Imported directly to catch httpx.HTTPError from xr-ai-models' transport.
-    "httpx>=0.27",
     "xr-ai-logging",
     "xr-ai-models",
+    "xr-ai-nat[mcp,vision]",
 ]
 
 [project.scripts]
@@ -26,6 +23,7 @@ vlm_mcp_server = "vlm_mcp_server.__main__:run"
 [tool.uv.sources]
 xr-ai-logging = { path = "../../utils/xr-ai-logging", editable = true }
 xr-ai-models  = { path = "../../agent-sdk/xr-ai-models", editable = true }
+xr-ai-nat     = { path = "../../agent-sdk/xr-ai-nat", editable = true }
 
 [tool.hatch.build.targets.wheel]
 packages = ["vlm_mcp_server"]

--- a/agent-mcp-servers/vlm-mcp/vlm_mcp_server/__main__.py
+++ b/agent-mcp-servers/vlm-mcp/vlm_mcp_server/__main__.py
@@ -61,7 +61,6 @@ from nat.builder.workflow_builder import WorkflowBuilder
 from xr_ai_logging import setup_logging
 from xr_ai_nat.adapters.mcp import create_mcp_server
 from xr_ai_nat.functions.vision import VisionFunctionsConfig
-from xr_ai_nat.functions.vision._images import load_jpeg_data_url as _load_jpeg_data_url  # noqa: F401
 from xr_ai_models import (
     ModelsConfig,
     VLMSpec,

--- a/agent-mcp-servers/vlm-mcp/vlm_mcp_server/__main__.py
+++ b/agent-mcp-servers/vlm-mcp/vlm_mcp_server/__main__.py
@@ -4,12 +4,12 @@
 """
 VLM MCP server.
 
-Pure FastMCP — one tool at /mcp on port 8240. There are no REST endpoints,
-no hub IPC subscription, and no `xr-ai-agent` runtime dependency.
+Thin MCP compatibility process — one tool at /mcp on port 8240. There are no
+REST endpoints, hub IPC subscriptions, or `xr-ai-agent` runtime dependencies.
 
 The single tool ``ask_image(question, image_path)`` reads a local PNG path,
-encodes it as a JPEG data URL, and calls the VLM via ``xr-ai-models``
-``OpenAICompatVLM``. The model's answer is returned verbatim.
+republishes the native ``xr_vision`` image-question function. Image
+normalization and the VLM call stay in the native function.
 
 Typical two-step agent flow
 ───────────────────────────
@@ -48,22 +48,20 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import base64
-import io
 import pathlib
-import re
 import sys
 from contextlib import asynccontextmanager
 from typing import Any
 
-import httpx
 import uvicorn
 import yaml
-from fastmcp import FastMCP
 from loguru import logger
-from PIL import Image
+from nat.builder.workflow_builder import WorkflowBuilder
 
 from xr_ai_logging import setup_logging
+from xr_ai_nat.adapters.mcp import create_mcp_server
+from xr_ai_nat.functions.vision import VisionFunctionsConfig
+from xr_ai_nat.functions.vision._images import load_jpeg_data_url as _load_jpeg_data_url  # noqa: F401
 from xr_ai_models import (
     ModelsConfig,
     VLMSpec,
@@ -137,129 +135,22 @@ def _make_vlm_from_cfg(cfg: dict[str, Any]) -> tuple[VLMService, float]:
     return make_vlm(config, "vlm"), vlm_request_timeout_s
 
 
-# ── image helpers ─────────────────────────────────────────────────────────────
-
-def _load_jpeg_data_url(image_path: str, quality: int = 85) -> str:
-    """Open *image_path*, convert to RGB, encode as a JPEG data URL.
-
-    Runs synchronously — caller is expected to invoke via
-    ``loop.run_in_executor`` to keep the asyncio loop responsive.
-    """
-    with Image.open(image_path) as img:
-        img = img.convert("RGB")
-        buf = io.BytesIO()
-        img.save(buf, format="JPEG", quality=quality)
-    b64 = base64.b64encode(buf.getvalue()).decode("ascii")
-    return f"data:image/jpeg;base64,{b64}"
-
-
 # ── FastMCP build ─────────────────────────────────────────────────────────────
 
-def build_mcp(vlm: VLMService) -> FastMCP:
-    """Return a FastMCP server with the single ``ask_image`` tool bound."""
-    mcp = FastMCP("vlm-mcp")
+async def build_mcp(vlm: VLMService):
+    """Republish the native vision function under the existing MCP tool name."""
 
-    @mcp.tool()
-    async def ask_image(question: str, image_path: str) -> str:
-        """
-        Ask the vision-language model a question about a local image file.
+    async with WorkflowBuilder() as builder:
+        await builder.add_function_group("vision", VisionFunctionsConfig(vlm=vlm))
+        group = await builder.get_function_group("vision")
+        functions = await group.get_all_functions()
 
-        This is the primary tool for any task that requires visual understanding
-        of the XR scene: describing what the user sees, reading text on screen,
-        identifying objects, checking UI state, answering user questions about
-        their environment, and so on.
-
-        Typical usage pattern
-        ---------------------
-        Step 1 — acquire a frame::
-
-            frame = video_mcp.get_frame_from_time(
-                participant_id="alice",
-                second_ago=0,            # live frame (what the user sees right now)
-                # second_ago=3,          # frame from 3 seconds ago
-                # reference_time_us=..., # pass the user's speech timestamp to avoid
-                #                        # LLM-thinking delay shifting the frame
-            )
-            # frame["path"] is an absolute path to a PNG on the local filesystem
-
-        Step 2 — ask the VLM::
-
-            answer = vlm_mcp.ask_image(
-                question="What objects are on the table?",
-                image_path=frame["path"],
-            )
-
-        Good ``question`` values
-        -------------------------
-        - The user's exact words:  "what is that?"
-        - A rephrasing:            "Describe what the user is looking at."
-        - A specific sub-question: "What text appears on the whiteboard?"
-        - A follow-up:             "List every distinct color visible in the scene."
-        - Counting:                "How many people are in the frame?"
-        - Spatial:                 "Is there anything in the top-left corner?"
-
-        Parameters
-        ----------
-        question
-            Free-form natural-language question or instruction for the VLM.
-            The model receives both the image and this text in the same turn.
-        image_path
-            Absolute path to a local image file (PNG or JPEG). Typically the
-            ``path`` value returned by ``video_mcp.get_frame_from_time``.
-            The file is read from disk and sent to vlm-server as a
-            base64-encoded JPEG (quality 85).
-
-        Returns
-        -------
-        str
-            The VLM's answer, trimmed of leading/trailing whitespace.
-            On error (file not found, server unreachable, etc.) returns a
-            human-readable error string starting with ``"ask_image: ..."``.
-
-        Notes
-        -----
-        - ``image_path`` MUST be the ``path`` value returned by a prior call to
-          ``get_frame_from_time`` or ``get_latest_frame``.  Never invent or guess
-          a path — the tool will return an error and the task will fail.
-        - Image I/O runs in a thread pool so the asyncio event loop is never
-          blocked even for large frames.
-        - The tool does NOT maintain conversation history. Each call is
-          independent; pass relevant context in ``question`` if needed.
-        - vlm-server must be running at the ``base_url`` configured under
-          ``models.vlm`` in ``vlm_mcp_server.yaml`` (default: http://localhost:8100).
-        """
-        if not image_path:
-            return "ask_image: image_path is empty — call video_mcp.get_frame_from_time first."
-        path = pathlib.Path(image_path)
-        if not path.exists():
-            return f"ask_image: file not found at {image_path!r}."
-
-        loop = asyncio.get_running_loop()
-        try:
-            data_url = await loop.run_in_executor(None, _load_jpeg_data_url, str(path))
-        except Exception as exc:
-            logger.exception("ask_image: failed to load {}", image_path)
-            return f"ask_image: failed to read image at {image_path!r}: {exc}"
-
-        try:
-            response = await vlm.ask_image(data_url, question)
-            content = response.content
-        except httpx.HTTPError as exc:
-            logger.exception("ask_image: vlm-server HTTP error")
-            return f"ask_image: vlm-server request failed: {exc}"
-
-        # Belt-and-suspenders: strip any <think> that leaked through despite
-        # enable_thinking=False — cosmos_vlm preset sets this to False but
-        # some model revisions may still emit reasoning tokens.
-        content = re.sub(r"<think>.*?</think>", "", content, flags=re.DOTALL).strip()
-
-        logger.debug(
-            "ask_image  q={!r}  image={}  -> {} chars",
-            question[:80], path.name, len(content),
-        )
-        return content
-
-    return mcp
+    function = functions["vision__ask_image"]
+    return create_mcp_server(
+        "vlm-mcp",
+        [function],
+        tool_names={function.instance_name: "ask_image"},
+    )
 
 
 # ── server ────────────────────────────────────────────────────────────────────
@@ -269,7 +160,7 @@ async def _serve(cfg: dict, ready_file: pathlib.Path | None = None) -> None:
     port = int(cfg.get("port", 8240))
 
     vlm, vlm_request_timeout_s = _make_vlm_from_cfg(cfg)
-    mcp = build_mcp(vlm)
+    mcp = await build_mcp(vlm)
     app = mcp.http_app(path="/mcp")
 
     @asynccontextmanager

--- a/agent-sdk/xr-ai-nat/README.md
+++ b/agent-sdk/xr-ai-nat/README.md
@@ -64,9 +64,10 @@ await builder.add_function_group("vision", config)
 ```
 
 Image acquisition is intentionally separate. A live-frame or video-memory
-function obtains the image first, then passes its path to `vision__ask_image`.
-The vision function performs image I/O off the event loop, normalizes the input
-to JPEG, and makes the model request through `xr-ai-models`.
+function obtains the image first, then passes its exact returned path to
+`vision__ask_image`; callers must never invent or guess a path. The vision
+function performs image I/O off the event loop, normalizes the input to JPEG,
+and makes the model request through `xr-ai-models`.
 
 ## MCP compatibility
 

--- a/agent-sdk/xr-ai-nat/README.md
+++ b/agent-sdk/xr-ai-nat/README.md
@@ -52,6 +52,22 @@ It exposes `add_transcript`, `query_transcripts`, `list_sources`, and
 `get_transcript_stats` as native functions. Source identifiers are preserved in
 sidecar files even when their filesystem names require sanitization.
 
+## Vision
+
+Install `xr-ai-nat[vision]` to use the `xr_vision` function group. The group
+accepts an injected `xr-ai-models` `VLMService` and exposes `ask_image` for a
+local PNG or JPEG path:
+
+```python
+config = VisionFunctionsConfig(vlm=vlm, system_prompt="Answer briefly.")
+await builder.add_function_group("vision", config)
+```
+
+Image acquisition is intentionally separate. A live-frame or video-memory
+function obtains the image first, then passes its path to `vision__ask_image`.
+The vision function performs image I/O off the event loop, normalizes the input
+to JPEG, and makes the model request through `xr-ai-models`.
+
 ## MCP compatibility
 
 Install `xr-ai-nat[mcp]` and pass an explicit list of native functions to

--- a/agent-sdk/xr-ai-nat/pyproject.toml
+++ b/agent-sdk/xr-ai-nat/pyproject.toml
@@ -17,10 +17,15 @@ dependencies = [
 
 [project.optional-dependencies]
 mcp = ["fastmcp>=3.4,<4"]
+vision = ["httpx>=0.27", "Pillow>=10.0", "xr-ai-models"]
 
 [project.entry-points."nat.plugins"]
 xr_ai_nat_spatial_math = "xr_ai_nat.functions.spatial_math.functions"
 xr_ai_nat_text_memory = "xr_ai_nat.functions.text_memory.functions"
+xr_ai_nat_vision = "xr_ai_nat.functions.vision.functions"
+
+[tool.uv.sources]
+xr-ai-models = { path = "../xr-ai-models", editable = true }
 
 [tool.hatch.build.targets.wheel]
 packages = ["xr_ai_nat"]

--- a/agent-sdk/xr-ai-nat/xr_ai_nat/functions/vision/__init__.py
+++ b/agent-sdk/xr-ai-nat/xr_ai_nat/functions/vision/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public native vision function group."""
+
+from .functions import VisionFunctionsConfig
+
+__all__ = ["VisionFunctionsConfig"]

--- a/agent-sdk/xr-ai-nat/xr_ai_nat/functions/vision/_images.py
+++ b/agent-sdk/xr-ai-nat/xr_ai_nat/functions/vision/_images.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Image normalization for VLM inputs."""
+
+import base64
+import io
+from pathlib import Path
+
+
+def load_jpeg_data_url(image_path: str | Path, quality: int = 85) -> str:
+    """Convert a local image to an RGB JPEG data URL."""
+
+    from PIL import Image
+
+    with Image.open(image_path) as image:
+        buffer = io.BytesIO()
+        image.convert("RGB").save(buffer, format="JPEG", quality=quality)
+    encoded = base64.b64encode(buffer.getvalue()).decode("ascii")
+    return f"data:image/jpeg;base64,{encoded}"

--- a/agent-sdk/xr-ai-nat/xr_ai_nat/functions/vision/functions.py
+++ b/agent-sdk/xr-ai-nat/xr_ai_nat/functions/vision/functions.py
@@ -29,8 +29,16 @@ async def vision_functions(config: VisionFunctionsConfig, _builder: Builder):
     group = FunctionGroup(config=config)
 
     async def ask_image(
-        question: Annotated[str, Field(description="Question to answer from the image.")],
-        image_path: Annotated[str, Field(description="Absolute path to a local PNG or JPEG image.")],
+        question: Annotated[str, Field(description="Question to answer from the acquired image.")],
+        image_path: Annotated[
+            str,
+            Field(
+                description=(
+                    "Absolute local PNG or JPEG path returned by image acquisition. "
+                    "Never invent or guess a path."
+                )
+            ),
+        ],
     ) -> str:
         if not image_path:
             return "ask_image: image_path is empty — acquire an image first."
@@ -46,17 +54,15 @@ async def vision_functions(config: VisionFunctionsConfig, _builder: Builder):
             _LOGGER.exception("Failed to load image at %s", image_path)
             return f"ask_image: failed to read image at {image_path!r}: {exc}"
 
+        import httpx
+
         try:
             response = await config.vlm.ask_image(
                 data_url,
                 question,
                 system_prompt=config.system_prompt,
             )
-        except Exception as exc:
-            import httpx
-
-            if not isinstance(exc, httpx.HTTPError):
-                raise
+        except httpx.HTTPError as exc:
             _LOGGER.exception("VLM request failed")
             return f"ask_image: vlm-server request failed: {exc}"
 
@@ -72,8 +78,9 @@ async def vision_functions(config: VisionFunctionsConfig, _builder: Builder):
         "ask_image",
         ask_image,
         description=(
-            "Ask a vision-language model a question about a local image file. "
-            "Acquire the image through the appropriate live or recorded-frame capability first."
+            "Ask a vision-language model a question about an acquired local image file. "
+            "First acquire an image through the appropriate live or recorded-frame capability, "
+            "then pass its exact returned path. Never invent or guess an image path."
         ),
     )
 

--- a/agent-sdk/xr-ai-nat/xr_ai_nat/functions/vision/functions.py
+++ b/agent-sdk/xr-ai-nat/xr_ai_nat/functions/vision/functions.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Native NAT functions for vision-language model queries."""
+
+import asyncio
+import logging
+import re
+from pathlib import Path
+from typing import Annotated, Any
+
+from nat.plugin_api import Builder, FunctionGroup, FunctionGroupBaseConfig, register_function_group
+from pydantic import ConfigDict, Field
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class VisionFunctionsConfig(FunctionGroupBaseConfig, name="xr_vision"):
+    """Configure image-question answering over an injected VLM service."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    vlm: Any = Field(exclude=True, repr=False)
+    system_prompt: str = ""
+
+
+@register_function_group(config_type=VisionFunctionsConfig)
+async def vision_functions(config: VisionFunctionsConfig, _builder: Builder):
+    group = FunctionGroup(config=config)
+
+    async def ask_image(
+        question: Annotated[str, Field(description="Question to answer from the image.")],
+        image_path: Annotated[str, Field(description="Absolute path to a local PNG or JPEG image.")],
+    ) -> str:
+        if not image_path:
+            return "ask_image: image_path is empty — acquire an image first."
+        path = Path(image_path)
+        if not path.exists():
+            return f"ask_image: file not found at {image_path!r}."
+
+        from ._images import load_jpeg_data_url
+
+        try:
+            data_url = await asyncio.to_thread(load_jpeg_data_url, path)
+        except Exception as exc:
+            _LOGGER.exception("Failed to load image at %s", image_path)
+            return f"ask_image: failed to read image at {image_path!r}: {exc}"
+
+        try:
+            response = await config.vlm.ask_image(
+                data_url,
+                question,
+                system_prompt=config.system_prompt,
+            )
+        except Exception as exc:
+            import httpx
+
+            if not isinstance(exc, httpx.HTTPError):
+                raise
+            _LOGGER.exception("VLM request failed")
+            return f"ask_image: vlm-server request failed: {exc}"
+
+        content = re.sub(
+            r"<think>.*?</think>",
+            "",
+            response.content,
+            flags=re.DOTALL,
+        ).strip()
+        return content
+
+    group.add_function(
+        "ask_image",
+        ask_image,
+        description=(
+            "Ask a vision-language model a question about a local image file. "
+            "Acquire the image through the appropriate live or recorded-frame capability first."
+        ),
+    )
+
+    yield group
+
+
+__all__ = ["VisionFunctionsConfig"]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,14 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-07-17 — Image question answering becomes a native vision function
+
+The `xr_vision` NAT function group owns local-image normalization and the
+`xr-ai-models` VLM call. It accepts an already acquired image path so live and
+recorded frame sources remain independently composable. VLM MCP keeps its
+existing `ask_image` tool and configuration, but now republishes the native
+function through the generic MCP adapter.
+
 ### 2026-07-17 — Text history becomes native with optional MCP export
 
 The `xr_text_memory` NAT function group now owns persistent transcript JSONL

--- a/tests/test_vision_functions.py
+++ b/tests/test_vision_functions.py
@@ -8,9 +8,11 @@ from __future__ import annotations
 import base64
 from types import SimpleNamespace
 
+import httpx
 from nat.builder.workflow_builder import WorkflowBuilder
 from PIL import Image
 from xr_ai_nat.functions.vision import VisionFunctionsConfig
+from xr_ai_nat.functions.vision._images import load_jpeg_data_url
 
 
 class _Vlm:
@@ -21,6 +23,21 @@ class _Vlm:
     async def ask_image(self, image: str, question: str, *, system_prompt: str = ""):
         self.calls.append((image, question, system_prompt))
         return SimpleNamespace(content=self.content)
+
+
+class _HttpErrorVlm(_Vlm):
+    async def ask_image(self, image: str, question: str, *, system_prompt: str = ""):
+        raise httpx.HTTPError("backend unavailable")
+
+
+def test_load_jpeg_data_url_emits_data_url(tmp_path) -> None:
+    image_path = tmp_path / "frame.png"
+    Image.new("RGB", (4, 4), color=(20, 40, 60)).save(image_path)
+
+    image_url = load_jpeg_data_url(image_path)
+
+    assert image_url.startswith("data:image/jpeg;base64,")
+    assert base64.b64decode(image_url.split(",", 1)[1]).startswith(b"\xff\xd8")
 
 
 async def test_vision_function_normalizes_image_and_returns_clean_answer(tmp_path) -> None:
@@ -65,3 +82,32 @@ async def test_vision_function_reports_missing_image_without_calling_model(tmp_p
 
     assert "file not found" in answer
     assert vlm.calls == []
+
+
+async def test_vision_function_reports_empty_image_path_without_calling_model() -> None:
+    vlm = _Vlm("unused")
+    async with WorkflowBuilder() as builder:
+        await builder.add_function_group("vision", VisionFunctionsConfig(vlm=vlm))
+        group = await builder.get_function_group("vision")
+        functions = await group.get_all_functions()
+        answer = await functions["vision__ask_image"].ainvoke(
+            {"question": "What is shown?", "image_path": ""}
+        )
+
+    assert answer == "ask_image: image_path is empty — acquire an image first."
+    assert vlm.calls == []
+
+
+async def test_vision_function_reports_http_error(tmp_path) -> None:
+    image_path = tmp_path / "frame.png"
+    Image.new("RGB", (4, 4), color=(20, 40, 60)).save(image_path)
+    vlm = _HttpErrorVlm("unused")
+    async with WorkflowBuilder() as builder:
+        await builder.add_function_group("vision", VisionFunctionsConfig(vlm=vlm))
+        group = await builder.get_function_group("vision")
+        functions = await group.get_all_functions()
+        answer = await functions["vision__ask_image"].ainvoke(
+            {"question": "What is shown?", "image_path": str(image_path)}
+        )
+
+    assert answer == "ask_image: vlm-server request failed: backend unavailable"

--- a/tests/test_vision_functions.py
+++ b/tests/test_vision_functions.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU-only tests for the native image-question vision function."""
+
+from __future__ import annotations
+
+import base64
+from types import SimpleNamespace
+
+from nat.builder.workflow_builder import WorkflowBuilder
+from PIL import Image
+from xr_ai_nat.functions.vision import VisionFunctionsConfig
+
+
+class _Vlm:
+    def __init__(self, content: str) -> None:
+        self.content = content
+        self.calls: list[tuple[str, str, str]] = []
+
+    async def ask_image(self, image: str, question: str, *, system_prompt: str = ""):
+        self.calls.append((image, question, system_prompt))
+        return SimpleNamespace(content=self.content)
+
+
+async def test_vision_function_normalizes_image_and_returns_clean_answer(tmp_path) -> None:
+    image_path = tmp_path / "frame.png"
+    Image.new("RGB", (4, 4), color=(20, 40, 60)).save(image_path)
+    vlm = _Vlm("<think>inspect pixels</think>\n  a blue square  ")
+    config = VisionFunctionsConfig(vlm=vlm, system_prompt="Answer briefly.")
+
+    async with WorkflowBuilder() as builder:
+        await builder.add_function_group("vision", config)
+        group = await builder.get_function_group("vision")
+        functions = await group.get_all_functions()
+        answer = await functions["vision__ask_image"].ainvoke(
+            {"question": "What is shown?", "image_path": str(image_path)}
+        )
+
+    assert set(functions) == {"vision__ask_image"}
+    assert set(functions["vision__ask_image"].input_schema.model_json_schema()["properties"]) == {
+        "question",
+        "image_path",
+    }
+    assert answer == "a blue square"
+    image_url, question, system_prompt = vlm.calls[0]
+    assert question == "What is shown?"
+    assert system_prompt == "Answer briefly."
+    assert image_url.startswith("data:image/jpeg;base64,")
+    assert base64.b64decode(image_url.split(",", 1)[1]).startswith(b"\xff\xd8")
+    dumped_config = config.model_dump()
+    assert "vlm" not in dumped_config
+    assert dumped_config["system_prompt"] == "Answer briefly."
+
+
+async def test_vision_function_reports_missing_image_without_calling_model(tmp_path) -> None:
+    vlm = _Vlm("unused")
+    async with WorkflowBuilder() as builder:
+        await builder.add_function_group("vision", VisionFunctionsConfig(vlm=vlm))
+        group = await builder.get_function_group("vision")
+        functions = await group.get_all_functions()
+        answer = await functions["vision__ask_image"].ainvoke(
+            {"question": "What is shown?", "image_path": str(tmp_path / "missing.png")}
+        )
+
+    assert "file not found" in answer
+    assert vlm.calls == []

--- a/tests/test_vlm_mcp.py
+++ b/tests/test_vlm_mcp.py
@@ -14,7 +14,6 @@ the unreachable-server error path).
 """
 from __future__ import annotations
 
-import base64
 import socket
 import struct
 import zlib
@@ -23,11 +22,11 @@ from typing import Any
 
 import pytest
 from aiohttp import web
+from fastmcp import Client as McpClient
 
 from xr_ai_models.openai_compat import OpenAICompatVLM
 
 from vlm_mcp_server.__main__ import (
-    _load_jpeg_data_url,
     _make_vlm_from_cfg,
     build_mcp,
 )
@@ -119,21 +118,20 @@ def _stub_vlm(stub: StubOpenAI, *, enable_thinking: bool = False) -> OpenAICompa
     )
 
 
-# ── image helper tests ─────────────────────────────────────────────────────────
-
-async def test_load_jpeg_data_url_emits_data_url(png_path: Path):
-    url = _load_jpeg_data_url(str(png_path))
-    assert url.startswith("data:image/jpeg;base64,")
-    # The payload must round-trip through base64 cleanly.
-    head, _, payload = url.partition(",")
-    assert head == "data:image/jpeg;base64"
-    raw = base64.b64decode(payload)
-    # JPEG SOI / EOI markers — proves PIL re-encoded as JPEG, not just relayed PNG.
-    assert raw[:2] == b"\xff\xd8"
-    assert raw[-2:] == b"\xff\xd9"
-
-
 # ── wire-shape golden tests (StubOpenAI) ──────────────────────────────────────
+
+async def test_mcp_tool_description_requires_an_acquired_image_path() -> None:
+    stub = StubOpenAI()
+    async with _stub_vlm(stub) as vlm:
+        mcp = await build_mcp(vlm)
+        async with McpClient(mcp) as client:
+            tools = await client.list_tools()
+
+    assert len(tools) == 1
+    assert "Never invent or guess an image path." in tools[0].description
+    assert tools[0].inputSchema["properties"]["image_path"]["description"] == (
+        "Absolute local PNG or JPEG path returned by image acquisition. Never invent or guess a path."
+    )
 
 async def test_ask_image_relays_response_and_request_shape(png_path: Path):
     """Wire shape with enable_thinking=False (default / cosmos_vlm preset default)."""

--- a/tests/test_vlm_mcp.py
+++ b/tests/test_vlm_mcp.py
@@ -140,7 +140,7 @@ async def test_ask_image_relays_response_and_request_shape(png_path: Path):
     stub = StubOpenAI()
     stub.set_chat_message(content="a cat sitting on a mat")
     async with _stub_vlm(stub, enable_thinking=False) as vlm:
-        mcp = build_mcp(vlm)
+        mcp = await build_mcp(vlm)
 
         result = await mcp.call_tool(
             "ask_image",
@@ -168,7 +168,7 @@ async def test_ask_image_enable_thinking_sets_template_kwarg_true(png_path: Path
     stub = StubOpenAI()
     stub.set_chat_message(content="the answer is yes")
     async with _stub_vlm(stub, enable_thinking=True) as vlm:
-        mcp = build_mcp(vlm)
+        mcp = await build_mcp(vlm)
         await mcp.call_tool(
             "ask_image",
             {"question": "describe", "image_path": str(png_path)},
@@ -183,7 +183,7 @@ async def test_ask_image_strips_think_block(png_path: Path):
     stub = StubOpenAI()
     stub.set_chat_message(content="<think>let me look</think>\n  the answer is yes  ")
     async with _stub_vlm(stub) as vlm:
-        mcp = build_mcp(vlm)
+        mcp = await build_mcp(vlm)
         result = await mcp.call_tool(
             "ask_image",
             {"question": "q?", "image_path": str(png_path)},
@@ -197,7 +197,7 @@ async def test_ask_image_missing_path_returns_error_string(png_path: Path):
     """Missing image_path is a user error — must not raise, returns guidance."""
     stub = StubOpenAI()
     async with _stub_vlm(stub) as vlm:
-        mcp = build_mcp(vlm)
+        mcp = await build_mcp(vlm)
 
         empty = await mcp.call_tool("ask_image", {"question": "q", "image_path": ""})
         assert empty.structured_content["result"].startswith("ask_image: image_path is empty")
@@ -214,7 +214,7 @@ async def test_ask_image_http_error_returns_error_string(png_path: Path):
     stub = StubOpenAI()
     stub.set_chat_status(500)
     async with _stub_vlm(stub) as vlm:
-        mcp = build_mcp(vlm)
+        mcp = await build_mcp(vlm)
         result = await mcp.call_tool(
             "ask_image",
             {"question": "q", "image_path": str(png_path)},
@@ -235,7 +235,7 @@ async def test_make_vlm_from_cfg_legacy_path(mock_vlm, png_path: Path):
         "enable_thinking":       False,
     })
     assert timeout == 5.0
-    mcp = build_mcp(vlm)
+    mcp = await build_mcp(vlm)
     try:
         result = await mcp.call_tool(
             "ask_image",
@@ -266,7 +266,7 @@ async def test_make_vlm_from_cfg_new_models_block(mock_vlm, png_path: Path):
         "vlm_request_timeout_s": 5.0,
         "enable_thinking":       False,
     })
-    mcp = build_mcp(vlm)
+    mcp = await build_mcp(vlm)
     try:
         result = await mcp.call_tool(
             "ask_image",
@@ -304,7 +304,7 @@ async def test_wire_trace_golden_matches_pre_migration_shape(png_path: Path):
     stub = StubOpenAI()
     stub.set_chat_message(content="answer")
     async with _stub_vlm(stub, enable_thinking=False) as vlm:
-        mcp = build_mcp(vlm)
+        mcp = await build_mcp(vlm)
         await mcp.call_tool(
             "ask_image",
             {"question": "test question", "image_path": str(png_path)},


### PR DESCRIPTION
## Stack

P02 of 3. This PR is stacked on #286 and targets `migration/01-native-text-memory`.

- P00: #285 — native spatial-math functions
- P01: #286 — native text-memory functions and MCP export
- **P02:** native vision functions

Review this PR as the incremental diff from P01. Its base will move down the stack as the earlier PRs merge.

## What changed

- Adds a direct vision `nat.plugins` entry point alongside the inherited capabilities instead of extending a central registration module.

- Adds the `xr_vision` NAT function group for asking a VLM questions about an acquired local image.
- Injects the repository `VLMService`, normalizes image input off the event loop, and keeps all model I/O behind `xr-ai-models`.
- Keeps image acquisition separate so live-frame and future video-memory functions can compose with the same vision function.
- Rebuilds VLM MCP as a thin export of `vision__ask_image` through the generic NAT-to-MCP adapter.
- Preserves the existing MCP `ask_image` name, arguments, result shape, error behavior, and model request payload.

## Why

Vision reasoning is reusable native agent functionality. It should not own participant, hub, recording, or MCP state. Accepting an already acquired image path keeps frame acquisition and model reasoning independently composable while allowing MCP-only clients to use the same implementation.

## Compatibility and impact

- Existing VLM MCP configuration and public tool interface are preserved.
- Existing model presets and OpenAI-compatible request behavior remain in `xr-ai-models`.
- No existing sample is migrated or removed in this PR.
- P00 and P01 remain separate review and merge units.

## Validation

- Full CPU presubmit on Python 3.11: 441 passed, 1 skipped, 37 GPU-only deselected.
- Full CPU presubmit on Python 3.12: 441 passed, 1 skipped, 37 GPU-only deselected.
- Existing VLM MCP contract suite: 10 passed.
- Combined native spatial-math, text-memory, adapter, and vision tests passed.
- Existing transcript and Vec MCP regression tests passed.
- Ruff, SPDX, DCO, dependency resolution, compilation, and diff checks passed.