### PR TITLE
ci(docs): publish per-PR documentation previews

### DIFF
--- a/.github/actions/deploy-docs-site/action.yaml
+++ b/.github/actions/deploy-docs-site/action.yaml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Deploy the current ``gh-pages`` branch contents to GitHub Pages.
+#
+# Pages stays on the "GitHub Actions" build type and ``gh-pages`` is only
+# storage: a push to it deploys nothing on its own, because commits pushed by a
+# workflow using GITHUB_TOKEN do not trigger a Pages build. Every job that
+# mutates the branch therefore ends by re-uploading the whole branch and
+# deploying it.
+#
+# The calling job must set:
+#   permissions: {contents: write, pages: write, id-token: write}
+#   environment: github-pages
+name: Deploy docs site
+description: Upload the gh-pages branch as a Pages artifact and deploy it.
+
+runs:
+  using: composite
+  steps:
+    - name: Collect the gh-pages branch
+      id: collect
+      shell: bash
+      env:
+        REMOTE: https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git
+      run: |
+        set -euo pipefail
+        site="${RUNNER_TEMP}/pages-site"
+        if ! git ls-remote --exit-code --heads "$REMOTE" gh-pages >/dev/null 2>&1; then
+          echo "No gh-pages branch; nothing to deploy."
+          echo "present=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        rm -rf "$site"
+        git clone --quiet --depth 1 --branch gh-pages "$REMOTE" "$site"
+        # The artifact is served verbatim; the clone's own history is not part
+        # of the site.
+        rm -rf "$site/.git"
+        echo "present=true" >> "$GITHUB_OUTPUT"
+
+    - uses: actions/upload-pages-artifact@v3
+      if: steps.collect.outputs.present == 'true'
+      with:
+        path: ${{ runner.temp }}/pages-site
+
+    - uses: actions/deploy-pages@v4
+      if: steps.collect.outputs.present == 'true'

--- a/.github/scripts/publish_docs.sh
+++ b/.github/scripts/publish_docs.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Publish a built documentation site to the ``gh-pages`` branch.
+#
+#   publish_docs.sh <site-dir>          publish to the branch root
+#   PR_NUMBER=42 publish_docs.sh <dir>  publish to preview/pr-42/
+#
+# Publishing the site replaces everything at the root except ``preview/``, so a
+# deleted release tag does not leave a stale directory behind while open PR
+# previews survive. Publishing a preview touches only that PR's directory.
+#
+# Callers must serialize: every invocation pushes the same branch. The retry
+# loop only covers a lost race, not concurrent use as a general strategy.
+set -euo pipefail
+
+src="${1:?usage: publish_docs.sh <site-dir>}"
+: "${GITHUB_TOKEN:?GITHUB_TOKEN is required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+: "${GITHUB_SHA:?GITHUB_SHA is required}"
+pr="${PR_NUMBER:-}"
+
+remote="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+work="$(mktemp -d)"
+
+if git ls-remote --exit-code --heads "$remote" gh-pages >/dev/null 2>&1; then
+  git clone --quiet --depth 1 --branch gh-pages "$remote" "$work"
+else
+  # First publish: start an empty branch rather than branching off the default
+  # one, so the site never carries the source tree's history.
+  git init --quiet --initial-branch gh-pages "$work"
+  git -C "$work" remote add origin "$remote"
+fi
+
+if [[ -n "$pr" ]]; then
+  dest="$work/preview/pr-${pr}"
+  rm -rf "$dest"
+  mkdir -p "$dest"
+  cp -R "$src/." "$dest/"
+  message="docs: preview for PR #${pr}"
+else
+  find "$work" -mindepth 1 -maxdepth 1 ! -name .git ! -name preview -exec rm -rf {} +
+  cp -R "$src/." "$work/"
+  message="docs: publish ${GITHUB_SHA:0:8}"
+fi
+
+# Sphinx writes .nojekyll per build directory; the branch root needs its own or
+# Jekyll drops every _static/ path.
+touch "$work/.nojekyll"
+
+cd "$work"
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git add --all
+
+if git diff --cached --quiet; then
+  echo "Documentation is unchanged; nothing to publish."
+  exit 0
+fi
+
+git commit --quiet --message "$message"
+
+for attempt in 1 2 3; do
+  if git push --quiet origin gh-pages; then
+    exit 0
+  fi
+  echo "Push rejected (attempt ${attempt}); rebasing onto the current branch."
+  git fetch --quiet --depth 1 origin gh-pages
+  git rebase --quiet FETCH_HEAD
+done
+
+echo "Could not publish to gh-pages after 3 attempts." >&2
+exit 1

--- a/.github/scripts/publish_docs.sh
+++ b/.github/scripts/publish_docs.sh
@@ -45,8 +45,9 @@ else
   message="docs: publish ${GITHUB_SHA:0:8}"
 fi
 
-# Sphinx writes .nojekyll per build directory; the branch root needs its own or
-# Jekyll drops every _static/ path.
+# Pages serves this branch through an artifact upload, so Jekyll never runs;
+# .nojekyll is kept at the root so the branch is still correct if it is ever
+# served directly.
 touch "$work/.nojekyll"
 
 cd "$work"

--- a/.github/scripts/remove_docs_preview.sh
+++ b/.github/scripts/remove_docs_preview.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Remove one PR's documentation preview from the ``gh-pages`` branch.
+#
+#   remove_docs_preview.sh <pr-number>
+#
+# Idempotent: a missing branch or a missing directory is success, so it is safe
+# to call speculatively. Callers must serialize with publish_docs.sh — both
+# push the same branch.
+set -euo pipefail
+
+pr="${1:?usage: remove_docs_preview.sh <pr-number>}"
+: "${GITHUB_TOKEN:?GITHUB_TOKEN is required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+
+remote="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+if ! git ls-remote --exit-code --heads "$remote" gh-pages >/dev/null 2>&1; then
+  echo "No gh-pages branch; nothing to remove."
+  exit 0
+fi
+
+work="$(mktemp -d)"
+git clone --quiet --depth 1 --branch gh-pages "$remote" "$work"
+
+if [[ ! -d "$work/preview/pr-${pr}" ]]; then
+  echo "No preview for PR #${pr}."
+  exit 0
+fi
+
+cd "$work"
+rm -rf "preview/pr-${pr}"
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git add --all
+git commit --quiet --message "docs: drop preview for PR #${pr}"
+
+for attempt in 1 2 3; do
+  if git push --quiet origin gh-pages; then
+    echo "Removed preview for PR #${pr}."
+    exit 0
+  fi
+  echo "Push rejected (attempt ${attempt}); rebasing onto the current branch."
+  git fetch --quiet --depth 1 origin gh-pages
+  git rebase --quiet FETCH_HEAD
+done
+
+echo "Could not remove the preview for PR #${pr} after 3 attempts." >&2
+exit 1

--- a/.github/scripts/remove_docs_preview.sh
+++ b/.github/scripts/remove_docs_preview.sh
@@ -2,16 +2,20 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Remove one PR's documentation preview from the ``gh-pages`` branch.
+# Remove documentation previews from the ``gh-pages`` branch.
 #
-#   remove_docs_preview.sh <pr-number>
+#   remove_docs_preview.sh <pr-number> [pr-number ...]
 #
-# Idempotent: a missing branch or a missing directory is success, so it is safe
-# to call speculatively. Callers must serialize with publish_docs.sh — both
-# push the same branch.
+# Several numbers are removed in one commit so the nightly sweep does not push
+# once per stale preview. Idempotent: a missing branch or a missing directory is
+# success, so it is safe to call speculatively. Callers must serialize with
+# publish_docs.sh — both push the same branch.
 set -euo pipefail
 
-pr="${1:?usage: remove_docs_preview.sh <pr-number>}"
+if [[ $# -lt 1 ]]; then
+  echo "usage: remove_docs_preview.sh <pr-number> [pr-number ...]" >&2
+  exit 1
+fi
 : "${GITHUB_TOKEN:?GITHUB_TOKEN is required}"
 : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
 
@@ -24,22 +28,36 @@ fi
 
 work="$(mktemp -d)"
 git clone --quiet --depth 1 --branch gh-pages "$remote" "$work"
+cd "$work"
 
-if [[ ! -d "$work/preview/pr-${pr}" ]]; then
-  echo "No preview for PR #${pr}."
+removed=()
+for pr in "$@"; do
+  if [[ -d "preview/pr-${pr}" ]]; then
+    rm -rf "preview/pr-${pr}"
+    removed+=("#${pr}")
+  else
+    echo "No preview for PR #${pr}."
+  fi
+done
+
+if [[ ${#removed[@]} -eq 0 ]]; then
   exit 0
 fi
 
-cd "$work"
-rm -rf "preview/pr-${pr}"
+if [[ ${#removed[@]} -eq 1 ]]; then
+  message="docs: drop preview for PR ${removed[0]}"
+else
+  message="docs: drop previews for PRs ${removed[*]}"
+fi
+
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 git add --all
-git commit --quiet --message "docs: drop preview for PR #${pr}"
+git commit --quiet --message "$message"
 
 for attempt in 1 2 3; do
   if git push --quiet origin gh-pages; then
-    echo "Removed preview for PR #${pr}."
+    echo "Removed ${#removed[@]} preview(s): ${removed[*]}"
     exit 0
   fi
   echo "Push rejected (attempt ${attempt}); rebasing onto the current branch."
@@ -47,5 +65,5 @@ for attempt in 1 2 3; do
   git rebase --quiet FETCH_HEAD
 done
 
-echo "Could not remove the preview for PR #${pr} after 3 attempts." >&2
+echo "Could not remove previews ${removed[*]} after 3 attempts." >&2
 exit 1

--- a/.github/workflows/docs-preview-cleanup.yaml
+++ b/.github/workflows/docs-preview-cleanup.yaml
@@ -27,12 +27,13 @@ jobs:
     concurrency:
       # Shares the publisher's group: both push the gh-pages branch.
       #
-      # GitHub keeps only one *pending* job per group, so a burst of publishers
-      # can evict this job while it waits. That is tolerated rather than worked
-      # around: docs-preview-sweep.yaml reconciles the branch against the set of
-      # open PRs nightly and removes whatever a lost cleanup left behind.
+      # queue: max matters most here. Under the default (single), a burst of
+      # publishers would cancel this job while it sat pending and the preview
+      # would outlive its PR until the nightly sweep noticed. Queued cleanups
+      # now wait their turn in FIFO order instead.
       group: docs-gh-pages
       cancel-in-progress: false
+      queue: max
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/docs-preview-cleanup.yaml
+++ b/.github/workflows/docs-preview-cleanup.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Remove a PR's docs preview from the gh-pages branch once the PR closes.
+# Runs on pull_request_target so a fork PR's own head can never supply the code
+# that runs with write access — this workflow checks out the base branch only.
+#
+# This is not the sole guarantee. A docs build queued before the close can
+# publish after this job has already run; docs.yaml re-checks the PR state
+# after publishing and removes the directory it just wrote.
+name: Docs preview cleanup
+
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  cleanup:
+    name: Remove preview
+    if: github.repository == 'NVIDIA/xr-ai'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      # Shares the publisher's group: both push the gh-pages branch.
+      group: docs-gh-pages
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/scripts
+      - name: Remove preview/pr-${{ github.event.pull_request.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          .github/scripts/remove_docs_preview.sh \
+            "${{ github.event.pull_request.number }}"

--- a/.github/workflows/docs-preview-cleanup.yaml
+++ b/.github/workflows/docs-preview-cleanup.yaml
@@ -21,14 +21,24 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pages: write
+      id-token: write
+    environment: github-pages
     concurrency:
       # Shares the publisher's group: both push the gh-pages branch.
+      #
+      # GitHub keeps only one *pending* job per group, so a burst of publishers
+      # can evict this job while it waits. That is tolerated rather than worked
+      # around: docs-preview-sweep.yaml reconciles the branch against the set of
+      # open PRs nightly and removes whatever a lost cleanup left behind.
       group: docs-gh-pages
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
         with:
-          sparse-checkout: .github/scripts
+          sparse-checkout: |
+            .github/scripts
+            .github/actions
       - name: Remove preview/pr-${{ github.event.pull_request.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -36,3 +46,5 @@ jobs:
         run: |
           .github/scripts/remove_docs_preview.sh \
             "${{ github.event.pull_request.number }}"
+      - name: Deploy the site
+        uses: ./.github/actions/deploy-docs-site

--- a/.github/workflows/docs-preview-cleanup.yaml
+++ b/.github/workflows/docs-preview-cleanup.yaml
@@ -40,11 +40,24 @@ jobs:
             .github/scripts
             .github/actions
       - name: Remove preview/pr-${{ github.event.pull_request.number }}
+        id: remove
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         shell: bash
         run: |
-          .github/scripts/remove_docs_preview.sh \
-            "${{ github.event.pull_request.number }}"
+          set -euo pipefail
+          before="$(git ls-remote "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            refs/heads/gh-pages | cut -f1)"
+          .github/scripts/remove_docs_preview.sh "$PR_NUMBER"
+          after="$(git ls-remote "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            refs/heads/gh-pages | cut -f1)"
+          if [[ "$before" != "$after" ]]; then
+            echo "removed=true" >> "$GITHUB_OUTPUT"
+          fi
+      # Most closes have no preview to remove — a fork PR never had one, and
+      # neither did a PR that never touched docs. Only deploy when the branch
+      # actually moved.
       - name: Deploy the site
+        if: steps.remove.outputs.removed == 'true'
         uses: ./.github/actions/deploy-docs-site

--- a/.github/workflows/docs-preview-sweep.yaml
+++ b/.github/workflows/docs-preview-sweep.yaml
@@ -31,6 +31,7 @@ jobs:
       # Shares the publisher's group: both push the gh-pages branch.
       group: docs-gh-pages
       cancel-in-progress: false
+      queue: max
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/docs-preview-sweep.yaml
+++ b/.github/workflows/docs-preview-sweep.yaml
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Nightly reconciliation for docs previews on the gh-pages branch.
+#
+# docs.yaml and docs-preview-cleanup.yaml already remove a preview along every
+# ordering of publish and close. This sweep exists so the branch does not depend
+# on every event firing correctly: it compares what is on the branch against
+# what is actually open and removes the difference. It covers a cleanup job that
+# failed its pushes, a stale API read in the publisher's post-publish check, and
+# previews written before this workflow reached the default branch.
+name: Docs preview sweep
+
+on:
+  schedule:
+    - cron: "17 4 * * *"
+  workflow_dispatch:
+
+jobs:
+  sweep:
+    name: Remove previews for closed PRs
+    if: github.repository == 'NVIDIA/xr-ai'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    concurrency:
+      # Shares the publisher's group: both push the gh-pages branch.
+      group: docs-gh-pages
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/scripts
+      - name: Remove previews whose PR is no longer open
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          previews="$(gh api "repos/${GITHUB_REPOSITORY}/contents/preview?ref=gh-pages" \
+            --jq '.[] | select(.type == "dir") | .name' 2>/dev/null || true)"
+          if [[ -z "$previews" ]]; then
+            echo "No previews on gh-pages."
+            exit 0
+          fi
+
+          stale=()
+          for name in $previews; do
+            [[ "$name" =~ ^pr-([0-9]+)$ ]] || { echo "Ignoring '$name'."; continue; }
+            pr="${BASH_REMATCH[1]}"
+            # A number that no longer resolves to a PR cannot be an open one, so
+            # a failed lookup counts as stale rather than as a reason to keep it.
+            state="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr}" --jq .state 2>/dev/null || echo unknown)"
+            if [[ "$state" == open ]]; then
+              echo "PR #${pr} is open; keeping its preview."
+            else
+              echo "PR #${pr} is ${state}; queuing its preview for removal."
+              stale+=("$pr")
+            fi
+          done
+
+          if [[ ${#stale[@]} -eq 0 ]]; then
+            echo "Every preview belongs to an open PR."
+            exit 0
+          fi
+
+          .github/scripts/remove_docs_preview.sh "${stale[@]}"
+          printf 'Swept %d stale preview(s): %s\n' "${#stale[@]}" "${stale[*]}" \
+            >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docs-preview-sweep.yaml
+++ b/.github/workflows/docs-preview-sweep.yaml
@@ -24,6 +24,9 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
+      pages: write
+      id-token: write
+    environment: github-pages
     concurrency:
       # Shares the publisher's group: both push the gh-pages branch.
       group: docs-gh-pages
@@ -31,8 +34,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          sparse-checkout: .github/scripts
+          sparse-checkout: |
+            .github/scripts
+            .github/actions
       - name: Remove previews whose PR is no longer open
+        id: sweep
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -40,8 +46,20 @@ jobs:
         run: |
           set -euo pipefail
 
-          previews="$(gh api "repos/${GITHUB_REPOSITORY}/contents/preview?ref=gh-pages" \
-            --jq '.[] | select(.type == "dir") | .name' 2>/dev/null || true)"
+          err="$(mktemp)"
+
+          # Only a 404 means there is nothing there; any other failure is
+          # operational and must not be read as "no previews".
+          if previews="$(gh api "repos/${GITHUB_REPOSITORY}/contents/preview?ref=gh-pages" \
+              --jq '.[] | select(.type == "dir") | .name' 2>"$err")"; then
+            :
+          elif grep -q 'HTTP 404' "$err"; then
+            previews=""
+          else
+            echo "::error::Could not list previews: $(cat "$err")"
+            exit 1
+          fi
+
           if [[ -z "$previews" ]]; then
             echo "No previews on gh-pages."
             exit 0
@@ -51,9 +69,18 @@ jobs:
           for name in $previews; do
             [[ "$name" =~ ^pr-([0-9]+)$ ]] || { echo "Ignoring '$name'."; continue; }
             pr="${BASH_REMATCH[1]}"
-            # A number that no longer resolves to a PR cannot be an open one, so
-            # a failed lookup counts as stale rather than as a reason to keep it.
-            state="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr}" --jq .state 2>/dev/null || echo unknown)"
+            # Only a confirmed state removes a preview. A 404 means the number
+            # never resolved to a PR and is safe to drop; rate limiting, a 5xx,
+            # or an auth failure must fail the sweep instead of deleting a live
+            # preview. The next run reconciles whatever this one skipped.
+            if state="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr}" --jq .state 2>"$err")"; then
+              :
+            elif grep -q 'HTTP 404' "$err"; then
+              state="missing"
+            else
+              echo "::error::Could not read PR #${pr}: $(cat "$err")"
+              exit 1
+            fi
             if [[ "$state" == open ]]; then
               echo "PR #${pr} is open; keeping its preview."
             else
@@ -68,5 +95,11 @@ jobs:
           fi
 
           .github/scripts/remove_docs_preview.sh "${stale[@]}"
+          echo "swept=true" >> "$GITHUB_OUTPUT"
           printf 'Swept %d stale preview(s): %s\n' "${#stale[@]}" "${stale[*]}" \
             >> "$GITHUB_STEP_SUMMARY"
+      # Only when the branch actually changed: a quiet night should not spend a
+      # Pages deployment re-serving identical content.
+      - name: Deploy the site
+        if: steps.sweep.outputs.swept == 'true'
+        uses: ./.github/actions/deploy-docs-site

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -122,8 +122,13 @@ jobs:
     concurrency:
       # Every publisher pushes the same branch. Serialize them all — including
       # across PRs — and never cancel a run mid-push.
+      #
+      # queue: max because the default (single) cancels whatever is already
+      # pending in the group when a new run arrives, which would silently drop
+      # a queued cleanup or publish during a burst.
       group: docs-gh-pages
       cancel-in-progress: false
+      queue: max
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -5,6 +5,16 @@
 # GitHub Pages defaults to the latest semantic-version release while retaining
 # ``main`` as development docs. Its environment admits only main and ``v*``
 # refs; sphinx-multiversion selects release tags from complete Git history.
+#
+# The site is published from the ``gh-pages`` branch rather than as a Pages
+# artifact, because one artifact can only serve one site and per-PR previews
+# need to live beside the real one:
+#
+#   /                      the published site (root redirect -> latest release)
+#   /preview/pr-<N>/       one preview per open same-repo PR
+#
+# Publishing the site never touches ``preview/``; closing a PR removes only its
+# own directory (see docs-preview-cleanup.yaml).
 name: Docs
 
 on:
@@ -38,7 +48,6 @@ jobs:
           # sphinx-multiversion reads the release tags and main directly from Git.
           fetch-depth: 0
       - name: Make current docs build ref available
-        if: github.event_name == 'push'
         run: |
           if ! git show-ref --verify --quiet refs/heads/main; then
             git branch main origin/main
@@ -48,23 +57,17 @@ jobs:
           python-version: "3.12"
       - name: Install doc deps
         run: pip install -r docs/requirements.txt
+      # sphinx-multiversion builds the refs recorded in Git, so it never renders
+      # a PR's own content. Build the checked-out tree too and publish it under
+      # ``current/`` so a docs PR can be reviewed for content as well as chrome.
       - name: Strict checked-out documentation build
         if: github.event_name == 'pull_request'
         env:
           DOCS_GITHUB_REF: ${{ github.event.pull_request.head.sha }}
         run: make -C docs strict
-      - name: Upload documentation preview
-        if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
-        with:
-          name: docs-preview
-          path: docs/_build/current
-          if-no-files-found: error
       - name: Strict versioned documentation build
-        if: github.event_name == 'push'
         run: make -C docs strict-versions
       - name: Point the site root at the latest release
-        if: github.event_name == 'push'
         shell: bash
         run: |
           latest_release="$(make -s -C docs latest-release)"
@@ -78,23 +81,90 @@ jobs:
           sed "s|__XR_AI_DOCS_TARGET__|${latest_target}|g" \
             docs/source/_static/latest-redirect.html > docs/_build/latest/index.html
           cp docs/source/_static/root-redirect.html docs/_build/index.html
-      - name: Upload Pages artifact
-        if: github.event_name == 'push' && github.repository == 'NVIDIA/xr-ai'
-        uses: actions/upload-pages-artifact@v3
+      - name: Upload documentation site
+        uses: actions/upload-artifact@v4
         with:
+          name: docs-site
           path: docs/_build
+          if-no-files-found: error
 
-  deploy:
-    name: Deploy to GitHub Pages
-    if: github.event_name == 'push' && github.repository == 'NVIDIA/xr-ai'
+  publish:
+    name: Publish to GitHub Pages
+    # Fork PRs get the build artifact only: their token is read-only, so the
+    # preview cannot be published and the job is skipped rather than failed.
+    if: >-
+      github.repository == 'NVIDIA/xr-ai'
+      && (github.event_name == 'push'
+          || github.event.pull_request.head.repo.full_name == github.repository)
     needs: build
     runs-on: ubuntu-latest
     permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      contents: write
+    concurrency:
+      # Every publisher pushes the same branch. Serialize them all — including
+      # across PRs — and never cancel a run mid-push.
+      group: docs-gh-pages
+      cancel-in-progress: false
     steps:
-      - id: deployment
-        uses: actions/deploy-pages@v4
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/scripts
+      - name: Download documentation site
+        uses: actions/download-artifact@v4
+        with:
+          name: docs-site
+          path: site
+      # A build queued before the PR closed can reach this job after the close
+      # event's cleanup has already run and found nothing to remove. Checking
+      # the state before publishing skips the common case; checking again after
+      # makes it durable, because a close that lands inside that window is
+      # observed here and undone. A close after the second check still has its
+      # own cleanup run ahead of it.
+      - name: Confirm the pull request is still open
+        id: before
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: |
+          state="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .state)"
+          echo "state=${state}" >> "$GITHUB_OUTPUT"
+          if [[ "$state" != open ]]; then
+            echo "::notice::PR #${PR_NUMBER} is ${state}; skipping the preview publish."
+          fi
+      - name: Publish
+        if: github.event_name == 'push' || steps.before.outputs.state == 'open'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Empty on push, which selects the site root instead of a preview dir.
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: .github/scripts/publish_docs.sh site
+      - name: Drop the preview if the pull request closed mid-publish
+        id: after
+        if: github.event_name == 'pull_request' && steps.before.outputs.state == 'open'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: |
+          state="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .state)"
+          if [[ "$state" != open ]]; then
+            echo "::notice::PR #${PR_NUMBER} closed during the publish; removing the preview."
+            .github/scripts/remove_docs_preview.sh "$PR_NUMBER"
+            echo "removed=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Summarize
+        if: >-
+          (github.event_name == 'push' || steps.before.outputs.state == 'open')
+          && steps.after.outputs.removed != 'true'
+        shell: bash
+        run: |
+          if [[ -n "${{ github.event.pull_request.number }}" ]]; then
+            url="https://nvidia.github.io/xr-ai/preview/pr-${{ github.event.pull_request.number }}/"
+          else
+            url="https://nvidia.github.io/xr-ai/"
+          fi
+          echo "Docs published to <$url>" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -37,6 +37,7 @@ on:
       - ".github/scripts/select_latest_docs_release.py"
       - ".github/scripts/publish_docs.sh"
       - ".github/scripts/remove_docs_preview.sh"
+      - ".github/actions/deploy-docs-site/action.yaml"
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
@@ -45,6 +46,7 @@ on:
       - ".github/scripts/select_latest_docs_release.py"
       - ".github/scripts/publish_docs.sh"
       - ".github/scripts/remove_docs_preview.sh"
+      - ".github/actions/deploy-docs-site/action.yaml"
 
 concurrency:
   # A tag deployment also rebuilds ``main``. Serialize deployments so an older

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,18 +3,28 @@
 #
 # Build the XR AI Sphinx docs. On every docs PR: strict build (warnings = errors).
 # GitHub Pages defaults to the latest semantic-version release while retaining
-# ``main`` as development docs. Its environment admits only main and ``v*``
-# refs; sphinx-multiversion selects release tags from complete Git history.
+# ``main`` as development docs; sphinx-multiversion selects release tags from
+# complete Git history.
 #
-# The site is published from the ``gh-pages`` branch rather than as a Pages
-# artifact, because one artifact can only serve one site and per-PR previews
-# need to live beside the real one:
+# The site is assembled on the ``gh-pages`` branch rather than straight from a
+# build artifact, because one artifact can only serve one site and per-PR
+# previews need to live beside the real one:
 #
 #   /                      the published site (root redirect -> latest release)
 #   /preview/pr-<N>/       one preview per open same-repo PR
 #
 # Publishing the site never touches ``preview/``; closing a PR removes only its
 # own directory (see docs-preview-cleanup.yaml).
+#
+# Pages itself stays on the "GitHub Actions" build type: the branch is storage,
+# and each job that mutates it re-uploads the branch and deploys it (see
+# .github/actions/deploy-docs-site). Branch mode is not usable here because
+# commits pushed by a workflow using GITHUB_TOKEN do not trigger a Pages build,
+# so previews would push without ever deploying.
+#
+# Repo settings this depends on: the ``github-pages`` environment must not
+# restrict deployments to main and ``v*``, or preview deploys from pull_request
+# refs are rejected.
 name: Docs
 
 on:
@@ -25,12 +35,16 @@ on:
       - "docs/**"
       - ".github/workflows/docs.yaml"
       - ".github/scripts/select_latest_docs_release.py"
+      - ".github/scripts/publish_docs.sh"
+      - ".github/scripts/remove_docs_preview.sh"
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
       - "docs/**"
       - ".github/workflows/docs.yaml"
       - ".github/scripts/select_latest_docs_release.py"
+      - ".github/scripts/publish_docs.sh"
+      - ".github/scripts/remove_docs_preview.sh"
 
 concurrency:
   # A tag deployment also rebuilds ``main``. Serialize deployments so an older
@@ -100,6 +114,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pages: write
+      id-token: write
+    environment: github-pages
     concurrency:
       # Every publisher pushes the same branch. Serialize them all — including
       # across PRs — and never cancel a run mid-push.
@@ -108,7 +125,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          sparse-checkout: .github/scripts
+          sparse-checkout: |
+            .github/scripts
+            .github/actions
       - name: Download documentation site
         uses: actions/download-artifact@v4
         with:
@@ -156,6 +175,12 @@ jobs:
             .github/scripts/remove_docs_preview.sh "$PR_NUMBER"
             echo "removed=true" >> "$GITHUB_OUTPUT"
           fi
+      # The push above deploys nothing on its own; this is what makes the new
+      # branch contents live. It runs after the mid-publish removal too, so a
+      # preview undone by that step is also gone from the served site.
+      - name: Deploy the site
+        if: github.event_name == 'push' || steps.before.outputs.state == 'open'
+        uses: ./.github/actions/deploy-docs-site
       - name: Summarize
         if: >-
           (github.event_name == 'push' || steps.before.outputs.state == 'open')


### PR DESCRIPTION
Split out of #330, which was just the version-switcher template change. This is the deployment-model half: it changes how the site is published and adds a branch that CI writes to, with its own lifecycle and race cases.

## Problem

Reviewing a docs change meant merging it. The PR artifact was a zip, and it held only the single-version build — where the version switcher is absent by construction (`{% if versions %}`). #330's change was literally invisible before it went live.

## Fix

Assemble the site on a `gh-pages` branch, then deploy that whole branch as the Pages artifact. One artifact can only serve one site if CI builds it fresh each time; a branch accumulates state, carrying the real site at the root and a preview per open PR:

```
/                   the published site (root redirect -> latest release)
/preview/pr-<N>/    one preview per open same-repo PR
```

Publishing the site replaces the root but never touches `preview/`, so a deleted release tag leaves no stale directory while open previews survive.

Pages itself stays on the **"GitHub Actions"** build type. Branch mode is not usable here: GitHub's docs state that *"commits pushed by a GitHub Actions workflow that uses the `GITHUB_TOKEN` do not trigger a GitHub Pages build"*, so previews would be written to the branch and never deploy. The alternative — pushing with a PAT or GitHub App token — buys nothing here and adds a secret to provision and rotate.

So `gh-pages` is storage, not a publishing source. Every job that mutates it ends by re-uploading the branch and deploying it, via the shared `.github/actions/deploy-docs-site` composite action.

PRs now build the versioned site too, and keep the checked-out build under `current/`. sphinx-multiversion renders the refs recorded in Git, so it never shows a PR's own content — only how that PR's templates and config render. `current/` covers the other half: content changes in the working tree.

## The close/publish race

A build queued before a PR closes can reach the shared `docs-gh-pages` concurrency group *after* the `pull_request_target` cleanup has already run and found no directory. It would then write `preview/pr-<N>/` with no further close event to remove it.

Ordering is not something the publisher can win by checking earlier, so it checks again afterwards. With *C* the close, *K* the cleanup job, and *B → P → A* the before-check, publish and after-check inside one job:

| ordering | outcome |
| --- | --- |
| *C* before *B* | `before` reads `closed`, publish skipped, nothing written |
| *C* between *B* and *A* | `after` reads `closed` and removes what it just wrote |
| *C* after *A* | *K* runs and removes it |

The shared concurrency group is what makes this hold. GitHub acquires it when a job *starts*, so *K* can never interleave between *P* and *A* — it queues behind the whole publish job, removal included. `cancel-in-progress: false` keeps a cleanup from cancelling a publisher mid-push, and the git push is atomic, so a cancelled run leaves no half-written tree.

All three jobs in the group also set `queue: max`. The default (`single`) cancels whatever is already *pending* in a group when a new run arrives, so a burst of publishers could silently drop a queued cleanup and strand a preview. `queue: max` holds them FIFO instead.

## Nightly sweep

Each of those paths still depends on its event firing and its pushes landing. A cleanup job that exhausts its retries, or a preview written before this workflow reached the default branch, would leave a directory nothing revisits.

`docs-preview-sweep.yaml` reconciles once a night: list `preview/pr-*`, ask which of those PRs are still open, remove the difference. Only a confirmed state removes a preview — a `404` means the number never resolved to a PR and is safe to drop, while rate limiting, a 5xx or an auth failure fails the sweep rather than deleting a live preview. It joins the same concurrency group and removes a whole backlog in one commit.

## Safety

Fork PRs get the build artifact only — the publish job is skipped rather than failed, so no fork head ever runs with write access. Cleanup runs on `pull_request_target` and checks out the base branch alone, with event data passed through `env:` rather than interpolated into the shell body. Publishing uses plain `git` in `.github/scripts/`, so no new third-party action is introduced.

One deliberate loosening, worth a reviewer's attention: the `github-pages` environment's deployment branch policy (previously `main` + `v*`) had to be **removed**, because previews deploy from `refs/pull/<N>/merge` and deployment branch policies match branch and tag names only — there is no pattern that admits merge refs. The remaining gate is the job-level condition in `docs.yaml` (`github.repository` plus a same-repo head check). This is inherent to serving previews through `deploy-pages`: per-PR previews or a restrictive environment policy, not both.

## ⚠️ Merge notes

**No Pages settings change is required, and the Pages source must stay on "GitHub Actions".** Switching it to the `gh-pages` branch would disable all future deploys, for the `GITHUB_TOKEN` reason above.

The only settings change this needed has already been made: removing the `github-pages` environment's deployment branch policy (see Safety).

While this PR is open, the `gh-pages` root is empty — the branch has only ever been written by *preview* publishes — so a preview deploy serves a site with no root and https://nvidia.github.io/xr-ai/ 404s until the next `main` deploy re-runs. **This resolves itself on merge:** the squash commit touches `.github/workflows/docs.yaml`, which is in the push path filter, so merging triggers Docs on `main`, `publish_docs.sh` runs with no `PR_NUMBER`, and the root is written alongside `preview/`. From then on both serve together.

Note that `pull_request_target` loads its workflow from the default branch, so preview cleanup is inert until this merges. The sweep is what recovers anything stranded before then.

## Verification

Both scripts were exercised against a scratch repository:

| case | result |
| --- | --- |
| first publish (no branch yet) | branch created with no source history |
| preview publish | `preview/pr-N/` written, root untouched |
| republish site | stale `v1/` removed, `v2/` added, `preview/pr-N/` retained |
| no-op publish | "Documentation is unchanged; nothing to publish" |
| remove several PRs at once | one commit, unknown numbers skipped, other previews and the site root untouched |
| remove again / unknown PR only | success, no commit |
| remove with no arguments | usage error, exit 1 |

The sweep's selection loop was run against a stubbed API: a closed PR queued for removal, an open one kept, and a non-conforming directory name ignored.

Live on this PR: the `Publish to GitHub Pages` job writes `preview/pr-333/` and deploys it, and https://nvidia.github.io/xr-ai/preview/pr-333/ served 200 with the merged switcher in `main/index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
