### PR TITLE
fix(video): require PyNvVideoCodec 2.2 packet API

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -15,11 +15,9 @@
 ## Python version
 
 Every `pyproject.toml` in this repo pins `requires-python = ">=3.11,<3.13"` by
-convention. The upper bound exists because `PyNvVideoCodec` (used by
-`xr-media-hub` and `video-memory-service` for NVENC encode / NVDEC decode) does not
-yet publish wheels for Python 3.13. With the cap in place, `uv sync` will pick
-3.12 even on a host where 3.13 is also installed. Loosen the upper bound only
-after `PyNvVideoCodec` ships 3.13 wheels.
+convention. PyNvVideoCodec 2.2 publishes Python 3.13 wheels, but the rest of the
+repository dependency graph and test matrix have not been qualified on 3.13.
+Loosen the upper bound only as a coordinated repository-wide change.
 
 A project may state a different range when its dependencies require it; the
 constraints stay honest because `.github/workflows/lock-check.yml` runs
@@ -220,7 +218,7 @@ xr-media-hub  (server-runtime/)
     └── numpy >=1.24
     └── pyyaml >=6.0
     └── cryptography >=42.0
-    PyNvVideoCodec >=1.0 (NVENC H.264 encoder; used when video_recording.enabled: true)
+    PyNvVideoCodec >=2.2 (NVENC H.264 encoder; used when video_recording.enabled: true)
 
 transcript-mcp-server  (agent-mcp-servers/transcript-mcp/)
     └── uvicorn[standard] >=0.29
@@ -261,7 +259,7 @@ video-mcp-server  (agent-mcp-servers/video-mcp/)
 xr-video-memory-service  (services/video-memory-service/)
     └── xr-ai-logging [editable: ../../utils/xr-ai-logging]
     └── xr-ai-nat[services] [editable: ../../agent-sdk/xr-ai-nat]
-    └── PyNvVideoCodec >=1.0
+    └── PyNvVideoCodec >=2.2
     └── Pillow >=10.0
     └── numpy >=1.24
     └── pyyaml >=6.0

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,17 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-07-30 — Adopt the PyNvVideoCodec 2.2 packet contract
+
+`xr-media-hub` and `video-memory-service` now require PyNvVideoCodec 2.2 or
+newer. Version 2.2 changed `Encode()` and `EndEncode()` from returning one byte
+string to returning a list of packet dictionaries whose `data` values hold the
+bitstream. The recorder consumes that packet contract directly; passing the new
+result to `bytearray.extend()` dropped every frame with
+`TypeError: 'dict' object cannot be interpreted as an integer`. The
+historical-video GPU fixture follows the same contract and no longer masks type
+errors as unavailable NVENC hardware.
+
 ### 2026-07-29 — xr-ai-models internal modules are privatized
 
 The `xr-ai-models` implementation modules `config.py`, `factory.py`,

--- a/server-runtime/pyproject.toml
+++ b/server-runtime/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     # TLS certificate generation
     "cryptography>=42.0",
     # NVENC video recording (opt-in at runtime via video_recording.enabled in YAML)
-    "PyNvVideoCodec>=1.0",
+    "PyNvVideoCodec>=2.2",
 ]
 
 [project.scripts]

--- a/server-runtime/xr_media_hub/video/_recorder.py
+++ b/server-runtime/xr_media_hub/video/_recorder.py
@@ -156,9 +156,7 @@ class VideoRecorder:
                 old_encoder = enc.encoder
                 enc.encoder = None
                 try:
-                    flushed = old_encoder.EndEncode()
-                    if flushed:
-                        enc.chunk_buf.extend(flushed)
+                    _append_encoded_packets(enc.chunk_buf, old_encoder.EndEncode())
                 except Exception as e:
                     logger.warning(
                         "recorder  EndEncode error on resolution change pid={!r}: {}",
@@ -194,17 +192,13 @@ class VideoRecorder:
                 if enc.failed:
                     return
 
-            encoded = enc.encoder.Encode(nv12)
-            if encoded:
-                enc.chunk_buf.extend(encoded)
+            _append_encoded_packets(enc.chunk_buf, enc.encoder.Encode(nv12))
 
             enc.chunk_frames += 1
 
     def _rotate_chunk(self, enc: _TrackEncoder, pid: str) -> None:
         try:
-            flushed = enc.encoder.EndEncode()
-            if flushed:
-                enc.chunk_buf.extend(flushed)
+            _append_encoded_packets(enc.chunk_buf, enc.encoder.EndEncode())
         except Exception as e:
             logger.warning("recorder  EndEncode error pid={!r}: {}", pid, e)
         self._flush_chunk(enc)
@@ -319,12 +313,30 @@ class VideoRecorder:
                 # failed; skip EndEncode but still flush any buffered chunk.
                 if enc.encoder is not None:
                     try:
-                        flushed = enc.encoder.EndEncode()
-                        if flushed:
-                            enc.chunk_buf.extend(flushed)
+                        _append_encoded_packets(enc.chunk_buf, enc.encoder.EndEncode())
                     except Exception as e:
                         logger.warning("recorder  flush error pid={!r}: {}", pid, e)
                 self._flush_chunk(enc)
+
+
+# ── encoded packets ───────────────────────────────────────────────────────────
+
+def _append_encoded_packets(
+    buffer: bytearray,
+    packets: list[dict[str, object]],
+) -> None:
+    """Append bitstream data from PyNvVideoCodec 2.2 encoded packets."""
+    for packet in packets:
+        if not isinstance(packet, dict):
+            raise TypeError(
+                f"unexpected PyNvVideoCodec packet: {type(packet).__name__}",
+            )
+        data = packet.get("data")
+        if not isinstance(data, bytes):
+            raise TypeError(
+                f"unexpected PyNvVideoCodec packet data: {type(data).__name__}",
+            )
+        buffer.extend(data)
 
 
 # ── pixel format conversion ───────────────────────────────────────────────────

--- a/services/video-memory-service/pyproject.toml
+++ b/services/video-memory-service/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "xr-ai-nat[services]",
     "numpy>=1.24",
     "Pillow>=10.0",
-    "PyNvVideoCodec>=1.0",
+    "PyNvVideoCodec>=2.2",
     "pyyaml>=6.0",
 ]
 

--- a/tests/test_gpu_video_mcp.py
+++ b/tests/test_gpu_video_mcp.py
@@ -42,6 +42,7 @@ pytest.importorskip("fastmcp")
 from fastmcp import Client as McpClient  # noqa: E402
 from xr_ai_agent import PixelFormat  # noqa: E402
 from xr_media_hub.ipc import ConnectorEndpoint  # noqa: E402
+from xr_media_hub.video._recorder import _append_encoded_packets  # noqa: E402
 
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.gpu]
@@ -87,12 +88,8 @@ def _encode_chunk(out_dir: pathlib.Path, pid: str, start_us: int) -> dict:
 
     buf = bytearray()
     for i in range(_FRAMES):
-        chunk = encoder.Encode(_synthetic_nv12(i))
-        if chunk:
-            buf.extend(chunk)
-    flushed = encoder.EndEncode()
-    if flushed:
-        buf.extend(flushed)
+        _append_encoded_packets(buf, encoder.Encode(_synthetic_nv12(i)))
+    _append_encoded_packets(buf, encoder.EndEncode())
 
     h264_path = pid_dir / f"{start_us}.264"
     h264_path.write_bytes(bytes(buf))
@@ -167,7 +164,7 @@ async def test_get_frame_from_time_returns_valid_png(tmp_path: pathlib.Path) -> 
     start_us = int(time.time() * 1_000_000)
     try:
         meta = _encode_chunk(rec_dir, pid, start_us)
-    except Exception as exc:  # noqa: BLE001
+    except (RuntimeError, OSError) as exc:
         # No NVENC hardware (or driver mismatch) — skip cleanly per the
         # task brief; we only care about the path when the GPU is present.
         pytest.skip(f"NVENC unavailable: {exc!r}")

--- a/tests/test_video_recorder.py
+++ b/tests/test_video_recorder.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from xr_media_hub.video._recorder import _append_encoded_packets
+
+
+@pytest.mark.parametrize(
+    ("output", "expected"),
+    [
+        (
+            [
+                {"data": b"\x02", "timestamp": 0, "picture_type": 1},
+                {"data": b"\x03\x04", "timestamp": 1, "picture_type": 2},
+            ],
+            b"\x02\x03\x04",
+        ),
+        ([], b""),
+    ],
+)
+def test_append_encoded_packets(
+    output: list[dict[str, object]],
+    expected: bytes,
+) -> None:
+    buffer = bytearray(b"\xff")
+
+    _append_encoded_packets(buffer, output)
+
+    assert buffer == b"\xff" + expected
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        b"pre-2.2-byte-output",
+        [b"not-a-packet"],
+        [{"timestamp": 0, "picture_type": 1}],
+        [{"data": "not-bytes", "timestamp": 0, "picture_type": 1}],
+    ],
+)
+def test_append_encoded_packets_rejects_unknown_contracts(output: object) -> None:
+    with pytest.raises(TypeError, match="unexpected PyNvVideoCodec"):
+        _append_encoded_packets(bytearray(), output)


### PR DESCRIPTION
## Summary

- require PyNvVideoCodec 2.2+ in both `xr-media-hub` and `video-memory-service`
- consume only the 2.2 encoded-packet contract in every recorder encode and flush path
- use the same packet handling in the historical-video GPU fixture
- ensure type-contract errors fail the GPU fixture instead of being mislabeled as unavailable NVENC hardware
- add packet-contract regression coverage and update dependency documentation

Fixes #302

## Root cause

PyNvVideoCodec 2.2 changed `Encode()` and `EndEncode()` from returning `bytes`
to returning a list of packet dictionaries with the bitstream under `data`.
The recorder passed that list directly to `bytearray.extend()`, raising
`TypeError: 'dict' object cannot be interpreted as an integer`. Frame errors
were logged and dropped, so no H.264 chunks or sidecars were written.

This PR adopts the 2.2 packet API as the repository's only supported contract;
it does not retain support for the pre-2.2 byte return shape.

## Testing

- `uv run pytest -q test_video_recorder.py` — 6 passed
- targeted GPU tests on NVIDIA L40S with PyNvVideoCodec 2.2.0 — 3 passed
  - synthetic recorder
  - resolution-change recorder
  - historical NVENC → NVDEC → PNG
- `uv run pytest -q -m 'not gpu'` — 642 passed, 2 skipped, 10 deselected
- standalone lock resolution and package builds for both affected projects — passed
- Ruff 0.15.16, SPDX validation, and `git diff --check` — passed
