### PR TITLE
fix(launcher): preflight reused services

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -153,8 +153,12 @@ xr-ai-launcher  (utils/xr-ai-launcher/)
     profiles: `NATIVE_DEVICE_PROFILES`, `is_native_profile(profile)`, and
     `read_device_profile(yaml_path)` (env-first NV_DEVICE_PROFILE read, regex
     YAML fallback). `load_model_deployment()` reads the selected wrapped JSON
-    model profile using only stdlib to derive managed/reused services and
-    required credential names, without adding a YAML or model-SDK dependency.
+    model profile using only stdlib to derive managed/reused services, external
+    endpoint probes, and required credential names without adding a YAML or
+    model-SDK dependency.
+    Reused and external HTTP endpoints are health-checked at their profile-
+    selected URL before any owned process is spawned; the launcher remains
+    stdlib-only via `urllib.request`.
 
 xr-ai-logging  (utils/xr-ai-logging/)
     └── loguru >=0.7

--- a/agent-samples/simple-vlm-example/README.md
+++ b/agent-samples/simple-vlm-example/README.md
@@ -54,7 +54,11 @@ The worker and orchestrator consume the deployment profile selected by
 - `models.omni.json` reuses the Nemotron-Omni VLM service on port 8108.
 
 The same profile owns model behavior, endpoints, credentials, readiness, and
-launcher process ownership.
+launcher process ownership. Reused and external endpoints with
+`readiness: "health"` are checked before local processes start; the launcher
+uses the configured API-key environment variable when the health route requires
+authentication. Use `readiness: "none"` only when the provider exposes no
+health route, as in the bundled hosted NIM profile.
 
 ## Relay visibility
 

--- a/agent-samples/simple-vlm-example/main.py
+++ b/agent-samples/simple-vlm-example/main.py
@@ -29,6 +29,7 @@ from dataclasses import replace
 from pathlib import Path
 
 from xr_ai_launcher import (
+    EndpointProbe,
     Process,
     ensure_credentials,
     load_model_deployment,
@@ -45,24 +46,32 @@ _MODEL_PROCESSES = {
     "vlm": Process(
         "vlm", "../../services/vlm-server", "vlm_server",
         config="yaml/vlm_server.yaml",
+        port=8100,
     ),
     "vlm-omni": Process(
         "vlm-omni",
         "../../services/nemotron-omni-llm",
         "nemotron_omni_llm_server",
+        port=8108,
     ),
     "stt": Process(
         "stt", "../../services/stt-server", "stt_server",
         config="yaml/stt_server.yaml",
+        port=8103,
     ),
     "tts": Process(
         "tts", "../../services/piper-tts", "piper_tts_server",
         config="yaml/piper_tts_server.yaml",
+        port=8105,
     ),
 }
 
 
-def _build_processes() -> tuple[list[Process], tuple[str, ...]]:
+def _build_processes() -> tuple[
+    list[Process],
+    tuple[str, ...],
+    tuple[EndpointProbe, ...],
+]:
     deployment = load_model_deployment(_BASE / _WORKER_CONFIG)
     unknown_services = deployment.services.keys() - _MODEL_PROCESSES.keys()
     if unknown_services:
@@ -76,14 +85,35 @@ def _build_processes() -> tuple[list[Process], tuple[str, ...]]:
     for service, process in _MODEL_PROCESSES.items():
         launch_mode = deployment.launch_mode(service)
         if launch_mode is not None:
-            procs.append(replace(process, launch_mode=launch_mode))
+            if launch_mode == "reuse":
+                endpoint = deployment.reused_endpoints[service]
+                procs.append(
+                    replace(
+                        process,
+                        launch_mode=launch_mode,
+                        health_url=endpoint.health_url,
+                        readiness=endpoint.readiness,
+                        api_key_env=endpoint.api_key_env,
+                    )
+                )
+            else:
+                procs.append(replace(process, launch_mode=launch_mode))
     procs.append(
         Process(
             "worker", "worker", "simple_vlm_example_worker",
             config=_WORKER_CONFIG,
         )
     )
-    return procs, deployment.required_credentials
+    endpoint_probes = tuple(
+        EndpointProbe(
+            name=role,
+            health_url=endpoint.health_url,
+            readiness=endpoint.readiness,
+            api_key_env=endpoint.api_key_env,
+        )
+        for role, endpoint in deployment.external_endpoints.items()
+    )
+    return procs, deployment.required_credentials, endpoint_probes
 
 
 def run() -> None:
@@ -95,13 +125,13 @@ def run() -> None:
                         "downloads may stall indefinitely).")
     ns, _ = p.parse_known_args()
 
-    processes, credentials = _build_processes()
+    processes, credentials, endpoint_probes = _build_processes()
     # A missing HF_TOKEN silently stalls the multi-GB first-run download; see
     # docs/source/getting_started/credentials.md.
     require_credentials("HF_TOKEN", allow_missing=ns.allow_anonymous)
     for credential in credentials:
         ensure_credentials(credential)
-    run_stack(processes, _BASE)
+    run_stack(processes, _BASE, endpoint_probes=endpoint_probes)
 
 
 if __name__ == "__main__":

--- a/agent-samples/xr-render-demo/main.py
+++ b/agent-samples/xr-render-demo/main.py
@@ -90,14 +90,19 @@ def _model_backend() -> str:
 # agent-llm / vlm model-servers. STT/TTS stay local. See
 # docs/source/components/ai-services.md "Hosting models on NVIDIA NIM".
 def _build_processes() -> list[Process]:
-    return [
+    processes = [
         Process("stt",       "../../services/stt-server",            "stt_server",
-                launch_mode="reuse"),
-        Process("agent-llm", "../../services/nemotron3-nano-llm",    "nemotron3_nano_llm_server",
-                launch_mode="reuse"),
-        Process("vlm",       "../../services/vlm-server",            "vlm_server",
-                launch_mode="reuse"),
-        Process("hub",        "../../services/xr-media-hub",                "xr_media_hub",
+                launch_mode="reuse", port=8103),
+    ]
+    if _model_backend() != "nim":
+        processes.extend([
+            Process("agent-llm", "../../services/nemotron3-nano-llm",
+                    "nemotron3_nano_llm_server", launch_mode="reuse", port=8107),
+            Process("vlm", "../../services/vlm-server", "vlm_server",
+                    launch_mode="reuse", port=8100),
+        ])
+    processes.extend([
+        Process("hub",        "../../services/xr-media-hub",         "xr_media_hub",
                 config="yaml/xr_media_hub.yaml"),
         Process("cloudxr",    "../../services/cloudxr-runtime",      "cloudxr_runtime",
                 config="yaml/cloudxr_runtime.yaml"),
@@ -112,7 +117,8 @@ def _build_processes() -> list[Process]:
                 quiet_native_output=True),
         Process("worker",     "worker",                              "xr_render_demo_worker",
                 config=_WORKER_CONFIG),
-    ]
+    ])
+    return processes
 
 
 # Match an uncommented `lovr_bin:` line with a non-empty value.

--- a/agent-sdk/xr-ai-models/xr_ai_models/_openai_compat.py
+++ b/agent-sdk/xr-ai-models/xr_ai_models/_openai_compat.py
@@ -90,13 +90,22 @@ def _request_headers(
     return result
 
 
-async def _http_health(client: httpx.AsyncClient, url: str, enabled: bool) -> bool:
+async def _http_health(
+    client: httpx.AsyncClient,
+    url: str,
+    enabled: bool,
+    api_key: str | None,
+) -> bool:
     # Remote endpoints (hosted NIM) expose no local /health route; the spec
     # sets health_check=false, in which case readiness is assumed.
     if not enabled:
         return True
     try:
-        resp = await client.get(url, timeout=3.0)
+        resp = await client.get(
+            url,
+            headers=_auth_headers(api_key),
+            timeout=3.0,
+        )
         return resp.is_success
     except httpx.HTTPError:
         return False
@@ -397,7 +406,12 @@ class OpenAICompatLLM:
                     yield content
 
     async def health(self) -> bool:
-        return await _http_health(self._client, self.health_url, self._health_check)
+        return await _http_health(
+            self._client,
+            self.health_url,
+            self._health_check,
+            self._api_key,
+        )
 
     async def close(self) -> None:
         if self._owns_client:
@@ -645,7 +659,12 @@ class OpenAICompatSTT:
         return resp.json().get("text", "")
 
     async def health(self) -> bool:
-        return await _http_health(self._client, self.health_url, self._health_check)
+        return await _http_health(
+            self._client,
+            self.health_url,
+            self._health_check,
+            self._api_key,
+        )
 
     async def close(self) -> None:
         if self._owns_client:
@@ -702,7 +721,12 @@ class OpenAICompatTTS:
         return resp.content
 
     async def health(self) -> bool:
-        return await _http_health(self._client, self.health_url, self._health_check)
+        return await _http_health(
+            self._client,
+            self.health_url,
+            self._health_check,
+            self._api_key,
+        )
 
     async def close(self) -> None:
         if self._owns_client:
@@ -765,7 +789,12 @@ class OpenAICompatEmbedding:
         return [[float(value) for value in row["embedding"]] for row in rows]
 
     async def health(self) -> bool:
-        return await _http_health(self._client, self.health_url, self._health_check)
+        return await _http_health(
+            self._client,
+            self.health_url,
+            self._health_check,
+            self._api_key,
+        )
 
     async def close(self) -> None:
         if self._owns_client:

--- a/docs/source/components/launcher-and-process-model.md
+++ b/docs/source/components/launcher-and-process-model.md
@@ -61,6 +61,13 @@ def run() -> None:
 - The worker never imports anything from `xr_media_hub` or `xr_ai_launcher`.
 - Process management lives in `utils/xr-ai-launcher/`, not inside any process it manages.
 - `run_stack` is fail-fast: if any process exits, the rest are terminated.
+- A process declared with `launch_mode="reuse"` and `readiness="health"` must
+  declare either an explicit `health_url` or an HTTP `port` fallback. Remote
+  or otherwise external dependencies can be passed as `EndpointProbe` values.
+  Before spawning anything, `run_stack` requires each endpoint to return a 2xx
+  response and sends a bearer token when `api_key_env` is configured.
+  Profile-driven stacks use the selected model endpoint; `readiness="none"`
+  skips the probe.
 
 ## Serial and parallel items
 
@@ -131,7 +138,8 @@ its IPC receive loop is active.
 - `"reuse"` — the launcher does **not** spawn this process; it is assumed to be
   already running (e.g. started by `model-servers`). The entry in the process
   list documents the dependency; the launcher skips it entirely and does not
-  kill it on shutdown.
+  kill it on shutdown. Its explicit `health_url` or `port` fallback lets the
+  launcher verify readiness before it starts any owned process.
 
 On a clean ready-exit, `persist` and `reuse` processes are left running. On an
 abort during startup (Ctrl-C, or a process exiting before it signals ready)

--- a/tests/test_launcher_config.py
+++ b/tests/test_launcher_config.py
@@ -3,6 +3,7 @@
 
 """Tests for stdlib-only launcher model deployment reads."""
 
+import importlib.util
 import json
 from pathlib import Path
 
@@ -12,6 +13,14 @@ from xr_ai_models import load_models_config
 
 _ROOT = Path(__file__).resolve().parents[1]
 _SIMPLE_VLM_YAML = _ROOT / "agent-samples" / "simple-vlm-example" / "yaml"
+_SIMPLE_VLM_MAIN = _ROOT / "agent-samples" / "simple-vlm-example" / "main.py"
+_SIMPLE_VLM_SPEC = importlib.util.spec_from_file_location(
+    "simple_vlm_example_main",
+    _SIMPLE_VLM_MAIN,
+)
+assert _SIMPLE_VLM_SPEC and _SIMPLE_VLM_SPEC.loader
+_simple_vlm = importlib.util.module_from_spec(_SIMPLE_VLM_SPEC)
+_SIMPLE_VLM_SPEC.loader.exec_module(_simple_vlm)
 
 
 def _write_profile(path: Path, *, credential: str | None = None) -> None:
@@ -123,6 +132,28 @@ def test_bundled_simple_vlm_profiles_have_launcher_sdk_parity(
 
     assert deployment.services == expected_services
     assert deployment.required_credentials == models.required_credentials
+    expected_reused = {
+        spec.deployment.service: (spec.endpoint.base_url, spec.endpoint.readiness)
+        for spec in models.entries.values()
+        if spec.deployment.ownership == "reused"
+    }
+    assert {
+        service: (endpoint.base_url, endpoint.readiness)
+        for service, endpoint in deployment.reused_endpoints.items()
+    } == expected_reused
+    expected_external = {
+        role: (
+            spec.endpoint.base_url,
+            spec.endpoint.readiness,
+            spec.endpoint.api_key_env,
+        )
+        for role, spec in models.entries.items()
+        if spec.deployment.ownership == "external"
+    }
+    assert {
+        role: (endpoint.base_url, endpoint.readiness, endpoint.api_key_env)
+        for role, endpoint in deployment.external_endpoints.items()
+    } == expected_external
 
 
 def test_launcher_rejects_worker_only_yaml_profile(tmp_path) -> None:
@@ -213,3 +244,107 @@ def test_bundled_worker_selects_local_profile() -> None:
     )
 
     assert deployment.profile_path == _SIMPLE_VLM_YAML / "models.local.json"
+
+
+def _write_reused_omni_profile(path: Path, *, readiness: str) -> None:
+    path.write_text(
+        json.dumps({
+            "models": {
+                "vlm": {
+                    "category": "vlm",
+                    "adapter": {
+                        "kind": "openai_compat",
+                        "model_name": "llm",
+                    },
+                    "endpoint": {
+                        "base_url": "http://localhost:9000",
+                        "readiness": readiness,
+                    },
+                    "deployment": {
+                        "ownership": "reused",
+                        "service": "vlm-omni",
+                    },
+                }
+            }
+        }),
+        encoding="utf-8",
+    )
+
+
+def test_omni_reused_service_uses_profile_health_endpoint(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    profile = tmp_path / "models.omni.json"
+    _write_reused_omni_profile(profile, readiness="health")
+    worker_config = tmp_path / "worker.yaml"
+    worker_config.write_text(
+        f'models_config: "{profile}"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(_simple_vlm, "_WORKER_CONFIG", str(worker_config))
+
+    processes, _credentials, _endpoint_probes = _simple_vlm._build_processes()
+    reused = next(process for process in processes if process.launch_mode == "reuse")
+
+    assert reused.name == "vlm-omni"
+    assert reused.health_url == "http://localhost:9000/health"
+    assert reused.readiness == "health"
+
+
+def test_omni_reused_service_honors_disabled_readiness(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    profile = tmp_path / "models.omni.json"
+    _write_reused_omni_profile(profile, readiness="none")
+    worker_config = tmp_path / "worker.yaml"
+    worker_config.write_text(f'models_config: "{profile}"\n', encoding="utf-8")
+    monkeypatch.setattr(_simple_vlm, "_WORKER_CONFIG", str(worker_config))
+
+    processes, _credentials, _endpoint_probes = _simple_vlm._build_processes()
+    reused = next(process for process in processes if process.launch_mode == "reuse")
+
+    assert reused.health_url == "http://localhost:9000/health"
+    assert reused.readiness == "none"
+
+
+def test_external_remote_service_becomes_authenticated_endpoint_probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    profile = tmp_path / "models.remote.json"
+    profile.write_text(
+        json.dumps({
+            "models": {
+                "vlm": {
+                    "category": "vlm",
+                    "adapter": {
+                        "kind": "openai_compat",
+                        "model_name": "remote-vlm",
+                    },
+                    "endpoint": {
+                        "base_url": "https://models.example.test/api",
+                        "api_key_env": "REMOTE_MODEL_KEY",
+                        "readiness": "health",
+                    },
+                    "deployment": {"ownership": "external"},
+                }
+            }
+        }),
+        encoding="utf-8",
+    )
+    worker_config = tmp_path / "worker.yaml"
+    worker_config.write_text(f'models_config: "{profile}"\n', encoding="utf-8")
+    monkeypatch.setattr(_simple_vlm, "_WORKER_CONFIG", str(worker_config))
+
+    _processes, credentials, endpoint_probes = _simple_vlm._build_processes()
+
+    assert credentials == ("REMOTE_MODEL_KEY",)
+    assert endpoint_probes == (
+        _simple_vlm.EndpointProbe(
+            name="vlm",
+            health_url="https://models.example.test/api/health",
+            api_key_env="REMOTE_MODEL_KEY",
+        ),
+    )

--- a/tests/test_launcher_stack.py
+++ b/tests/test_launcher_stack.py
@@ -21,6 +21,9 @@ class TestProcessDataclass:
         assert p.gpu is None
         assert p.launch_mode == "own"
         assert p.port is None
+        assert p.health_url is None
+        assert p.readiness == "health"
+        assert p.api_key_env is None
 
     def test_all_fields(self):
         p = _stack.Process(
@@ -29,11 +32,17 @@ class TestProcessDataclass:
             gpu="0",
             launch_mode="persist",
             port=8100,
+            health_url="http://models.test/health",
+            readiness="none",
+            api_key_env="MODEL_API_KEY",
         )
         assert p.config == "yaml/vlm.yaml"
         assert p.gpu == "0"
         assert p.launch_mode == "persist"
         assert p.port == 8100
+        assert p.health_url == "http://models.test/health"
+        assert p.readiness == "none"
+        assert p.api_key_env == "MODEL_API_KEY"
 
     def test_frozen_immutability(self):
         p = _stack.Process("hub", "../../services/xr-media-hub", "xr_media_hub")
@@ -67,6 +76,113 @@ class TestParallelDataclass:
         group = _stack.Parallel([])
         with pytest.raises((AttributeError, TypeError)):
             group.processes = ()  # type: ignore[misc]
+
+
+class TestReusePreflight:
+    class _Response:
+        def __init__(self, status=200):
+            self.status = status
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+    def test_healthy_service_passes(self, monkeypatch):
+        requested = []
+
+        def healthy(request, timeout):
+            requested.append((request.full_url, timeout))
+            return self._Response(204)
+
+        monkeypatch.setattr(
+            _stack._HEALTH_OPENER,
+            "open",
+            healthy,
+        )
+        process = _stack.Process(
+            "vlm",
+            ".",
+            "vlm_server",
+            launch_mode="reuse",
+            port=8100,
+            health_url="http://localhost:9000/health",
+        )
+
+        _stack._preflight_reused([process])
+
+        assert requested == [("http://localhost:9000/health", 3.0)]
+
+    def test_remote_endpoint_sends_bearer_token(self, monkeypatch):
+        requested = []
+        monkeypatch.setenv("REMOTE_MODEL_KEY", "secret")
+
+        def healthy(request, timeout):
+            requested.append((
+                request.full_url,
+                request.get_header("Authorization"),
+                timeout,
+            ))
+            return self._Response()
+
+        monkeypatch.setattr(_stack._HEALTH_OPENER, "open", healthy)
+        probe = _stack.EndpointProbe(
+            "remote-vlm",
+            "https://models.example.test/health",
+            api_key_env="REMOTE_MODEL_KEY",
+        )
+
+        _stack._preflight_dependencies([], [probe])
+
+        assert requested == [(
+            "https://models.example.test/health",
+            "Bearer secret",
+            3.0,
+        )]
+
+    def test_missing_port_is_rejected(self):
+        process = _stack.Process("vlm", ".", "vlm_server", launch_mode="reuse")
+
+        with pytest.raises(ValueError, match="health-check URL or port"):
+            _stack._preflight_reused([process])
+
+    def test_readiness_none_skips_probe(self, monkeypatch):
+        def unexpected_probe(_url, _timeout):
+            raise AssertionError("readiness=none must not probe")
+
+        monkeypatch.setattr(_stack._HEALTH_OPENER, "open", unexpected_probe)
+        process = _stack.Process(
+            "vlm",
+            ".",
+            "vlm_server",
+            launch_mode="reuse",
+            readiness="none",
+        )
+
+        _stack._preflight_reused([process])
+
+    def test_invalid_readiness_is_rejected(self):
+        process = _stack.Process(
+            "vlm",
+            ".",
+            "vlm_server",
+            launch_mode="reuse",
+            readiness="ready-file",
+        )
+
+        with pytest.raises(ValueError, match="unsupported readiness"):
+            _stack._preflight_reused([process])
+
+    def test_unhealthy_service_stops_before_spawn(self, monkeypatch):
+        def unavailable(_url, timeout):
+            raise OSError("connection refused")
+
+        monkeypatch.setattr(_stack._HEALTH_OPENER, "open", unavailable)
+        process = _stack.Process("vlm", ".", "vlm_server", launch_mode="reuse", port=8100)
+
+        with pytest.raises(SystemExit, match="required endpoint is not healthy"):
+            _stack._preflight_reused([_stack.Parallel([process])])
 
 
 class _FakePopen:
@@ -139,6 +255,41 @@ class TestRunStackShutdownContract:
 
         # Clean exit preserves the persist set so the container outlives us.
         assert stub_stack["no_kill"] == {"vlm"}
+
+    def test_external_endpoint_is_checked_before_spawn(
+        self,
+        stub_stack,
+        tmp_path,
+        monkeypatch,
+    ):
+        calls = []
+
+        def probe(endpoint):
+            calls.append(("probe", endpoint.name))
+
+        def spawn(proc, base, ready_file):
+            calls.append(("spawn", proc.name))
+            return _FakePopen(proc.name)
+
+        monkeypatch.setattr(_stack, "_require_endpoint_ready", probe)
+        monkeypatch.setattr(_stack, "_spawn", spawn)
+        monkeypatch.setattr(_stack, "_wait_ready", lambda name, rf, proc: None)
+
+        _stack.run_stack(
+            [_stack.Process("worker", "worker", "worker")],
+            tmp_path,
+            endpoint_probes=[
+                _stack.EndpointProbe(
+                    "remote-vlm",
+                    "https://models.example.test/health",
+                )
+            ],
+            exit_after_ready=True,
+        )
+
+        assert calls == [("probe", "remote-vlm"), ("spawn", "worker")]
+
+
 class TestStripConflictingCudnn:
     """LD_LIBRARY_PATH sanitization so a host cuDNN can't shadow the venv one."""
 

--- a/tests/test_models_openai_compat.py
+++ b/tests/test_models_openai_compat.py
@@ -325,6 +325,19 @@ async def test_llm_health_true_on_200() -> None:
         assert (await llm.health()) is True
 
 
+async def test_llm_health_sends_bearer_when_api_key_env_set(monkeypatch) -> None:
+    monkeypatch.setenv("STUB_API_KEY", "sk-health-123")
+    stub = StubOpenAI()
+    async with OpenAICompatLLM(
+        "http://stub",
+        "llm",
+        api_key_env="STUB_API_KEY",
+        client=stub.client(),
+    ) as llm:
+        assert (await llm.health()) is True
+    assert stub.last_request().headers["Authorization"] == "Bearer sk-health-123"
+
+
 async def test_llm_health_false_on_503() -> None:
     stub = StubOpenAI()
     stub.set_health_status(503)

--- a/tests/test_xr_render_orchestrator.py
+++ b/tests/test_xr_render_orchestrator.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for xr-render-demo process selection."""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_MAIN_PATH = _REPO_ROOT / "agent-samples/xr-render-demo/main.py"
+_SPEC = importlib.util.spec_from_file_location("xr_render_demo_main", _MAIN_PATH)
+assert _SPEC and _SPEC.loader
+_render_demo = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_render_demo)
+
+
+def _reused_ports(processes: list[object]) -> dict[str, int | None]:
+    return {
+        process.name: process.port
+        for process in processes
+        if process.launch_mode == "reuse"
+    }
+
+
+def test_local_reused_models_declare_health_ports(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_render_demo, "_model_backend", lambda: "local")
+
+    assert _reused_ports(_render_demo._build_processes()) == {
+        "stt": 8103,
+        "agent-llm": 8107,
+        "vlm": 8100,
+    }
+
+
+def test_nim_omits_hosted_models_from_reuse_preflight(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_render_demo, "_model_backend", lambda: "nim")
+
+    assert _reused_ports(_render_demo._build_processes()) == {"stt": 8103}

--- a/utils/xr-ai-launcher/xr_ai_launcher/__init__.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/__init__.py
@@ -43,7 +43,7 @@ from ._credentials import (
 from ._gpu import detect_gpu_config
 from ._models import ModelDeployment, load_model_deployment
 from ._processes import ManagedProcess
-from ._stack import Parallel, Process, run_stack
+from ._stack import EndpointProbe, Parallel, Process, run_stack
 
 __all__ = [
     "XR_RUNTIME_VAR", "load_cloudxr_env",
@@ -53,5 +53,5 @@ __all__ = [
     "detect_gpu_config",
     "ModelDeployment", "load_model_deployment",
     "ManagedProcess",
-    "Parallel", "Process", "run_stack",
+    "EndpointProbe", "Parallel", "Process", "run_stack",
 ]

--- a/utils/xr-ai-launcher/xr_ai_launcher/_models.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/_models.py
@@ -5,13 +5,27 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
 from ._config import read_config_scalar
 
 LaunchMode = Literal["own", "reuse"]
+Readiness = Literal["health", "none"]
+
+
+@dataclass(frozen=True)
+class DeploymentEndpoint:
+    """Profile-selected endpoint and readiness policy for a dependency."""
+
+    base_url: str
+    readiness: Readiness
+    api_key_env: str | None = None
+
+    @property
+    def health_url(self) -> str:
+        return self.base_url.rstrip("/") + "/health"
 
 
 @dataclass(frozen=True)
@@ -21,6 +35,8 @@ class ModelDeployment:
     profile_path: Path
     services: dict[str, LaunchMode]
     required_credentials: tuple[str, ...]
+    reused_endpoints: dict[str, DeploymentEndpoint] = field(default_factory=dict)
+    external_endpoints: dict[str, DeploymentEndpoint] = field(default_factory=dict)
 
     def launch_mode(self, service: str) -> LaunchMode | None:
         return self.services.get(service)
@@ -52,6 +68,8 @@ def load_model_deployment(worker_config: Path) -> ModelDeployment:
         raise ValueError(f"{profile_path}: 'models' must be an object")
 
     services: dict[str, LaunchMode] = {}
+    reused_endpoints: dict[str, DeploymentEndpoint] = {}
+    external_endpoints: dict[str, DeploymentEndpoint] = {}
     credentials: set[str] = set()
     for role, model in models.items():
         if not isinstance(role, str) or not role:
@@ -87,6 +105,16 @@ def load_model_deployment(worker_config: Path) -> ModelDeployment:
 
         ownership = deployment.get("ownership", "external")
         if ownership == "external":
+            base_url = endpoint.get("base_url")
+            if not isinstance(base_url, str) or not base_url:
+                raise ValueError(
+                    f"{profile_path}: external role {role!r} needs endpoint.base_url"
+                )
+            external_endpoints[role] = DeploymentEndpoint(
+                base_url,
+                readiness,
+                credential,
+            )
             continue
         if ownership == "managed":
             launch_mode: LaunchMode = "own"
@@ -107,9 +135,24 @@ def load_model_deployment(worker_config: Path) -> ModelDeployment:
             raise ValueError(
                 f"{profile_path}: conflicting ownership for service {service!r}"
             )
+        if launch_mode == "reuse":
+            base_url = endpoint.get("base_url")
+            if not isinstance(base_url, str) or not base_url:
+                raise ValueError(
+                    f"{profile_path}: reused role {role!r} needs endpoint.base_url"
+                )
+            reused_endpoint = DeploymentEndpoint(base_url, readiness, credential)
+            previous_endpoint = reused_endpoints.setdefault(service, reused_endpoint)
+            if previous_endpoint != reused_endpoint:
+                raise ValueError(
+                    f"{profile_path}: conflicting endpoints for reused service "
+                    f"{service!r}"
+                )
 
     return ModelDeployment(
         profile_path=profile_path,
         services=services,
+        reused_endpoints=reused_endpoints,
+        external_endpoints=external_endpoints,
         required_credentials=tuple(sorted(credentials)),
     )

--- a/utils/xr-ai-launcher/xr_ai_launcher/_stack.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/_stack.py
@@ -44,6 +44,7 @@ import sys
 import tempfile
 import threading
 import time
+import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Sequence, Union
@@ -52,6 +53,7 @@ from ._credentials import load_credentials
 
 _READY_INTERVAL = 5.0   # seconds between progress lines
 _STOP_TIMEOUT   = 20.0  # seconds before SIGKILL during shutdown
+_HEALTH_OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({}))
 
 # launcher/ stays stdlib-only per AGENTS.md, so this module uses
 # ``logging.getLogger`` rather than loguru. The orchestrator's
@@ -74,7 +76,8 @@ class Process:
                            processes that take no config.
     gpu                  — optional CUDA_VISIBLE_DEVICES value (e.g. ``"0"``, ``"0,1"``).
     launch_mode          — controls spawn + shutdown behaviour:
-    port                 — optional service port, used to stop ``persist`` services.
+    port                 — service port, used as a fallback target for ``reuse``
+                           health preflight and to stop ``persist`` services.
     quiet_native_output  — when True, captured subprocess lines that don't look like
                            Python loguru output (no ``HH:MM:SS.SSS`` prefix) are routed
                            through stdlib ``logging`` at DEBUG instead of printed to
@@ -82,6 +85,13 @@ class Process:
                            (e.g. OpenXR loader output) interleaved with their own Python
                            loguru lines. Default ``False`` — every other Process keeps
                            today's unconditional ``print`` behavior verbatim.
+    health_url           — optional explicit health endpoint for ``reuse``
+                           preflight. Profile-driven stacks should use this so
+                           the launcher probes the same endpoint as the worker.
+    readiness            — ``"health"`` (default) probes a reused service before
+                           startup; ``"none"`` skips its readiness probe.
+    api_key_env           — optional environment variable whose value is sent as
+                           a bearer token by the health probe.
 
       ``"own"``     (default) — launcher spawns this process and kills it on shutdown.
       ``"persist"`` — launcher spawns this process but leaves it running on shutdown.
@@ -100,6 +110,20 @@ class Process:
     launch_mode:         str = "own"
     port:                int | None = None
     quiet_native_output: bool = False
+    health_url:          str | None = None
+    readiness:           str = "health"
+    api_key_env:         str | None = None
+
+
+@dataclass(frozen=True)
+class EndpointProbe:
+    """Readiness check for an already-running local or remote dependency."""
+
+    name: str
+    health_url: str | None
+    readiness: str = "health"
+    api_key_env: str | None = None
+    timeout: float = 3.0
 
 
 @dataclass(frozen=True)
@@ -247,6 +271,82 @@ def _spawn(proc: Process, base: Path, ready_file: Path) -> subprocess.Popen:
 
 
 # ── readiness wait ─────────────────────────────────────────────────────────────
+
+def _require_endpoint_ready(probe: EndpointProbe) -> None:
+    """Fail unless an already-running endpoint satisfies its readiness policy."""
+    if probe.readiness == "none":
+        log.info("[%s] endpoint readiness check disabled", probe.name)
+        return
+    if probe.readiness != "health":
+        raise ValueError(
+            f"endpoint {probe.name!r} has unsupported readiness "
+            f"{probe.readiness!r}"
+        )
+    if probe.health_url is None:
+        raise ValueError(
+            f"endpoint {probe.name!r} must declare its health-check URL"
+        )
+
+    headers: dict[str, str] = {}
+    if probe.api_key_env:
+        api_key = os.environ.get(probe.api_key_env)
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+    request = urllib.request.Request(probe.health_url, headers=headers)
+
+    try:
+        with _HEALTH_OPENER.open(request, timeout=probe.timeout) as response:
+            if 200 <= response.status < 300:
+                log.info("[%s] endpoint ready at %s", probe.name, probe.health_url)
+                return
+            failure = f"HTTP {response.status}"
+    except Exception as exc:
+        failure = f"{type(exc).__name__}: {exc}"
+
+    raise SystemExit(
+        f"[{probe.name}] required endpoint is not healthy at {probe.health_url}.\n"
+        f"Last health check: {failure}"
+    )
+
+
+def _reused_probe(proc: Process) -> EndpointProbe:
+    """Build a probe for a reused process, retaining the legacy port fallback."""
+    health_url = proc.health_url
+    if health_url is None:
+        if proc.port is None:
+            if proc.readiness == "health":
+                raise ValueError(
+                    f"reused process {proc.name!r} must declare its health-check "
+                    "URL or port"
+                )
+        else:
+            health_url = f"http://127.0.0.1:{proc.port}/health"
+    return EndpointProbe(
+        name=proc.name,
+        health_url=health_url,
+        readiness=proc.readiness,
+        api_key_env=proc.api_key_env,
+    )
+
+
+def _preflight_dependencies(
+    processes: Sequence[Union[Process, Parallel]],
+    endpoint_probes: Sequence[EndpointProbe] = (),
+) -> None:
+    """Validate reused processes and explicit endpoint dependencies."""
+    for item in processes:
+        members = item.processes if isinstance(item, Parallel) else (item,)
+        for proc in members:
+            if proc.launch_mode == "reuse":
+                _require_endpoint_ready(_reused_probe(proc))
+    for probe in endpoint_probes:
+        _require_endpoint_ready(probe)
+
+
+def _preflight_reused(processes: Sequence[Union[Process, Parallel]]) -> None:
+    """Backward-compatible wrapper for reused-process preflight tests."""
+    _preflight_dependencies(processes)
+
 
 def _wait_ready(name: str, ready_file: Path, proc: subprocess.Popen) -> None:
     """Block until *ready_file* exists. Print a progress line every 5 s."""
@@ -402,6 +502,7 @@ def run_stack(
     processes: Sequence[Union[Process, Parallel]],
     base: Path,
     *,
+    endpoint_probes: Sequence[EndpointProbe] = (),
     exit_after_ready: bool = False,
 ) -> None:
     """
@@ -423,6 +524,10 @@ def run_stack(
     instead — useful for launchers whose processes are all ``launch_mode="persist"``
     and should outlive the orchestrator (e.g. ``model-servers``).
 
+    ``endpoint_probes`` declares already-running dependencies that have no
+    local ``Process`` entry, such as a remote model server. They are checked
+    alongside reused processes before any owned process is spawned.
+
     *base* is the sample root — all relative paths in ``Process.project``
     and ``Process.config`` are resolved against it::
 
@@ -443,6 +548,7 @@ def run_stack(
             run_stack(PROCESSES, _BASE)
     """
     load_credentials()
+    _preflight_dependencies(processes, endpoint_probes)
 
     # "persist" and "reuse" processes are left running on shutdown.
     # "reuse" processes are not spawned at all — assumed already running.


### PR DESCRIPTION
## Summary

- require reused processes to declare their HTTP port
- check `/health` before spawning any owned process
- fail immediately with the dependency name and endpoint when it is unavailable

## Why

`launch_mode="reuse"` previously skipped startup unconditionally, so a missing shared service surfaced later as a worker connection failure.

## Validation

- `uv run --project tests pytest -q tests/test_launcher_stack.py`
- `ruff check` on changed Python files
- SPDX header check
