### PR TITLE
ci: fix notify job failing with 'not a git repository'

### DIFF
--- a/.github/workflows/nightly-xr-ai-test.yml
+++ b/.github/workflows/nightly-xr-ai-test.yml
@@ -319,7 +319,6 @@ jobs:
     if: >-
       always()
       && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
-      && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/nightly-xr-ai-test.yml
+++ b/.github/workflows/nightly-xr-ai-test.yml
@@ -331,6 +331,7 @@ jobs:
         # run links until someone fixes it and closes it.
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           EVENT_NAME: ${{ github.event_name }}
           COMMIT_SHA: ${{ github.sha }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/nightly-xr-ai-test.yml
+++ b/.github/workflows/nightly-xr-ai-test.yml
@@ -319,6 +319,7 @@ jobs:
     if: >-
       always()
       && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
+      && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:


### PR DESCRIPTION
## Summary

- The `notify` (alert on failure) job runs on a fresh `ubuntu-latest` runner with **no checkout step**
- `gh` CLI falls back to running git to detect the repo, which fails with `fatal: not a git repository (or any of the parent directories): .git`
- Fix: add `GH_REPO: ${{ github.repository }}` to the step's env block — `gh` honors this env var and skips git detection entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)