### PR TITLE
fix(text-memory): constrain storage paths

### DIFF
--- a/agent-sdk/xr-ai-nat/xr_ai_nat/functions/text_memory/_store.py
+++ b/agent-sdk/xr-ai-nat/xr_ai_nat/functions/text_memory/_store.py
@@ -23,9 +23,9 @@ class TextMemoryStore:
     """Persistent timestamped text keyed by an arbitrary source identifier."""
 
     def __init__(self, directory: str | Path) -> None:
-        self.directory = Path(directory)
+        self.directory = Path(directory).resolve()
         self.directory.mkdir(parents=True, exist_ok=True)
-        self._root = self.directory.resolve()
+        self._root = self.directory
         self._lock = Lock()
 
     def _check(self, path: Path) -> Path:
@@ -39,29 +39,30 @@ class TextMemoryStore:
         suffix = 1
         while True:
             stem = safe if suffix == 1 else f"{safe}_{suffix}"
-            identity = self.directory / f"{stem}.identity"
-            data = self.directory / f"{stem}.jsonl"
+            identity = self._check(self.directory / f"{stem}.identity")
+            data = self._check(self.directory / f"{stem}.jsonl")
             if not identity.exists() and not data.exists():
                 identity.write_text(source_id, encoding="utf-8")
-                return self._check(data)
+                return data
             if identity.exists() and identity.read_text(encoding="utf-8") == source_id:
-                return self._check(data)
+                return data
             if not identity.exists() and data.exists() and source_id == safe and suffix == 1:
                 identity.write_text(source_id, encoding="utf-8")
-                return self._check(data)
+                return data
             suffix += 1
 
     def _resolve_existing(self, source_id: str) -> Path | None:
         safe = _safe_name(source_id)
-        canonical_data = self.directory / f"{safe}.jsonl"
-        canonical_identity = self.directory / f"{safe}.identity"
+        canonical_data = self._check(self.directory / f"{safe}.jsonl")
+        canonical_identity = self._check(self.directory / f"{safe}.identity")
         if canonical_data.exists():
             if canonical_identity.exists():
                 if canonical_identity.read_text(encoding="utf-8").strip() == source_id.strip():
-                    return self._check(canonical_data)
+                    return canonical_data
             elif source_id == safe:
-                return self._check(canonical_data)
+                return canonical_data
         for identity in sorted(self.directory.glob("*.identity")):
+            identity = self._check(identity)
             if identity.read_text(encoding="utf-8").strip() == source_id.strip():
                 data = self._check(identity.with_suffix(".jsonl"))
                 return data if data.exists() else None
@@ -100,9 +101,11 @@ class TextMemoryStore:
             sources: list[str] = []
             identified: set[str] = set()
             for identity in sorted(self.directory.glob("*.identity")):
+                identity = self._check(identity)
                 sources.append(identity.read_text(encoding="utf-8"))
                 identified.add(identity.stem)
             for data in sorted(self.directory.glob("*.jsonl")):
+                data = self._check(data)
                 if data.stem not in identified:
                     sources.append(data.stem)
         return sources

--- a/tests/test_text_memory_functions.py
+++ b/tests/test_text_memory_functions.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
+from pathlib import Path
 
 import pytest
 from fastmcp import Client as McpClient
@@ -13,6 +14,7 @@ from nat.builder.workflow_builder import WorkflowBuilder
 from transcript_mcp_server.__main__ import build_mcp
 from xr_ai_nat.adapters.mcp import create_mcp_server
 from xr_ai_nat.functions.text_memory import TextMemoryError, TextMemoryFunctionsConfig
+from xr_ai_nat.functions.text_memory._store import TextMemoryStore
 
 
 @asynccontextmanager
@@ -132,6 +134,18 @@ async def test_text_memory_disambiguates_sanitized_source_names(tmp_path) -> Non
     assert [segment.text for segment in question] == ["question"]
     assert (tmp_path / "room_a.identity").read_text() == "room/a"
     assert (tmp_path / "room_a_2.identity").read_text() == "room?a"
+
+
+def test_text_memory_store_does_not_follow_identity_symlinks(tmp_path: Path) -> None:
+    root = tmp_path / "transcripts"
+    outside = tmp_path / "outside.identity"
+    outside.write_text("malicious", encoding="utf-8")
+    store = TextMemoryStore(root)
+    (root / "malicious.jsonl").write_text("", encoding="utf-8")
+    (root / "malicious.identity").symlink_to(outside)
+
+    with pytest.raises(ValueError, match="escapes text-memory directory"):
+        store.query("malicious", 0, 1)
 
 
 async def test_mcp_adapter_rejects_ambiguous_or_unknown_names(tmp_path) -> None:


### PR DESCRIPTION
## What changed

- Validate every text-memory identity and transcript path against the configured storage directory before filesystem access.
- Add regression coverage for an identity symlink that resolves outside the text-memory store.

## Why

Sonar S2083 identified a user-controlled source identifier flowing into a filesystem path.

## Impact

The existing source-ID and on-disk filename scheme is unchanged. Paths that resolve outside the configured text-memory directory are rejected before they can be read or written.

## Validation

- `uv run --project tests pytest tests/test_text_memory_functions.py -q`
- `pre-commit run --files agent-sdk/xr-ai-nat/xr_ai_nat/functions/text_memory/_store.py tests/test_text_memory_functions.py`

`pyright` was unavailable in the test environment.
