### PR TITLE
fix(magpie-tts): pin HF model revision to fix nightly GPU test

### DIFF
--- a/.github/workflows/nightly-xr-ai-test.yml
+++ b/.github/workflows/nightly-xr-ai-test.yml
@@ -171,6 +171,17 @@ jobs:
         working-directory: tests
         run: uv sync --python 3.12
 
+      - name: Pre-warm magpie TTS venv
+        # The magpie venv is not part of the main `tests/` workspace — it
+        # lives under ai-services/tts/magpie and is only synced lazily inside
+        # the test.  Pre-warm here so that (a) the ~1 GB NeMo install doesn't
+        # count against the 900 s port-open timeout inside the test, and (b)
+        # failures during install produce a named step, not a cryptic "exited
+        # with code 1" from inside the test.
+        run: |
+          set -euo pipefail
+          uv sync --directory ai-services/tts/magpie
+
       - name: Purge leftover xr-ai-vllm containers (pre)
         # Containers are named `xr-ai-vllm-*` by the vLLM launcher. On a
         # persistent self-hosted runner these can survive a previous run

--- a/ai-services/tts/magpie/magpie_tts_server.yaml
+++ b/ai-services/tts/magpie/magpie_tts_server.yaml
@@ -10,6 +10,13 @@
 #                                         ~1 GB VRAM
 model: nvidia/magpie_tts_multilingual_357m
 
+# Pin to a specific HuggingFace commit so we always load the revision that was
+# validated against the NeMo version in pyproject.toml.  The 2025-07 HEAD added
+# a pt-BR tokenizer that requires newer NeMo API (locale_specific_punct kwarg).
+# Remove this pin after upgrading nemo_toolkit to a version that supports the
+# new model config.
+model_revision: "34d7e40da85cabc97f92198889b65cea27bc7fd1"
+
 # Inference device: "cuda", "cpu", or "auto" (CUDA if available, else CPU).
 device: auto
 

--- a/ai-services/tts/magpie/magpie_tts_server/__main__.py
+++ b/ai-services/tts/magpie/magpie_tts_server/__main__.py
@@ -17,6 +17,8 @@ Accepts --config <path>.yaml (auto-passed by xr-ai-launcher).
 Config keys
 -----------
     model:          str   NeMo TTS model name (required)
+    model_revision: str   HuggingFace commit hash to pin (optional, HF models only).
+                          Omit to always pull HEAD.
     device:         str   "cuda" | "cpu" | "auto" (default: "auto")
     port:           int   HTTP port (default: 8104)
     host:           str   Bind address (default: "0.0.0.0")
@@ -53,11 +55,12 @@ class _TtsBackend:
     """Thread-safe lazy loader for NeMo TTS models."""
 
     def __init__(self, model_name: str, device: str, sample_rate: int,
-                 model_cache: Path) -> None:
+                 model_cache: Path, revision: str | None = None) -> None:
         self._model_name = model_name
         self._device     = device
         self._sample_rate = sample_rate
         self._cache      = model_cache
+        self._revision   = revision
         self._model      = None
         self._lock       = threading.Lock()
 
@@ -75,7 +78,30 @@ class _TtsBackend:
                 device = "cuda" if torch.cuda.is_available() else "cpu"
 
             logger.info("Loading NeMo TTS {!r} on {}…", self._model_name, device)
-            model = MagpieTTSModel.from_pretrained(self._model_name)
+            if self._revision and "/" in self._model_name:
+                # Download a pinned revision from HuggingFace directly, then
+                # restore from the cached .nemo file.  NeMo's from_pretrained()
+                # always pulls HEAD, so we bypass it when a revision is pinned.
+                import nemo
+                from pathlib import PurePosixPath
+                from huggingface_hub import hf_hub_download
+                from huggingface_hub import get_token as _get_hf_token
+
+                nemo_filename = PurePosixPath(self._model_name).name + ".nemo"
+                logger.info("Pinned HF revision {!r} — downloading {} …",
+                            self._revision, nemo_filename)
+                nemo_path = hf_hub_download(
+                    repo_id=self._model_name,
+                    filename=nemo_filename,
+                    revision=self._revision,
+                    library_name="nemo",
+                    library_version=nemo.__version__,
+                    token=_get_hf_token(),
+                )
+                logger.info("Restoring from {}", nemo_path)
+                model = MagpieTTSModel.restore_from(restore_path=nemo_path)
+            else:
+                model = MagpieTTSModel.from_pretrained(self._model_name)
             model.eval()
             if device == "cuda":
                 model = model.cuda()
@@ -115,8 +141,9 @@ def _build_app(cfg: dict, model_cache: Path):
     model_name  = cfg["model"]
     device      = cfg.get("device", "auto")
     sample_rate = int(cfg.get("sample_rate", _DEFAULT_SAMPLE_RATE))
+    revision    = cfg.get("model_revision") or None
 
-    backend = _TtsBackend(model_name, device, sample_rate, model_cache)
+    backend = _TtsBackend(model_name, device, sample_rate, model_cache, revision=revision)
 
     app = FastAPI(title="TTS Server", version="0.1.0")
 

--- a/tests/test_gpu_magpie_tts.py
+++ b/tests/test_gpu_magpie_tts.py
@@ -66,8 +66,17 @@ async def _wait_for_port(port: int, *, proc: subprocess.Popen, timeout: float) -
     deadline = asyncio.get_running_loop().time() + timeout
     while asyncio.get_running_loop().time() < deadline:
         if proc.poll() is not None:
+            out = b""
+            if proc.stdout:
+                out = proc.stdout.read()
+            server_log = (
+                f"\n--- server output (last 8 KB) ---\n{out[-8192:].decode(errors='replace')}"
+                if out
+                else "\n(no server output captured)"
+            )
             raise RuntimeError(
                 f"magpie_tts_server exited early with code {proc.returncode}"
+                + server_log
             )
         if _port_open(port):
             return
@@ -111,15 +120,19 @@ async def test_magpie_tts_smoke(tmp_path: Path) -> None:
 
     port = _pick_port(_DEFAULT_PORT)
 
-    cfg_path = tmp_path / "magpie_tts_server.yaml"
-    cfg_path.write_text(yaml.safe_dump({
+    test_cfg: dict = {
         "model":       model_name,
         "device":      "auto",
         "port":        port,
         "host":        "127.0.0.1",
         "sample_rate": sample_rate,
         "model_cache": str(model_cache),
-    }))
+    }
+    if ref_cfg.get("model_revision"):
+        test_cfg["model_revision"] = ref_cfg["model_revision"]
+
+    cfg_path = tmp_path / "magpie_tts_server.yaml"
+    cfg_path.write_text(yaml.safe_dump(test_cfg))
 
     env = {**os.environ, "XR_AI_LOG_ROOT": str(tmp_path / "logs")}
 


### PR DESCRIPTION
## Summary

- `nvidia/magpie_tts_multilingual_357m` was updated on HuggingFace (commit `195d9d3`) to add a Portuguese-Brazilian tokenizer (`pt-BR`), but NeMo 2.7.x does not support the `pt-BR` locale in `IpaG2p` (`SUPPORTED_LOCALES` list) and also lacks the `locale_specific_punct` kwarg in `IPATokenizer` — both introduced in a newer NeMo version.
- The server crashed immediately on startup with exit code 1, but the test only showed `"exited early with code 1"` — no crash details.
- Nightly GPU tests have been failing since the model was updated.

**Changes:**
- **`magpie_tts_server.yaml`**: Pin `model_revision` to `34d7e40` (the last HF commit compatible with NeMo 2.7.x), with a comment explaining when to remove the pin.
- **`__main__.py`**: Add `model_revision` config key — when set, bypasses NeMo's `from_pretrained()` (which always pulls HEAD) and uses `hf_hub_download(revision=...)` + `restore_from()` instead.
- **`test_gpu_magpie_tts.py`**: Pass `model_revision` through to the test config YAML so the test honours the same pin; also capture server stdout/stderr on early exit (tail 8 KB) so future mystery crashes are diagnosable.
- **`nightly-xr-ai-test.yml`**: Add a pre-warm step that runs `uv sync` for the magpie venv before pytest, so venv-install failures surface as a named CI step rather than a cryptic early-exit inside the test.

## Test plan

- [x] `test_magpie_tts_smoke` passes locally with the pinned revision (verified on GPU machine)
- [x] Nightly GPU CI run with this branch should pass `pytest (gpu)` and confirm the tracking issue is opened/updated by the `alert on failure` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)