### PR TITLE
Apply low-risk fixes from WSL2 setup report

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -353,7 +353,10 @@ xr-ai-tests  (tests/)
     tests, the vlm-mcp adapter, and the sample-local scene native groups plus
     render-mcp adapter surface (LOVR is stubbed). oxr-mcp is not
     included: it needs native isaacteleop + a CloudXR runtime, so its
-    smoke test self-skips on CPU (see tests/README.md).
+    smoke test self-skips on CPU (see tests/README.md). Root pytest adds
+    ai-services/stt-server to its Python path (not a dependency) so the
+    endpoint tests can import its FastAPI app with a mocked backend,
+    avoiding a test-time NeMo installation.
 
     Tests marked `@pytest.mark.gpu` are the local-only set (skipped by
     `-m "not gpu"` in CI). They spawn real ai-services via `uv run` (e.g.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ endpoint and no local GPU is required for the agent or hub.
 
 | Requirement | Version | Notes |
 |---|---|---|
-| OS | Linux | Ubuntu 22.04 / 24.04 recommended |
+| OS | Linux | Ubuntu 22.04 / 24.04 recommended; WSL2 is not officially supported (see **Windows (WSL2)** below) |
 | Python | 3.11 or 3.12 | 3.10 and 3.13 are not supported |
 | [uv](https://docs.astral.sh/uv/) | latest | dependency manager used by all samples |
 | NVIDIA driver | 570+ | required for local model inference |
@@ -83,6 +83,14 @@ Quick smoke-test once installed:
 ```bash
 docker run --rm --gpus all nvidia/cuda:13.0.3-base-ubuntu24.04 nvidia-smi
 ```
+
+**Windows (WSL2)**: not an officially supported or tested platform.
+Per a single field report, `model-servers` and `simple-vlm-example` ran
+end-to-end under WSL2 with Docker Engine installed inside the distribution
+(Docker Desktop's WSL integration does not work for this stack), while
+`xr-render-demo` cannot run there at all (no Vulkan ICD in the WSL GPU
+stack).  Networking caveats and workarounds:
+[Windows (WSL2)](docs/source/getting_started/requirements.md#windows-wsl2).
 
 **GPU-profile prerequisites** — install before `uv sync` for these targets:
 
@@ -167,10 +175,9 @@ they cannot be stopped, avoiding GPU overcommit.
 uv run model_servers --omni-stack
 ```
 
-The default models are public, so no HuggingFace token is required.  Set
-`HF_TOKEN` to lift download rate limits / speed, or to use a gated model — see
-[`docs/credentials.md`](docs/credentials.md).  The launcher won't prompt; it
-prints a one-line notice and continues if the token is unset.
+`HF_TOKEN` is required by default: without it the ~50 GB first-run download
+can stall indefinitely.  See [`docs/credentials.md`](docs/credentials.md)
+for how to set it, or pass `--allow-anonymous` to run without one.
 
 To stop all model servers when done:
 
@@ -207,8 +214,8 @@ uv run simple_vlm_example
 ```
 
 On the very first run weights download from HuggingFace (~23 GB; can take
-several minutes).  The default model is public — no HuggingFace token needed;
-set `HF_TOKEN` only to lift rate limits / speed or for a gated model (see
+several minutes).  `HF_TOKEN` is required by default; pass
+`--allow-anonymous` to run without one (see
 [`docs/credentials.md`](docs/credentials.md)).
 
 **With model-servers pre-running** — if VLM (port 8100) and STT (port 8103)

--- a/agent-samples/model-servers/main.py
+++ b/agent-samples/model-servers/main.py
@@ -30,7 +30,7 @@ import argparse
 import os
 from pathlib import Path
 
-from xr_ai_launcher import Process, detect_gpu_config, run_stack, warn_if_missing
+from xr_ai_launcher import Process, detect_gpu_config, require_credentials, run_stack
 from xr_ai_logging import setup_logging
 from xr_ai_vllm import stop_persistent_servers
 
@@ -125,16 +125,18 @@ def run() -> None:
         help="Start the default Nemotron-3-Nano + Cosmos VLM stack.",
     )
     p.set_defaults(stack="vlm-llm")
+    p.add_argument("--allow-anonymous", action="store_true",
+                   help="Start without HF_TOKEN (unauthenticated downloads "
+                        "of the multi-GB checkpoints may stall indefinitely).")
     ns, _ = p.parse_known_args()
 
     if ns.stop:
         _stop_models()
         return
 
-    # HF_TOKEN is optional for the default (public) models — it only raises HF
-    # rate limits / download speed and is required only for gated models.
-    # Warn instead of prompting; see docs/credentials.md.
-    warn_if_missing("HF_TOKEN")
+    # A missing HF_TOKEN silently stalls the multi-GB first-run download; see
+    # docs/credentials.md.
+    require_credentials("HF_TOKEN", allow_missing=ns.allow_anonymous)
     _stop_incompatible_stack(ns.stack)
     run_stack(_build_processes(ns.stack), _BASE, exit_after_ready=True)
 

--- a/agent-samples/simple-vlm-example/main.py
+++ b/agent-samples/simple-vlm-example/main.py
@@ -24,6 +24,7 @@ profile replaces only the VLM with NVIDIA NIM.
 How to run (from agent-samples/simple-vlm-example/):
     uv sync && uv run simple_vlm_example
 """
+import argparse
 from dataclasses import replace
 from pathlib import Path
 
@@ -31,8 +32,8 @@ from xr_ai_launcher import (
     Process,
     ensure_credentials,
     load_model_deployment,
+    require_credentials,
     run_stack,
-    warn_if_missing,
 )
 from xr_ai_logging import setup_logging
 
@@ -87,11 +88,17 @@ def _build_processes() -> tuple[list[Process], tuple[str, ...]]:
 
 def run() -> None:
     setup_logging("orchestrator", namespace="simple-vlm-example")
+
+    p = argparse.ArgumentParser(add_help=False)
+    p.add_argument("--allow-anonymous", action="store_true",
+                   help="Start without HF_TOKEN (unauthenticated checkpoint "
+                        "downloads may stall indefinitely).")
+    ns, _ = p.parse_known_args()
+
     processes, credentials = _build_processes()
-    # HF_TOKEN is optional for the default (public) model — it only raises HF
-    # rate limits / download speed and is required only for gated models.
-    # Warn instead of prompting; see docs/credentials.md.
-    warn_if_missing("HF_TOKEN")
+    # A missing HF_TOKEN silently stalls the multi-GB first-run download; see
+    # docs/credentials.md.
+    require_credentials("HF_TOKEN", allow_missing=ns.allow_anonymous)
     for credential in credentials:
         ensure_credentials(credential)
     run_stack(processes, _BASE)

--- a/agent-samples/simple-vlm-example/yaml/xr_media_hub.yaml
+++ b/agent-samples/simple-vlm-example/yaml/xr_media_hub.yaml
@@ -21,3 +21,6 @@ web_client_dir:    ../../../client-samples/web
 
 # ── Optional: token server ────────────────────────────────────────────────────
 enable_token_server: true
+# Change if another service holds port 8000 (e.g. iphlpsvc under WSL2 mirrored
+# networking; see the note in server-runtime/xr_media_hub.yaml).
+# token_server_port: 8000

--- a/agent-samples/xr-render-demo/yaml/xr_media_hub.yaml
+++ b/agent-samples/xr-render-demo/yaml/xr_media_hub.yaml
@@ -25,6 +25,9 @@ web_client_dir:    ../../../client-samples/web-xr
 
 # ── Optional: token server ────────────────────────────────────────────────────
 enable_token_server: true
+# Change if another service holds port 8000 (e.g. iphlpsvc under WSL2 mirrored
+# networking; see the note in server-runtime/xr_media_hub.yaml).
+# token_server_port: 8000
 
 # ── Video recording ──────────────────────────────────────────────────────────
 # Disabled: xr-render-demo obtains current frames through LiveFrameSource.

--- a/ai-services/stt-server/stt_server/__main__.py
+++ b/ai-services/stt-server/stt_server/__main__.py
@@ -160,12 +160,6 @@ def _build_app(cfg: dict, model_cache: Path):
                     tmp.write(audio_bytes)
                     tmp_path = tmp.name
                 return backend.transcribe(tmp_path)
-            except Exception as exc:
-                # NeMo can throw on very short / noisy audio — return empty
-                # rather than letting the exception become a 500.
-                import logging as _log
-                _log.getLogger("stt_server").warning("transcribe failed: %s", exc)
-                return ""
             finally:
                 if tmp_path:
                     os.unlink(tmp_path)
@@ -173,8 +167,10 @@ def _build_app(cfg: dict, model_cache: Path):
         try:
             text = await loop.run_in_executor(None, _run)
         except Exception as exc:
+            # Full detail goes to the server log only; the wire gets a stable
+            # generic message so backend paths and runtime state don't leak.
             logger.exception("transcription failed: {}", exc)
-            raise HTTPException(status_code=500, detail=str(exc)) from exc
+            raise HTTPException(status_code=500, detail="transcription failed") from exc
 
         if response_format == "text":
             return PlainTextResponse(text)

--- a/docs/ai-services.md
+++ b/docs/ai-services.md
@@ -37,28 +37,34 @@ All model weights land in `models/` at the repo root (gitignored, shared across
 all servers). Each YAML configures `model_cache` — resolved relative to the
 YAML file.
 
-## Two HuggingFace cache roots under `models/`
+## Two HuggingFace cache roots
 
 The servers use two different `HF_HOME` values, so HuggingFace weights live in
-two separate trees:
+two separate trees under the service's resolved `model_cache`:
 
 | Consumer | `HF_HOME` | Hub cache |
 |---|---|---|
-| vLLM-backed servers (pip and docker) | `models/` | `models/hub/` |
-| STT and Magpie TTS (NeMo host processes) | `models/huggingface/` | `models/huggingface/hub/` |
+| vLLM-backed servers (pip and docker) | `<model_cache>/` | `<model_cache>/hub/` |
+| STT and Magpie TTS (NeMo host processes) | `<model_cache>/huggingface/` | `<model_cache>/huggingface/hub/` |
 
-(The NeMo servers additionally cache non-HF artifacts under `models/nemo/`.)
+(The NeMo servers additionally cache non-HF artifacts under `<model_cache>/nemo/`.)
 
-A model downloaded into one tree is invisible to consumers of the other, so
-check both paths before concluding a model is missing. For a manual
-`hf download`, set `HF_HOME` to match the consumer that will load the model:
+`model_cache` itself is set per YAML and resolved relative to the YAML file,
+so it differs by launch layout: the model-servers profile YAMLs resolve it to
+`models/` at the repo root, while the standalone YAMLs shipped next to each
+service resolve it to `ai-services/models/`. A model downloaded into one tree
+is invisible to consumers of the others, so check the tree your YAML actually
+points at before concluding a model is missing. For a manual `hf download`,
+set `HF_HOME` to match both the consumer and the layout:
 
 ```bash
-# For a vLLM-served model (VLM / LLM servers):
-HF_HOME=models hf download nvidia/Llama-3.1-Nemotron-Nano-8B-v1
+# vLLM-served model, launched via a model-servers profile
+# (model_cache resolves to models/ at the repo root):
+HF_HOME=models hf download nvidia/Cosmos-Reason1-7B
 
-# For the STT / Magpie TTS servers:
-HF_HOME=models/huggingface hf download nvidia/parakeet-tdt-0.6b-v3
+# STT server launched from its standalone YAML
+# (model_cache resolves to ai-services/models/):
+HF_HOME=ai-services/models/huggingface hf download nvidia/parakeet-tdt-0.6b-v3
 ```
 
 ## Adding a server to a sample

--- a/docs/ai-services.md
+++ b/docs/ai-services.md
@@ -33,9 +33,10 @@ tool-calling / reasoning / hardware trade-offs documented below.
 | `agent-mcp-servers/video-mcp/` | `video_mcp_server` | 8210 | — | FastMCP → recorded-video service + live hub IPC |
 | `agent-mcp-servers/vlm-mcp/` | `vlm_mcp_server` | 8220 | — | FastMCP → vlm-server (`ask_image` tool) |
 
-All model weights land in `models/` at the repo root (gitignored, shared across
-all servers). Each YAML configures `model_cache` — resolved relative to the
-YAML file.
+All model weights land in the service's `model_cache` directory, set per YAML
+and resolved relative to the YAML file (every `models/` tree is gitignored).
+The model-servers profiles share `models/` at the repo root; the exact layout
+per launch style is below.
 
 ## Two HuggingFace cache roots
 

--- a/docs/ai-services.md
+++ b/docs/ai-services.md
@@ -37,6 +37,30 @@ All model weights land in `models/` at the repo root (gitignored, shared across
 all servers). Each YAML configures `model_cache` — resolved relative to the
 YAML file.
 
+## Two HuggingFace cache roots under `models/`
+
+The servers use two different `HF_HOME` values, so HuggingFace weights live in
+two separate trees:
+
+| Consumer | `HF_HOME` | Hub cache |
+|---|---|---|
+| vLLM-backed servers (pip and docker) | `models/` | `models/hub/` |
+| STT and Magpie TTS (NeMo host processes) | `models/huggingface/` | `models/huggingface/hub/` |
+
+(The NeMo servers additionally cache non-HF artifacts under `models/nemo/`.)
+
+A model downloaded into one tree is invisible to consumers of the other, so
+check both paths before concluding a model is missing. For a manual
+`hf download`, set `HF_HOME` to match the consumer that will load the model:
+
+```bash
+# For a vLLM-served model (VLM / LLM servers):
+HF_HOME=models hf download nvidia/Llama-3.1-Nemotron-Nano-8B-v1
+
+# For the STT / Magpie TTS servers:
+HF_HOME=models/huggingface hf download nvidia/parakeet-tdt-0.6b-v3
+```
+
 ## Adding a server to a sample
 
 **1 — Add the process to the orchestrator:**

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -393,8 +393,10 @@ exactly the declared fields, so their behaviour is unchanged.
 
 ### 2026-07-27 — STT transcription failures are 5xx, not empty 200s
 
-The STT endpoint lets backend exceptions propagate to an HTTP 500 with the
-error detail. The endpoint used to catch every backend exception and return
+The STT endpoint lets backend exceptions propagate to an HTTP 500 carrying a
+stable generic detail ("transcription failed"); the full exception is logged
+server-side only, so backend paths and runtime state stay out of responses.
+The endpoint used to catch every backend exception and return
 200 with an empty transcript, a deliberate guard against NeMo throwing on
 very short audio; in practice that guard made a fully broken backend look
 healthy while every transcription failed. The voice pipeline catches the

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -391,6 +391,37 @@ rather than dropped (the previous coordinate base used Pydantic's default
 that carry fields outside the model — the spatial-math/tracking call sites pass
 exactly the declared fields, so their behaviour is unchanged.
 
+### 2026-07-27 — STT transcription failures are 5xx, not empty 200s
+
+The STT endpoint lets backend exceptions propagate to an HTTP 500 with the
+error detail. The endpoint used to catch every backend exception and return
+200 with an empty transcript, a deliberate guard against NeMo throwing on
+very short audio; in practice that guard made a fully broken backend look
+healthy while every transcription failed. The voice pipeline catches the
+resulting client error, logs it, and drops the utterance, so a session
+survives individual failures. Successful transcriptions of silent or
+unintelligible audio still return 200 with an empty transcript.
+
+### 2026-07-27 — vLLM container logs are streamed by a supervisor
+
+The docker log streamer waits for the container to exist before attaching
+`docker logs -f` and re-attaches (with `--since`) if the stream exits while
+the container is still expected. A single unsupervised attach races
+`docker run`: attaching before dockerd registers the container writes one
+"No such container" line and never recovers, leaving the advertised log
+file empty for the whole run.
+
+### 2026-07-27 — HF_TOKEN is required by checkpoint-downloading samples
+
+`model_servers` and `simple_vlm_example` now call
+`require_credentials("HF_TOKEN")` and exit with instructions when no token is
+found, instead of warning and continuing. Unauthenticated HuggingFace
+downloads are rate-limited to the point of stalling indefinitely on the
+multi-GB checkpoints, with no error and no progress output, so the previous
+one-line warning turned a missing token into an apparent hang on first
+launch. The `--allow-anonymous` flag restores the old warn-and-continue
+behavior for already-cached weights or deliberate anonymous runs.
+
 ### 2026-07-21 — Video memory is recorded history, not live capture
 
 `video-memory-service` reads the H.264 chunks written by XR Media Hub and no

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -19,18 +19,21 @@ stack automatically — no per-sample wiring needed.
 
 ## HuggingFace token (`HF_TOKEN`)
 
-**Optional.** The samples' default models are **public**, so they download
-without a token. Set `HF_TOKEN` when you want:
+**Required by default** for the samples that download model checkpoints
+(`model_servers`, `simple_vlm_example`). The default models are public, but
+unauthenticated Hub downloads are rate-limited to the point of **stalling
+indefinitely** on multi-GB checkpoints (no error, no progress output), so the
+orchestrators refuse to start without a token rather than hang silently on
+first launch. A token is also required outright for:
 
 - **Gated models** — any model whose HuggingFace page requires accepting a
-  license / requesting access. These *require* a token (and license
-  acceptance on your account) or the download fails.
-- **Higher rate limits and faster downloads** — unauthenticated Hub requests
-  are rate-limited and slower; an authenticated token lifts both.
+  license / requesting access (plus license acceptance on your account).
 
 The samples **do not prompt** for it. If `HF_TOKEN` is not set, the
-orchestrator prints a one-line notice and continues (public models still
-download). Provide it any one of these ways — all are picked up automatically:
+orchestrator prints an actionable error and exits; pass `--allow-anonymous`
+to start without a token anyway (all weights already cached, or you accept
+the stall risk). Provide the token any one of these ways; all are picked up
+automatically:
 
 ```bash
 # 1. Environment variable (highest priority; good for CI / one-off overrides)
@@ -79,8 +82,11 @@ this priority order, highest first:
 4. *(interactive paths only)* prompted, then saved to both locations
 
 `warn_if_missing(...)` runs steps 1–3 and, if the token is still absent, prints
-an actionable notice and continues **without prompting** — this is how
-`HF_TOKEN` is handled in the samples.
+an actionable notice and continues **without prompting**.
+`require_credentials(...)` runs the same steps but exits non-zero when the
+token is absent (unless called with `allow_missing=True`, wired to the
+orchestrators' `--allow-anonymous` flag); this is how `HF_TOKEN` is handled
+in the checkpoint-downloading samples.
 
 ## Managing saved tokens
 

--- a/docs/source/components/ai-services.md
+++ b/docs/source/components/ai-services.md
@@ -36,6 +36,30 @@ All model weights land in `models/` at the repository root (not checked into ver
 all servers). Each YAML configures `model_cache` — resolved relative to the
 YAML file.
 
+## Two HuggingFace cache roots under `models/`
+
+The servers use two different `HF_HOME` values, so HuggingFace weights live in
+two separate trees:
+
+| Consumer | `HF_HOME` | Hub cache |
+|---|---|---|
+| vLLM-backed servers (pip and docker) | `models/` | `models/hub/` |
+| STT and Magpie TTS (NeMo host processes) | `models/huggingface/` | `models/huggingface/hub/` |
+
+(The NeMo servers additionally cache non-HF artifacts under `models/nemo/`.)
+
+A model downloaded into one tree is invisible to consumers of the other, so
+check both paths before concluding a model is missing. For a manual
+`hf download`, set `HF_HOME` to match the consumer that will load the model:
+
+```bash
+# For a vLLM-served model (VLM / LLM servers):
+HF_HOME=models hf download nvidia/Llama-3.1-Nemotron-Nano-8B-v1
+
+# For the STT / Magpie TTS servers:
+HF_HOME=models/huggingface hf download nvidia/parakeet-tdt-0.6b-v3
+```
+
 ## Adding a server to a sample
 
 **1 — Add the process to the orchestrator:**

--- a/docs/source/components/ai-services.md
+++ b/docs/source/components/ai-services.md
@@ -32,9 +32,10 @@ tool-calling, reasoning, and hardware trade-offs documented below.
 | `agent-mcp-servers/video-mcp/` | `video_mcp_server` | 8210 | — | FastMCP → recorded service + live hub IPC |
 | `agent-mcp-servers/vlm-mcp/` | `vlm_mcp_server` | 8240 | — | FastMCP → vlm-server (`ask_image` tool) |
 
-All model weights land in `models/` at the repository root (not checked into version control, shared across
-all servers). Each YAML configures `model_cache` — resolved relative to the
-YAML file.
+All model weights land in the service's `model_cache` directory, set per YAML
+and resolved relative to the YAML file (every `models/` tree is excluded from
+version control). The model-servers profiles share `models/` at the
+repository root; the exact layout per launch style is below.
 
 ## Two HuggingFace cache roots
 

--- a/docs/source/components/ai-services.md
+++ b/docs/source/components/ai-services.md
@@ -36,28 +36,34 @@ All model weights land in `models/` at the repository root (not checked into ver
 all servers). Each YAML configures `model_cache` — resolved relative to the
 YAML file.
 
-## Two HuggingFace cache roots under `models/`
+## Two HuggingFace cache roots
 
 The servers use two different `HF_HOME` values, so HuggingFace weights live in
-two separate trees:
+two separate trees under the service's resolved `model_cache`:
 
 | Consumer | `HF_HOME` | Hub cache |
 |---|---|---|
-| vLLM-backed servers (pip and docker) | `models/` | `models/hub/` |
-| STT and Magpie TTS (NeMo host processes) | `models/huggingface/` | `models/huggingface/hub/` |
+| vLLM-backed servers (pip and docker) | `<model_cache>/` | `<model_cache>/hub/` |
+| STT and Magpie TTS (NeMo host processes) | `<model_cache>/huggingface/` | `<model_cache>/huggingface/hub/` |
 
-(The NeMo servers additionally cache non-HF artifacts under `models/nemo/`.)
+(The NeMo servers additionally cache non-HF artifacts under `<model_cache>/nemo/`.)
 
-A model downloaded into one tree is invisible to consumers of the other, so
-check both paths before concluding a model is missing. For a manual
-`hf download`, set `HF_HOME` to match the consumer that will load the model:
+`model_cache` itself is set per YAML and resolved relative to the YAML file,
+so it differs by launch layout: the model-servers profile YAMLs resolve it to
+`models/` at the repository root, while the standalone YAMLs shipped next to
+each service resolve it to `ai-services/models/`. A model downloaded into one
+tree is invisible to consumers of the others, so check the tree your YAML
+actually points at before concluding a model is missing. For a manual
+`hf download`, set `HF_HOME` to match both the consumer and the layout:
 
 ```bash
-# For a vLLM-served model (VLM / LLM servers):
-HF_HOME=models hf download nvidia/Llama-3.1-Nemotron-Nano-8B-v1
+# vLLM-served model, launched via a model-servers profile
+# (model_cache resolves to models/ at the repository root):
+HF_HOME=models hf download nvidia/Cosmos-Reason1-7B
 
-# For the STT / Magpie TTS servers:
-HF_HOME=models/huggingface hf download nvidia/parakeet-tdt-0.6b-v3
+# STT server launched from its standalone YAML
+# (model_cache resolves to ai-services/models/):
+HF_HOME=ai-services/models/huggingface hf download nvidia/parakeet-tdt-0.6b-v3
 ```
 
 ## Adding a server to a sample

--- a/docs/source/getting_started/credentials.md
+++ b/docs/source/getting_started/credentials.md
@@ -20,18 +20,21 @@ stack automatically — no per-sample wiring needed.
 
 ## HuggingFace token (`HF_TOKEN`)
 
-**Optional.** The samples' default models are **public**, so they download
-without a token. Set `HF_TOKEN` when you want:
+**Required by default** for the samples that download model checkpoints
+(`model_servers`, `simple_vlm_example`). The default models are public, but
+unauthenticated Hub downloads are rate-limited to the point of **stalling
+indefinitely** on multi-GB checkpoints (no error, no progress output), so the
+orchestrators refuse to start without a token rather than hang silently on
+first launch. A token is also required outright for:
 
 - **Gated models** — any model whose HuggingFace page requires accepting a
-  license or requesting access. These *require* a token (and license
-  acceptance on your account) or the download fails.
-- **Higher rate limits and faster downloads** — unauthenticated Hub requests
-  are rate-limited and slower; an authenticated token lifts both.
+  license or requesting access (plus license acceptance on your account).
 
 The samples **do not prompt** for it. If `HF_TOKEN` is not set, the
-orchestrator prints a one-line notice and continues (public models still
-download). Provide it any one of these ways — all are picked up automatically:
+orchestrator prints an actionable error and exits; pass `--allow-anonymous`
+to start without a token anyway (all weights already cached, or you accept
+the stall risk). Provide the token any one of these ways; all are picked up
+automatically:
 
 ```bash
 # 1. Environment variable (highest priority; good for CI / one-off overrides)
@@ -80,8 +83,11 @@ this priority order, highest first:
 4. *(interactive paths only)* prompted, then saved to both locations
 
 `warn_if_missing(...)` runs steps 1–3 and, if the token is still absent, prints
-an actionable notice and continues **without prompting** — this is how
-`HF_TOKEN` is handled in the samples.
+an actionable notice and continues **without prompting**.
+`require_credentials(...)` runs the same steps but exits non-zero when the
+token is absent (unless called with `allow_missing=True`, wired to the
+orchestrators' `--allow-anonymous` flag); this is how `HF_TOKEN` is handled
+in the checkpoint-downloading samples.
 
 ## Managing saved tokens
 

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -39,10 +39,10 @@ they cannot be stopped, avoiding GPU overcommit.
 uv run model_servers --omni-stack
 ```
 
-The default models are public, so no HuggingFace token is required. Set
-`HF_TOKEN` to lift download rate limits and speed, or to use a gated model: refer
-to the credentials guide. The launcher won't prompt; it prints a one-line notice
-and continues if the token is unset.
+`HF_TOKEN` is required by default: without it the ~50 GB first-run download
+can stall indefinitely. Refer to the
+{doc}`credentials guide </getting_started/credentials>` for how to set it, or
+pass `--allow-anonymous` to run without one.
 
 To stop all model servers when done:
 
@@ -73,9 +73,9 @@ uv run simple_vlm_example
 ```
 
 On the very first run weights download from HuggingFace (~23 GB; can take
-several minutes). The default model is public — no HuggingFace token needed; set
-`HF_TOKEN` only to lift rate limits and speed or for a gated model (refer to the
-credentials guide).
+several minutes). `HF_TOKEN` is required by default; pass `--allow-anonymous`
+to run without one (refer to the
+{doc}`credentials guide </getting_started/credentials>`).
 
 **With model-servers pre-running** — if VLM (port 8100) and STT (port 8103) are
 already up from `model-servers`, the demo detects them at startup and reuses

--- a/docs/source/getting_started/requirements.md
+++ b/docs/source/getting_started/requirements.md
@@ -28,7 +28,7 @@ local GPU is required for the agent or XR-Media-Hub.
 
 | Requirement | Version | Notes |
 |---|---|---|
-| OS | Linux | Ubuntu 22.04 / 24.04 recommended |
+| OS | Linux | Ubuntu 22.04 / 24.04 recommended; WSL2 is not officially supported (refer to [Windows (WSL2)](#windows-wsl2) below) |
 | Python | 3.11 or 3.12 | 3.10 and 3.13 are not supported |
 | [uv](https://docs.astral.sh/uv/) | latest | dependency manager used by all samples |
 | NVIDIA driver | 570+ | required for local model inference |
@@ -65,6 +65,48 @@ nvcc + FlashInfer. If you switch a profile to `vllm_backend: pip`, refer to the
 troubleshooting guide for the host CUDA toolchain prerequisite.
 
 If `uv sync` or the VLM fails on first run, refer to the troubleshooting guide.
+
+## Windows (WSL2)
+
+WSL2 is not an officially supported or tested platform. The notes below come
+from a single field report (Windows 11, RTX PRO 6000 Blackwell, Ubuntu WSL2
+distribution with in-distro Docker Engine) and may not generalize to other
+setups:
+
+- **model-servers and simple-vlm-example ran end-to-end** in that
+  configuration. Docker Desktop's WSL integration did not work for this
+  stack: `--network host` attaches containers to the Docker Desktop VM's
+  network namespace, not the distribution's, so LiveKit signaling succeeds
+  but WebRTC media never flows (clients drop after ~18 s).
+- **xr-render-demo cannot run under WSL2.** The WSL2 GPU stack is compute-only
+  (CUDA, NVENC, NVML) with no Vulkan ICD, so Vulkan falls back to the llvmpipe
+  software rasterizer and the `VK_KHR_external_semaphore_fd` /
+  `VK_KHR_external_fence_fd` device extensions CloudXR Runtime requires are
+  unavailable. This sample needs bare-metal Linux.
+- **NAT networking (the WSL default) limits the stack to a browser on the
+  same Windows machine.** The WSL `eth0` address is on a host-internal
+  virtual subnet that other devices on the LAN cannot reach, and Windows'
+  NAT port forwarding (`netsh portproxy`) is TCP-only, so external clients
+  (headset, phone) have no WebRTC media path into a NAT-mode WSL VM.
+  Reaching them would require mirrored networking (untested with this stack,
+  and subject to the port-8000 collision below).
+- **For that same-machine browser under NAT, localhost forwarding is TCP
+  only**: signaling works via `localhost` but WebRTC media silently fails.
+  Open the web client at the WSL distribution's `eth0` address instead (note
+  it can change across reboots). Microphone capture needs a secure context.
+  Prefer the hub's default HTTPS web server (`https://<eth0-ip>:8080`): an HTTPS
+  origin is a secure context once you trust the hub's self-signed cert
+  (download it from `https://<eth0-ip>:8080/cert`, or copy
+  `~/.local/share/xr-ai/web-server.crt` out of the WSL filesystem via
+  `\\wsl$\`, then install it into the Windows cert store) or click through
+  the browser warning. On a plain-HTTP path (the legacy token server, or
+  `web_server_tls: false`), the report's verified workaround is
+  whitelisting the exact origin in
+  `chrome://flags/#unsafely-treat-insecure-origin-as-secure`; the HTTPS route
+  was not exercised in the report.
+- **Mirrored networking collides with the token server**: Windows' IP Helper
+  service occupies port 8000. Refer to the `token_server_port` note in
+  `server-runtime/xr_media_hub.yaml`.
 
 ## Running on other GPUs
 

--- a/docs/source/guides/troubleshooting.md
+++ b/docs/source/guides/troubleshooting.md
@@ -374,5 +374,7 @@ time.
 the repository root (gitignored, ~16 GB for Cosmos-Reason1-7B alone).
 
 **Fix:** wait. Subsequent runs use the cached weights and start in
-~30–60 s. If a download fails, check that `HF_TOKEN` is set if the model
-needs it (see [`docs/credentials.md`](https://github.com/NVIDIA/xr-ai/blob/main/docs/credentials.md)).
+~30–60 s. If the download makes no progress, note that unauthenticated
+downloads (runs started with `--allow-anonymous`) are rate-limited and can
+stall indefinitely; set `HF_TOKEN` and restart
+(see [`docs/credentials.md`](https://github.com/NVIDIA/xr-ai/blob/main/docs/credentials.md)).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -384,5 +384,7 @@ time.
 the repo root (gitignored, ~16 GB for Cosmos-Reason1-7B alone).
 
 **Fix:** wait. Subsequent runs use the cached weights and start in
-~30–60 s. If a download fails, check that `HF_TOKEN` is set if the model
-needs it (see [`docs/credentials.md`](credentials.md)).
+~30–60 s. If the download makes no progress, note that unauthenticated
+downloads (runs started with `--allow-anonymous`) are rate-limited and can
+stall indefinitely; set `HF_TOKEN` and restart
+(see [`docs/credentials.md`](credentials.md)).

--- a/server-runtime/xr_media_hub.yaml
+++ b/server-runtime/xr_media_hub.yaml
@@ -40,6 +40,12 @@ web_client_dir:    ../client-samples/web
 
 # ── Optional: token server (legacy plain-HTTP entry point) ────────────────────
 enable_token_server: true
+# Bind port for the token server (default 8000). Change it if another service
+# already holds 8000. Under WSL2 mirrored networking, Windows' IP Helper
+# service (iphlpsvc) occupies 8000 and the hub aborts with "[Errno 98] address
+# already in use"; either set a free port here, or add `ignoredPorts=8000`
+# under `[experimental]` in %UserProfile%\.wslconfig and run `wsl --shutdown`.
+# token_server_port: 8000
 
 # ── Video recording (NVENC, optional) ─────────────────────────────────────────
 # Requires pynvvideocodec.  Frames are encoded via NVENC and written as

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -69,7 +69,9 @@ packages = ["xr_ai_tests"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths    = ["."]
-pythonpath   = ["../services/openxr-service"]
+# stt-server is on pythonpath (not a dependency) so the endpoint tests can
+# import its FastAPI app without pulling the NeMo dependency tree.
+pythonpath   = ["../services/openxr-service", "../ai-services/stt-server"]
 markers = [
     "gpu: requires local GPU / Docker / NVENC; skipped in CI",
     "integration: spawns a real server subprocess (CPU-only); runs in CI",

--- a/tests/test_launcher_credentials.py
+++ b/tests/test_launcher_credentials.py
@@ -142,6 +142,47 @@ class TestEnsureCredentials:
         assert hf_file.read_text().strip() == "new_tok"
 
 
+class TestRequireCredentials:
+    """require_credentials exits non-zero on a missing token; NEVER prompts."""
+
+    def test_missing_token_exits(self, fake_creds_dir, monkeypatch):
+        with patch("getpass.getpass", side_effect=AssertionError("must not prompt")):
+            with pytest.raises(SystemExit) as exc_info:
+                _creds.require_credentials("HF_TOKEN")
+        assert exc_info.value.code == 2
+
+    def test_allow_missing_downgrades_to_warning(self, fake_creds_dir, monkeypatch):
+        with patch("getpass.getpass", side_effect=AssertionError("must not prompt")):
+            _creds.require_credentials("HF_TOKEN", allow_missing=True)
+        assert not os.environ.get("HF_TOKEN")
+
+    def test_env_token_passes(self, fake_creds_dir, monkeypatch):
+        monkeypatch.setenv("HF_TOKEN", "env_tok")
+        _creds.require_credentials("HF_TOKEN")
+        assert os.environ["HF_TOKEN"] == "env_tok"
+
+    def test_saved_token_passes(self, fake_creds_dir, monkeypatch):
+        creds_file, _ = fake_creds_dir
+        creds_file.write_text(json.dumps({"HF_TOKEN": "saved_tok"}))
+        _creds.require_credentials("HF_TOKEN")
+        assert os.environ.get("HF_TOKEN") == "saved_tok"
+
+    def test_hf_token_file_passes(self, fake_creds_dir, monkeypatch):
+        _, hf_file = fake_creds_dir
+        hf_file.write_text("file_tok\n")
+        _creds.require_credentials("HF_TOKEN")
+        assert os.environ.get("HF_TOKEN") == "file_tok"
+
+    def test_mixed_present_and_missing_exits(self, fake_creds_dir, monkeypatch, capsys):
+        monkeypatch.setenv("HF_TOKEN", "env_tok")
+        with pytest.raises(SystemExit) as exc_info:
+            _creds.require_credentials("HF_TOKEN", "NGC_API_KEY")
+        assert exc_info.value.code == 2
+        err = capsys.readouterr().err
+        assert "NGC API key" in err
+        assert "HuggingFace token" not in err
+
+
 class TestWarnIfMissing:
     """warn_if_missing surfaces a missing token but NEVER prompts."""
 

--- a/tests/test_model_servers.py
+++ b/tests/test_model_servers.py
@@ -143,7 +143,7 @@ def test_cli_selects_requested_stack(
 ) -> None:
     selected: list[str] = []
     monkeypatch.setattr(_model_servers, "setup_logging", lambda *_a, **_k: None)
-    monkeypatch.setattr(_model_servers, "warn_if_missing", lambda *_a, **_k: None)
+    monkeypatch.setattr(_model_servers, "require_credentials", lambda *_a, **_k: None)
     monkeypatch.setattr(_model_servers, "_stop_incompatible_stack", lambda _stack: None)
     monkeypatch.setattr(_model_servers, "_build_processes", lambda stack: selected.append(stack) or [])
     monkeypatch.setattr(_model_servers, "run_stack", lambda *_a, **_k: None)
@@ -168,7 +168,7 @@ def test_cli_stops_incompatible_stack_before_starting(
 ) -> None:
     calls: list[object] = []
     monkeypatch.setattr(_model_servers, "setup_logging", lambda *_a, **_k: None)
-    monkeypatch.setattr(_model_servers, "warn_if_missing", lambda *_a, **_k: None)
+    monkeypatch.setattr(_model_servers, "require_credentials", lambda *_a, **_k: None)
     monkeypatch.setattr(
         _model_servers,
         "stop_persistent_servers",
@@ -188,7 +188,7 @@ def test_cli_aborts_when_incompatible_stack_cannot_stop(
 ) -> None:
     started: list[bool] = []
     monkeypatch.setattr(_model_servers, "setup_logging", lambda *_a, **_k: None)
-    monkeypatch.setattr(_model_servers, "warn_if_missing", lambda *_a, **_k: None)
+    monkeypatch.setattr(_model_servers, "require_credentials", lambda *_a, **_k: None)
     monkeypatch.setattr(_model_servers, "stop_persistent_servers", lambda _services: False)
     monkeypatch.setattr(_model_servers, "run_stack", lambda *_a, **_k: started.append(True))
     monkeypatch.setattr(sys, "argv", ["model_servers", "--omni-stack"])

--- a/tests/test_stt_server_endpoint.py
+++ b/tests/test_stt_server_endpoint.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Endpoint tests for ai-services/stt-server with a mocked ASR backend.
+
+No GPU or NeMo: the module is imported via pythonpath and the backend's
+``transcribe`` is replaced, so these run in CI. The GPU smoke test that
+boots the real model lives in test_gpu_stt_server.py.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from stt_server.__main__ import _build_app
+
+_WAV = ("file", ("audio.wav", b"RIFF....WAVE", "audio/wav"))
+
+
+@pytest.fixture()
+def app_and_backend(tmp_path):
+    return _build_app({"model": "dummy"}, tmp_path)
+
+
+def test_transcription_success(app_and_backend, monkeypatch):
+    app, backend = app_and_backend
+    monkeypatch.setattr(backend, "transcribe", lambda path: "hello world")
+    with TestClient(app) as client:
+        resp = client.post("/v1/audio/transcriptions", files=[_WAV])
+    assert resp.status_code == 200
+    assert resp.json() == {"text": "hello world"}
+
+
+def test_backend_failure_returns_500(app_and_backend, monkeypatch):
+    """A backend exception surfaces as a 5xx with a generic detail: not an
+    empty 200, and not the exception text (backend internals must not leak)."""
+    app, backend = app_and_backend
+
+    def _boom(path):
+        raise RuntimeError("INTERNAL ASSERT FAILED at /internal/path CUDACachingAllocator")
+
+    monkeypatch.setattr(backend, "transcribe", _boom)
+    with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.post("/v1/audio/transcriptions", files=[_WAV])
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "transcription failed"
+    assert "CUDACachingAllocator" not in resp.text
+
+
+def test_transcription_text_format_success(app_and_backend, monkeypatch):
+    app, backend = app_and_backend
+    monkeypatch.setattr(backend, "transcribe", lambda path: "hello world")
+    with TestClient(app) as client:
+        resp = client.post(
+            "/v1/audio/transcriptions",
+            files=[_WAV],
+            data={"response_format": "text"},
+        )
+    assert resp.status_code == 200
+    assert resp.text == "hello world"
+    assert resp.headers["content-type"].startswith("text/plain")

--- a/tests/test_vllm_docker.py
+++ b/tests/test_vllm_docker.py
@@ -349,7 +349,7 @@ class TestRun:
             patch("xr_ai_vllm._docker._maybe_ngc_login"),
             patch("xr_ai_vllm._docker.build_run_argv", return_value=argv),
             patch("xr_ai_vllm._docker.subprocess.Popen", return_value=process) as popen,
-            patch("xr_ai_vllm._docker._start_log_streamer", return_value=(None, None)),
+            patch("xr_ai_vllm._docker._LogStreamer", return_value=MagicMock()),
             patch("xr_ai_vllm._docker._lifecycle.wait_until_healthy"),
             patch("xr_ai_vllm._docker._lifecycle.idle_until_stopped"),
             patch("xr_ai_vllm._docker.signal.getsignal", return_value=None),

--- a/tests/test_vllm_docker.py
+++ b/tests/test_vllm_docker.py
@@ -5,11 +5,14 @@
 from __future__ import annotations
 
 import json
+import threading
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from xr_ai_vllm._docker import (
     _already_logged_in,
+    _LogStreamer,
     _registry_for,
     build_run_argv,
     container_exists,
@@ -182,6 +185,130 @@ class TestBuildRunArgv:
         bash_cmd = argv[-1]
         assert "pip install -q hf_transfer" in bash_cmd
         assert "pip install -q --no-build-isolation mamba-ssm causal-conv1d" in bash_cmd
+
+
+class _FakeLogProc:
+    """Stands in for the `docker logs -f` Popen inside _LogStreamer."""
+
+    def __init__(self):
+        self._done = threading.Event()
+
+    def wait(self, timeout=None):
+        self._done.wait(timeout)
+        return 0
+
+    def poll(self):
+        return 0 if self._done.is_set() else None
+
+    def terminate(self):
+        self._done.set()
+
+    kill = terminate
+
+
+def _wait_for(predicate, timeout_s=5.0):
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.02)
+    return False
+
+
+class TestLogStreamer:
+    def _make(self, monkeypatch, tmp_path, exists):
+        attached: list[_FakeLogProc] = []
+        monkeypatch.setattr(
+            "xr_ai_vllm._docker._container_log_path",
+            lambda name: tmp_path / f"{name}.log",
+        )
+        monkeypatch.setattr(
+            "xr_ai_vllm._docker.container_exists", lambda name: exists.is_set(),
+        )
+
+        def _fake_attach(self):
+            proc = _FakeLogProc()
+            attached.append(proc)
+            return proc
+
+        monkeypatch.setattr(_LogStreamer, "_attach", _fake_attach)
+        return _LogStreamer("fake-container"), attached
+
+    def test_attach_waits_for_container(self, monkeypatch, tmp_path):
+        exists = threading.Event()
+        streamer, attached = self._make(monkeypatch, tmp_path, exists)
+        try:
+            time.sleep(0.3)
+            assert not attached  # container absent — must not attach yet
+            exists.set()
+            assert _wait_for(lambda: len(attached) == 1)
+        finally:
+            streamer.stop()
+
+    def test_reattaches_after_streamer_exit(self, monkeypatch, tmp_path):
+        exists = threading.Event()
+        exists.set()
+        streamer, attached = self._make(monkeypatch, tmp_path, exists)
+        try:
+            assert _wait_for(lambda: len(attached) == 1)
+            attached[0].terminate()  # simulate "docker logs -f" dying
+            assert _wait_for(lambda: len(attached) == 2)
+        finally:
+            streamer.stop()
+
+    def test_stop_terminates_streamer(self, monkeypatch, tmp_path):
+        exists = threading.Event()
+        exists.set()
+        streamer, attached = self._make(monkeypatch, tmp_path, exists)
+        assert _wait_for(lambda: len(attached) == 1)
+        streamer.stop()
+        assert attached[0].poll() is not None
+        assert not streamer._thread.is_alive()
+
+    def test_stop_before_container_exists(self, monkeypatch, tmp_path):
+        exists = threading.Event()
+        streamer, attached = self._make(monkeypatch, tmp_path, exists)
+        streamer.stop()
+        assert not streamer._thread.is_alive()
+        assert not attached
+
+    def test_reattach_passes_since(self, monkeypatch, tmp_path):
+        """A re-attach must not replay the container log from the start."""
+        exists = threading.Event()
+        exists.set()
+        streamer, attached = self._make(monkeypatch, tmp_path, exists)
+        try:
+            assert _wait_for(lambda: len(attached) == 1)
+            assert streamer._since is None
+            attached[0].terminate()
+            assert _wait_for(lambda: len(attached) == 2)
+            assert streamer._since is not None
+        finally:
+            streamer.stop()
+
+    def test_unwritable_log_path_ends_supervisor(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            "xr_ai_vllm._docker._container_log_path",
+            lambda name: tmp_path / "missing-dir" / f"{name}.log",
+        )
+        monkeypatch.setattr("xr_ai_vllm._docker.container_exists", lambda name: True)
+        streamer = _LogStreamer("fake-container")
+        assert _wait_for(lambda: not streamer._thread.is_alive())
+        streamer.stop()
+
+    def test_popen_oserror_ends_supervisor(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            "xr_ai_vllm._docker._container_log_path",
+            lambda name: tmp_path / f"{name}.log",
+        )
+        monkeypatch.setattr("xr_ai_vllm._docker.container_exists", lambda name: True)
+        monkeypatch.setattr(
+            "xr_ai_vllm._docker.subprocess.Popen",
+            lambda *a, **kw: (_ for _ in ()).throw(OSError("no fds")),
+        )
+        streamer = _LogStreamer("fake-container")
+        assert _wait_for(lambda: not streamer._thread.is_alive())
+        streamer.stop()
 
 
 class TestContainerHelpers:

--- a/utils/xr-ai-launcher/xr_ai_launcher/__init__.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/__init__.py
@@ -33,7 +33,12 @@ from ._cloudxr_env import (
     load_cloudxr_env,
     read_device_profile,
 )
-from ._credentials import ensure_credentials, load_credentials, warn_if_missing
+from ._credentials import (
+    ensure_credentials,
+    load_credentials,
+    require_credentials,
+    warn_if_missing,
+)
 from ._gpu import detect_gpu_config
 from ._models import ModelDeployment, load_model_deployment
 from ._processes import ManagedProcess
@@ -42,7 +47,7 @@ from ._stack import Parallel, Process, run_stack
 __all__ = [
     "XR_RUNTIME_VAR", "load_cloudxr_env",
     "NATIVE_DEVICE_PROFILES", "is_native_profile", "read_device_profile",
-    "ensure_credentials", "load_credentials", "warn_if_missing",
+    "ensure_credentials", "load_credentials", "require_credentials", "warn_if_missing",
     "detect_gpu_config",
     "ModelDeployment", "load_model_deployment",
     "ManagedProcess",

--- a/utils/xr-ai-launcher/xr_ai_launcher/_credentials.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/_credentials.py
@@ -39,9 +39,9 @@ _KNOWN: dict[str, tuple[str, str, str]] = {
     "HF_TOKEN": (
         "HuggingFace token",
         "https://huggingface.co/settings/tokens",
-        "Without HF_TOKEN, requests to the HuggingFace Hub are unauthenticated "
-        "— rate limits are lower, downloads are slower, and gated models will "
-        "fail to download.",
+        "Without HF_TOKEN, Hub requests are rate-limited: large checkpoint "
+        "downloads can stall indefinitely with no error output, and gated "
+        "models fail to download.",
     ),
     "NGC_API_KEY": (
         "NGC API key",
@@ -104,13 +104,9 @@ def warn_if_missing(*names: str) -> None:
     """
     Non-interactively surface missing optional tokens — NEVER prompts.
 
-    Loads saved / `huggingface-cli login` / env tokens, then prints one
-    actionable line per still-missing token (pointing at docs/credentials.md)
-    so a missing token is visible early without blocking startup on an
-    interactive prompt. Use this in orchestrators that pull HuggingFace / NGC
-    artifacts instead of ``ensure_credentials`` when the token is optional
-    (e.g. the default models are public — a token only raises rate limits and
-    download speed, and is required only for gated models).
+    Loads saved / `huggingface-cli login` / env tokens, then prints an
+    actionable notice per still-missing token and continues, so a missing
+    token is visible early without blocking startup on an interactive prompt.
     """
     load_credentials()
     for name in names:
@@ -125,6 +121,34 @@ def warn_if_missing(*names: str) -> None:
                    if name == "HF_TOKEN" else f"`export {name}=...`")
             print(f"  To enable it: get one at {url}, then {how}.", file=sys.stderr)
         print("  See docs/credentials.md.", file=sys.stderr)
+
+
+def require_credentials(*names: str, allow_missing: bool = False) -> None:
+    """
+    Exit non-zero unless each named token is available; NEVER prompts.
+
+    *allow_missing* (wired to the orchestrators' ``--allow-anonymous`` flag)
+    downgrades to ``warn_if_missing`` behavior.
+    """
+    if allow_missing:
+        warn_if_missing(*names)
+        return
+    load_credentials()
+    missing = [name for name in names if not os.environ.get(name)]
+    if not missing:
+        return
+    for name in missing:
+        label, url, why = _KNOWN.get(name, (name, "", ""))
+        print(f"\n[credentials] {label} is required but not set.", file=sys.stderr)
+        if why:
+            print(f"  {why}", file=sys.stderr)
+        if url:
+            how = ("`export HF_TOKEN=...` or `huggingface-cli login`"
+                   if name == "HF_TOKEN" else f"`export {name}=...`")
+            print(f"  Get one at {url}, then {how}.", file=sys.stderr)
+        print("  Or pass --allow-anonymous to start without it. "
+              "See docs/credentials.md.", file=sys.stderr)
+    sys.exit(2)
 
 
 def ensure_credentials(*names: str) -> None:

--- a/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
@@ -27,7 +27,7 @@ import subprocess
 import sys
 import threading
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from . import _lifecycle
@@ -379,7 +379,12 @@ class _LogStreamer:
                 log.info("container logs → %s", self.log_path)
             proc.wait()
             self._proc = None
-            self._since = datetime.now(timezone.utc).isoformat()
+            # Back-date the cursor: lines the dead follower never delivered
+            # would land before "now" and be skipped forever. A re-attach may
+            # duplicate up to 30 s of output; losing diagnostics is worse.
+            self._since = (
+                datetime.now(timezone.utc) - timedelta(seconds=30)
+            ).isoformat()
             # docker logs -f also exits when the container stops; pause so a
             # stopped-but-expected container doesn't spin the attach loop.
             self._stop_evt.wait(1.0)

--- a/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
@@ -25,7 +25,9 @@ import shlex
 import signal
 import subprocess
 import sys
+import threading
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 from . import _lifecycle
@@ -300,7 +302,7 @@ def _container_log_path(container_name: str) -> Path:
     return log_dir / f"{container_name}.log"
 
 
-def _start_log_streamer(container_name: str) -> tuple[subprocess.Popen | None, Path | None]:
+class _LogStreamer:
     """Stream container stdout/stderr to a sibling file (not to the terminal).
 
     `docker run -d` does not pipe container output back to the parent and
@@ -310,40 +312,98 @@ def _start_log_streamer(container_name: str) -> tuple[subprocess.Popen | None, P
     sinks) stay quiet — the user reads the container log on demand via
     ``tail -f``. ``docker logs -f`` replays from container start, so a
     fast crash is still captured.
+
+    ``docker run`` returns before dockerd registers the container, and a
+    ``docker logs -f`` attached too early exits with "No such container"
+    and never recovers. A supervisor thread therefore waits for the container
+    to exist before attaching (image pulls can hold this off for minutes) and
+    re-attaches if the streamer exits while the container is still expected,
+    i.e. until :meth:`stop`.
     """
-    log_path = _container_log_path(container_name)
-    try:
-        out_fd = open(log_path, "ab", buffering=0)
-    except OSError as exc:
-        log.warning("vllm_docker: could not open %s for streaming: %s", log_path, exc)
-        return None, None
-    try:
-        proc = subprocess.Popen(
-            # -t prefixes each line with the daemon-side RFC3339 timestamp so
-            # the file is searchable without going through loguru.
-            ["docker", "logs", "-f", "-t", container_name],
-            stdout=out_fd, stderr=out_fd,
+
+    def __init__(self, container_name: str) -> None:
+        self._name    = container_name
+        self.log_path = _container_log_path(container_name)
+        self._stop_evt  = threading.Event()
+        self._proc: subprocess.Popen | None = None
+        self._announced = False
+        # RFC3339 start point for re-attaches; a plain `docker logs -f`
+        # replays from container start, duplicating the file's contents.
+        self._since: str | None = None
+        self._thread = threading.Thread(
+            target=self._supervise, name=f"docker-logs-{container_name}", daemon=True,
         )
-    except FileNotFoundError:
-        out_fd.close()
-        return None, None
-    out_fd.close()  # the child holds its own dup'd fd
-    log.info("container logs → %s", log_path)
-    return proc, log_path
+        self._thread.start()
 
+    def _attach(self) -> subprocess.Popen | None:
+        try:
+            out_fd = open(self.log_path, "ab", buffering=0)
+        except OSError as exc:
+            log.warning("vllm_docker: could not open %s for streaming: %s",
+                        self.log_path, exc)
+            return None
+        argv = ["docker", "logs", "-f", "-t"]
+        if self._since:
+            argv += ["--since", self._since]
+        argv.append(self._name)
+        try:
+            proc = subprocess.Popen(
+                # -t prefixes each line with the daemon-side RFC3339 timestamp
+                # so the file is searchable without going through loguru.
+                argv,
+                stdout=out_fd, stderr=out_fd,
+            )
+        except OSError as exc:
+            log.warning("vllm_docker: could not attach docker logs: %s", exc)
+            return None
+        finally:
+            out_fd.close()  # on success the child holds its own dup'd fd
+        return proc
 
-def _stop_log_streamer(proc: subprocess.Popen | None) -> None:
-    if proc is None or proc.poll() is not None:
-        return
-    proc.terminate()
-    try:
-        proc.wait(timeout=2)
-    except subprocess.TimeoutExpired:
-        proc.kill()
+    def _supervise(self) -> None:
+        while not self._stop_evt.is_set():
+            delay = 0.2
+            while not container_exists(self._name):
+                if self._stop_evt.wait(delay):
+                    return
+                delay = min(delay * 2, 5.0)
+            proc = self._attach()
+            if proc is None:
+                return
+            self._proc = proc
+            if self._stop_evt.is_set():
+                self._terminate(proc)
+                return
+            if not self._announced:
+                self._announced = True
+                log.info("container logs → %s", self.log_path)
+            proc.wait()
+            self._proc = None
+            self._since = datetime.now(timezone.utc).isoformat()
+            # docker logs -f also exits when the container stops; pause so a
+            # stopped-but-expected container doesn't spin the attach loop.
+            self._stop_evt.wait(1.0)
+
+    @staticmethod
+    def _terminate(proc: subprocess.Popen) -> None:
+        if proc.poll() is not None:
+            return
+        proc.terminate()
         try:
             proc.wait(timeout=2)
         except subprocess.TimeoutExpired:
-            pass
+            proc.kill()
+            try:
+                proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                pass
+
+    def stop(self) -> None:
+        self._stop_evt.set()
+        proc = self._proc
+        if proc is not None:
+            self._terminate(proc)
+        self._thread.join(timeout=5)
 
 
 def _append_post_mortem(container_name: str, log_path: Path | None, n: int = 200) -> None:
@@ -433,7 +493,8 @@ def run(
         stop_container(container_name, timeout_s=10)
         remove_container(container_name)
         sp = _state["streamer"]
-        _stop_log_streamer(sp if isinstance(sp, subprocess.Popen) else None)
+        if isinstance(sp, _LogStreamer):
+            sp.stop()
         sys.exit(130)
 
     signal.signal(signal.SIGINT,  _on_signal)
@@ -483,8 +544,8 @@ def run(
     proc = subprocess.Popen(argv, start_new_session=True)
     _state["proc"] = proc
 
-    streamer_proc, log_path = _start_log_streamer(container_name)
-    _state["streamer"] = streamer_proc
+    streamer = _LogStreamer(container_name)
+    _state["streamer"] = streamer
     try:
         _lifecycle.wait_until_healthy(
             health_url,
@@ -500,10 +561,9 @@ def run(
         if _state["handling"]:
             raise
         time.sleep(0.5)
-        _append_post_mortem(container_name, log_path)
-        _stop_log_streamer(streamer_proc)
-        if log_path is not None:
-            log.error("vLLM container failed — see %s", log_path)
+        streamer.stop()
+        _append_post_mortem(container_name, streamer.log_path)
+        log.error("vLLM container failed — see %s", streamer.log_path)
         raise
 
     log.info("Ready  →  http://localhost:%d/v1  (docker: %s)", port, container_name)
@@ -520,7 +580,7 @@ def run(
     try:
         _lifecycle.idle_until_stopped(health_url, log_prefix)
     finally:
-        _stop_log_streamer(streamer_proc)
+        streamer.stop()
 
 
 # ── port → container / pid (used by the stop helper) ────────────────────────


### PR DESCRIPTION
Included:
- Require HF_TOKEN by default
- STT: return 5xx on backend failure
- Fix vLLM container log-streamer race
- Document token_server_port
- Document the two HF cache roots
- Document WSL2 support status