### PR TITLE
feat(vlm): default to Cosmos3 Nano Reasoner

### DIFF
--- a/.github/workflows/nightly-xr-ai-test.yml
+++ b/.github/workflows/nightly-xr-ai-test.yml
@@ -114,6 +114,12 @@ jobs:
           set -euo pipefail
           uv sync --directory services/magpie-tts
 
+      - name: Pre-pull Cosmos3 vLLM image
+        # The public NVIDIA vLLM image supports anonymous pulls. Pull it in a
+        # named step so a cold runner does not spend the GPU test's startup
+        # budget downloading the new Cosmos3-capable runtime.
+        run: docker pull nvcr.io/nvidia/vllm:26.07-py3
+
       - name: Purge leftover xr-ai-vllm containers (pre)
         # Containers are named `xr-ai-vllm-*` by the vLLM launcher. On a
         # persistent self-hosted runner these can survive a previous run

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -103,7 +103,8 @@ xr-ai-models  (agent-sdk/xr-ai-models/)
     seam: reasoning-field aliasing (nano_v3 →
     `reasoning`, nemotron_v3 → `reasoning_content`), `chat_template_kwargs`
     plumbing for `enable_thinking` / `thinking_budget`, and built-in presets
-    for the in-tree services. Workers depend on this instead of rolling their
+    for the in-tree services, including distinct Cosmos3 Nano Reasoner and
+    Cosmos-Reason1 VLM profiles. Workers depend on this instead of rolling their
     own httpx wrappers. Profiles may separate adapter, endpoint, and deployment
     metadata while the existing flat YAML schema remains valid.
 
@@ -261,12 +262,15 @@ xr-ai-tests  (tests/)
     service rather than being redeclared here.
 
 vlm-server  (services/vlm-server/)
-    └── vllm >=0.12.0
+    └── vllm >=0.23.0
     └── pyyaml >=6.0
     └── hf-transfer >=0.1.4
     └── xr-ai-logging  [editable: ../../utils/xr-ai-logging]
     └── xr-ai-vllm     [editable: ../../utils/xr-ai-vllm]
-    Model: nvidia/Cosmos-Reason1-7B (Qwen2.5-VL architecture, vLLM).
+    Default model: the text-output Reasoner from nvidia/Cosmos3-Nano. Runtime
+    selection details are documented in
+    docs/source/components/ai-services.md#per-server-notes.
+    nvidia/Cosmos-Reason1-7B remains configurable with the cosmos_vlm preset.
     Wrapper Popens `vllm serve` so the launcher's killpg() does not reach
     vLLM — model survives stack restarts.
     vllm_backend: pip|docker — pip path uses the wrapper's vllm; docker path
@@ -360,7 +364,7 @@ piper-tts-server  (services/piper-tts/)
 
 | Server | Package | Command | Default port | Model | Backend |
 |---|---|---|---|---|---|
-| `services/vlm-server/` | `vlm-server` | `vlm_server` | 8100 | Cosmos-Reason1-7B | vLLM (pip or docker) |
+| `services/vlm-server/` | `vlm-server` | `vlm_server` | 8100 | Cosmos3 Nano Reasoner | vLLM (pip or docker) |
 | `services/stt-server/` | `stt-server` | `stt_server` | 8103 | parakeet-tdt-0.6b-v3 | NeMo ASR in-process |
 | `services/magpie-tts/` | `magpie-tts-server` | `magpie_tts_server` | 8104 | magpie_tts_multilingual_357m | NeMo TTS in-process |
 | `services/piper-tts/` | `piper-tts-server` | `piper_tts_server` | 8105 | rhasspy/piper-voices (ONNX) | piper-tts in-process |
@@ -448,9 +452,10 @@ The sample has no MCP or legacy agent-framework dependency.
 Worker calls stt-server (8103), vlm-server (8100), and piper-tts-server
 (8105) over HTTP via `xr-ai-models` SDK — no model weights loaded
 in-process. The `models_config` key selects a structured deployment profile:
-`models.local.json` manages the default services, `models.hosted.json` uses an
-external NVIDIA NIM VLM, and `models.omni.json` reuses Nemotron-Omni on port
-8108. These profiles separate adapter behavior, endpoint readiness and
+`models.local.json` manages the default Cosmos3 Nano Reasoner service,
+`models.hosted.json` uses the hosted Cosmos3 Nano Reasoner NIM, and
+`models.omni.json` reuses Nemotron-Omni on port 8108. These profiles separate
+adapter behavior, endpoint readiness and
 credentials, and launcher ownership. Voice-gate knobs are configured via
 `yaml/voice_gate.yaml`.
 
@@ -514,6 +519,7 @@ Keep non-obvious fan-out in the same change:
 | `utils/xr-ai-launcher/` process API | [Process model](docs/source/components/launcher-and-process-model.md) and sample orchestrators |
 | `utils/xr-ai-vllm/` API or `vllm_backend` / `vllm_image` keys | Every vLLM service wrapper and YAML, every per-profile sample copy, and [AI services](docs/source/components/ai-services.md) |
 | Model-service package, command, port, or container name | `services/README.md`, model-server orchestration and cleanup, this map, and [AI services](docs/source/components/ai-services.md) |
+| vlm-server model or configuration | Its reference YAML, every model-server profile, model presets, and [AI services](docs/source/components/ai-services.md) |
 | CloudXR configuration or native-profile helpers | `agent-samples/xr-render-demo/yaml/cloudxr_runtime.yaml`, its orchestrator, [Adding CloudXR](docs/source/guides/adding-cloudxr.md), and [xr-render reference](docs/source/reference/xr-render-demo.md) |
 | Scene-service configuration | Scene YAML, xr-render orchestrator, and [xr-render reference](docs/source/reference/xr-render-demo.md) |
 | Any `pyproject.toml` dependency | This dependency map and a local lock regeneration |

--- a/README.md
+++ b/README.md
@@ -157,6 +157,17 @@ immediately — the services keep running in the background with weights hot.
 Start this once before running `xr-render-demo`, or whenever you want to
 pre-warm models:
 
+> [!IMPORTANT]
+> After updating, stop any existing model servers before starting this stack:
+>
+> ```bash
+> uv run model_servers --stop
+> ```
+>
+> Persisted vLLM processes or containers may otherwise keep serving the
+> previous model and image even though the checked-in configuration now selects
+> Cosmos3.
+
 ```bash
 cd agent-samples/model-servers
 uv sync
@@ -164,10 +175,12 @@ uv run model_servers
 ```
 
 GPU profiles are auto-detected (`dual_48G_ada` / `spark` / `96G_blackwell`).
-On first run each model downloads from HuggingFace (~50 GB total; can take
-tens of minutes).  On subsequent runs the containers restart in under a minute.
+On first run the stack downloads roughly 60 GB from Hugging Face and can take
+tens of minutes. The VLM process loads the Cosmos3 8B Reasoner weights. On
+subsequent runs the containers restart in under a minute.
 
-The default `--vlm-llm-stack` starts Nemotron-3 Nano (8107), Cosmos (8100),
+The default `--vlm-llm-stack` starts Nemotron-3 Nano (8107), the Cosmos3 Nano
+Reasoner (8100),
 STT (8103), and embeddings (8109). Use `--omni-stack` to replace Nano and
 Cosmos with Nemotron-3 Nano Omni (8108); STT and embeddings remain available.
 On `dual_48G_ada`, the default stack places Cosmos and embeddings on GPU 0;
@@ -179,7 +192,7 @@ they cannot be stopped, avoiding GPU overcommit.
 uv run model_servers --omni-stack
 ```
 
-`HF_TOKEN` is required by default: without it the ~50 GB first-run download
+`HF_TOKEN` is required by default: without it the roughly 60 GB first-run download
 can stall indefinitely.  See [`docs/source/getting_started/credentials.md`](docs/source/getting_started/credentials.md)
 for how to set it, or pass `--allow-anonymous` to run without one.
 
@@ -206,7 +219,9 @@ remains private to the voice runtime and no MCP client is involved. See the
 [sample README](agent-samples/simple-vlm-example/README.md) for the worker
 layout and configuration boundaries.
 
-Uses `nvidia/Cosmos-Reason1-7B` (NVIDIA Open Model License + Apache 2.0).
+Uses the text-output Reasoner from `nvidia/Cosmos3-Nano` by default. See the
+[VLM server notes](docs/source/components/ai-services.md#per-server-notes) for
+runtime-selection details.
 
 There are two ways to run it:
 
@@ -219,7 +234,7 @@ uv sync
 uv run simple_vlm_example
 ```
 
-On the very first run weights download from HuggingFace (~23 GB; can take
+On the very first run weights download from HuggingFace (tens of GB; can take
 several minutes).  `HF_TOKEN` is required by default; pass
 `--allow-anonymous` to run without one (see
 [`docs/source/getting_started/credentials.md`](docs/source/getting_started/credentials.md)).
@@ -269,6 +284,9 @@ after a moment, and you hear the reply through your speakers.
 
 **Local model** — override the model weights or GPU settings by editing
 `vlm_server.yaml` in the sample directory.
+
+To use Cosmos-Reason1 instead, set `model: nvidia/Cosmos-Reason1-7B` in that
+file and select `cosmos_vlm` as the VLM adapter preset in `models.local.json`.
 
 **Remote model** — copy `yaml/models.hosted.json`, point its VLM endpoint at
 your server, and select it in the worker config:

--- a/agent-samples/model-servers/main.py
+++ b/agent-samples/model-servers/main.py
@@ -12,7 +12,7 @@ Servers started
   default / --vlm-llm-stack
     stt        — nvidia/parakeet-tdt-0.6b-v3        port 8103  (NeMo ASR)
     agent-llm  — NVIDIA-Nemotron-3-Nano-30B-A3B     port 8107  (vLLM)
-    vlm        — nvidia/Cosmos-Reason1-7B           port 8100  (vLLM)
+    vlm        — nvidia/Cosmos3-Nano Reasoner       port 8100  (vLLM)
     embedding  — nvidia/llama-nemotron-embed-1b-v2  port 8109  (vLLM)
 
   --omni-stack

--- a/agent-samples/model-servers/yaml/96G_blackwell/vlm_server.yaml
+++ b/agent-samples/model-servers/yaml/96G_blackwell/vlm_server.yaml
@@ -5,22 +5,29 @@
 #
 # vlm is SECOND in load order: agent-llm → vlm.
 # free_at_startup ≈ 96 − 34 (agent-llm) − 2 (STT) ≈ 60 GiB.
-# 0.20 × 96 = 19.2 GiB cap: ~16 GiB Cosmos-7B weights + ~3 GiB KV.
+# 0.23 × 96 = 22.1 GiB cap: 16.8 GiB measured Reasoner weights plus
+# multimodal encoder profiling, runtime overhead, and KV cache.
+# hf_overrides selects the Reasoner runtime; details are documented in
+# docs/source/components/ai-services.md#per-server-notes.
 
-model: nvidia/Cosmos-Reason1-7B
+model: nvidia/Cosmos3-Nano
+hf_overrides:
+  architectures:
+    - Cosmos3ForConditionalGeneration
 hf_token: ""
 port: 8100
 host: "0.0.0.0"
 model_cache: ../../../../models
-gpu_memory_utilization: 0.20
+gpu_memory_utilization: 0.23
 max_num_seqs: 4
 enforce_eager: true
+async_scheduling: true
+mm_encoder_tp_mode: data
 max_videos_per_prompt: 0
-# 4 fits within the default max_model_len=8192 (each Qwen2.5-VL image is
-# ~1.5k tokens). Raise both together if multi-image turns get larger.
+# Raise max_model_len too if multi-image turns outgrow the context window.
 max_images_per_prompt: 4
 
 # vLLM runtime: pip (this wrapper's venv) or docker (NGC nvcr.io/nvidia/vllm).
 # See services/vlm-server/vlm_server.yaml for the full toggle docs.
 vllm_backend: docker
-vllm_image:   nvcr.io/nvidia/vllm:26.04-py3
+vllm_image:   nvcr.io/nvidia/vllm:26.07-py3

--- a/agent-samples/model-servers/yaml/dual_48G_ada/vlm_server.yaml
+++ b/agent-samples/model-servers/yaml/dual_48G_ada/vlm_server.yaml
@@ -1,37 +1,42 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# VLM server configuration — nvidia/Cosmos-Reason1-7B.
+# VLM server configuration — Cosmos3 Nano Reasoner.
 # Auto-discovered by xr-ai-launcher and passed as --config to vlm_server.
 # OpenAI-compatible API at http://localhost:8100/v1 (accepts image_url in messages)
 
-# HuggingFace model ID — any Qwen2.5-VL-compatible model is supported.
-# nvidia/Cosmos-Reason1-7B   — NVIDIA VLM; Apache 2.0 + NVIDIA Open Model License;
-#                              no HF login required; ~16 GB VRAM at BF16
-# nvidia/Cosmos-Reason2-8B   — stronger reasoning; gated — requires HF login + license
-model: nvidia/Cosmos-Reason1-7B
+# hf_overrides selects the Reasoner runtime; details are documented in
+# docs/source/components/ai-services.md#per-server-notes.
+# Cosmos-Reason1 compatibility uses nvidia/Cosmos-Reason1-7B with the
+# cosmos_vlm client preset.
+model: nvidia/Cosmos3-Nano
+hf_overrides:
+  architectures:
+    - Cosmos3ForConditionalGeneration
 
-# HuggingFace token — required for gated models (e.g. Cosmos-Reason2-8B).
-# Accept license at https://huggingface.co/nvidia/Cosmos-Reason2-8B first.
+# HuggingFace token — optional for this public model and required for gated
+# alternatives.
 # !! Do not commit this file with a real token !!
 hf_token: ""
 
 port: 8100
 host: "0.0.0.0"
-cuda_visible_devices: "0"   # share GPU 0 with STT; Nemotron-3-Nano on GPU 1
+cuda_visible_devices: "0"   # share GPU 0 with embeddings; Nemotron/STT use GPU 1
 
 model_cache: ../../../../models
 
-# 0.43 × 47 = 20.2 GiB budget: ~15 GiB model weights + ~5 GiB KV cache.
+# 0.47 × 47 = 22.1 GiB budget: 16.8 GiB Reasoner weights plus multimodal
+# encoder profiling, runtime overhead, and KV cache.
 # Single-image queries have short context so the KV budget is adequate.
-gpu_memory_utilization: 0.43
+gpu_memory_utilization: 0.47
 enforce_eager: true
+async_scheduling: true
+mm_encoder_tp_mode: data
 max_videos_per_prompt: 0
-# 4 fits within the default max_model_len=8192 (each Qwen2.5-VL image is
-# ~1.5k tokens). Raise both together if multi-image turns get larger.
+# Raise max_model_len too if multi-image turns outgrow the context window.
 max_images_per_prompt: 4
 
 # vLLM runtime: pip (this wrapper's venv) or docker (NGC nvcr.io/nvidia/vllm).
 # See services/vlm-server/vlm_server.yaml for the full toggle docs.
 vllm_backend: docker
-vllm_image:   nvcr.io/nvidia/vllm:26.04-py3
+vllm_image:   nvcr.io/nvidia/vllm:26.07-py3

--- a/agent-samples/model-servers/yaml/spark/vlm_server.yaml
+++ b/agent-samples/model-servers/yaml/spark/vlm_server.yaml
@@ -5,9 +5,14 @@
 #
 # vlm is SECOND in load order: agent-llm → vlm.
 # free_at_startup ≈ 120 − 42 (agent-llm) − 2 (STT) ≈ 76 GiB.
-# 0.20 × 120 = 24 GiB cap: ~16 GiB Cosmos-7B weights + ~8 GiB KV.
+# 0.20 × 120 = 24 GiB cap: ~16 GiB Cosmos3 Reasoner weights + ~8 GiB KV.
+# hf_overrides selects the Reasoner runtime; details are documented in
+# docs/source/components/ai-services.md#per-server-notes.
 
-model: nvidia/Cosmos-Reason1-7B
+model: nvidia/Cosmos3-Nano
+hf_overrides:
+  architectures:
+    - Cosmos3ForConditionalGeneration
 hf_token: ""
 port: 8100
 host: "0.0.0.0"
@@ -15,12 +20,13 @@ model_cache: ../../../../models
 gpu_memory_utilization: 0.20
 max_num_seqs: 4
 enforce_eager: true
+async_scheduling: true
+mm_encoder_tp_mode: data
 max_videos_per_prompt: 0
-# 4 fits within the default max_model_len=8192 (each Qwen2.5-VL image is
-# ~1.5k tokens). Raise both together if multi-image turns get larger.
+# Raise max_model_len too if multi-image turns outgrow the context window.
 max_images_per_prompt: 4
 
 # vLLM runtime: pip (this wrapper's venv) or docker (NGC nvcr.io/nvidia/vllm).
 # See services/vlm-server/vlm_server.yaml for the full toggle docs.
 vllm_backend: docker
-vllm_image:   nvcr.io/nvidia/vllm:26.04-py3
+vllm_image:   nvcr.io/nvidia/vllm:26.07-py3

--- a/agent-samples/simple-vlm-example/yaml/models.hosted.json
+++ b/agent-samples/simple-vlm-example/yaml/models.hosted.json
@@ -9,7 +9,7 @@
       "category": "vlm",
       "adapter": {
         "kind": "openai_compat",
-        "model_name": "nvidia/nemotron-nano-12b-v2-vl",
+        "model_name": "nvidia/cosmos3-nano-reasoner",
         "capabilities": {"streaming": true, "vision": true}
       },
       "endpoint": {

--- a/agent-samples/simple-vlm-example/yaml/models.local.json
+++ b/agent-samples/simple-vlm-example/yaml/models.local.json
@@ -6,7 +6,7 @@
       "deployment": {"ownership": "managed", "service": "stt"}
     },
     "vlm": {
-      "adapter": {"preset": "cosmos_vlm"},
+      "adapter": {"preset": "cosmos3_nano_reasoner"},
       "endpoint": {"base_url": "http://localhost:8100", "readiness": "health"},
       "deployment": {"ownership": "managed", "service": "vlm"}
     },

--- a/agent-samples/simple-vlm-example/yaml/vlm_server.yaml
+++ b/agent-samples/simple-vlm-example/yaml/vlm_server.yaml
@@ -3,12 +3,19 @@
 
 # vlm-server configuration for vlm-agent.
 # Auto-discovered by the launcher and passed as --config to vlm_server.
+# hf_overrides selects the Reasoner runtime; details are documented in
+# docs/source/components/ai-services.md#per-server-notes.
 
-model:       nvidia/Cosmos-Reason1-7B
+model:       nvidia/Cosmos3-Nano
+hf_overrides:
+  architectures:
+    - Cosmos3ForConditionalGeneration
 port:        8100
 model_cache: ../../../models
+async_scheduling: true
+mm_encoder_tp_mode: data
 
 # vLLM runtime: pip (this wrapper's venv) or docker (NGC nvcr.io/nvidia/vllm).
 # See services/vlm-server/vlm_server.yaml for the full toggle docs.
 vllm_backend: docker
-vllm_image:   nvcr.io/nvidia/vllm:26.04-py3
+vllm_image:   nvcr.io/nvidia/vllm:26.07-py3

--- a/agent-samples/xr-render-demo/yaml/models.nim.yaml
+++ b/agent-samples/xr-render-demo/yaml/models.nim.yaml
@@ -38,16 +38,14 @@ agent_llm:
     tool_calls: true
     reasoning:  true
 
-# Visual question answering used by native vision tools.
-# nvidia/cosmos-reason1-7b mirrors the local default (services/vlm-server
-# also runs Cosmos-Reason1-7B), so the render-demo's ask_image prompts behave
-# the same on NIM as locally. Swap to any hosted vision model on
-# build.nvidia.com if you prefer.
+# Visual question answering used by native vision tools. The hosted model
+# is the Cosmos3 Nano Reasoner, matching the role of the local Reasoner-only
+# vLLM service; it is not the separate Cosmos3 Generator.
 vlm:
   kind:        openai_compat
   category:    vlm
   base_url:    https://integrate.api.nvidia.com
-  model_name:  nvidia/cosmos-reason1-7b
+  model_name:  nvidia/cosmos3-nano-reasoner
   api_key_env: NGC_API_KEY
   health_check: false
   capabilities:

--- a/agent-samples/xr-render-demo/yaml/models.yaml
+++ b/agent-samples/xr-render-demo/yaml/models.yaml
@@ -23,5 +23,5 @@ tts:
   base_url: http://localhost:8105
 
 vlm:
-  kind: preset:cosmos_vlm
+  kind: preset:cosmos3_nano_reasoner
   base_url: http://localhost:8100

--- a/agent-sdk/xr-ai-models/README.md
+++ b/agent-sdk/xr-ai-models/README.md
@@ -51,7 +51,8 @@ Built-in presets — see `xr_ai_models/presets/`:
 
 | Preset | Service it targets | Notes |
 |---|---|---|
-| `cosmos_vlm`     | vlm-server               | image + video; `enable_thinking=false` by default. Video requires vlm-server's `max_videos_per_prompt >= 1` |
+| `cosmos3_nano_reasoner` | vlm-server          | default; Cosmos3 Nano text-output Reasoner, image + video; video requires `max_videos_per_prompt >= 1` |
+| `cosmos_vlm`     | vlm-server               | Cosmos-Reason1 compatibility option; image + video; `enable_thinking=false` by default; video requires `max_videos_per_prompt >= 1` |
 | `llama_nemotron` | llama-nemotron-llm-server | OpenAI tool calling via llama3_json (server-side) |
 | `nemotron3_nano` | nemotron3-nano-llm-server | reasoning field: `reasoning` |
 | `nemotron_omni`  | nemotron-omni-llm-server  | reasoning field: `reasoning_content`, vision + video |
@@ -199,7 +200,7 @@ are a profile change:
       "category": "vlm",
       "adapter": {
         "kind": "openai_compat",
-        "model_name": "nvidia/cosmos-reason1-7b"
+        "model_name": "nvidia/cosmos3-nano-reasoner"
       },
       "endpoint": {
         "base_url": "https://integrate.api.nvidia.com",

--- a/agent-sdk/xr-ai-models/xr_ai_models/presets/__init__.py
+++ b/agent-sdk/xr-ai-models/xr_ai_models/presets/__init__.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Any
 
+from .cosmos3_nano_reasoner import COSMOS3_NANO_REASONER
 from .cosmos_vlm      import COSMOS_VLM
 from .llama_nemotron  import LLAMA_NEMOTRON
 from .magpie_tts      import MAGPIE_TTS
@@ -24,6 +25,7 @@ from .piper_tts       import PIPER_TTS
 
 
 _PRESETS: dict[str, dict[str, Any]] = {
+    "cosmos3_nano_reasoner": COSMOS3_NANO_REASONER,
     "cosmos_vlm":     COSMOS_VLM,
     "llama_nemotron": LLAMA_NEMOTRON,
     "magpie_tts":     MAGPIE_TTS,

--- a/agent-sdk/xr-ai-models/xr_ai_models/presets/cosmos3_nano_reasoner.py
+++ b/agent-sdk/xr-ai-models/xr_ai_models/presets/cosmos3_nano_reasoner.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Preset for the Cosmos3 Nano Reasoner served by ``vlm-server``.
+
+Reasoner runtime selection and checkpoint-layout details are documented in
+``docs/source/components/ai-services.md``. The official chat template needs
+neither ``default_extras`` nor a ``reasoning_field`` mapping.
+
+Video requests require ``max_videos_per_prompt >= 1`` in vlm-server's YAML;
+the server keeps video disabled by default to avoid reserving unused
+multimodal activation memory.
+"""
+
+COSMOS3_NANO_REASONER = {
+    "category":   "vlm",
+    "kind":       "openai_compat",
+    "model_name": "vlm",
+    "capabilities": {
+        "streaming": True,
+        "vision":    True,
+        "video":     True,
+    },
+}

--- a/docs/source/components/ai-services.md
+++ b/docs/source/components/ai-services.md
@@ -20,7 +20,7 @@ trade-offs documented below.
 
 | Server | Command | Port | Model | Backend |
 |---|---|---|---|---|
-| `services/vlm-server/` | `vlm_server` | 8100 | Cosmos-Reason1-7B | vLLM (pip or docker) |
+| `services/vlm-server/` | `vlm_server` | 8100 | Cosmos3 Nano Reasoner | vLLM (pip or docker) |
 | `services/stt-server/` | `stt_server` | 8103 | parakeet-tdt-0.6b-v3 | NeMo ASR in-process |
 | `services/magpie-tts/` | `magpie_tts_server` | 8104 | magpie_tts_multilingual_357m | NeMo TTS in-process |
 | `services/piper-tts/` | `piper_tts_server` | 8105 | rhasspy/piper-voices (ONNX) | piper-tts in-process |
@@ -56,7 +56,7 @@ match the consumer:
 ```bash
 # vLLM-served model, launched via a model-servers profile
 # (model_cache resolves to models/ at the repository root):
-HF_HOME=models hf download nvidia/Cosmos-Reason1-7B
+HF_HOME=models hf download nvidia/Cosmos3-Nano
 
 # NeMo STT server launched from its standalone YAML:
 HF_HOME=models/huggingface hf download nvidia/parakeet-tdt-0.6b-v3
@@ -212,7 +212,7 @@ disables endpoint health probing, and declares external ownership:
       "category": "vlm",
       "adapter": {
         "kind": "openai_compat",
-        "model_name": "nvidia/cosmos-reason1-7b",
+        "model_name": "nvidia/cosmos3-nano-reasoner",
         "capabilities": {"vision": true, "streaming": true}
       },
       "endpoint": {
@@ -298,12 +298,15 @@ Both modes honor identical configuration keys — same model, same port, same vL
 flags. The dispatcher lives in `utils/xr-ai-vllm/`. Switching is one YAML edit:
 
 ```yaml
+# vlm-server (Cosmos3)
 vllm_backend: docker
-vllm_image:   nvcr.io/nvidia/vllm:26.04-py3
+vllm_image:   nvcr.io/nvidia/vllm:26.07-py3
 ```
 
-`vllm_image:` defaults to `nvcr.io/nvidia/vllm:26.04-py3`; override to pin
-another tag, an internal mirror, or a custom build.
+`vllm_image:` defaults to `nvcr.io/nvidia/vllm:26.07-py3` for vlm-server,
+whose Cosmos3 support requires vLLM 0.23 or newer. The other wrappers retain
+their `26.04-py3` default. Override either to pin another tag, an internal
+mirror, or a custom build.
 
 ### docker mode — prerequisites
 
@@ -356,10 +359,18 @@ cleanup.
 
 ## Per-server notes
 
-- **vlm-server** is a thin launcher around `vllm serve` for Cosmos-Reason1-7B
-  (or any Qwen2.5-VL-compatible VLM). vLLM handles weight loading, image
-  decoding, and the OpenAI-compatible HTTP API. Hosting backend is selectable
-  per YAML — refer to *Choosing the vLLM runtime* above.
+- **vlm-server** defaults to the Cosmos3 Nano Reasoner. Hugging Face publishes
+  Reasoner and Generator weights in the unified `nvidia/Cosmos3-Nano`
+  checkpoint. The required `Cosmos3ForConditionalGeneration` architecture
+  override selects vLLM's native Reasoner loader: despite its generic class
+  name, it maps only the understanding tower and vision encoder and drops the
+  Generator weights. The Generator requires vLLM's separate `--omni` path,
+  which xr-ai intentionally does not enable. The checkpoint's official chat
+  template emits the assistant answer directly and has no `enable_thinking`
+  branch or `<think>` delimiters, so the client preset needs no reasoning-field
+  mapping. Cosmos-Reason1 remains available by pairing
+  `model: nvidia/Cosmos-Reason1-7B` with the `cosmos_vlm` client preset. Hosting
+  backend is selectable per YAML — refer to *Choosing the vLLM runtime* above.
 - **llama-nemotron-llm** is a thin wrapper around `vllm serve` for
   `Llama-3.1-Nemotron-Nano-8B-v1`. vLLM handles native Llama-3.1 tool calling
   via the `llama3_json` parser — `tools=[...]` in the request is rendered via

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -17,6 +17,17 @@ immediately — the services keep running in the background with weights hot.
 Start this once before running `xr-render-demo`, or whenever you want to
 pre-warm models:
 
+:::{important}
+After updating, stop any existing model servers before starting this stack:
+
+```bash
+uv run model_servers --stop
+```
+
+Persisted vLLM processes or containers may otherwise keep serving the previous
+model and image even though the checked-in configuration now selects Cosmos3.
+:::
+
 ```bash
 cd agent-samples/model-servers
 uv sync
@@ -26,7 +37,7 @@ uv run model_servers
 GPU profiles are auto-detected (`dual_48G_ada`, `spark`, `96G_blackwell`). These
 are presets for common configurations; to run on a different GPU, refer to
 {doc}`Running on other GPUs </getting_started/requirements>`.
-On first run each model downloads from HuggingFace (~50 GB total; can take
+On first run each model downloads from HuggingFace (tens of GB; can take
 tens of minutes). On subsequent runs the containers restart in under a minute.
 
 The default `--vlm-llm-stack` starts Nemotron-3 Nano (8107), Cosmos (8100),
@@ -39,7 +50,7 @@ they cannot be stopped, avoiding GPU overcommit.
 uv run model_servers --omni-stack
 ```
 
-`HF_TOKEN` is required by default: without it the ~50 GB first-run download
+`HF_TOKEN` is required by default: without it the large first-run download
 can stall indefinitely. Refer to the
 {doc}`credentials guide </getting_started/credentials>` for how to set it, or
 pass `--allow-anonymous` to run without one.
@@ -59,7 +70,8 @@ channel, or send the literal text `"ping"` — all routes go through the same VL
 pipeline against the latest video frame. Replies arrive as streaming Piper TTS
 audio plus a `vlm.response` text message.
 
-Uses `nvidia/Cosmos-Reason1-7B` (NVIDIA Open Model License + Apache 2.0).
+Uses the text-output Reasoner from `nvidia/Cosmos3-Nano` by default. Refer to
+{doc}`AI services </components/ai-services>` for runtime-selection details.
 
 There are two ways to run it:
 
@@ -72,7 +84,7 @@ uv sync
 uv run simple_vlm_example
 ```
 
-On the very first run weights download from HuggingFace (~23 GB; can take
+On the very first run weights download from HuggingFace (tens of GB; can take
 several minutes). `HF_TOKEN` is required by default; pass `--allow-anonymous`
 to run without one (refer to the
 {doc}`credentials guide </getting_started/credentials>`).
@@ -120,6 +132,9 @@ a moment, and you hear the reply through your speakers.
 
 **Local model** — override the model weights or GPU settings by editing
 `vlm_server.yaml` in the sample directory.
+
+To use Cosmos-Reason1 instead, set `model: nvidia/Cosmos-Reason1-7B` in that
+file and select `cosmos_vlm` as the VLM adapter preset in `models.local.json`.
 
 **Remote model** — copy `yaml/models.hosted.json`, point its VLM endpoint at
 your server, and select it in the worker config:

--- a/docs/source/guides/troubleshooting.md
+++ b/docs/source/guides/troubleshooting.md
@@ -368,7 +368,7 @@ to run while the stack is down.
 time.
 
 **Cause:** model weights are downloading from HuggingFace into `models/` at
-the repository root (gitignored, ~16 GB for Cosmos-Reason1-7B alone).
+the repository root (gitignored; the Cosmos3 checkpoint alone is tens of GB).
 
 **Fix:** wait. Subsequent runs use the cached weights and start in
 ~30–60 s. If the download makes no progress, note that unauthenticated

--- a/docs/source/reference/xr-render-demo.md
+++ b/docs/source/reference/xr-render-demo.md
@@ -123,14 +123,14 @@ calls (thinking stays off):
   position"* on a 10s repeat. Sent to the data channel only — never spoken,
   to avoid stacking up in the TTS queue behind the real response.
 
-## VLM — Cosmos-Reason1-7B
+## VLM — Cosmos3 Nano Reasoner
 
 Port 8100 (`vlm-server`).
 
-Loaded in-process by `vlm-server` via HuggingFace transformers
-(Qwen2.5-VL architecture). `<think>…</think>` blocks are stripped before
-returning. The render agent selects a current or recorded frame first, then
-passes its `ImageReference` to `query_image`. Its native capability set also
+Served by vLLM from `nvidia/Cosmos3-Nano` as described in
+{doc}`AI services </components/ai-services>`. The render agent first selects a
+current or recorded frame and passes its `ImageReference` to `query_image`.
+Its native capability set also
 includes `query_images` for ordered collections and `query_video` for
 timestamped frame sequences; all use the same `xr-ai-models` multi-image VLM
 path, limited to four images by the shipped Cosmos configuration. These raw

--- a/services/vlm-server/pyproject.toml
+++ b/services/vlm-server/pyproject.toml
@@ -10,7 +10,7 @@ name = "vlm-server"
 version = "0.1.0"
 requires-python = ">=3.11,<3.13"
 dependencies = [
-    "vllm>=0.12.0",
+    "vllm>=0.23.0",
     "pyyaml>=6.0",
     "hf-transfer>=0.1.4",
     "xr-ai-logging",

--- a/services/vlm-server/vlm_server.yaml
+++ b/services/vlm-server/vlm_server.yaml
@@ -1,11 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# vlm-server — vLLM configuration for Cosmos-Reason1-7B.
+# vlm-server — vLLM configuration for the Cosmos3 Nano Reasoner.
 # OpenAI-compatible API at http://localhost:8100/v1  (served-model-name: "vlm")
 # Accepts image_url content blocks (base64 data URLs or HTTP URLs).
+#
+# The architecture override selects the Reasoner runtime; rationale and loader
+# details: docs/source/components/ai-services.md#per-server-notes.
 
-model: nvidia/Cosmos-Reason1-7B
+model: nvidia/Cosmos3-Nano
+hf_overrides:
+  architectures:
+    - Cosmos3ForConditionalGeneration
 
 host: "0.0.0.0"
 port: 8100
@@ -27,31 +33,28 @@ tensor_parallel_size:   1
 max_model_len:          8192
 gpu_memory_utilization: 0.85
 enforce_eager:          false
+# Recommended by NVIDIA for the Cosmos3 Reasoner vLLM path.
+async_scheduling:       true
+mm_encoder_tp_mode:     data
 
 # Max images accepted per request.
-#
-# Budget note: each Qwen2.5-VL image consumes ~1.5k tokens of context at the
-# default preprocessor settings (smart_resize, max 1280×28 patches), so 4
-# images fit comfortably inside max_model_len=8192 alongside a typical
-# system+user prompt. If you raise this above ~5, also raise max_model_len
-# or tighten the image-preprocessor patch limit, otherwise long multi-image
-# turns will be truncated by vLLM at request time.
+# Raise max_model_len as needed for larger multi-image prompts.
 max_images_per_prompt:  4
 
 # Max video items accepted per request. Default 0 (disabled).
-# Qwen2.5-VL-class models reserve activation memory at startup for the maximum
-# video feature size, which can cost tens of GiB even if no caller ever sends
-# video. Leave at 0 unless your worker sends video_url content blocks.
+# Multimodal models reserve activation memory at startup for the maximum video
+# feature size. Leave at 0 unless your worker sends video_url content blocks.
 max_videos_per_prompt:  0
 
 # vLLM runtime — pip-installed vllm (default) or NGC docker container.
 #   pip     — vllm CLI from this wrapper's venv (today's behavior)
 #   docker  — `docker run nvcr.io/nvidia/vllm:<tag> vllm serve …`
 # Both honor the same config keys above; only the runtime hosting vllm differs.
-# docker mode requires Docker Engine + NVIDIA Container Toolkit and a
-# `docker login nvcr.io` (or NGC_API_KEY in the environment).
+# docker mode requires Docker Engine + NVIDIA Container Toolkit. NVIDIA's
+# public vLLM image supports anonymous pulls; NGC login is only needed for a
+# restricted override image (and can be supplied through NGC_API_KEY).
 vllm_backend: docker
 
 # Container image used when vllm_backend: docker.  Override to pin a different
 # tag, an internal mirror, or a custom build.
-vllm_image: nvcr.io/nvidia/vllm:26.04-py3
+vllm_image: nvcr.io/nvidia/vllm:26.07-py3

--- a/services/vlm-server/vlm_server/__main__.py
+++ b/services/vlm-server/vlm_server/__main__.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-vlm_server — vLLM launcher for Cosmos-Reason1-7B (or any Qwen2.5-VL-compatible VLM).
+vlm_server — vLLM launcher for Cosmos3 Nano Reasoner (or another vLLM VLM).
 
 Reads config, builds vLLM serve flags, and dispatches through ``xr_ai_vllm.serve``
 to either the pip-installed ``vllm`` CLI or the NGC ``nvcr.io/nvidia/vllm``
@@ -26,15 +26,17 @@ Config keys
     max_model_len:           int    vLLM --max-model-len (default: 8192).
     gpu_memory_utilization:  float  vLLM --gpu-memory-utilization (default: 0.85).
     enforce_eager:           bool   Skip CUDA graph capture (default: false).
+    async_scheduling:        bool   Enable vLLM async scheduling (default: false).
+    hf_overrides:            dict   Hugging Face config overrides passed as JSON.
+    mm_encoder_tp_mode:      str    Multimodal encoder TP mode (optional).
     max_images_per_prompt:   int    Max images per request (default: 1).
     max_videos_per_prompt:   int    Max video items per request (default: 0).
                                     Set >0 only if your worker sends video;
                                     0 skips vLLM's video activation profiling
-                                    at startup, saving tens of GiB on
-                                    Qwen2.5-VL-class models.
+                                    at startup.
     vllm_backend:            str    "pip" (default) or "docker".
     vllm_image:              str    NGC image when vllm_backend=docker
-                                    (default: nvcr.io/nvidia/vllm:26.04-py3).
+                                    (default: nvcr.io/nvidia/vllm:26.07-py3).
 """
 import json
 import os
@@ -43,7 +45,6 @@ import sys
 from loguru import logger
 from xr_ai_logging import setup_logging
 from xr_ai_vllm import (
-    DEFAULT_IMAGE,
     load_config,
     resolve_model_cache,
     serve,
@@ -58,8 +59,13 @@ _DEFAULT_TP          = 1
 _DEFAULT_CTX         = 8192
 _DEFAULT_GPU_MEM     = 0.85
 _DEFAULT_EAGER       = False
+_DEFAULT_ASYNC       = False
 _DEFAULT_MAX_IMAGES  = 1
 _DEFAULT_MAX_VIDEOS  = 0
+_DEFAULT_VLLM_IMAGE  = "nvcr.io/nvidia/vllm:26.07-py3"
+
+_COSMOS3_NANO_MODEL = "nvidia/Cosmos3-Nano"
+_COSMOS3_REASONER_ARCHITECTURE = "Cosmos3ForConditionalGeneration"
 
 _CONTAINER_NAME = "xr-ai-vllm-vlm-server"
 
@@ -82,13 +88,30 @@ def run() -> None:
     max_ctx       = int(cfg.get("max_model_len",    _DEFAULT_CTX))
     gpu_mem       = float(cfg.get("gpu_memory_utilization", _DEFAULT_GPU_MEM))
     enforce_eager = bool(cfg.get("enforce_eager",   _DEFAULT_EAGER))
+    async_sched   = bool(cfg.get("async_scheduling", _DEFAULT_ASYNC))
+    hf_overrides  = cfg.get("hf_overrides")
+    mm_encoder_tp_mode = cfg.get("mm_encoder_tp_mode")
     max_images    = int(cfg.get("max_images_per_prompt", _DEFAULT_MAX_IMAGES))
     max_videos    = int(cfg.get("max_videos_per_prompt", _DEFAULT_MAX_VIDEOS))
     backend       = cfg.get("vllm_backend",         "pip")
-    image         = cfg.get("vllm_image",           DEFAULT_IMAGE)
+    image         = cfg.get("vllm_image",           _DEFAULT_VLLM_IMAGE)
 
     model_cache = resolve_model_cache(cfg, yaml_dir, default="../../models")
     cuda_devices = setup_hf_env(cfg, model_cache)
+
+    if model == _COSMOS3_NANO_MODEL:
+        architectures = (
+            hf_overrides.get("architectures")
+            if isinstance(hf_overrides, dict)
+            else None
+        )
+        if architectures != [_COSMOS3_REASONER_ARCHITECTURE]:
+            logger.error(
+                "Cosmos3 Nano requires hf_overrides.architectures=[{}] to "
+                "guarantee vLLM's Reasoner-only weight-mapping path",
+                _COSMOS3_REASONER_ARCHITECTURE,
+            )
+            sys.exit(1)
 
     extra_serve_args = [
         "--served-model-name", served_name,
@@ -101,6 +124,12 @@ def run() -> None:
     ]
     if enforce_eager:
         extra_serve_args.append("--enforce-eager")
+    if async_sched:
+        extra_serve_args.append("--async-scheduling")
+    if hf_overrides:
+        extra_serve_args.extend(["--hf-overrides", json.dumps(hf_overrides)])
+    if mm_encoder_tp_mode:
+        extra_serve_args.extend(["--mm-encoder-tp-mode", str(mm_encoder_tp_mode)])
 
     serve(
         backend=backend,

--- a/tests/test_gpu_vlm_server.py
+++ b/tests/test_gpu_vlm_server.py
@@ -5,15 +5,15 @@
 
 Spawns the real ``vlm_server`` subprocess against a generated temp YAML, waits
 for the HTTP port to open, issues one chat-completions request with a tiny
-embedded PNG, and checks for a non-empty content string.
+embedded PNG, and checks for a non-empty final answer without reasoning markup.
 
-Skipped automatically when ``uv`` is missing or no Cosmos-Reason1-7B weights
-are present on disk.
+Skipped automatically when ``uv`` is missing.
 """
 from __future__ import annotations
 
 import asyncio
 import base64
+import json
 import os
 import shutil
 import signal
@@ -35,10 +35,10 @@ pytestmark = [pytest.mark.asyncio, pytest.mark.gpu]
 
 _REPO_ROOT       = Path(__file__).resolve().parent.parent
 _VLM_SERVER_DIR  = _REPO_ROOT / "services" / "vlm-server"
-_DEFAULT_WEIGHTS = Path("~/.cache/huggingface/hub/models--nvidia--Cosmos-Reason1-7B").expanduser()
+_DEFAULT_WEIGHTS = Path("~/.cache/huggingface/hub/models--nvidia--Cosmos3-Nano").expanduser()
 
-# 30 min — enough for a cold first-time weights download (~15 GB) plus
-# vLLM compilation. Cached runs complete in ~60 s.
+# 30 min — enough for a cold first-time weights download plus vLLM compilation.
+# Cached runs complete in ~60 s.
 _STARTUP_TIMEOUT_S   = 1800.0
 _SHUTDOWN_TIMEOUT_S  = 30.0
 
@@ -128,7 +128,7 @@ async def test_vlm_server_chat_completions_smoke():
         cfg_yaml = td_path / "vlm_server.yaml"
         ready_file = td_path / "ready"
         cfg = {
-            "model": "nvidia/Cosmos-Reason1-7B",
+            "model": "nvidia/Cosmos3-Nano",
             "host": "127.0.0.1",
             "port": port,
             "served_model_name": "vlm",
@@ -138,10 +138,16 @@ async def test_vlm_server_chat_completions_smoke():
             "max_model_len": 4096,
             "gpu_memory_utilization": 0.80,
             "enforce_eager": True,  # skip CUDA graph capture for faster smoke
+            "async_scheduling": True,
+            "hf_overrides": {
+                "architectures": ["Cosmos3ForConditionalGeneration"],
+            },
+            "mm_encoder_tp_mode": "data",
             "max_images_per_prompt": 1,
             "max_videos_per_prompt": 0,
             # docker backend: nvcc + flashinfer are pre-built in the NGC image.
             "vllm_backend": "docker",
+            "vllm_image": "nvcr.io/nvidia/vllm:26.07-py3",
         }
         cfg_yaml.write_text(yaml.safe_dump(cfg))
 
@@ -172,16 +178,39 @@ async def test_vlm_server_chat_completions_smoke():
                 }],
                 "max_tokens": 20,
                 "temperature": 0,
+                "stream": True,
             }
+            content_chunks: list[str] = []
+            saw_done = False
             async with httpx.AsyncClient(timeout=60.0) as client:
-                r = await client.post(
+                async with client.stream(
+                    "POST",
                     f"http://127.0.0.1:{port}/v1/chat/completions",
                     json=payload,
-                )
-            assert r.status_code == 200, f"HTTP {r.status_code}: {r.text[:500]}"
-            data = r.json()
-            content = data["choices"][0]["message"]["content"]
-            assert isinstance(content, str) and content.strip(), f"empty content: {data!r}"
+                ) as response:
+                    if response.status_code != 200:
+                        await response.aread()
+                    assert response.status_code == 200, (
+                        f"HTTP {response.status_code}: {response.text[:500]}"
+                    )
+                    async for line in response.aiter_lines():
+                        if not line.startswith("data:"):
+                            continue
+                        event = line.removeprefix("data:").strip()
+                        if event == "[DONE]":
+                            saw_done = True
+                            break
+                        data = json.loads(event)
+                        delta = data["choices"][0]["delta"]
+                        if isinstance(delta.get("content"), str):
+                            content_chunks.append(delta["content"])
+
+            assert saw_done, "stream ended without the OpenAI [DONE] event"
+            content = "".join(content_chunks).strip()
+            assert content, "stream returned no content"
+            assert "<think>" not in content.casefold(), (
+                "Cosmos3 Reasoner leaked reasoning markup into streamed content"
+            )
         finally:
             await _terminate(proc)
             kill_orphan_vllm(port)

--- a/tests/test_models_config.py
+++ b/tests/test_models_config.py
@@ -42,8 +42,9 @@ def test_package_root_exports_complete_config_surface() -> None:
     assert LLMSpec in get_args(Spec)
 
 
-def test_eight_presets_registered() -> None:
+def test_nine_presets_registered() -> None:
     assert set(available_presets()) == {
+        "cosmos3_nano_reasoner",
         "cosmos_vlm",
         "llama_nemotron",
         "magpie_tts",
@@ -231,7 +232,7 @@ def test_profile_rejects_non_mapping_sections(section, value) -> None:
         load_models_config_from_dict(profile)
 
 
-def test_vlm_preset(tmp_path) -> None:
+def test_cosmos1_vlm_preset_remains_available(tmp_path) -> None:
     cfg = load_models_config(_write(tmp_path, """
 vlm:
   kind:     preset:cosmos_vlm
@@ -245,6 +246,20 @@ vlm:
     }
     assert spec.capabilities.get("vision") is True
     assert spec.capabilities.get("video")  is True
+
+
+def test_cosmos3_nano_reasoner_preset(tmp_path) -> None:
+    cfg = load_models_config(_write(tmp_path, """
+vlm:
+  kind:     preset:cosmos3_nano_reasoner
+  base_url: http://localhost:8100
+"""))
+    spec = cfg.vlm("vlm")
+    assert isinstance(spec, VLMSpec)
+    assert spec.model_name == "vlm"
+    assert spec.default_extras == {}
+    assert spec.capabilities.get("vision") is True
+    assert spec.capabilities.get("video") is True
 
 
 def test_stt_and_tts_presets(tmp_path) -> None:

--- a/tests/test_vlm_server_config.py
+++ b/tests/test_vlm_server_config.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""VLM server configuration coverage."""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SERVER_MAIN = _REPO_ROOT / "services" / "vlm-server" / "vlm_server" / "__main__.py"
+_SERVER_YAML = _REPO_ROOT / "services" / "vlm-server" / "vlm_server.yaml"
+_SAMPLES = _REPO_ROOT / "agent-samples"
+_MODEL_PROFILES = _SAMPLES / "model-servers" / "yaml"
+_LOCAL_VLM_CONFIGS = (
+    _SERVER_YAML,
+    _SAMPLES / "simple-vlm-example" / "yaml" / "vlm_server.yaml",
+    _MODEL_PROFILES / "96G_blackwell" / "vlm_server.yaml",
+    _MODEL_PROFILES / "dual_48G_ada" / "vlm_server.yaml",
+    _MODEL_PROFILES / "spark" / "vlm_server.yaml",
+)
+
+
+def _load_server_module():
+    spec = importlib.util.spec_from_file_location("_test_vlm_server_main", _SERVER_MAIN)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_default_cosmos3_service_uses_reasoner_only_path(monkeypatch, tmp_path) -> None:
+    server = _load_server_module()
+    cfg = yaml.safe_load(_SERVER_YAML.read_text())
+    captured = {}
+
+    monkeypatch.setattr(server, "setup_logging", lambda _name: None)
+    monkeypatch.setattr(
+        server,
+        "load_config",
+        lambda: (cfg, _SERVER_YAML.parent, None),
+    )
+    monkeypatch.setattr(
+        server,
+        "resolve_model_cache",
+        lambda *_args, **_kwargs: tmp_path,
+    )
+    monkeypatch.setattr(server, "setup_hf_env", lambda *_args: None)
+    monkeypatch.setattr(server, "serve", lambda **kwargs: captured.update(kwargs))
+
+    server.run()
+
+    args = captured["extra_serve_args"]
+    assert captured["model"] == "nvidia/Cosmos3-Nano"
+    assert captured["image"] == "nvcr.io/nvidia/vllm:26.07-py3"
+    assert "--async-scheduling" in args
+    overrides_index = args.index("--hf-overrides")
+    assert json.loads(args[overrides_index + 1]) == {
+        "architectures": ["Cosmos3ForConditionalGeneration"],
+    }
+    encoder_mode_index = args.index("--mm-encoder-tp-mode")
+    assert args[encoder_mode_index + 1] == "data"
+    assert "--omni" not in args
+    assert "--model-class-name" not in args
+    assert "Cosmos3OmniDiffusersPipeline" not in args
+
+
+def test_all_local_profiles_select_cosmos3_reasoner_runtime() -> None:
+    for config_path in _LOCAL_VLM_CONFIGS:
+        cfg = yaml.safe_load(config_path.read_text())
+        assert cfg["model"] == "nvidia/Cosmos3-Nano", config_path
+        assert cfg["vllm_image"] == "nvcr.io/nvidia/vllm:26.07-py3", config_path
+        assert cfg["async_scheduling"] is True, config_path
+        assert cfg["hf_overrides"] == {
+            "architectures": ["Cosmos3ForConditionalGeneration"],
+        }, config_path
+        assert cfg["mm_encoder_tp_mode"] == "data", config_path
+
+
+def test_hardware_profiles_reserve_measured_reasoner_memory() -> None:
+    blackwell = yaml.safe_load(
+        (_MODEL_PROFILES / "96G_blackwell" / "vlm_server.yaml").read_text()
+    )
+    dual_ada = yaml.safe_load(
+        (_MODEL_PROFILES / "dual_48G_ada" / "vlm_server.yaml").read_text()
+    )
+
+    assert blackwell["gpu_memory_utilization"] == 0.23
+    assert dual_ada["gpu_memory_utilization"] == 0.47
+
+
+def test_cosmos3_rejects_missing_reasoner_override(monkeypatch, tmp_path) -> None:
+    server = _load_server_module()
+    cfg = yaml.safe_load(_SERVER_YAML.read_text())
+    del cfg["hf_overrides"]
+
+    monkeypatch.setattr(server, "setup_logging", lambda _name: None)
+    monkeypatch.setattr(
+        server,
+        "load_config",
+        lambda: (cfg, _SERVER_YAML.parent, None),
+    )
+    monkeypatch.setattr(
+        server,
+        "resolve_model_cache",
+        lambda *_args, **_kwargs: tmp_path,
+    )
+    monkeypatch.setattr(server, "setup_hf_env", lambda *_args: None)
+
+    with pytest.raises(SystemExit, match="1"):
+        server.run()
+
+
+def test_sample_model_profiles_select_cosmos3_reasoner() -> None:
+    simple = _SAMPLES / "simple-vlm-example" / "yaml"
+    simple_local = json.loads((simple / "models.local.json").read_text())
+    simple_hosted = json.loads((simple / "models.hosted.json").read_text())
+    assert simple_local["models"]["vlm"]["adapter"]["preset"] == (
+        "cosmos3_nano_reasoner"
+    )
+    assert simple_hosted["models"]["vlm"]["adapter"]["model_name"] == (
+        "nvidia/cosmos3-nano-reasoner"
+    )
+
+    render = _SAMPLES / "xr-render-demo" / "yaml"
+    render_local = yaml.safe_load((render / "models.yaml").read_text())
+    render_hosted = yaml.safe_load((render / "models.nim.yaml").read_text())
+    assert render_local["vlm"]["kind"] == "preset:cosmos3_nano_reasoner"
+    assert render_hosted["vlm"]["model_name"] == (
+        "nvidia/cosmos3-nano-reasoner"
+    )

--- a/utils/xr-ai-vllm/xr_ai_vllm/__init__.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/__init__.py
@@ -56,6 +56,8 @@ from ._config import (
 log = logging.getLogger(__name__)
 
 # Default NGC image. Override per-server via `vllm_image:` in YAML.
+# vlm-server intentionally pins a newer tag locally for Cosmos3 support; keep
+# that service-specific override in mind when updating this shared default.
 DEFAULT_IMAGE = "nvcr.io/nvidia/vllm:26.04-py3"
 
 


### PR DESCRIPTION
## Summary

- replace Cosmos-Reason1 with the Cosmos3 Nano Reasoner in the shipped local VLM configurations and use `nvidia/cosmos3-nano-reasoner` for hosted NIM profiles
- retain `cosmos_vlm` as the Cosmos-Reason1 compatibility preset and add a dedicated `cosmos3_nano_reasoner` preset
- load `nvidia/Cosmos3-Nano` through vLLM's `Cosmos3ForConditionalGeneration` reasoner-only weight mapper, with async scheduling and the 26.07 NGC vLLM image
- reserve the measured Reasoner memory budget in the Blackwell and dual-Ada model-server profiles
- update direct documentation and regression/GPU-smoke coverage

The branch is rebuilt as one signed-off commit directly on current `main`. The unrelated persistent-vLLM lifecycle commit previously present in this PR has been removed.

## Reasoner, not Generator

Hugging Face publishes `nvidia/Cosmos3-Nano` as a unified checkpoint rather than a separate Reasoner repository. Every local Cosmos3 configuration therefore supplies:

```yaml
hf_overrides:
  architectures:
    - Cosmos3ForConditionalGeneration
```

In the pinned NGC vLLM runtime, that loader maps the understanding transformer and vision encoder and skips the Generator weights. xr-ai does not enable vLLM-Omni or `--omni`.

The VLM wrapper rejects a Cosmos3 launch if this override is absent, preventing a configuration change from silently selecting the wrong architecture.

## Hardware profiles

- RTX PRO 6000 Blackwell 96 GB: `gpu_memory_utilization: 0.23` (22.1 GiB)
- dual RTX 6000 Ada 48 GB: `gpu_memory_utilization: 0.47` on GPU 0 (22.1 GiB), sharing that GPU with the 0.08 embedding allocation
- DGX Spark: `gpu_memory_utilization: 0.20` (24 GiB)

The Blackwell smoke run measured 16.79 GiB of Reasoner weights, 2.32 GiB of KV cache / 16,912 KV tokens, and returned HTTP 200 for an image query. The dual-Ada profile has the same effective VLM budget; its allocation is covered by configuration tests but was not physically run in this environment.

## Compatibility

Cosmos-Reason1 remains available by configuring `model: nvidia/Cosmos-Reason1-7B` and selecting the `cosmos_vlm` client preset. Its existing `enable_thinking=false` behavior is unchanged.

## Validation

- focused VLM/model/profile/wire tests: 98 passed
- full CPU suite: 767 passed, 10 GPU tests deselected
- `python3 -m py_compile` on changed Python modules
- `git diff --check`

References:
- https://github.com/NVIDIA/cosmos/blob/main/cookbooks/cosmos3/reasoner/README.md
- https://huggingface.co/nvidia/Cosmos3-Nano
