### PR TITLE
feat(samples): add YAML-driven tea-making guide

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -550,6 +550,24 @@ in-process. The `models_config` key selects a structured deployment profile:
 external NVIDIA NIM VLM, and `models.omni.json` reuses Nemotron-Omni on port
 8108. Voice-gate knobs are configured via `yaml/voice_gate.yaml`.
 
+### tea-making-sample  (agent-samples/tea-making-sample/)
+
+YAML-defined visual guide: step-specific VLM captions feed a constrained agent
+loop, while participant-local context, manual navigation, reminders, and timer
+steps are managed by the generic worker.
+
+| Sub-project | Package | Internal deps | External deps |
+|---|---|---|---|
+| Orchestrator | `tea-making-sample` | `xr-ai-launcher`, `xr-ai-logging` | - |
+| Worker | `tea-making-worker` | `xr-ai-hub-client [editable]`, `xr-ai-logging [editable]`, `xr-ai-models [editable]`, `xr-ai-nat[vision] [editable]`, `xr-ai-voice [editable]`, `xr-ai-voicegate [editable]` | pyyaml >=6.0 |
+
+The launcher starts STT (8103), Nemotron-Omni (8108), the embedding server
+(8109), RAG service (8340), hub, Piper TTS (8105), and the worker. Nemotron-Omni
+serves both `agent_llm` and `vlm`; there is no Llama-Nemotron chat model. The
+worker registers `RAGFunctionsConfig` in-process and calls the native RAG
+service through its typed retrieve function. Step 5 is timer-only and does not
+invoke the VLM or step agent.
+
 ### model-servers  (agent-samples/model-servers/)
 
 Standalone launcher that starts the shared AI inference servers and keeps

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -565,8 +565,8 @@ The launcher starts STT (8103), Nemotron-Omni (8108), the embedding server
 (8109), RAG service (8340), hub, Piper TTS (8105), and the worker. Nemotron-Omni
 serves both `agent_llm` and `vlm`; there is no Llama-Nemotron chat model. The
 worker registers `RAGFunctionsConfig` in-process and calls the native RAG
-service through its typed retrieve function. Step 5 is timer-only and does not
-invoke the VLM or step agent.
+service through its typed retrieve function. The final steeping step uses the
+VLM until immersion is detected, then switches to timer-tool polling.
 
 ### model-servers  (agent-samples/model-servers/)
 

--- a/README.md
+++ b/README.md
@@ -285,6 +285,31 @@ for the full option list.
 
 ---
 
+### Tea-making guide (YAML-driven visual workflow)
+
+The tea-making sample demonstrates a reusable guided-task engine. Each YAML
+step supplies its own VLM prompt, agent prompt, context schema, tools,
+completion rule, and skip defaults. The guide updates context silently from
+live frames, waits for the user to request the next step, and answers questions
+from current state or native RAG at any point.
+
+Nemotron-Omni provides both vision and agent reasoning. The final steeping step
+uses a wall-clock timer without running the VLM, answers elapsed/remaining-time
+questions, and announces when steeping is complete. See the
+[sample README](agent-samples/tea-making-sample/README.md) for the workflow and
+customization format.
+
+```bash
+cd agent-samples/tea-making-sample
+uv sync
+uv run tea_making_sample
+```
+
+The sample owns its model processes. Stop the shared `model-servers` stack
+first so Nemotron-Omni has enough free GPU memory.
+
+---
+
 ### XR render demo (voice-driven sphere in CloudXR)
 
 Speak to the web client and a sphere in the streamed scene tracks your

--- a/README.md
+++ b/README.md
@@ -294,8 +294,8 @@ live frames, waits for the user to request the next step, and answers questions
 from current state or native RAG at any point.
 
 Nemotron-Omni provides both vision and agent reasoning. The final steeping step
-uses a wall-clock timer without running the VLM, answers elapsed/remaining-time
-questions, and announces when steeping is complete. See the
+uses vision to detect immersion, then switches to a wall-clock timer, answers
+elapsed/remaining-time questions, and announces when steeping is complete. See the
 [sample README](agent-samples/tea-making-sample/README.md) for the workflow and
 customization format.
 

--- a/agent-samples/tea-making-sample/README.md
+++ b/agent-samples/tea-making-sample/README.md
@@ -12,63 +12,53 @@ feeding that caption into a tool-calling LLM loop, and updating step context.
 The code is intentionally generic. The main customization points are:
 
 - `yaml/workflow.yaml`: shared context fields, step reads and writes, VLM prompts,
-  agent prompts, per-step tools, completion rules, skip defaults, and timers.
+  agent prompts, mechanism names, per-step tools, completion rules, and skip defaults.
 - `rag-documents/`: Markdown reference documents indexed by the native RAG
   service and returned through `rag_lookup`.
 - `worker/tea_making_worker/prompts/system.txt`: user-question answering behavior.
 
 ## Workflow Shape
 
-Visual steps follow the same loop:
+Every active tea step uses the default `caption_agent` mechanism. A step only
+needs a `mechanism` key when it overrides that default:
 
-1. The worker periodically captures the latest live camera frame.
-2. The step's `vlm_prompt` captions only the visual facts needed for that step.
-3. The step enters a mini state machine: `started`, `needs_input`, or `complete`.
-4. The LLM receives the caption, the step's projected context, a schema for its
-   writable fields, and the step's `agent_prompt`.
-5. The LLM can call only the tools enabled by that step's `agent_tools`, then
-   returns a partial JSON context patch.
-6. The worker marks the step ready when `advance_when` is satisfied.
-7. The worker waits for a semantic proceed command before moving to the next
-   step. If the step is incomplete, it applies that step's `skip_defaults` first.
+1. The guide resolves the step's YAML `mechanism` through a mechanism registry.
+2. If the step has a `vlm_prompt`, the mechanism captures one fresh frame and
+   produces one internal caption. A step without that prompt skips vision.
+3. The LLM receives the optional caption, projected context, writable-field
+   schema, and `agent_prompt`.
+4. The LLM can call only the tools listed in `agent_tools`, then returns one
+   partial JSON context patch.
+5. The guide applies that patch and marks the step ready when `advance_when` is
+   satisfied.
+6. The guide waits for a semantic proceed command before moving to the next
+   step. If incomplete, it applies that step's `skip_defaults` first.
 
-The worker gives the step's `on_enter_message` once at the beginning. Periodic
-VLM/LLM passes silently update context. If the step still lacks required
-information after `runtime.reminder_interval_s`, it sends one delayed reminder
-by default. It does not repeat every VLM caption or rephrase the same opening
-instruction.
+The guide gives `on_enter_message` once. Periodic mechanism iterations silently
+update context. If information is still missing after
+`runtime.reminder_interval_s`, it sends one delayed reminder by default.
 
-Tools that must run for correctness can set `auto_invoke: true` in
-`agent_tools`, with `when_context_empty` and `context_outputs` mappings. The
-worker then invokes the tool as soon as its optional VLM verdict policy matches
-and merges mapped results authoritatively, while prompts remain responsible for
-task-specific interpretation and guidance.
-
-A step may define a YAML `timer` instead of a `vlm_prompt`. Timer-only steps do
-not capture frames or invoke the step agent. The worker derives elapsed and
-remaining time from context, answers timer questions deterministically, and
-sends the configured completion notice when time expires.
-
-A visual step can declaratively map structured VLM output into context with
-`state_updates`:
+There is no separate caption-to-state mapping. The caption always goes through
+the agent, and the agent's patch is the only state update. New captions can
+replace writable observations during the same incomplete step:
 
 ```yaml
-state_updates:
-  - context_field: measured_value
-    observation_key: MEASURED_VALUE
-    states: [started, needs_input, complete]
-    value_map:
-      not_visible: "not visible"
+mechanism: caption_agent
+vlm_prompt: "Read the current display."
+agent_prompt: "Replace measured_value with the newest visible reading."
+writes: [measured_value]
 ```
 
-The worker parses the named observation line, coerces the value using the
-context field's YAML type, and applies it authoritatively before and after the
-step agent runs. `states` controls which step mini-states accept the update. A
-mapping that includes `complete` keeps that field current while the completed
-step waits for the wearer to say next, without reopening the step or repeating
-guidance. `value_map` is optional and can translate VLM labels into typed
-context values such as booleans. This mechanism is task-independent; changing
-the workflow YAML is sufficient to reuse it for other observed state.
+Time is handled like other external information. Step 4 enables
+`get_current_time` so the agent can record when steeping starts. Step 5 has no
+`vlm_prompt`; its periodic agent iteration calls `get_timer_status` and sets
+`steeping_complete` when the tool reports expiration. User timer questions use
+the same tool through the answer agent.
+
+`CaptionAgentStepMechanism` is separate from `WorkflowGuide` in
+`step_mechanism.py`. Another workflow can implement the small `StepMechanism`
+protocol, register it in `StepMechanisms`, and select it by name for any YAML
+step. Session, reminder, completion, and navigation lifecycle stays shared.
 
 Workflow state is persistent and sparse. Declare reusable fields once under
 `context.fields`; then give each step a `reads` list and a `writes` list:
@@ -105,9 +95,8 @@ can recognize conversational commands such as "carry on to the next part";
 ordinary progress reports do not advance the workflow.
 
 The worker logs guide decisions to `worker.log`: user query text, classifier
-intent, step transitions, VLM observations, context patch keys, dropped updates
-that contradict VLM verdict lines, tool calls/results, reminders, notices, and
-final response text.
+intent, mechanism iterations, step transitions, VLM observations, agent context
+patch keys, tool calls/results, reminders, notices, and final response text.
 
 Transient web-client disconnects pause visual monitoring without clearing the
 active step or accumulated context. Monitoring resumes when the same
@@ -117,8 +106,8 @@ VLM captions are internal evidence. They are stored in the per-participant
 observation log and returned to the LLM through `get_recent_vlm_observations`
 when historical evidence is needed, but they are not posted directly to the
 user. For present-tense visual questions, `inspect_current_view` captures a new
-frame using the wearer's actual question. This also works in timer-only steps;
-it does not turn periodic VLM monitoring back on.
+frame using the wearer's actual question. This also works in no-caption steps;
+it does not turn periodic VLM monitoring on for those steps.
 
 Messages support speech-oriented template filters: `| duration` turns seconds
 into natural durations, `| local_time` renders epoch or ISO timestamps as local
@@ -132,7 +121,7 @@ The included tea workflow has these steps:
 - `2` Fill water and start heating
 - `3` Wait for water to boil
 - `4` Steeping the tea
-- `5` Wait for steeping to finish (timer only; no VLM captions)
+- `5` Wait for steeping to finish (agent tool only; no VLM captions)
 
 After steeping starts, advance to step 5 with wording such as "next", "let's
 proceed", or "carry on". While the timer is active, questions such as "how much
@@ -188,7 +177,7 @@ Then rerun `tea_making_sample`.
 To build a different guided task, copy `yaml/workflow.yaml` and replace the
 field registry, step projections, prompts, and RAG documents. The worker does
 not know about tea-specific fields; it loads the YAML, generates write schemas,
-runs visual or timer steps, applies `skip_defaults`, and evaluates
-`advance_when`. Keep task-specific behavior in `vlm_prompt`, `agent_prompt`,
-`state_updates`, `agent_tools`, and timer mappings rather than adding task
-branches to the worker.
+runs the selected step mechanism, applies `skip_defaults`, and evaluates
+`advance_when`. Keep task-specific behavior in `vlm_prompt`, `agent_prompt`, and
+the plain `agent_tools` list. Add a new `StepMechanism` only when a workflow
+step genuinely needs a different execution strategy.

--- a/agent-samples/tea-making-sample/README.md
+++ b/agent-samples/tea-making-sample/README.md
@@ -1,0 +1,162 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# tea-making-sample
+
+`tea-making-sample` is a YAML-driven guided workflow sample. It guides the
+wearer through making tea by periodically running a step-specific VLM prompt,
+feeding that caption into a tool-calling LLM loop, and updating step context.
+
+The code is intentionally generic. The main customization points are:
+
+- `yaml/workflow.yaml`: step IDs, names, descriptions, VLM prompts,
+  agent prompts, per-step tools, context output fields, completion rules,
+  skip defaults, and optional timers.
+- `rag-documents/`: Markdown reference documents indexed by the native RAG
+  service and returned through `rag_lookup`.
+- `worker/tea_making_worker/prompts/system.txt`: user-question answering behavior.
+
+## Workflow Shape
+
+Visual steps follow the same loop:
+
+1. The worker periodically captures the latest live camera frame.
+2. The step's `vlm_prompt` captions only the visual facts needed for that step.
+3. The step enters a mini state machine: `started`, `needs_input`, or `complete`.
+4. The LLM receives the caption, current context, generated context schema, and
+   the step's `agent_prompt`.
+5. The LLM can call only the tools enabled by that step's `agent_tools`, then
+   returns JSON context updates.
+6. The worker marks the step ready when `advance_when` is satisfied.
+7. The worker waits for a semantic proceed command before moving to the next
+   step. If the step is incomplete, it applies that step's `skip_defaults` first.
+
+The worker gives the step's `on_enter_message` once at the beginning. Periodic
+VLM/LLM passes silently update context. If the step still lacks required
+information after `runtime.reminder_interval_s`, it sends one delayed reminder
+by default. It does not repeat every VLM caption or rephrase the same opening
+instruction.
+
+Tools that must run for correctness can set `auto_invoke: true` in
+`agent_tools`, with `when_context_empty` and `context_outputs` mappings. The
+worker then invokes the tool as soon as its optional VLM verdict policy matches
+and merges mapped results authoritatively, while prompts remain responsible for
+task-specific interpretation and guidance.
+
+A step may define a YAML `timer` instead of a `vlm_prompt`. Timer-only steps do
+not capture frames or invoke the step agent. The worker derives elapsed and
+remaining time from context, answers timer questions deterministically, and
+sends the configured completion notice when time expires.
+
+A visual step can declaratively map structured VLM output into context with
+`state_updates`:
+
+```yaml
+state_updates:
+  - context_field: measured_value
+    observation_key: MEASURED_VALUE
+    states: [started, needs_input, complete]
+    value_map:
+      not_visible: "not visible"
+```
+
+The worker parses the named observation line, coerces the value using the
+context field's YAML type, and applies it authoritatively before and after the
+step agent runs. `states` controls which step mini-states accept the update. A
+mapping that includes `complete` keeps that field current while the completed
+step waits for the wearer to say next, without reopening the step or repeating
+guidance. `value_map` is optional and can translate VLM labels into typed
+context values such as booleans. This mechanism is task-independent; changing
+the workflow YAML is sufficient to reuse it for other observed state.
+
+Completing or skipping the final step ends the session and resets it to idle.
+The guide does not continue from the completed context; a phrase such as
+"start making tea" creates a fresh workflow at step 1.
+
+Navigation commands use a short LLM classifier, with a YAML-backed local
+fast path for obvious start, stop, status, and proceed commands. The classifier
+can recognize conversational commands such as "carry on to the next part";
+ordinary progress reports do not advance the workflow.
+
+The worker logs guide decisions to `worker.log`: user query text, classifier
+intent, step transitions, VLM observations, context patch keys, dropped updates
+that contradict VLM verdict lines, tool calls/results, reminders, notices, and
+final response text.
+
+Transient web-client disconnects pause visual monitoring without clearing the
+active step or accumulated context. Monitoring resumes when the same
+participant ID reconnects.
+
+VLM captions are internal evidence. They are stored in the per-participant
+observation log and returned to the LLM through `get_recent_vlm_observations`
+when visual evidence is needed, but they are not posted directly to the user.
+
+The included tea workflow has these steps:
+
+- `0` Idle
+- `1` Identify tea information
+- `2` Fill water and start heating
+- `3` Wait for water to boil
+- `4` Steeping the tea
+- `5` Wait for steeping to finish (timer only; no VLM captions)
+
+After steeping starts, advance to step 5 with wording such as "next", "let's
+proceed", or "carry on". While the timer is active, questions such as "how much
+time has passed?" and "how long do I still need to wait?" return elapsed and
+remaining time. The guide announces when the steeping time is up.
+
+## Run
+
+Run the sample:
+
+```bash
+uv run --project agent-samples/tea-making-sample tea_making_sample
+```
+
+The launcher starts STT, Nemotron-Omni, the embedding server, native RAG
+service, media hub, TTS, and this worker. Nemotron-Omni handles both visual
+captioning and agent reasoning; no Llama-Nemotron chat model is used. The
+embedding model is used only to index and retrieve the local Markdown
+documents.
+
+The launcher uses `nvidia-smi` to select one of two deployment profiles before
+starting any model service:
+
+| Hardware | Profile | Allocation |
+|---|---|---|
+| 1 x 96 GiB Blackwell | `yaml/96G_blackwell/` | NVFP4 Omni, STT, and embedding on GPU 0. Omni is capped at 80%, embedding at 5%, and RTX Pro uses the Triton MoE backend. |
+| 2 x 48 GiB L40/L40S | `yaml/dual_48G_ada/` | FP8 Omni alone on GPU 0; STT and embedding on GPU 1. |
+
+DGX Spark detection reuses the Blackwell profile. The Omni server starts first
+so vLLM profiles its reservation on an otherwise empty GPU. It pins
+`vllm/vllm-openai:v0.20.0`, the minimum release that registers the model
+architecture, and limits Omni to 8 sequences and a 32K context because this
+interactive workflow does not need the model card's server-scale defaults.
+Open the web client served by the media hub and say "help me make tea".
+
+`yaml/tea_making_worker.yaml` bounds camera acquisition with
+`frame_timeout_s` and each Omni caption request with `vlm_timeout_s`. The
+worker log records separate frame-wait and VLM-request timings when diagnosing
+a delayed observation.
+
+If Omni fails with a message like "Free memory on device ... is less than
+desired GPU memory utilization", another GPU model service is still loaded.
+Stop the shared model-server stack first:
+
+```bash
+uv run --project agent-samples/model-servers model_servers --stop
+```
+
+Then rerun `tea_making_sample`.
+
+## Adapting The Sample
+
+To build a different guided task, copy `yaml/workflow.yaml` and replace the
+step prompts, context fields, and RAG documents. The worker does not know about
+tea-specific fields; it loads the YAML, generates the context-output prompt,
+runs visual or timer steps, applies `skip_defaults`, and evaluates
+`advance_when`. Keep task-specific behavior in `vlm_prompt`, `agent_prompt`,
+`agent_tools`, and timer mappings rather than adding task branches to the
+worker.

--- a/agent-samples/tea-making-sample/README.md
+++ b/agent-samples/tea-making-sample/README.md
@@ -11,9 +11,8 @@ feeding that caption into a tool-calling LLM loop, and updating step context.
 
 The code is intentionally generic. The main customization points are:
 
-- `yaml/workflow.yaml`: step IDs, names, descriptions, VLM prompts,
-  agent prompts, per-step tools, context output fields, completion rules,
-  skip defaults, and optional timers.
+- `yaml/workflow.yaml`: shared context fields, step reads and writes, VLM prompts,
+  agent prompts, per-step tools, completion rules, skip defaults, and timers.
 - `rag-documents/`: Markdown reference documents indexed by the native RAG
   service and returned through `rag_lookup`.
 - `worker/tea_making_worker/prompts/system.txt`: user-question answering behavior.
@@ -25,10 +24,10 @@ Visual steps follow the same loop:
 1. The worker periodically captures the latest live camera frame.
 2. The step's `vlm_prompt` captions only the visual facts needed for that step.
 3. The step enters a mini state machine: `started`, `needs_input`, or `complete`.
-4. The LLM receives the caption, current context, generated context schema, and
-   the step's `agent_prompt`.
+4. The LLM receives the caption, the step's projected context, a schema for its
+   writable fields, and the step's `agent_prompt`.
 5. The LLM can call only the tools enabled by that step's `agent_tools`, then
-   returns JSON context updates.
+   returns a partial JSON context patch.
 6. The worker marks the step ready when `advance_when` is satisfied.
 7. The worker waits for a semantic proceed command before moving to the next
    step. If the step is incomplete, it applies that step's `skip_defaults` first.
@@ -71,6 +70,31 @@ guidance. `value_map` is optional and can translate VLM labels into typed
 context values such as booleans. This mechanism is task-independent; changing
 the workflow YAML is sufficient to reuse it for other observed state.
 
+Workflow state is persistent and sparse. Declare reusable fields once under
+`context.fields`; then give each step a `reads` list and a `writes` list:
+
+```yaml
+context:
+  fields:
+    measured_value:
+      type: number
+    check_complete:
+      type: boolean
+
+steps:
+  - id: 1
+    reads: [measured_value]
+    writes: [check_complete]
+```
+
+Only populated fields are carried in a session. A field is created at startup
+only when its declaration has an `initial` value. Steps do not need to repeat
+carried field schemas, and the state agent may return any subset of its writable
+fields. Writes are mutable by default, so newer observations can replace older
+ones within the same step. For a small workflow, a step may also declare a new
+field inline by making `writes` a mapping of field names to schemas. The older
+per-step `context_output.fields` format remains supported.
+
 Completing or skipping the final step ends the session and resets it to idle.
 The guide does not continue from the completed context; a phrase such as
 "start making tea" creates a fresh workflow at step 1.
@@ -91,7 +115,15 @@ participant ID reconnects.
 
 VLM captions are internal evidence. They are stored in the per-participant
 observation log and returned to the LLM through `get_recent_vlm_observations`
-when visual evidence is needed, but they are not posted directly to the user.
+when historical evidence is needed, but they are not posted directly to the
+user. For present-tense visual questions, `inspect_current_view` captures a new
+frame using the wearer's actual question. This also works in timer-only steps;
+it does not turn periodic VLM monitoring back on.
+
+Messages support speech-oriented template filters: `| duration` turns seconds
+into natural durations, `| local_time` renders epoch or ISO timestamps as local
+clock times, and `| spoken` expands common temperature units. Final responses
+also normalize temperature notation before reaching text to speech.
 
 The included tea workflow has these steps:
 
@@ -154,9 +186,9 @@ Then rerun `tea_making_sample`.
 ## Adapting The Sample
 
 To build a different guided task, copy `yaml/workflow.yaml` and replace the
-step prompts, context fields, and RAG documents. The worker does not know about
-tea-specific fields; it loads the YAML, generates the context-output prompt,
+field registry, step projections, prompts, and RAG documents. The worker does
+not know about tea-specific fields; it loads the YAML, generates write schemas,
 runs visual or timer steps, applies `skip_defaults`, and evaluates
 `advance_when`. Keep task-specific behavior in `vlm_prompt`, `agent_prompt`,
-`agent_tools`, and timer mappings rather than adding task branches to the
-worker.
+`state_updates`, `agent_tools`, and timer mappings rather than adding task
+branches to the worker.

--- a/agent-samples/tea-making-sample/README.md
+++ b/agent-samples/tea-making-sample/README.md
@@ -34,6 +34,20 @@ needs a `mechanism` key when it overrides that default:
 6. The guide waits for a semantic proceed command before moving to the next
    step. If incomplete, it applies that step's `skip_defaults` first.
 
+The selected mechanism receives both kinds of active-step trigger:
+
+- A `periodic` event may run the step VLM prompt and return a writable context
+  patch.
+- A `voice` event receives the same projected context and step procedure, but
+  has a read-only response contract. It can inspect a fresh frame, query RAG,
+  read timers, and read the observation log, but it cannot update context or
+  complete a step. Navigation is classified before either path.
+
+This capability split is enforced in code: voice events are offered only tools
+marked `read_only`, return no state schema, and any context patch returned by a
+custom mechanism is discarded by the guide. This keeps one mechanism and one
+tool-calling loop without allowing an answer to mutate workflow state.
+
 The guide gives `on_enter_message` once. Periodic mechanism iterations silently
 update context. If information is still missing after
 `runtime.reminder_interval_s`, it sends one delayed reminder by default.
@@ -49,16 +63,33 @@ agent_prompt: "Replace measured_value with the newest visible reading."
 writes: [measured_value]
 ```
 
-Time is handled like other external information. Step 4 enables
-`get_current_time` so the agent can record when steeping starts. Step 5 has no
-`vlm_prompt`; its periodic agent iteration calls `get_timer_status` and sets
-`steeping_complete` when the tool reports expiration. User timer questions use
-the same tool through the answer agent.
+Time is handled like other external information. The final steeping step enables
+`get_current_time` and `get_timer_status`. It uses `vlm_stop_when` to caption
+frames only until the steeping start timestamp exists; later periodic iterations
+are tool-only until the timer expires. `suppress_reminders_when` prevents the
+missing-immersion reminder after the timestamp is recorded. These conditions
+are generic YAML rules and can be used by other workflows.
 
 `CaptionAgentStepMechanism` is separate from `WorkflowGuide` in
 `step_mechanism.py`. Another workflow can implement the small `StepMechanism`
 protocol, register it in `StepMechanisms`, and select it by name for any YAML
 step. Session, reminder, completion, and navigation lifecycle stays shared.
+`StepEvent` and `StepIteration` are task-neutral trigger and result contracts,
+so a future mechanism can use a sensor, deterministic service, or different
+agent while preserving the same guide lifecycle.
+
+Agent tools use `AgentTool` and `ToolCatalog` from `tools.py`. A tool pairs its
+model-facing schema with an async handler and a `read_only` capability. Tools
+created for one request, such as `inspect_current_view`, use the same contract
+as long-lived tools such as RAG and timers. This removes tool-name branches from
+the generic LLM loop and gives future agents one place to select tools by name
+and capability.
+
+Voice prompts include only the current step projection and the previous user
+request, not prior assistant measurements. Repeated timer questions therefore
+call `get_timer_status` again instead of anchoring on an earlier spoken value.
+Future-step details are absent from ordinary answer prompts; an explicit request
+uses the read-only `get_next_workflow_step` tool to retrieve the exact YAML step.
 
 Workflow state is persistent and sparse. Declare reusable fields once under
 `context.fields`; then give each step a `reads` list and a `writes` list:
@@ -87,7 +118,9 @@ per-step `context_output.fields` format remains supported.
 
 Completing or skipping the final step ends the session and resets it to idle.
 The guide does not continue from the completed context; a phrase such as
-"start making tea" creates a fresh workflow at step 1.
+"Agent, start making tea" creates a fresh workflow at step 1. Canceling in
+the middle uses the same reset path and clears context, observations, reminders,
+and conversation history.
 
 Navigation commands use a short LLM classifier, with a YAML-backed local
 fast path for obvious start, stop, status, and proceed commands. The classifier
@@ -98,9 +131,15 @@ The worker logs guide decisions to `worker.log`: user query text, classifier
 intent, mechanism iterations, step transitions, VLM observations, agent context
 patch keys, tool calls/results, reminders, notices, and final response text.
 
-Transient web-client disconnects pause visual monitoring without clearing the
-active step or accumulated context. Monitoring resumes when the same
-participant ID reconnects.
+Disconnecting clears the participant's active workflow and removes the session.
+Reconnecting starts from a fresh idle state; unfinished context and visual
+observations are never resumed.
+
+`yaml/voice_gate.yaml` requires every spoken command to begin with "Agent"
+or "Hey agent". The follow-up grace window is disabled, so an ungated second
+utterance is ignored. On connection, the shared voice gate speaks the configured
+welcome message explaining that the user should say "Agent, help me make
+tea." Worker-generated reminders and completion notices bypass the wake gate.
 
 VLM captions are internal evidence. They are stored in the per-participant
 observation log and returned to the LLM through `get_recent_vlm_observations`
@@ -118,15 +157,14 @@ The included tea workflow has these steps:
 
 - `0` Idle
 - `1` Identify tea information
-- `2` Fill water and start heating
-- `3` Wait for water to boil
-- `4` Steeping the tea
-- `5` Wait for steeping to finish (agent tool only; no VLM captions)
+- `2` Fill water
+- `3` Start heating and reach the target temperature
+- `4` Steep the tea (VLM until immersion, then timer tool only)
 
-After steeping starts, advance to step 5 with wording such as "next", "let's
-proceed", or "carry on". While the timer is active, questions such as "how much
-time has passed?" and "how long do I still need to wait?" return elapsed and
-remaining time. The guide announces when the steeping time is up.
+While the final timer is active, questions such as "Agent, how much time has
+passed?" and "Agent, how long do I still need to wait?" return a fresh
+elapsed or remaining value. The guide announces when the steeping time is up and
+returns to idle.
 
 ## Run
 
@@ -155,7 +193,8 @@ so vLLM profiles its reservation on an otherwise empty GPU. It pins
 `vllm/vllm-openai:v0.20.0`, the minimum release that registers the model
 architecture, and limits Omni to 8 sequences and a 32K context because this
 interactive workflow does not need the model card's server-scale defaults.
-Open the web client served by the media hub and say "help me make tea".
+Open the web client served by the media hub. After the welcome message, say
+"Agent, help me make tea".
 
 `yaml/tea_making_worker.yaml` bounds camera acquisition with
 `frame_timeout_s` and each Omni caption request with `vlm_timeout_s`. The
@@ -180,4 +219,7 @@ not know about tea-specific fields; it loads the YAML, generates write schemas,
 runs the selected step mechanism, applies `skip_defaults`, and evaluates
 `advance_when`. Keep task-specific behavior in `vlm_prompt`, `agent_prompt`, and
 the plain `agent_tools` list. Add a new `StepMechanism` only when a workflow
-step genuinely needs a different execution strategy.
+step genuinely needs a different execution strategy. The event, mechanism, and
+tool-catalog contracts are deliberately sample-local for now; move them into a
+shared SDK package after a second workflow validates that their APIs cover more
+than this example.

--- a/agent-samples/tea-making-sample/eval/cases.yaml
+++ b/agent-samples/tea-making-sample/eval/cases.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+navigation:
+  - utterance: "Let's proceed to the following stage."
+    proposed_intent: advance
+    explicit_command: true
+    expected_intent: advance
+  - utterance: "Carry on to whatever comes after this."
+    proposed_intent: advance
+    explicit_command: true
+    expected_intent: advance
+  - utterance: "I just placed the infuser in the cup."
+    proposed_intent: advance
+    explicit_command: false
+    expected_intent: answer
+  - utterance: "Use another camera frame."
+    proposed_intent: advance
+    explicit_command: false
+    expected_intent: answer
+  - utterance: "What temperature is visible?"
+    proposed_intent: status
+    explicit_command: false
+    expected_intent: answer
+  - utterance: "Don't move on yet."
+    proposed_intent: advance
+    explicit_command: true
+    expected_intent: answer
+
+timer_questions:
+  - utterance: "How much time has passed?"
+    expected: elapsed
+  - utterance: "How long do I still need to wait?"
+    expected: remaining
+  - utterance: "How much longer?"
+    expected: remaining
+  - utterance: "What is the elapsed time?"
+    expected: elapsed

--- a/agent-samples/tea-making-sample/main.py
+++ b/agent-samples/tea-making-sample/main.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+tea-making-sample orchestrator - YAML-driven guided workflow over voice.
+
+How to run:
+
+    uv run --project agent-samples/tea-making-sample tea_making_sample
+"""
+
+import socket
+from pathlib import Path
+
+from xr_ai_launcher import Process, detect_gpu_config, run_stack, warn_if_missing
+from xr_ai_logging import setup_logging
+
+_BASE = Path(__file__).resolve().parent
+
+_WORKER_CONFIG = "yaml/tea_making_worker.yaml"
+_OMNI_PORT = 8108
+_EMBEDDING_PORT = 8109
+_PROFILE_ALIASES = {"spark": "96G_blackwell"}
+_SUPPORTED_PROFILES = {"96G_blackwell", "dual_48G_ada"}
+_LEGACY_MODEL_PORTS = {
+    8100: "VLM",
+    8106: "Llama-Nemotron",
+    8107: "Nemotron-Nano",
+}
+
+
+def _build_processes(profile: str | None = None) -> list[Process]:
+    detected_profile = profile or detect_gpu_config()
+    selected_profile = _PROFILE_ALIASES.get(detected_profile, detected_profile)
+    if selected_profile not in _SUPPORTED_PROFILES:
+        supported = ", ".join(sorted(_SUPPORTED_PROFILES))
+        raise RuntimeError(
+            f"Unsupported GPU profile {detected_profile!r}; expected one of: {supported}"
+        )
+    ai = f"yaml/{selected_profile}"
+
+    return [
+        Process(
+            "omni",
+            "../../ai-services/llm/nemotron_omni",
+            "nemotron_omni_llm_server",
+            config=f"{ai}/nemotron_omni_llm_server.yaml",
+            port=_OMNI_PORT,
+        ),
+        Process(
+            "stt",
+            "../../ai-services/stt-server",
+            "stt_server",
+            config=f"{ai}/stt_server.yaml",
+            port=8103,
+        ),
+        Process(
+            "embedding",
+            "../../ai-services/embedding-server",
+            "embedding_server",
+            config=f"{ai}/embedding_server.yaml",
+            port=_EMBEDDING_PORT,
+        ),
+        Process(
+            "rag",
+            "../../services/rag-service",
+            "rag_service",
+            config="yaml/rag_service.yaml",
+        ),
+        Process(
+            "hub",
+            "../../server-runtime",
+            "xr_media_hub",
+            config="yaml/xr_media_hub.yaml",
+        ),
+        Process(
+            "tts",
+            "../../ai-services/tts/piper",
+            "piper_tts_server",
+            config="yaml/piper_tts_server.yaml",
+            port=8105,
+        ),
+        Process(
+            "worker",
+            "worker",
+            "tea_making_worker",
+            config=_WORKER_CONFIG,
+        ),
+    ]
+
+
+def _port_open(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(0.2)
+        return sock.connect_ex(("127.0.0.1", port)) == 0
+
+
+def _check_model_ports() -> None:
+    if _port_open(_OMNI_PORT):
+        return
+    busy = [
+        f"{name} on {port}"
+        for port, name in _LEGACY_MODEL_PORTS.items()
+        if _port_open(port)
+    ]
+    if not busy:
+        return
+    raise SystemExit(
+        "tea-making-sample uses Nemotron-Omni on port 8108, but these local "
+        f"model services are already running and likely occupy GPU memory: {', '.join(busy)}.\n"
+        "Stop the shared model-server stack first:\n"
+        "  uv run --project agent-samples/model-servers model_servers --stop\n"
+        "Then rerun:\n"
+        "  uv run --project agent-samples/tea-making-sample tea_making_sample"
+    )
+
+
+def run() -> None:
+    setup_logging("orchestrator", namespace="tea-making-sample")
+    warn_if_missing("HF_TOKEN")
+    _check_model_ports()
+    run_stack(_build_processes(), _BASE)
+
+
+if __name__ == "__main__":
+    run()

--- a/agent-samples/tea-making-sample/pyproject.toml
+++ b/agent-samples/tea-making-sample/pyproject.toml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "tea-making-sample"
+version = "0.1.0"
+requires-python = ">=3.11,<3.13"
+dependencies = [
+    "xr-ai-launcher",
+    "xr-ai-logging",
+]
+
+[tool.uv.sources]
+xr-ai-launcher = { path = "../../utils/xr-ai-launcher", editable = true }
+xr-ai-logging  = { path = "../../utils/xr-ai-logging", editable = true }
+
+[project.scripts]
+tea_making_sample = "main:run"
+
+[tool.hatch.build.targets.wheel]
+only-include = ["main.py"]

--- a/agent-samples/tea-making-sample/rag-documents/hot-water-safety.md
+++ b/agent-samples/tea-making-sample/rag-documents/hot-water-safety.md
@@ -1,0 +1,14 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Hot water safety
+
+Use a stable heat-safe vessel, avoid overfilling the kettle or pot, and keep
+hands away from steam. Do not heat a sealed container. Keep electrical kettle
+bases and cords dry.
+
+If using a microwave, use a microwave-safe cup and follow the appliance
+instructions to reduce the risk of superheated water. Handle the vessel
+carefully and avoid leaning over it when adding tea.

--- a/agent-samples/tea-making-sample/rag-documents/tea-brewing.md
+++ b/agent-samples/tea-making-sample/rag-documents/tea-brewing.md
@@ -1,0 +1,30 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Tea brewing reference
+
+Package instructions take priority over these general guidelines.
+
+Black tea commonly uses water at 200-212 F / 93-100 C. A typical target is
+3 minutes (180 seconds), with some teas allowing up to 5 minutes.
+
+Green tea commonly uses water at 160-180 F / 70-82 C. A typical target is
+2 minutes (120 seconds), with some teas allowing 1-3 minutes. Let freshly
+boiled water cool before adding green tea.
+
+White tea commonly uses water at 170-185 F / 77-85 C. A typical target is
+3 minutes (180 seconds), with some teas allowing 2-5 minutes.
+
+Oolong tea commonly uses water at 185-205 F / 85-96 C. A typical target is
+3 minutes (180 seconds), with some teas allowing 2-5 minutes. Rolled oolongs
+may support several short infusions.
+
+Herbal tea and tisanes commonly use boiling water at 200-212 F / 93-100 C.
+A typical target is 5 minutes (300 seconds), with some blends allowing up to
+7 minutes. Follow package warnings for medicinal herbs or ingredients.
+
+Pu-erh commonly uses near-boiling or boiling water. A typical first infusion
+target is 3 minutes (180 seconds), unless the package specifies short repeated
+infusions.

--- a/agent-samples/tea-making-sample/rag-documents/tea-brewing.md
+++ b/agent-samples/tea-making-sample/rag-documents/tea-brewing.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # **Numi Organic Tea: Comprehensive Variety & Brewing Guide**
 
 Welcome to the complete reference manual for Numi Organic Teas. Founded on the principles of organic integrity, Fair Trade sourcing, and pure ingredients (100% real fruits, flowers, and spices with zero synthetic flavorings), Numi offers a diverse portfolio of tea categories.

--- a/agent-samples/tea-making-sample/rag-documents/tea-brewing.md
+++ b/agent-samples/tea-making-sample/rag-documents/tea-brewing.md
@@ -1,30 +1,268 @@
-<!--
-  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-  SPDX-License-Identifier: Apache-2.0
--->
+# **Numi Organic Tea: Comprehensive Variety & Brewing Guide**
 
-# Tea brewing reference
+Welcome to the complete reference manual for Numi Organic Teas. Founded on the principles of organic integrity, Fair Trade sourcing, and pure ingredients (100% real fruits, flowers, and spices with zero synthetic flavorings), Numi offers a diverse portfolio of tea categories.
 
-Package instructions take priority over these general guidelines.
+This document serves as an exhaustive guide to each Numi tea blend, detailing flavor profiles, caffeine levels, origins, and precise brewing parameters.
 
-Black tea commonly uses water at 200-212 F / 93-100 C. A typical target is
-3 minutes (180 seconds), with some teas allowing up to 5 minutes.
+## **Essential Brewing Principles & Preparation**
 
-Green tea commonly uses water at 160-180 F / 70-82 C. A typical target is
-2 minutes (120 seconds), with some teas allowing 1-3 minutes. Let freshly
-boiled water cool before adding green tea.
+### **Water Quality & Temperature**
 
-White tea commonly uses water at 170-185 F / 77-85 C. A typical target is
-3 minutes (180 seconds), with some teas allowing 2-5 minutes.
+* **Water Selection:** Always use fresh, cold, filtered or spring water. Tap water containing high chlorine or heavy mineral content degrades delicate tea volatile oils.  
+* **Avoid Re-boiling:** Do not repeatedly re-boil water, as it depletes oxygen content essential for unlocking nuanced flavors.  
+* **Pre-heating Vessel:** Warm your teapot or mug with a splash of hot water prior to brewing to prevent premature temperature drop.
 
-Oolong tea commonly uses water at 185-205 F / 85-96 C. A typical target is
-3 minutes (180 seconds), with some teas allowing 2-5 minutes. Rolled oolongs
-may support several short infusions.
+### **Ratios**
 
-Herbal tea and tisanes commonly use boiling water at 200-212 F / 93-100 C.
-A typical target is 5 minutes (300 seconds), with some blends allowing up to
-7 minutes. Follow package warnings for medicinal herbs or ingredients.
+* **Tea Bag:** 1 tea bag per 8–10 oz (240–300 mL) of hot water.  
+* **Loose Leaf:** 1 rounded teaspoon (2–3 grams) per 8 oz (240 mL) of hot water.  
+* **Iced Tea:** Double the concentration (2 tea bags or 2 tsp per 8 oz), steep hot, then pour over ice.
 
-Pu-erh commonly uses near-boiling or boiling water. A typical first infusion
-target is 3 minutes (180 seconds), unless the package specifies short repeated
-infusions.
+## **1\. Black Teas**
+
+Numi’s black teas are full-bodied, rich in antioxidants, and sourced from Fair Trade Certified gardens in India (Assam, Darjeeling), Sri Lanka, and China.
+
+### **Aged Earl Grey™**
+
+* **Flavor Profile:** Bold, smooth black tea infused with real Italian bergamot orange. Citrusy, floral, and balanced.  
+* **Caffeine Level:** High  
+* **Origin:** Assam, India (Aged with organic bergamot)  
+* **Brewing Parameters:**  
+  * Water Temp: **208°F – 212°F (98°C – 100°C)**  
+  * Steep Time: **4 – 5 minutes**  
+* **Serving Suggestion:** Excellent plain or with a splash of milk and raw honey.
+
+### **Breakfast Blend (Morning Rise)**
+
+* **Flavor Profile:** Robust, malty, and complex blend of Assam, Ceylon, and Darjeeling teas.  
+* **Caffeine Level:** High  
+* **Origin:** Blend (India & Sri Lanka)  
+* **Brewing Parameters:**  
+  * Water Temp: **212°F (100°C)**  
+  * Steep Time: **4 – 5 minutes**  
+* **Serving Suggestion:** Pairs exceptionally well with milk, oat milk, or lemon.
+
+### **Chinese Breakfast**
+
+* **Flavor Profile:** Rich, earthy Yunnan black tea with natural chocolate and peppery undertones.  
+* **Caffeine Level:** High  
+* **Origin:** Yunnan Province, China  
+* **Brewing Parameters:**  
+  * Water Temp: **205°F – 212°F (96°C – 100°C)**  
+  * Steep Time: **3 – 4 minutes**  
+* **Serving Suggestion:** Best enjoyed black to appreciate subtle malty cacao notes.
+
+### **Golden Chai™**
+
+* **Flavor Profile:** Traditional Indian spice blend—Assam black tea with cinnamon, cardamom, ginger, and cloves.  
+* **Caffeine Level:** High  
+* **Origin:** India  
+* **Brewing Parameters:**  
+  * Water Temp: **212°F (100°C)**  
+  * Steep Time: **5 minutes**  
+* **Serving Suggestion:** Ideal for Chai Lattes (brew strong, add warm steamed milk and sweeten with honey or maple syrup).
+
+### **Decaf Aged Earl Grey™**
+
+* **Flavor Profile:** Classic bergamot black tea profile, naturally decaffeinated using an organic CO2 process.  
+* **Caffeine Level:** Decaffeinated (\< 2mg)  
+* **Brewing Parameters:**  
+  * Water Temp: **208°F – 212°F (98°C – 100°C)**  
+  * Steep Time: **4 – 5 minutes**
+
+## **2\. Green Teas**
+
+Green teas require lower water temperatures to preserve delicate antioxidants (EGCG) and prevent bitter tannins from dominating the flavor profile.
+
+### **Jasmine Green**
+
+* **Flavor Profile:** Fragrant, romantic, and smooth. Organic green tea scented with fresh jasmine blossoms over multiple nights.  
+* **Caffeine Level:** Medium  
+* **Origin:** Jiangxi Province, China  
+* **Brewing Parameters:**  
+  * Water Temp: **175°F – 180°F (80°C – 82°C)**  
+  * Steep Time: **2 – 3 minutes**  
+* **Note:** Do not use boiling water; water that is too hot will scald the leaves and create astringency.
+
+### **Gunpowder Green**
+
+* **Flavor Profile:** Earthy, slightly smoky, crisp, and refreshing. Full leaves tightly rolled into small pinhead pearls.  
+* **Caffeine Level:** Medium  
+* **Origin:** Zhejiang Province, China  
+* **Brewing Parameters:**  
+  * Water Temp: **170°F – 180°F (77°C – 82°C)**  
+  * Steep Time: **2 – 3 minutes**  
+* **Pro Tip:** Leaves uncurl completely during steeping; re-steepable up to 2 times.
+
+### **Toasted Rice (Genmaicha)**
+
+* **Flavor Profile:** Nutty, savory, warm, and toasted. Blend of green tea leaves and toasted brown rice.  
+* **Caffeine Level:** Low to Medium  
+* **Origin:** Japan / China  
+* **Brewing Parameters:**  
+  * Water Temp: **175°F – 180°F (80°C – 82°C)**  
+  * Steep Time: **2 minutes**
+
+### **Maté Lemon Green**
+
+* **Flavor Profile:** Bright, uplifting, herbaceous, and zesty. A blend of green tea, South American Yerba Maté, and lemon myrtle.  
+* **Caffeine Level:** High (Energy-boosting)  
+* **Brewing Parameters:**  
+  * Water Temp: **175°F – 185°F (80°C – 85°C)**  
+  * Steep Time: **3 minutes**
+
+### **Matcha Toasted Rice & Ginger Matcha**
+
+* **Flavor Profile:** Umami-rich green tea enhanced with pure Japanese ceremonial/culinary grade matcha powder.  
+* **Caffeine Level:** Medium to High  
+* **Brewing Parameters:**  
+  * Water Temp: **165°F – 175°F (74°C – 80°C)**  
+  * Steep Time: **2 minutes** (Gently agitate or whisk bag to distribute matcha powder).
+
+## **3\. White Teas**
+
+White teas consist of young tea buds and leaves, lightly withered and dried. They require tender care during steeping.
+
+### **White Rose™**
+
+* **Flavor Profile:** Delicate, floral, sweet, and soft. White tea blended with whole organic rosebuds.  
+* **Caffeine Level:** Low  
+* **Origin:** Fujian Province, China  
+* **Brewing Parameters:**  
+  * Water Temp: **170°F – 180°F (77°C – 82°C)**  
+  * Steep Time: **2 – 3 minutes**
+
+### **White Peony (Bai Mu Dan)**
+
+* **Flavor Profile:** Smooth, sweet, subtle, with notes of nectarine and wild spring vegetation.  
+* **Caffeine Level:** Low  
+* **Origin:** Fujian Province, China  
+* **Brewing Parameters:**  
+  * Water Temp: **175°F (80°C)**  
+  * Steep Time: **3 minutes**
+
+## **4\. Pu-Erh Teas (Fermented Teas)**
+
+Numi pioneered commercial organic Pu-erh in North America. Pu-erh undergoes a natural microbial fermentation process, resulting in deep, grounding earthiness and high digestion support.
+
+### **Emperor’s Pu-Erh™**
+
+* **Flavor Profile:** Deep, bold, rich, and earthy with malty chocolate undertones. Highly grounding.  
+* **Caffeine Level:** High  
+* **Origin:** Yunnan, China (sourced from ancient wild tea trees)  
+* **Brewing Parameters:**  
+  * Water Temp: **212°F (100°C)**  
+  * Steep Time: **4 – 5 minutes**  
+* **Pro Tip:** Highly resilient to multiple steepings. Second infusion yields a smoother sweetness.
+
+### **Chocolate Pu-Erh™**
+
+* **Flavor Profile:** Decadent blend of earthy Pu-erh, organic cocoa nibs, sweet nutmeg, cardamom, and cinnamon.  
+* **Caffeine Level:** Medium to High  
+* **Brewing Parameters:**  
+  * Water Temp: **212°F (100°C)**  
+  * Steep Time: **4 – 5 minutes**  
+* **Serving Suggestion:** Add warm milk and maple syrup for a healthy dark chocolate elixir.
+
+### **Cardamom / Ginger / Jasmine Pu-Erh**
+
+* **Flavor Profile:** Earthy base balanced by aromatic botanical infusions (warming spice or exotic flowers).  
+* **Caffeine Level:** High  
+* **Brewing Parameters:**  
+  * Water Temp: **205°F – 212°F (96°C – 100°C)**  
+  * Steep Time: **4 minutes**
+
+## **5\. Herbal Teasans & Botanical Infusions**
+
+100% caffeine-free herbs, fruits, and flowers. Naturally soothing and rich in essential oils.
+
+### **Moroccan Mint (NaNa Mint)**
+
+* **Flavor Profile:** Crisp, sweet, vibrant spearmint flavor harvested from North African NaNa mint.  
+* **Caffeine Level:** Caffeine-Free  
+* **Origin:** Faiyum, Egypt  
+* **Brewing Parameters:**  
+  * Water Temp: **212°F (100°C)**  
+  * Steep Time: **5 – 6 minutes**
+
+### **Chamomile Lemon / Emperor's Chamomile**
+
+* **Flavor Profile:** Sweet, calm, floral Egyptian chamomile heads paired with Australian lemon myrtle.  
+* **Caffeine Level:** Caffeine-Free  
+* **Brewing Parameters:**  
+  * Water Temp: **212°F (100°C)**  
+  * Steep Time: **5 – 7 minutes**
+
+### **Rooibos & Rooibos Chai**
+
+* **Flavor Profile:** Rich, nutty, honeyed red bush tea from South Africa. Rooibos Chai adds warming spices (clove, cinnamon, cardamom).  
+* **Caffeine Level:** Caffeine-Free  
+* **Origin:** Cederberg Mountains, South Africa  
+* **Brewing Parameters:**  
+  * Water Temp: **212°F (100°C)**  
+  * Steep Time: **5 – 6 minutes**
+
+### **Sweet Night (Sleep Blend)**
+
+* **Flavor Profile:** Calming, floral, herbal blend containing Valerian root, chamomile, lavender, lemon balm, and passionflower.  
+* **Caffeine Level:** Caffeine-Free  
+* **Brewing Parameters:**  
+  * Water Temp: **212°F (100°C)**  
+  * Steep Time: **4 – 6 minutes** (Keep cup covered while steeping to lock in volatile essential oils).
+
+### **Dry Desert Lime (Loomi)**
+
+* **Flavor Profile:** Tart, citrusy, complex, and smoky. Made from whole sun-dried wild limes.  
+* **Caffeine Level:** Caffeine-Free  
+* **Brewing Parameters:**  
+  * Water Temp: **212°F (100°C)**  
+  * Steep Time: **5 – 7 minutes**
+
+## **6\. Turmeric Teasans**
+
+Turmeric teasans utilize organic turmeric root blended with herbs and spices for vitality and anti-inflammatory wellness.
+
+### **Amber Sun Turmeric**
+
+* **Flavor Profile:** Smooth, warm, peppery, and sweet. Turmeric blended with rooibos, cardamom, and cinnamon.  
+* **Caffeine Level:** Caffeine-Free  
+* **Brewing Parameters:**  
+  * Water Temp: **212°F (100°C)**  
+  * Steep Time: **5 – 7 minutes**
+
+### **Three Roots Turmeric**
+
+* **Flavor Profile:** Earthy, pungent, and spicy. Synergistic blend of three organic roots: Turmeric, Ginger, and Licorice.  
+* **Caffeine Level:** Caffeine-Free  
+* **Brewing Parameters:**  
+  * Water Temp: **212°F (100°C)**  
+  * Steep Time: **5 – 7 minutes**
+
+## **Special Preparation Techniques**
+
+### **1\. Iced Tea Method (Flash Brew)**
+
+1. Place **2 Numi tea bags** in an 8–10 oz heat-safe glass or mug.  
+2. Pour boiling/hot water (temperature according to tea type) filling halfway (4–5 oz).  
+3. Steep for recommended maximum time.  
+4. Remove tea bags and sweeten while hot if desired.  
+5. Fill a 16 oz glass with fresh ice cubes and pour hot concentrated tea directly over ice to chill instantly.
+
+### **2\. Cold Brew Method**
+
+1. Place **4–5 Numi tea bags** per 1 quart (32 oz) of room temperature filtered water in a glass pitcher.  
+2. Cover and refrigerate for **8 to 12 hours** (6 hours for Green/White teas).  
+3. Remove tea bags and enjoy smooth, low-tannin iced tea.
+
+### **3\. Specialty Tea Latte Method**
+
+1. Steep **2 tea bags** (Golden Chai, Aged Earl Grey, or Chocolate Pu-Erh) in 4 oz boiling water for **5–7 minutes**.  
+2. Warm/froth 4–6 oz of milk (dairy, oat, almond, or soy).  
+3. Combine concentrated tea shot with frothed milk.  
+4. Sweeten with 1 tbsp honey, maple syrup, or agave. Top with ground cinnamon or nutmeg.
+
+## **Storage & Maintenance**
+
+* **Air & Light:** Store tea in an airtight container away from direct sunlight, moisture, and high heat.  
+* **Aroma Protection:** Keep tea separated from strong kitchen spices or coffee beans, as tea leaves absorb surrounding aromas easily.  
+* **Shelf Life:** For optimal flavor, consume within 24 months of production.

--- a/agent-samples/tea-making-sample/worker/pyproject.toml
+++ b/agent-samples/tea-making-sample/worker/pyproject.toml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "tea-making-worker"
+version = "0.1.0"
+requires-python = ">=3.11,<3.13"
+dependencies = [
+    "pyyaml>=6.0",
+    "xr-ai-hub-client",
+    "xr-ai-logging",
+    "xr-ai-models",
+    "xr-ai-nat[vision]",
+    "xr-ai-voice",
+    "xr-ai-voicegate",
+]
+
+[tool.uv.sources]
+xr-ai-hub-client = { path = "../../../agent-sdk/xr-ai-hub-client", editable = true }
+xr-ai-logging    = { path = "../../../utils/xr-ai-logging", editable = true }
+xr-ai-models     = { path = "../../../agent-sdk/xr-ai-models", editable = true }
+xr-ai-nat        = { path = "../../../agent-sdk/xr-ai-nat", editable = true }
+xr-ai-voice      = { path = "../../../agent-sdk/xr-ai-voice", editable = true }
+xr-ai-voicegate  = { path = "../../../utils/xr-ai-voicegate", editable = true }
+
+[project.scripts]
+tea_making_worker = "tea_making_worker.__main__:run"
+
+[tool.hatch.build.targets.wheel]
+packages = ["tea_making_worker"]

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/__init__.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""YAML-driven guided workflow worker for the tea-making sample."""
+
+__all__ = []

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/__main__.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/__main__.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Parse launcher arguments and run the tea-making worker."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from pathlib import Path
+
+from .app import run_app
+from .config import load_config
+
+
+def run() -> None:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--config", type=Path, default=None)
+    parser.add_argument("--ready-file", type=Path, default=None)
+    args, _ = parser.parse_known_args()
+    asyncio.run(run_app(load_config(args.config), ready_file=args.ready_file))
+
+
+if __name__ == "__main__":
+    run()

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/agent.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/agent.py
@@ -12,9 +12,9 @@ from pathlib import Path
 from typing import Any
 
 from loguru import logger
-from xr_ai_models import ChatMessage, LLMService, ToolCall, ToolDef
+from xr_ai_models import ChatMessage, LLMService, ToolDef
 
-from .tools import GuideTools
+from .tools import AgentTool, GuideTools, ToolCatalog
 from .workflow import (
     WorkflowDefinition,
     WorkflowSession,
@@ -24,7 +24,16 @@ from .workflow import (
 
 _OBSERVATION_LOG_TOOL = "get_recent_vlm_observations"
 _VISUAL_INSPECTION_TOOL = "inspect_current_view"
+_NEXT_STEP_TOOL = "get_next_workflow_step"
+_TASK_CONTROL_KEYS = {
+    "navigation_examples",
+    "start_triggers",
+    "status_triggers",
+    "stop_triggers",
+}
 VisualQueryFn = Callable[[str], Awaitable[dict[str, Any]]]
+
+
 @dataclass(frozen=True, slots=True)
 class StepAgentResult:
     """Structured output from one step-agent iteration."""
@@ -58,13 +67,8 @@ class WorkflowAgent:
         answer_prompt: Path,
     ) -> None:
         self._llm = llm
-        self._tools = tools
         self._workflow = workflow
-        self._tool_defs = [
-            *tools.definitions(),
-            _observation_log_tool_def(),
-            _visual_inspection_tool_def(),
-        ]
+        self._tool_catalog = ToolCatalog(_agent_tools(tools))
         self._answer_prompt_path = answer_prompt
         self._answer_prompt_cache = answer_prompt.read_text(encoding="utf-8").strip()
 
@@ -91,8 +95,7 @@ class WorkflowAgent:
         raw = await self._run_tool_loop(
             messages,
             max_tokens=1536,
-            observation_log=observation_log,
-            tool_defs=self._step_tool_defs(step),
+            tools=self._step_tools(step),
         )
         logger.debug(
             "step agent raw pid={} step={} text={!r}",
@@ -127,9 +130,7 @@ class WorkflowAgent:
     ) -> NavigationIntent:
         full_context = session.context if session is not None else self._workflow.initial_context()
         context = self._workflow.context_for_step(current_step, full_context)
-        history = (
-            "\n".join(f"User: {user}\nAssistant: {assistant}" for user, assistant in recent_turns[-2:]) or "(none)"
-        )
+        prior_user_request = recent_turns[-1][0] if recent_turns else "(none)"
         messages = [
             ChatMessage(role="system", content=_NAVIGATION_SYSTEM_PROMPT),
             ChatMessage(
@@ -146,7 +147,9 @@ class WorkflowAgent:
                     f"ready={bool(session and session.ready_step_id == current_step.id)}\n"
                     f"workflow_active={bool(session and session.active)}\n\n"
                     f"[Workflow context]\n{context_for_prompt(context)}\n\n"
-                    f"[Recent conversation]\n{history}\n\n"
+                    f"[Prior user request for follow-up reference]\n"
+                    f"{prior_user_request}\n"
+                    f"Do not reuse any earlier answer or measured value.\n\n"
                     f"[User utterance]\n{transcript}"
                 ),
             ),
@@ -193,11 +196,37 @@ class WorkflowAgent:
         recent_turns: list[tuple[str, str]],
         visual_query: VisualQueryFn | None = None,
     ) -> str:
-        system = self._read_answer_prompt()
         context = session.context if session is not None else self._workflow.initial_context()
-        history = (
-            "\n".join(f"User: {user}\nAssistant: {assistant}" for user, assistant in recent_turns[-4:]) or "(none)"
+        return await self.answer_step(
+            transcript=transcript,
+            context=context,
+            current_step=current_step,
+            step_state=session.step_state if session is not None else "idle",
+            ready=bool(session and session.ready_step_id == current_step.id),
+            workflow_active=bool(session and session.active),
+            observation_log=observation_log,
+            recent_turns=recent_turns,
+            visual_query=visual_query,
         )
+
+    async def answer_step(
+        self,
+        *,
+        transcript: str,
+        context: dict[str, Any],
+        current_step: WorkflowStep,
+        step_state: str,
+        ready: bool,
+        workflow_active: bool,
+        observation_log: list[dict[str, Any]],
+        recent_turns: list[tuple[str, str]],
+        visual_query: VisualQueryFn | None = None,
+    ) -> str:
+        """Answer one read-only voice event in the current step's scope."""
+
+        system = self._read_answer_prompt()
+        prompt_context = self._workflow.context_for_step(current_step, context)
+        prior_user_request = recent_turns[-1][0] if recent_turns else "(none)"
         latest_observation = _latest_step_observation(
             observation_log,
             current_step.id,
@@ -207,22 +236,24 @@ class WorkflowAgent:
             ChatMessage(
                 role="user",
                 content=(
-                    f"[Task]\n{json.dumps(self._workflow.task, ensure_ascii=True)}\n\n"
+                    f"[Task]\n{json.dumps(_task_context(self._workflow.task), ensure_ascii=True)}\n\n"
                     f"[Current step]\n"
                     f"id={current_step.id}\n"
                     f"name={current_step.name}\n"
                     f"description={current_step.description}\n\n"
                     f"[Step procedure]\n{current_step.agent_prompt}\n\n"
-                    f"[Recent conversation]\n{history}\n\n"
+                    f"[Prior user request for follow-up reference]\n"
+                    f"{prior_user_request}\n"
+                    f"Do not reuse any earlier answer or measured value.\n\n"
                     f"[Workflow snapshot]\n"
-                    f"The workflow context and latest step-monitor observation below "
+                    f"The current-step context and latest step-monitor observation below "
                     f"supersede older workflow observations, but they are not a fresh "
                     f"camera inspection for the current request.\n\n"
                     f"[Step state]\n"
-                    f"state={session.step_state if session is not None else 'idle'}\n"
-                    f"ready={bool(session and session.ready_step_id == current_step.id)}\n"
-                    f"workflow_active={bool(session and session.active)}\n\n"
-                    f"[Workflow context]\n{context_for_prompt(context)}\n\n"
+                    f"state={step_state}\n"
+                    f"ready={ready}\n"
+                    f"workflow_active={workflow_active}\n\n"
+                    f"[Current-step context only]\n{context_for_prompt(prompt_context)}\n\n"
                     f"[Latest step-monitor observation]\n{latest_observation}\n\n"
                     f"[VLM observation log]\n"
                     f"A rolling internal log is available through "
@@ -234,17 +265,20 @@ class WorkflowAgent:
         ]
         response = await self._run_tool_loop(
             messages,
-            max_tokens=1024,
-            observation_log=observation_log,
-            visual_query=visual_query,
+            max_tokens=256,
+            tools=self._answer_tools(
+                current_step=current_step,
+                observation_log=observation_log,
+                visual_query=visual_query,
+            ),
         )
         logger.info(
             "answer agent response active={} step={} text={!r}",
-            session is not None and session.active,
+            workflow_active,
             current_step.id,
             response[:1000],
         )
-        return response.strip() or "Done."
+        return response.strip() or "I could not determine that from the available information."
 
     def _step_user_prompt(
         self,
@@ -265,15 +299,15 @@ class WorkflowAgent:
             },
             "assistant_message": {
                 "type": "string",
-                "description": ("Optional short guidance, correction, or missing-info request."),
+                "description": ("Empty unless an immediate visible safety correction is required."),
             },
             "speak": {
                 "type": "boolean",
-                "description": ("Reserved for urgent notices; false for ordinary missing information."),
+                "description": ("True only for an immediate visible safety correction."),
             },
         }
         return (
-            f"[Task]\n{json.dumps(self._workflow.task, ensure_ascii=True)}\n\n"
+            f"[Task]\n{json.dumps(_task_context(self._workflow.task), ensure_ascii=True)}\n\n"
             f"[Step]\n"
             f"id={step.id}\n"
             f"name={step.name}\n"
@@ -290,16 +324,16 @@ class WorkflowAgent:
         messages: list[ChatMessage],
         *,
         max_tokens: int,
-        observation_log: list[dict[str, Any]] | None = None,
-        tool_defs: list[ToolDef] | None = None,
-        visual_query: VisualQueryFn | None = None,
+        tools: list[AgentTool] | None = None,
     ) -> str:
-        available_tools = self._tool_defs if tool_defs is None else tool_defs
+        available_tools = tools or []
+        definitions = [tool.definition for tool in available_tools]
+        catalog = ToolCatalog(available_tools)
         for iteration in range(self._workflow.max_agent_iterations):
             try:
                 response = await self._llm.chat(
                     messages,
-                    tools=available_tools,
+                    tools=definitions,
                     max_tokens=max_tokens,
                     temperature=0.0,
                     enable_thinking=False,
@@ -321,11 +355,26 @@ class WorkflowAgent:
                 )
             )
             for call in tool_calls:
-                result = await self._execute_tool(
-                    call,
-                    iteration=iteration,
-                    observation_log=observation_log or [],
-                    visual_query=visual_query,
+                try:
+                    arguments = json.loads(call.arguments or "{}")
+                except json.JSONDecodeError:
+                    arguments = {}
+                logger.debug(
+                    "guide tool call iter={} tool={} args={}",
+                    iteration,
+                    call.name,
+                    arguments,
+                )
+                try:
+                    result = await catalog.invoke(call.name, arguments)
+                except Exception as exc:
+                    logger.exception("guide tool failed: {}", call.name)
+                    result = {"error": str(exc)}
+                logger.debug(
+                    "guide tool result iter={} tool={} result={}",
+                    iteration,
+                    call.name,
+                    result,
                 )
                 messages.append(
                     ChatMessage(
@@ -336,20 +385,16 @@ class WorkflowAgent:
                 )
         return ""
 
-    def _step_tool_defs(
+    def _step_tools(
         self,
         step: WorkflowStep,
-    ) -> list[ToolDef]:
+    ) -> list[AgentTool]:
         if not step.agent_tools:
             return []
-        definitions = {tool.name: tool for tool in self._tool_defs}
-        enabled: list[ToolDef] = []
-        for name in step.agent_tools:
-            tool = definitions.get(name)
-            if tool is None:
-                logger.warning("step {} references unknown agent tool {}", step.id, name)
-                continue
-            enabled.append(tool)
+        missing = self._tool_catalog.missing(step.agent_tools)
+        for name in sorted(missing):
+            logger.warning("step {} references unknown agent tool {}", step.id, name)
+        enabled = self._tool_catalog.select(step.agent_tools)
         logger.debug(
             "step agent tools step={} enabled={}",
             step.id,
@@ -357,58 +402,49 @@ class WorkflowAgent:
         )
         return enabled
 
-    async def _execute_tool(
+    def _answer_tools(
         self,
-        call: ToolCall,
         *,
-        iteration: int,
+        current_step: WorkflowStep,
         observation_log: list[dict[str, Any]],
         visual_query: VisualQueryFn | None = None,
-    ) -> dict[str, Any]:
-        try:
-            arguments = json.loads(call.arguments or "{}")
-        except json.JSONDecodeError:
-            arguments = {}
-        logger.debug("guide tool call iter={} tool={} args={}", iteration, call.name, arguments)
-        if call.name == _OBSERVATION_LOG_TOOL:
-            result = _recent_observations(observation_log, arguments)
-            logger.debug(
-                "guide tool result iter={} tool={} result={}",
-                iteration,
-                call.name,
-                result,
-            )
-            return result
-        if call.name == _VISUAL_INSPECTION_TOOL:
+    ) -> list[AgentTool]:
+        async def recent(arguments: dict[str, Any]) -> dict[str, Any]:
+            return _recent_observations(observation_log, arguments)
+
+        async def inspect(arguments: dict[str, Any]) -> dict[str, Any]:
             question = str(arguments.get("question") or "").strip()
             if visual_query is None:
                 return {"error": "A live camera view is not available."}
             if not question:
                 return {"error": "question is required"}
-            try:
-                result = await visual_query(question)
-                logger.debug(
-                    "guide tool result iter={} tool={} result={}",
-                    iteration,
-                    call.name,
-                    result,
-                )
-                return result
-            except Exception as exc:
-                logger.exception("live visual inspection failed")
-                return {"error": str(exc)}
-        try:
-            result = await self._tools.invoke(call.name, arguments)
-            logger.debug(
-                "guide tool result iter={} tool={} result={}",
-                iteration,
-                call.name,
-                result,
+            return await visual_query(question)
+
+        async def next_step(_arguments: dict[str, Any]) -> dict[str, Any]:
+            following = (
+                self._workflow.first_active_step()
+                if current_step.is_idle
+                else self._workflow.next_step(current_step.id)
             )
-            return result
-        except Exception as exc:
-            logger.exception("guide tool failed: {}", call.name)
-            return {"error": str(exc)}
+            if following is None:
+                return {"has_next_step": False}
+            return {
+                "has_next_step": True,
+                "id": following.id,
+                "name": following.name,
+                "description": following.description,
+                "on_enter_message": following.on_enter_message,
+            }
+
+        scoped = [
+            AgentTool(_observation_log_tool_def(), recent, read_only=True),
+            AgentTool(_visual_inspection_tool_def(), inspect, read_only=True),
+            AgentTool(_next_step_tool_def(), next_step, read_only=True),
+        ]
+        return [
+            *self._tool_catalog.select(read_only_only=True),
+            *scoped,
+        ]
 
     def _read_answer_prompt(self) -> str:
         try:
@@ -426,20 +462,29 @@ step-specific procedure. Interpret the caption and perform every state update
 through the returned context patch. Call the step's enabled tools whenever its
 procedure requires current time, timer status, RAG, or other external data.
 
+Stay inside this step. Do not discuss, prepare, summarize, or give instructions
+for any future step. The latest VLM caption is the only authority for fields that
+describe what is visible now. Current context is prior state, not current visual
+evidence. When the procedure declares a field mutable, update it from every new
+caption and never substitute an older value. Derive readiness only from the
+latest caption, the projected context, enabled tool results, and the explicit
+advance condition.
+
 Return only valid JSON. The top-level object must contain:
 - context: a partial patch containing only fields this step can write and only
   values supported by the latest VLM observation, RAG, tools, or context.
 - ready_to_advance: whether this step is complete.
 - step_state: started, needs_input, or complete for this step's internal state.
 - assistant_message: optional concise high-level guidance or a missing-info
-  request. The worker controls reminder timing, so do not repeat yourself.
-- speak: false for ordinary missing information. The worker controls when to
-  speak delayed reminders and ready notices.
+  request. Leave it empty unless the latest evidence shows an immediate safety
+  problem requiring a correction.
+- speak: true only for that immediate safety correction; otherwise false. The
+  worker owns entry instructions, reminders, completion, and navigation speech.
 
 Never copy, summarize, or narrate the VLM observation as assistant_message.
 The VLM observation is internal evidence. assistant_message is only for a short
-actionable correction, missing-info request, or useful "ready for next" style
-notice.
+urgent safety correction. Do not announce status, readiness, tea details, the
+current step, or any next action from this loop.
 
 Do not change the workflow step number. Do not invent visible facts. A writable
 observation may change more than once within one step; prefer newer evidence to
@@ -493,6 +538,33 @@ def _observation_log_tool_def() -> ToolDef:
     )
 
 
+def _agent_tools(tools: GuideTools) -> list[AgentTool]:
+    """Adapt old tool providers while preferring capability-aware providers."""
+
+    provider = getattr(tools, "agent_tools", None)
+    if callable(provider):
+        return list(provider())
+
+    adapted: list[AgentTool] = []
+    for definition in tools.definitions():
+
+        async def invoke(
+            arguments: dict[str, Any],
+            *,
+            name: str = definition.name,
+        ) -> dict[str, Any]:
+            return await tools.invoke(name, arguments)
+
+        adapted.append(AgentTool(definition, invoke, read_only=False))
+    return adapted
+
+
+def _task_context(task: dict[str, Any]) -> dict[str, Any]:
+    """Remove navigation configuration from non-navigation model prompts."""
+
+    return {key: value for key, value in task.items() if key not in _TASK_CONTROL_KEYS}
+
+
 def _visual_inspection_tool_def() -> ToolDef:
     return ToolDef(
         name=_VISUAL_INSPECTION_TOOL,
@@ -515,6 +587,22 @@ def _visual_inspection_tool_def() -> ToolDef:
                 },
             },
             "required": ["question"],
+            "additionalProperties": False,
+        },
+    )
+
+
+def _next_step_tool_def() -> ToolDef:
+    return ToolDef(
+        name=_NEXT_STEP_TOOL,
+        description=(
+            "Return the exact next YAML-defined workflow step. Use only when the "
+            "wearer explicitly asks what comes next; never call it for an ordinary "
+            "current-step question or progress report."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {},
             "additionalProperties": False,
         },
     )
@@ -552,8 +640,7 @@ def _latest_step_observation(
         (
             entry
             for entry in reversed(observation_log)
-            if entry.get("step_id") == step_id
-            and entry.get("kind", "step_monitor") == "step_monitor"
+            if entry.get("step_id") == step_id and entry.get("kind", "step_monitor") == "step_monitor"
         ),
         None,
     )

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/agent.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/agent.py
@@ -6,8 +6,6 @@
 from __future__ import annotations
 
 import json
-import re
-import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -27,12 +25,6 @@ from .workflow import (
 _OBSERVATION_LOG_TOOL = "get_recent_vlm_observations"
 _VISUAL_INSPECTION_TOOL = "inspect_current_view"
 VisualQueryFn = Callable[[str], Awaitable[dict[str, Any]]]
-_VLM_VERDICT_RE = re.compile(
-    r"^\s*([A-Z][A-Z0-9_ ]+)\s*:\s*(yes|no|unclear)\b",
-    re.IGNORECASE | re.MULTILINE,
-)
-
-
 @dataclass(frozen=True, slots=True)
 class StepAgentResult:
     """Structured output from one step-agent iteration."""
@@ -80,17 +72,14 @@ class WorkflowAgent:
         self,
         *,
         step: WorkflowStep,
-        session: WorkflowSession,
+        participant_id: str,
+        context: dict[str, Any],
+        observation_log: list[dict[str, Any]],
         vlm_observation: str,
     ) -> StepAgentResult:
-        automatic_patch = await self._auto_invoke_step_tools(
-            step,
-            vlm_observation,
-            session.context,
-        )
         prompt_context = self._workflow.context_for_step(
             step,
-            {**session.context, **automatic_patch},
+            context,
         )
         messages = [
             ChatMessage(role="system", content=_STEP_SYSTEM_PROMPT),
@@ -102,26 +91,24 @@ class WorkflowAgent:
         raw = await self._run_tool_loop(
             messages,
             max_tokens=1536,
-            observation_log=session.observation_log,
-            tool_defs=self._step_tool_defs(step, vlm_observation),
+            observation_log=observation_log,
+            tool_defs=self._step_tool_defs(step),
         )
         logger.debug(
             "step agent raw pid={} step={} text={!r}",
-            session.participant_id,
+            participant_id,
             step.id,
             raw[:1000],
         )
         obj = _json_object(raw)
         if not isinstance(obj, dict):
             logger.warning("step agent did not return JSON: {!r}", raw[:200])
-            return StepAgentResult(context_patch=automatic_patch)
+            return StepAgentResult(context_patch={})
 
         context_patch = obj.get("context")
         if not isinstance(context_patch, dict):
             valid = step.writable_fields
             context_patch = {key: value for key, value in obj.items() if key in valid}
-        context_patch = {**context_patch, **automatic_patch}
-
         return StepAgentResult(
             context_patch=dict(context_patch),
             step_state=_valid_step_state(obj.get("step_state")),
@@ -208,7 +195,6 @@ class WorkflowAgent:
     ) -> str:
         system = self._read_answer_prompt()
         context = session.context if session is not None else self._workflow.initial_context()
-        timer_state = self._timer_state_for_prompt(session)
         history = (
             "\n".join(f"User: {user}\nAssistant: {assistant}" for user, assistant in recent_turns[-4:]) or "(none)"
         )
@@ -237,7 +223,6 @@ class WorkflowAgent:
                     f"ready={bool(session and session.ready_step_id == current_step.id)}\n"
                     f"workflow_active={bool(session and session.active)}\n\n"
                     f"[Workflow context]\n{context_for_prompt(context)}\n\n"
-                    f"[Authoritative timer state]\n{timer_state}\n\n"
                     f"[Latest step-monitor observation]\n{latest_observation}\n\n"
                     f"[VLM observation log]\n"
                     f"A rolling internal log is available through "
@@ -260,33 +245,6 @@ class WorkflowAgent:
             response[:1000],
         )
         return response.strip() or "Done."
-
-    def _timer_state_for_prompt(self, session: WorkflowSession | None) -> str:
-        if session is None:
-            return "No active timer."
-        status = self._workflow.find_timer_status(
-            session.context,
-            current_step_id=session.step_id,
-            now_us=time.time_ns() // 1_000,
-        )
-        if status is None:
-            return "No timer start and duration are currently recorded."
-        return json.dumps(
-            {
-                "label": status.label,
-                "started_at_us": status.started_at_us,
-                "duration_seconds": status.duration_seconds,
-                "elapsed_seconds": status.elapsed_seconds,
-                "remaining_seconds": status.remaining_seconds,
-                "expired": status.expired,
-                "instruction": (
-                    "Treat these derived values as authoritative. Never claim the timer "
-                    "is complete when expired is false."
-                ),
-            },
-            ensure_ascii=True,
-            sort_keys=True,
-        )
 
     def _step_user_prompt(
         self,
@@ -381,85 +339,23 @@ class WorkflowAgent:
     def _step_tool_defs(
         self,
         step: WorkflowStep,
-        vlm_observation: str,
     ) -> list[ToolDef]:
         if not step.agent_tools:
             return []
         definitions = {tool.name: tool for tool in self._tool_defs}
         enabled: list[ToolDef] = []
-        for name, policy in step.agent_tools.items():
+        for name in step.agent_tools:
             tool = definitions.get(name)
             if tool is None:
                 logger.warning("step {} references unknown agent tool {}", step.id, name)
                 continue
-            if _tool_policy_met(policy, vlm_observation):
-                enabled.append(tool)
+            enabled.append(tool)
         logger.debug(
             "step agent tools step={} enabled={}",
             step.id,
             [tool.name for tool in enabled],
         )
         return enabled
-
-    async def _auto_invoke_step_tools(
-        self,
-        step: WorkflowStep,
-        vlm_observation: str,
-        context: dict[str, Any],
-    ) -> dict[str, Any]:
-        patch: dict[str, Any] = {}
-        for name, policy in step.agent_tools.items():
-            if not policy.get("auto_invoke") or not _tool_policy_met(
-                policy,
-                vlm_observation,
-            ):
-                continue
-            empty_field = str(policy.get("when_context_empty") or "").strip()
-            effective_context = {**context, **patch}
-            if empty_field and _context_value_present(_dotted_value(effective_context, empty_field)):
-                logger.debug(
-                    "automatic step tool skipped step={} tool={} field={} reason=present",
-                    step.id,
-                    name,
-                    empty_field,
-                )
-                continue
-            arguments = policy.get("arguments") or {}
-            if not isinstance(arguments, dict):
-                arguments = {}
-            logger.info("automatic step tool call step={} tool={}", step.id, name)
-            try:
-                result = await self._tools.invoke(name, arguments)
-            except Exception:
-                logger.exception("automatic step tool failed step={} tool={}", step.id, name)
-                continue
-            logger.debug(
-                "automatic step tool result step={} tool={} result={}",
-                step.id,
-                name,
-                result,
-            )
-            outputs = policy.get("context_outputs") or {}
-            if not isinstance(result, dict) or not isinstance(outputs, dict):
-                logger.warning(
-                    "automatic step tool returned unmappable result step={} tool={}",
-                    step.id,
-                    name,
-                )
-                continue
-            mapped = {
-                str(context_field): _dotted_value(result, str(result_field))
-                for result_field, context_field in outputs.items()
-            }
-            mapped = {key: value for key, value in mapped.items() if value is not None}
-            patch.update(mapped)
-            logger.info(
-                "automatic step tool captured step={} tool={} context={}",
-                step.id,
-                name,
-                mapped,
-            )
-        return patch
 
     async def _execute_tool(
         self,
@@ -524,11 +420,11 @@ class WorkflowAgent:
             return self._answer_prompt_cache
 
 
-_STEP_SYSTEM_PROMPT = """You run one step of a YAML-defined guided workflow.
-You receive a VLM observation produced by the step's VLM prompt, the current
-workflow context, and the step-specific procedure. Use tools only when needed:
-RAG for task reference information, current time for timestamps, and the VLM
-observation log if earlier visual evidence matters.
+_STEP_SYSTEM_PROMPT = """You run one iteration of a YAML-defined workflow step.
+You receive the latest optional VLM caption, current workflow context, and the
+step-specific procedure. Interpret the caption and perform every state update
+through the returned context patch. Call the step's enabled tools whenever its
+procedure requires current time, timer status, RAG, or other external data.
 
 Return only valid JSON. The top-level object must contain:
 - context: a partial patch containing only fields this step can write and only
@@ -547,7 +443,9 @@ notice.
 
 Do not change the workflow step number. Do not invent visible facts. A writable
 observation may change more than once within one step; prefer newer evidence to
-older context. Omit unchanged fields instead of copying the entire context."""
+older context. For durable milestones, retain established true values unless
+the procedure says otherwise. Omit unchanged fields instead of copying the
+entire context."""
 
 
 _NAVIGATION_SYSTEM_PROMPT = """Classify one user utterance for a guided workflow.
@@ -662,39 +560,6 @@ def _latest_step_observation(
     if latest is None:
         return "(none)"
     return json.dumps(latest, ensure_ascii=True, sort_keys=True)
-
-
-def _tool_policy_met(policy: dict[str, Any], vlm_observation: str) -> bool:
-    verdict_name = str(policy.get("vlm_verdict") or "").strip()
-    if not verdict_name:
-        return True
-    raw_expected = policy.get("equals", "yes")
-    if isinstance(raw_expected, bool):
-        expected = "yes" if raw_expected else "no"
-    else:
-        expected = str(raw_expected).casefold().strip()
-    verdicts = {
-        _normalize_verdict_name(match.group(1)): match.group(2).casefold()
-        for match in _VLM_VERDICT_RE.finditer(vlm_observation)
-    }
-    return verdicts.get(_normalize_verdict_name(verdict_name)) == expected
-
-
-def _normalize_verdict_name(text: str) -> str:
-    return re.sub(r"[^A-Z0-9]+", "_", text.upper()).strip("_")
-
-
-def _dotted_value(data: dict[str, Any], dotted: str) -> Any:
-    value: Any = data
-    for part in dotted.split("."):
-        if not isinstance(value, dict):
-            return None
-        value = value.get(part)
-    return value
-
-
-def _context_value_present(value: Any) -> bool:
-    return value not in (None, "", 0, 0.0, False, [], {})
 
 
 def _valid_step_state(value: Any) -> str:

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/agent.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/agent.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 import re
 import time
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -24,6 +25,8 @@ from .workflow import (
 )
 
 _OBSERVATION_LOG_TOOL = "get_recent_vlm_observations"
+_VISUAL_INSPECTION_TOOL = "inspect_current_view"
+VisualQueryFn = Callable[[str], Awaitable[dict[str, Any]]]
 _VLM_VERDICT_RE = re.compile(
     r"^\s*([A-Z][A-Z0-9_ ]+)\s*:\s*(yes|no|unclear)\b",
     re.IGNORECASE | re.MULTILINE,
@@ -65,7 +68,11 @@ class WorkflowAgent:
         self._llm = llm
         self._tools = tools
         self._workflow = workflow
-        self._tool_defs = [*tools.definitions(), _observation_log_tool_def()]
+        self._tool_defs = [
+            *tools.definitions(),
+            _observation_log_tool_def(),
+            _visual_inspection_tool_def(),
+        ]
         self._answer_prompt_path = answer_prompt
         self._answer_prompt_cache = answer_prompt.read_text(encoding="utf-8").strip()
 
@@ -81,7 +88,10 @@ class WorkflowAgent:
             vlm_observation,
             session.context,
         )
-        prompt_context = {**session.context, **automatic_patch}
+        prompt_context = self._workflow.context_for_step(
+            step,
+            {**session.context, **automatic_patch},
+        )
         messages = [
             ChatMessage(role="system", content=_STEP_SYSTEM_PROMPT),
             ChatMessage(
@@ -108,7 +118,7 @@ class WorkflowAgent:
 
         context_patch = obj.get("context")
         if not isinstance(context_patch, dict):
-            valid = {field.name for field in step.context_fields}
+            valid = step.writable_fields
             context_patch = {key: value for key, value in obj.items() if key in valid}
         context_patch = {**context_patch, **automatic_patch}
 
@@ -128,11 +138,11 @@ class WorkflowAgent:
         current_step: WorkflowStep,
         recent_turns: list[tuple[str, str]],
     ) -> NavigationIntent:
-        context = session.context if session is not None else self._workflow.initial_context()
-        history = "\n".join(
-            f"User: {user}\nAssistant: {assistant}"
-            for user, assistant in recent_turns[-2:]
-        ) or "(none)"
+        full_context = session.context if session is not None else self._workflow.initial_context()
+        context = self._workflow.context_for_step(current_step, full_context)
+        history = (
+            "\n".join(f"User: {user}\nAssistant: {assistant}" for user, assistant in recent_turns[-2:]) or "(none)"
+        )
         messages = [
             ChatMessage(role="system", content=_NAVIGATION_SYSTEM_PROMPT),
             ChatMessage(
@@ -157,7 +167,7 @@ class WorkflowAgent:
         try:
             response = await self._llm.chat(
                 messages,
-                max_tokens=256,
+                max_tokens=64,
                 temperature=0.0,
                 enable_thinking=False,
                 timeout=self._workflow.navigation_timeout_s,
@@ -194,14 +204,14 @@ class WorkflowAgent:
         current_step: WorkflowStep,
         observation_log: list[dict[str, Any]],
         recent_turns: list[tuple[str, str]],
+        visual_query: VisualQueryFn | None = None,
     ) -> str:
         system = self._read_answer_prompt()
         context = session.context if session is not None else self._workflow.initial_context()
         timer_state = self._timer_state_for_prompt(session)
-        history = "\n".join(
-            f"User: {user}\nAssistant: {assistant}"
-            for user, assistant in recent_turns[-4:]
-        ) or "(none)"
+        history = (
+            "\n".join(f"User: {user}\nAssistant: {assistant}" for user, assistant in recent_turns[-4:]) or "(none)"
+        )
         latest_observation = _latest_step_observation(
             observation_log,
             current_step.id,
@@ -240,6 +250,7 @@ class WorkflowAgent:
             messages,
             max_tokens=1024,
             observation_log=observation_log,
+            visual_query=visual_query,
         )
         logger.info(
             "answer agent response active={} step={} text={!r}",
@@ -295,15 +306,11 @@ class WorkflowAgent:
             },
             "assistant_message": {
                 "type": "string",
-                "description": (
-                    "Optional short guidance, correction, or missing-info request."
-                ),
+                "description": ("Optional short guidance, correction, or missing-info request."),
             },
             "speak": {
                 "type": "boolean",
-                "description": (
-                    "Reserved for urgent notices; false for ordinary missing information."
-                ),
+                "description": ("Reserved for urgent notices; false for ordinary missing information."),
             },
         }
         return (
@@ -326,6 +333,7 @@ class WorkflowAgent:
         max_tokens: int,
         observation_log: list[dict[str, Any]] | None = None,
         tool_defs: list[ToolDef] | None = None,
+        visual_query: VisualQueryFn | None = None,
     ) -> str:
         available_tools = self._tool_defs if tool_defs is None else tool_defs
         for iteration in range(self._workflow.max_agent_iterations):
@@ -358,6 +366,7 @@ class WorkflowAgent:
                     call,
                     iteration=iteration,
                     observation_log=observation_log or [],
+                    visual_query=visual_query,
                 )
                 messages.append(
                     ChatMessage(
@@ -406,9 +415,7 @@ class WorkflowAgent:
                 continue
             empty_field = str(policy.get("when_context_empty") or "").strip()
             effective_context = {**context, **patch}
-            if empty_field and _context_value_present(
-                _dotted_value(effective_context, empty_field)
-            ):
+            if empty_field and _context_value_present(_dotted_value(effective_context, empty_field)):
                 logger.debug(
                     "automatic step tool skipped step={} tool={} field={} reason=present",
                     step.id,
@@ -459,6 +466,7 @@ class WorkflowAgent:
         *,
         iteration: int,
         observation_log: list[dict[str, Any]],
+        visual_query: VisualQueryFn | None = None,
     ) -> dict[str, Any]:
         try:
             arguments = json.loads(call.arguments or "{}")
@@ -474,6 +482,24 @@ class WorkflowAgent:
                 result,
             )
             return result
+        if call.name == _VISUAL_INSPECTION_TOOL:
+            question = str(arguments.get("question") or "").strip()
+            if visual_query is None:
+                return {"error": "A live camera view is not available."}
+            if not question:
+                return {"error": "question is required"}
+            try:
+                result = await visual_query(question)
+                logger.debug(
+                    "guide tool result iter={} tool={} result={}",
+                    iteration,
+                    call.name,
+                    result,
+                )
+                return result
+            except Exception as exc:
+                logger.exception("live visual inspection failed")
+                return {"error": str(exc)}
         try:
             result = await self._tools.invoke(call.name, arguments)
             logger.debug(
@@ -504,8 +530,8 @@ RAG for task reference information, current time for timestamps, and the VLM
 observation log if earlier visual evidence matters.
 
 Return only valid JSON. The top-level object must contain:
-- context: the context fields for this step, with updated values only when
-  they are supported by the VLM observation, RAG, tools, or existing context.
+- context: a partial patch containing only fields this step can write and only
+  values supported by the latest VLM observation, RAG, tools, or context.
 - ready_to_advance: whether this step is complete.
 - step_state: started, needs_input, or complete for this step's internal state.
 - assistant_message: optional concise high-level guidance or a missing-info
@@ -518,8 +544,9 @@ The VLM observation is internal evidence. assistant_message is only for a short
 actionable correction, missing-info request, or useful "ready for next" style
 notice.
 
-Do not change the workflow step number. Do not invent visible facts. Preserve
-existing context values unless new evidence improves them."""
+Do not change the workflow step number. Do not invent visible facts. A writable
+observation may change more than once within one step; prefer newer evidence to
+older context. Omit unchanged fields instead of copying the entire context."""
 
 
 _NAVIGATION_SYSTEM_PROMPT = """Classify one user utterance for a guided workflow.
@@ -567,6 +594,33 @@ def _observation_log_tool_def() -> ToolDef:
     )
 
 
+def _visual_inspection_tool_def() -> ToolDef:
+    return ToolDef(
+        name=_VISUAL_INSPECTION_TOOL,
+        description=(
+            "Capture a fresh camera frame and answer a question about what is visible "
+            "right now. Use this for present-tense visual questions, object or text "
+            "identification, current readings, quantities, appearance, placement, or "
+            "safety checks. Do not rely on an older workflow caption when this tool can "
+            "inspect the current view."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "question": {
+                    "type": "string",
+                    "description": (
+                        "The wearer's complete visual question, preserving the object, "
+                        "property, or text they want inspected."
+                    ),
+                },
+            },
+            "required": ["question"],
+            "additionalProperties": False,
+        },
+    )
+
+
 def _recent_observations(
     observation_log: list[dict[str, Any]],
     arguments: dict[str, Any],
@@ -583,11 +637,7 @@ def _recent_observations(
     except (TypeError, ValueError):
         step_id = None
 
-    entries = [
-        dict(entry)
-        for entry in observation_log
-        if step_id is None or entry.get("step_id") == step_id
-    ]
+    entries = [dict(entry) for entry in observation_log if step_id is None or entry.get("step_id") == step_id]
     return {
         "entries": entries[-count:],
         "returned": min(len(entries), count),
@@ -600,11 +650,7 @@ def _latest_step_observation(
     step_id: int,
 ) -> str:
     latest = next(
-        (
-            entry
-            for entry in reversed(observation_log)
-            if entry.get("step_id") == step_id
-        ),
+        (entry for entry in reversed(observation_log) if entry.get("step_id") == step_id),
         None,
     )
     if latest is None:
@@ -691,7 +737,7 @@ def _extract_json(text: str) -> str | None:
                 continue
             depth -= 1
             if depth == 0 and start >= 0:
-                return text[start:index + 1]
+                return text[start : index + 1]
     return None
 
 

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/agent.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/agent.py
@@ -1,0 +1,698 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tool-calling LLM loops for workflow state updates and user answers."""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+from xr_ai_models import ChatMessage, LLMService, ToolCall, ToolDef
+
+from .tools import GuideTools
+from .workflow import (
+    WorkflowDefinition,
+    WorkflowSession,
+    WorkflowStep,
+    context_for_prompt,
+)
+
+_OBSERVATION_LOG_TOOL = "get_recent_vlm_observations"
+_VLM_VERDICT_RE = re.compile(
+    r"^\s*([A-Z][A-Z0-9_ ]+)\s*:\s*(yes|no|unclear)\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class StepAgentResult:
+    """Structured output from one step-agent iteration."""
+
+    context_patch: dict[str, Any]
+    step_state: str = "started"
+    ready_to_advance: bool = False
+    assistant_message: str = ""
+    speak: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class NavigationIntent:
+    """User utterance classification for workflow-level commands."""
+
+    intent: str = "answer"
+    skip_requested: bool = False
+    explicit_command: bool = False
+    confidence: float = 0.0
+
+
+class WorkflowAgent:
+    """Runs the generic agentic loop around YAML-authored step prompts."""
+
+    def __init__(
+        self,
+        *,
+        llm: LLMService,
+        tools: GuideTools,
+        workflow: WorkflowDefinition,
+        answer_prompt: Path,
+    ) -> None:
+        self._llm = llm
+        self._tools = tools
+        self._workflow = workflow
+        self._tool_defs = [*tools.definitions(), _observation_log_tool_def()]
+        self._answer_prompt_path = answer_prompt
+        self._answer_prompt_cache = answer_prompt.read_text(encoding="utf-8").strip()
+
+    async def run_step(
+        self,
+        *,
+        step: WorkflowStep,
+        session: WorkflowSession,
+        vlm_observation: str,
+    ) -> StepAgentResult:
+        automatic_patch = await self._auto_invoke_step_tools(
+            step,
+            vlm_observation,
+            session.context,
+        )
+        prompt_context = {**session.context, **automatic_patch}
+        messages = [
+            ChatMessage(role="system", content=_STEP_SYSTEM_PROMPT),
+            ChatMessage(
+                role="user",
+                content=self._step_user_prompt(step, prompt_context, vlm_observation),
+            ),
+        ]
+        raw = await self._run_tool_loop(
+            messages,
+            max_tokens=1536,
+            observation_log=session.observation_log,
+            tool_defs=self._step_tool_defs(step, vlm_observation),
+        )
+        logger.debug(
+            "step agent raw pid={} step={} text={!r}",
+            session.participant_id,
+            step.id,
+            raw[:1000],
+        )
+        obj = _json_object(raw)
+        if not isinstance(obj, dict):
+            logger.warning("step agent did not return JSON: {!r}", raw[:200])
+            return StepAgentResult(context_patch=automatic_patch)
+
+        context_patch = obj.get("context")
+        if not isinstance(context_patch, dict):
+            valid = {field.name for field in step.context_fields}
+            context_patch = {key: value for key, value in obj.items() if key in valid}
+        context_patch = {**context_patch, **automatic_patch}
+
+        return StepAgentResult(
+            context_patch=dict(context_patch),
+            step_state=_valid_step_state(obj.get("step_state")),
+            ready_to_advance=bool(obj.get("ready_to_advance", False)),
+            assistant_message=str(obj.get("assistant_message") or "").strip(),
+            speak=bool(obj.get("speak", False)),
+        )
+
+    async def classify_intent(
+        self,
+        *,
+        transcript: str,
+        session: WorkflowSession | None,
+        current_step: WorkflowStep,
+        recent_turns: list[tuple[str, str]],
+    ) -> NavigationIntent:
+        context = session.context if session is not None else self._workflow.initial_context()
+        history = "\n".join(
+            f"User: {user}\nAssistant: {assistant}"
+            for user, assistant in recent_turns[-2:]
+        ) or "(none)"
+        messages = [
+            ChatMessage(role="system", content=_NAVIGATION_SYSTEM_PROMPT),
+            ChatMessage(
+                role="user",
+                content=(
+                    f"[Task]\n{json.dumps(self._workflow.task, ensure_ascii=True)}\n\n"
+                    f"[Workflow active]\n{session is not None and session.active}\n\n"
+                    f"[Current step]\n"
+                    f"id={current_step.id}\n"
+                    f"name={current_step.name}\n"
+                    f"description={current_step.description}\n\n"
+                    f"[Step state]\n"
+                    f"state={session.step_state if session is not None else 'idle'}\n"
+                    f"ready={bool(session and session.ready_step_id == current_step.id)}\n"
+                    f"workflow_active={bool(session and session.active)}\n\n"
+                    f"[Workflow context]\n{context_for_prompt(context)}\n\n"
+                    f"[Recent conversation]\n{history}\n\n"
+                    f"[User utterance]\n{transcript}"
+                ),
+            ),
+        ]
+        try:
+            response = await self._llm.chat(
+                messages,
+                max_tokens=256,
+                temperature=0.0,
+                enable_thinking=False,
+                timeout=self._workflow.navigation_timeout_s,
+            )
+        except Exception:
+            logger.exception("guide navigation classifier failed")
+            return NavigationIntent()
+
+        logger.debug(
+            "navigation classifier raw step={} text={!r} response={!r}",
+            current_step.id,
+            transcript,
+            (response.content or "")[:500],
+        )
+        obj = _json_object(response.content or "")
+        if not isinstance(obj, dict):
+            return NavigationIntent()
+        intent = str(obj.get("intent") or "answer").casefold().strip()
+        if intent not in {"start", "stop", "status", "advance", "answer"}:
+            intent = "answer"
+        confidence = _as_float(obj.get("confidence"), default=0.0)
+        return NavigationIntent(
+            intent=intent,
+            skip_requested=bool(obj.get("skip_requested", False)),
+            explicit_command=bool(obj.get("explicit_command", False)),
+            confidence=max(0.0, min(confidence, 1.0)),
+        )
+
+    async def answer_user(
+        self,
+        *,
+        transcript: str,
+        session: WorkflowSession | None,
+        current_step: WorkflowStep,
+        observation_log: list[dict[str, Any]],
+        recent_turns: list[tuple[str, str]],
+    ) -> str:
+        system = self._read_answer_prompt()
+        context = session.context if session is not None else self._workflow.initial_context()
+        timer_state = self._timer_state_for_prompt(session)
+        history = "\n".join(
+            f"User: {user}\nAssistant: {assistant}"
+            for user, assistant in recent_turns[-4:]
+        ) or "(none)"
+        latest_observation = _latest_step_observation(
+            observation_log,
+            current_step.id,
+        )
+        messages = [
+            ChatMessage(role="system", content=system),
+            ChatMessage(
+                role="user",
+                content=(
+                    f"[Task]\n{json.dumps(self._workflow.task, ensure_ascii=True)}\n\n"
+                    f"[Current step]\n"
+                    f"id={current_step.id}\n"
+                    f"name={current_step.name}\n"
+                    f"description={current_step.description}\n\n"
+                    f"[Step procedure]\n{current_step.agent_prompt}\n\n"
+                    f"[Recent conversation]\n{history}\n\n"
+                    f"[Authoritative current state]\n"
+                    f"The workflow context and latest VLM observation below supersede "
+                    f"older conversation turns and older observations.\n\n"
+                    f"[Step state]\n"
+                    f"state={session.step_state if session is not None else 'idle'}\n"
+                    f"ready={bool(session and session.ready_step_id == current_step.id)}\n"
+                    f"workflow_active={bool(session and session.active)}\n\n"
+                    f"[Workflow context]\n{context_for_prompt(context)}\n\n"
+                    f"[Authoritative timer state]\n{timer_state}\n\n"
+                    f"[Latest VLM observation]\n{latest_observation}\n\n"
+                    f"[VLM observation log]\n"
+                    f"A rolling internal log is available through "
+                    f"{_OBSERVATION_LOG_TOOL}. Use it only when visual evidence "
+                    f"is needed to answer the wearer.\n\n"
+                    f"[User request]\n{transcript}"
+                ),
+            ),
+        ]
+        response = await self._run_tool_loop(
+            messages,
+            max_tokens=1024,
+            observation_log=observation_log,
+        )
+        logger.info(
+            "answer agent response active={} step={} text={!r}",
+            session is not None and session.active,
+            current_step.id,
+            response[:1000],
+        )
+        return response.strip() or "Done."
+
+    def _timer_state_for_prompt(self, session: WorkflowSession | None) -> str:
+        if session is None:
+            return "No active timer."
+        status = self._workflow.find_timer_status(
+            session.context,
+            current_step_id=session.step_id,
+            now_us=time.time_ns() // 1_000,
+        )
+        if status is None:
+            return "No timer start and duration are currently recorded."
+        return json.dumps(
+            {
+                "label": status.label,
+                "started_at_us": status.started_at_us,
+                "duration_seconds": status.duration_seconds,
+                "elapsed_seconds": status.elapsed_seconds,
+                "remaining_seconds": status.remaining_seconds,
+                "expired": status.expired,
+                "instruction": (
+                    "Treat these derived values as authoritative. Never claim the timer "
+                    "is complete when expired is false."
+                ),
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        )
+
+    def _step_user_prompt(
+        self,
+        step: WorkflowStep,
+        context: dict[str, Any],
+        vlm_observation: str,
+    ) -> str:
+        schema = {
+            "context": step.context_schema(),
+            "ready_to_advance": {
+                "type": "boolean",
+                "description": "True only when this step's completion condition is satisfied.",
+            },
+            "step_state": {
+                "type": "string",
+                "enum": ["started", "needs_input", "complete"],
+                "description": "Mini state for this step, not the workflow step number.",
+            },
+            "assistant_message": {
+                "type": "string",
+                "description": (
+                    "Optional short guidance, correction, or missing-info request."
+                ),
+            },
+            "speak": {
+                "type": "boolean",
+                "description": (
+                    "Reserved for urgent notices; false for ordinary missing information."
+                ),
+            },
+        }
+        return (
+            f"[Task]\n{json.dumps(self._workflow.task, ensure_ascii=True)}\n\n"
+            f"[Step]\n"
+            f"id={step.id}\n"
+            f"name={step.name}\n"
+            f"description={step.description}\n\n"
+            f"[Current context]\n{context_for_prompt(context)}\n\n"
+            f"[Latest VLM observation]\n{vlm_observation or '(empty)'}\n\n"
+            f"[Step-specific procedure]\n{step.agent_prompt}\n\n"
+            f"[Advance condition]\n{json.dumps(step.advance_when, ensure_ascii=True)}\n\n"
+            f"[Required final JSON shape]\n{json.dumps(schema, indent=2, ensure_ascii=True)}"
+        )
+
+    async def _run_tool_loop(
+        self,
+        messages: list[ChatMessage],
+        *,
+        max_tokens: int,
+        observation_log: list[dict[str, Any]] | None = None,
+        tool_defs: list[ToolDef] | None = None,
+    ) -> str:
+        available_tools = self._tool_defs if tool_defs is None else tool_defs
+        for iteration in range(self._workflow.max_agent_iterations):
+            try:
+                response = await self._llm.chat(
+                    messages,
+                    tools=available_tools,
+                    max_tokens=max_tokens,
+                    temperature=0.0,
+                    enable_thinking=False,
+                )
+            except Exception:
+                logger.exception("guide agent LLM call failed")
+                return ""
+
+            content = (response.content or "").strip()
+            tool_calls = response.tool_calls or ()
+            if not tool_calls:
+                return content
+
+            messages.append(
+                ChatMessage(
+                    role="assistant",
+                    content=content,
+                    tool_calls=list(tool_calls),
+                )
+            )
+            for call in tool_calls:
+                result = await self._execute_tool(
+                    call,
+                    iteration=iteration,
+                    observation_log=observation_log or [],
+                )
+                messages.append(
+                    ChatMessage(
+                        role="tool",
+                        content=json.dumps(result, ensure_ascii=True, default=str),
+                        tool_call_id=call.id,
+                    )
+                )
+        return ""
+
+    def _step_tool_defs(
+        self,
+        step: WorkflowStep,
+        vlm_observation: str,
+    ) -> list[ToolDef]:
+        if not step.agent_tools:
+            return []
+        definitions = {tool.name: tool for tool in self._tool_defs}
+        enabled: list[ToolDef] = []
+        for name, policy in step.agent_tools.items():
+            tool = definitions.get(name)
+            if tool is None:
+                logger.warning("step {} references unknown agent tool {}", step.id, name)
+                continue
+            if _tool_policy_met(policy, vlm_observation):
+                enabled.append(tool)
+        logger.debug(
+            "step agent tools step={} enabled={}",
+            step.id,
+            [tool.name for tool in enabled],
+        )
+        return enabled
+
+    async def _auto_invoke_step_tools(
+        self,
+        step: WorkflowStep,
+        vlm_observation: str,
+        context: dict[str, Any],
+    ) -> dict[str, Any]:
+        patch: dict[str, Any] = {}
+        for name, policy in step.agent_tools.items():
+            if not policy.get("auto_invoke") or not _tool_policy_met(
+                policy,
+                vlm_observation,
+            ):
+                continue
+            empty_field = str(policy.get("when_context_empty") or "").strip()
+            effective_context = {**context, **patch}
+            if empty_field and _context_value_present(
+                _dotted_value(effective_context, empty_field)
+            ):
+                logger.debug(
+                    "automatic step tool skipped step={} tool={} field={} reason=present",
+                    step.id,
+                    name,
+                    empty_field,
+                )
+                continue
+            arguments = policy.get("arguments") or {}
+            if not isinstance(arguments, dict):
+                arguments = {}
+            logger.info("automatic step tool call step={} tool={}", step.id, name)
+            try:
+                result = await self._tools.invoke(name, arguments)
+            except Exception:
+                logger.exception("automatic step tool failed step={} tool={}", step.id, name)
+                continue
+            logger.debug(
+                "automatic step tool result step={} tool={} result={}",
+                step.id,
+                name,
+                result,
+            )
+            outputs = policy.get("context_outputs") or {}
+            if not isinstance(result, dict) or not isinstance(outputs, dict):
+                logger.warning(
+                    "automatic step tool returned unmappable result step={} tool={}",
+                    step.id,
+                    name,
+                )
+                continue
+            mapped = {
+                str(context_field): _dotted_value(result, str(result_field))
+                for result_field, context_field in outputs.items()
+            }
+            mapped = {key: value for key, value in mapped.items() if value is not None}
+            patch.update(mapped)
+            logger.info(
+                "automatic step tool captured step={} tool={} context={}",
+                step.id,
+                name,
+                mapped,
+            )
+        return patch
+
+    async def _execute_tool(
+        self,
+        call: ToolCall,
+        *,
+        iteration: int,
+        observation_log: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        try:
+            arguments = json.loads(call.arguments or "{}")
+        except json.JSONDecodeError:
+            arguments = {}
+        logger.debug("guide tool call iter={} tool={} args={}", iteration, call.name, arguments)
+        if call.name == _OBSERVATION_LOG_TOOL:
+            result = _recent_observations(observation_log, arguments)
+            logger.debug(
+                "guide tool result iter={} tool={} result={}",
+                iteration,
+                call.name,
+                result,
+            )
+            return result
+        try:
+            result = await self._tools.invoke(call.name, arguments)
+            logger.debug(
+                "guide tool result iter={} tool={} result={}",
+                iteration,
+                call.name,
+                result,
+            )
+            return result
+        except Exception as exc:
+            logger.exception("guide tool failed: {}", call.name)
+            return {"error": str(exc)}
+
+    def _read_answer_prompt(self) -> str:
+        try:
+            text = self._answer_prompt_path.read_text(encoding="utf-8").strip()
+            self._answer_prompt_cache = text
+            return text
+        except OSError:
+            logger.warning("answer prompt unreadable; using cached prompt")
+            return self._answer_prompt_cache
+
+
+_STEP_SYSTEM_PROMPT = """You run one step of a YAML-defined guided workflow.
+You receive a VLM observation produced by the step's VLM prompt, the current
+workflow context, and the step-specific procedure. Use tools only when needed:
+RAG for task reference information, current time for timestamps, and the VLM
+observation log if earlier visual evidence matters.
+
+Return only valid JSON. The top-level object must contain:
+- context: the context fields for this step, with updated values only when
+  they are supported by the VLM observation, RAG, tools, or existing context.
+- ready_to_advance: whether this step is complete.
+- step_state: started, needs_input, or complete for this step's internal state.
+- assistant_message: optional concise high-level guidance or a missing-info
+  request. The worker controls reminder timing, so do not repeat yourself.
+- speak: false for ordinary missing information. The worker controls when to
+  speak delayed reminders and ready notices.
+
+Never copy, summarize, or narrate the VLM observation as assistant_message.
+The VLM observation is internal evidence. assistant_message is only for a short
+actionable correction, missing-info request, or useful "ready for next" style
+notice.
+
+Do not change the workflow step number. Do not invent visible facts. Preserve
+existing context values unless new evidence improves them."""
+
+
+_NAVIGATION_SYSTEM_PROMPT = """Classify one user utterance for a guided workflow.
+Return only valid JSON with:
+- intent: one of start, stop, status, advance, answer
+- skip_requested: true only when the wearer wants to skip or proceed before the
+  current step is known complete
+- explicit_command: true only when the wearer directly commands the workflow to
+  start, stop, or move; false for observations, completion reports, and questions
+- confidence: number from 0 to 1
+
+Use advance when the wearer is commanding movement to the next step, including
+uncommon or conversational wording with that meaning. A report such as "I put
+the tea in the cup" describes task progress but does not command workflow
+movement, so classify it as answer with explicit_command false.
+Use answer when the wearer is asking a question, including "what is the next
+step?", "can I proceed?", "what should I do?", or task-specific questions.
+Use status only for requests asking where the workflow is. Use stop for cancel
+or end guidance requests. Use start for requests to begin the task when idle."""
+
+
+def _observation_log_tool_def() -> ToolDef:
+    return ToolDef(
+        name=_OBSERVATION_LOG_TOOL,
+        description=(
+            "Return recent internal VLM observations for this active workflow session. "
+            "Use this only when the wearer asks what was observed, asks about visual "
+            "status, or previous visual evidence is needed."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer",
+                    "description": "Number of recent observations to return, from 1 to 20.",
+                    "default": 6,
+                },
+                "step_id": {
+                    "type": "integer",
+                    "description": "Optional workflow step ID to filter observations.",
+                },
+            },
+            "additionalProperties": False,
+        },
+    )
+
+
+def _recent_observations(
+    observation_log: list[dict[str, Any]],
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    try:
+        count = int(arguments.get("count") or 6)
+    except (TypeError, ValueError):
+        count = 6
+    count = max(1, min(count, 20))
+
+    raw_step_id = arguments.get("step_id")
+    try:
+        step_id = int(raw_step_id) if raw_step_id is not None else None
+    except (TypeError, ValueError):
+        step_id = None
+
+    entries = [
+        dict(entry)
+        for entry in observation_log
+        if step_id is None or entry.get("step_id") == step_id
+    ]
+    return {
+        "entries": entries[-count:],
+        "returned": min(len(entries), count),
+        "available": len(entries),
+    }
+
+
+def _latest_step_observation(
+    observation_log: list[dict[str, Any]],
+    step_id: int,
+) -> str:
+    latest = next(
+        (
+            entry
+            for entry in reversed(observation_log)
+            if entry.get("step_id") == step_id
+        ),
+        None,
+    )
+    if latest is None:
+        return "(none)"
+    return json.dumps(latest, ensure_ascii=True, sort_keys=True)
+
+
+def _tool_policy_met(policy: dict[str, Any], vlm_observation: str) -> bool:
+    verdict_name = str(policy.get("vlm_verdict") or "").strip()
+    if not verdict_name:
+        return True
+    raw_expected = policy.get("equals", "yes")
+    if isinstance(raw_expected, bool):
+        expected = "yes" if raw_expected else "no"
+    else:
+        expected = str(raw_expected).casefold().strip()
+    verdicts = {
+        _normalize_verdict_name(match.group(1)): match.group(2).casefold()
+        for match in _VLM_VERDICT_RE.finditer(vlm_observation)
+    }
+    return verdicts.get(_normalize_verdict_name(verdict_name)) == expected
+
+
+def _normalize_verdict_name(text: str) -> str:
+    return re.sub(r"[^A-Z0-9]+", "_", text.upper()).strip("_")
+
+
+def _dotted_value(data: dict[str, Any], dotted: str) -> Any:
+    value: Any = data
+    for part in dotted.split("."):
+        if not isinstance(value, dict):
+            return None
+        value = value.get(part)
+    return value
+
+
+def _context_value_present(value: Any) -> bool:
+    return value not in (None, "", 0, 0.0, False, [], {})
+
+
+def _valid_step_state(value: Any) -> str:
+    state = str(value or "").casefold().strip()
+    return state if state in {"started", "needs_input", "complete"} else "started"
+
+
+def _as_float(value: Any, *, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _json_object(text: str) -> dict[str, Any] | None:
+    extracted = _extract_json(text)
+    if extracted is None:
+        return None
+    try:
+        value = json.loads(extracted)
+    except json.JSONDecodeError:
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _extract_json(text: str) -> str | None:
+    depth, start, in_string, escape = 0, -1, False, False
+    for index, char in enumerate(text):
+        if in_string:
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == '"':
+                in_string = False
+            continue
+        if char == '"':
+            in_string = True
+            continue
+        if char == "{":
+            if depth == 0:
+                start = index
+            depth += 1
+        elif char == "}":
+            if depth == 0:
+                continue
+            depth -= 1
+            if depth == 0 and start >= 0:
+                return text[start:index + 1]
+    return None
+
+
+__all__ = ["NavigationIntent", "StepAgentResult", "WorkflowAgent"]

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/agent.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/agent.py
@@ -228,16 +228,17 @@ class WorkflowAgent:
                     f"description={current_step.description}\n\n"
                     f"[Step procedure]\n{current_step.agent_prompt}\n\n"
                     f"[Recent conversation]\n{history}\n\n"
-                    f"[Authoritative current state]\n"
-                    f"The workflow context and latest VLM observation below supersede "
-                    f"older conversation turns and older observations.\n\n"
+                    f"[Workflow snapshot]\n"
+                    f"The workflow context and latest step-monitor observation below "
+                    f"supersede older workflow observations, but they are not a fresh "
+                    f"camera inspection for the current request.\n\n"
                     f"[Step state]\n"
                     f"state={session.step_state if session is not None else 'idle'}\n"
                     f"ready={bool(session and session.ready_step_id == current_step.id)}\n"
                     f"workflow_active={bool(session and session.active)}\n\n"
                     f"[Workflow context]\n{context_for_prompt(context)}\n\n"
                     f"[Authoritative timer state]\n{timer_state}\n\n"
-                    f"[Latest VLM observation]\n{latest_observation}\n\n"
+                    f"[Latest step-monitor observation]\n{latest_observation}\n\n"
                     f"[VLM observation log]\n"
                     f"A rolling internal log is available through "
                     f"{_OBSERVATION_LOG_TOOL}. Use it only when visual evidence "
@@ -650,7 +651,12 @@ def _latest_step_observation(
     step_id: int,
 ) -> str:
     latest = next(
-        (entry for entry in reversed(observation_log) if entry.get("step_id") == step_id),
+        (
+            entry
+            for entry in reversed(observation_log)
+            if entry.get("step_id") == step_id
+            and entry.get("kind", "step_monitor") == "step_monitor"
+        ),
         None,
     )
     if latest is None:

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/app.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/app.py
@@ -113,7 +113,7 @@ async def run_app(config: WorkerConfig, *, ready_file: Path | None = None) -> No
             await guide.release(participant_id)
 
         async def participant_joined(participant_id: str) -> None:
-            await guide.resume(participant_id)
+            await guide.reset(participant_id)
 
         monitor_task: asyncio.Task[None] | None = None
         async with session:

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/app.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/app.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compose models, voice, live vision, and the YAML workflow guide."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from pathlib import Path
+
+from loguru import logger
+from nat.builder.workflow_builder import WorkflowBuilder
+from xr_ai_logging import setup_logging
+from xr_ai_models import load_models_config, make_llm, make_stt, make_tts, make_vlm
+from xr_ai_nat.functions.rag import RAGFunctionsConfig
+from xr_ai_voice import TextMessageInput, VadConfig, VoiceQuery, VoiceSession
+from xr_ai_voicegate import load_voice_gate_config
+
+from .agent import WorkflowAgent
+from .config import WorkerConfig
+from .guide import WorkflowGuide
+from .tools import GuideTools
+from .vision import StepVision
+from .workflow import WorkflowDefinition
+
+
+class NoticeBridge:
+    """Turns background guidance notices into normal voice-session queries."""
+
+    def __init__(self, session: VoiceSession) -> None:
+        self._session = session
+        self._pending: dict[str, str] = {}
+
+    async def speak(self, participant_id: str, text: str) -> None:
+        if not self._session.is_running:
+            return
+        token = f"__tea_notice_{uuid.uuid4().hex}"
+        self._pending[token] = text
+        await self._session.enqueue_query(participant_id, token, fresh_match=True)
+
+    def pop(self, token: str) -> str | None:
+        return self._pending.pop(token, None)
+
+
+async def run_app(config: WorkerConfig, *, ready_file: Path | None = None) -> None:
+    """Run the tea-making guided workflow worker until shutdown."""
+
+    setup_logging("worker", namespace="tea-making-sample")
+    models = load_models_config(config.models_yaml)
+    agent_llm = make_llm(models, "agent_llm")
+    stt = make_stt(models, "stt")
+    tts = make_tts(models, "tts")
+    vlm = make_vlm(models, "vlm")
+
+    workflow = WorkflowDefinition.load(config.workflow_yaml)
+    voice_gate = load_voice_gate_config(config.voice_gate_yaml)
+
+    session = VoiceSession(
+        stt=stt,
+        tts=tts,
+        vad=VadConfig(
+            silence_duration=config.silence_duration,
+            min_speech=config.min_speech,
+            silero_threshold=config.silero_threshold,
+        ),
+        voice_gate=voice_gate,
+        probes={"agent-llm": agent_llm.health, "vlm": vlm.health},
+        ready_file=ready_file,
+        closeables=(agent_llm, vlm),
+        text_topic="agent.response",
+        idle_timeout_secs=config.idle_timeout_secs,
+    )
+    async with WorkflowBuilder() as builder:
+        await builder.add_function_group(
+            "rag",
+            RAGFunctionsConfig(endpoint=config.rag_endpoint),
+        )
+        rag_group = await builder.get_function_group("rag")
+        tools = GuideTools(await rag_group.get_all_functions())
+        notice_bridge = NoticeBridge(session)
+        vision = StepVision(
+            endpoint=session.transport.endpoint,
+            vlm=vlm,
+            frame_max_age_s=config.frame_max_age_s,
+            frame_timeout_s=config.frame_timeout_s,
+            vlm_timeout_s=config.vlm_timeout_s,
+            system_prompt=str(workflow.runtime.get("vlm_system_prompt", "")),
+        )
+        agent = WorkflowAgent(
+            llm=agent_llm,
+            tools=tools,
+            workflow=workflow,
+            answer_prompt=config.answer_prompt,
+        )
+        guide = WorkflowGuide(
+            workflow=workflow,
+            vision=vision,
+            agent=agent,
+            notice=notice_bridge.speak,
+        )
+
+        async def handler(turn: VoiceQuery) -> str:
+            notice = notice_bridge.pop(turn.text)
+            if notice is not None:
+                return notice
+            return await guide.handle_query(
+                participant_id=turn.participant_id,
+                text=turn.text,
+            )
+
+        async def participant_left(participant_id: str) -> None:
+            await guide.release(participant_id)
+
+        async def participant_joined(participant_id: str) -> None:
+            await guide.resume(participant_id)
+
+        monitor_task: asyncio.Task[None] | None = None
+        async with session:
+            TextMessageInput(session=session, fresh_match=True)
+            monitor_task = asyncio.create_task(
+                guide.monitor_forever(),
+                name="tea-guide-monitor",
+            )
+            logger.info("tea-making-sample worker starting")
+            try:
+                await session.run(
+                    handler,
+                    on_participant_joined=participant_joined,
+                    on_participant_left=participant_left,
+                    interrupt_on_supersede=True,
+                    queue_queries=True,
+                )
+            finally:
+                logger.info("tea-making-sample worker stopping")
+                await guide.close()
+                if monitor_task is not None:
+                    monitor_task.cancel()
+                    try:
+                        await monitor_task
+                    except asyncio.CancelledError:
+                        pass
+
+
+__all__ = ["run_app"]

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/config.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/config.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed worker configuration for the tea-making guided workflow sample."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerConfig:
+    """Resolved runtime settings for one guided workflow worker."""
+
+    models_yaml: Path
+    voice_gate_yaml: Path
+    workflow_yaml: Path
+    rag_endpoint: str
+    answer_prompt: Path
+    frame_max_age_s: float
+    frame_timeout_s: float
+    vlm_timeout_s: float
+    silence_duration: float
+    min_speech: float
+    silero_threshold: float
+    idle_timeout_secs: float | None
+
+
+def _read_config(path: Path | None) -> dict[str, Any]:
+    if path is None or not path.exists():
+        return {}
+    with path.open(encoding="utf-8") as stream:
+        data = yaml.safe_load(stream) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"worker config must be a YAML mapping: {path}")
+    return data
+
+
+def _resolve(raw: str, config_path: Path | None) -> Path:
+    path = Path(raw)
+    if config_path is not None and not path.is_absolute():
+        return config_path.parent / path
+    return path
+
+
+def load_config(path: Path | None) -> WorkerConfig:
+    """Load worker YAML and resolve paths relative to that file."""
+
+    data = _read_config(path)
+    idle_timeout = data.get("idle_timeout_secs")
+    return WorkerConfig(
+        models_yaml=_resolve(str(data.get("models_yaml", "models.yaml")), path),
+        voice_gate_yaml=_resolve(
+            str(data.get("voice_gate_yaml", "voice_gate.yaml")),
+            path,
+        ),
+        workflow_yaml=_resolve(str(data.get("workflow_yaml", "workflow.yaml")), path),
+        rag_endpoint=str(data.get("rag_endpoint", "tcp://127.0.0.1:8340")),
+        answer_prompt=_resolve(
+            str(data.get("answer_prompt", "../worker/tea_making_worker/prompts/system.txt")),
+            path,
+        ),
+        frame_max_age_s=float(data.get("frame_max_age_s", 5.0)),
+        frame_timeout_s=float(data.get("frame_timeout_s", 5.0)),
+        vlm_timeout_s=float(data.get("vlm_timeout_s", 15.0)),
+        silence_duration=float(data.get("silence_duration", 0.8)),
+        min_speech=float(data.get("min_speech", 0.15)),
+        silero_threshold=float(data.get("silero_threshold", 0.3)),
+        idle_timeout_secs=float(idle_timeout) if idle_timeout else None,
+    )
+
+
+__all__ = ["WorkerConfig", "load_config"]

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/guide.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/guide.py
@@ -21,6 +21,7 @@ from .workflow import (
     WorkflowSession,
     WorkflowStep,
     render_template,
+    speech_text,
 )
 
 NoticeFn = Callable[[str, str], Awaitable[None]]
@@ -126,12 +127,51 @@ class WorkflowGuide:
                 )
             else:
                 logger.debug("guide answer_user dispatch pid={} step={}", participant_id, step.id)
+
+                async def inspect_current_view(question: str) -> dict[str, Any]:
+                    if not hasattr(self._vision, "inspect"):
+                        return {"error": "A live camera view is not available."}
+                    observation = await self._vision.inspect(
+                        participant_id,
+                        question,
+                        step=step,
+                        context=dict(session.context) if session is not None else {},
+                        task=self._workflow.task,
+                    )
+                    observed_at_us = _now_us()
+                    if session is not None:
+                        async with session.lock:
+                            if session.active and session.step_id == step.id:
+                                self._store_observation(
+                                    session,
+                                    step,
+                                    observation.text,
+                                    observation.frame_pts_us,
+                                    kind="visual_question",
+                                    question=question,
+                                )
+                    result = {
+                        "question": question,
+                        "visual_evidence": observation.text,
+                        "frame_pts_us": observation.frame_pts_us,
+                        "observed_at_us": observed_at_us,
+                    }
+                    logger.info(
+                        "guide visual question pid={} step={} question={!r} answer={!r}",
+                        participant_id,
+                        step.id,
+                        question,
+                        observation.text[:500],
+                    )
+                    return result
+
                 response = await self._agent.answer_user(
                     transcript=clean,
                     session=session,
                     current_step=step,
                     observation_log=session.observation_log if session is not None else [],
                     recent_turns=self._history.get(participant_id, []),
+                    visual_query=inspect_current_view,
                 )
         finally:
             if session is not None:
@@ -139,6 +179,7 @@ class WorkflowGuide:
                 deferred_notice = session.deferred_notice
                 session.deferred_notice = ""
 
+        response = speech_text(response)
         self._record(participant_id, clean, response)
         logger.info(
             "guide response pid={} intent={} text={!r}",
@@ -187,10 +228,7 @@ class WorkflowGuide:
             return "No guided workflow is active."
         async with session.lock:
             current = self._workflow.step_by_id(session.step_id)
-            complete = (
-                session.ready_step_id == current.id
-                or self._workflow.advance_when_met(current, session.context)
-            )
+            complete = session.ready_step_id == current.id or self._workflow.advance_when_met(current, session.context)
             skipped = not complete
             applied: dict[str, Any] = {}
             if skipped:
@@ -242,10 +280,7 @@ class WorkflowGuide:
         if session is None or not session.active:
             return "No guided workflow is active."
         step = self._workflow.step_by_id(session.step_id)
-        suffix = (
-            " It is ready; say next when you want to continue."
-            if session.ready_step_id == step.id else ""
-        )
+        suffix = " It is ready; say next when you want to continue." if session.ready_step_id == step.id else ""
         return f"On step {step.id}: {step.name}. State: {session.step_state}.{suffix}"
 
     async def monitor_forever(self) -> None:
@@ -305,12 +340,7 @@ class WorkflowGuide:
         timer_step = False
         updating_complete = False
         async with session.lock:
-            if (
-                not session.active
-                or not session.connected
-                or session.evaluation_active
-                or session.user_turn_active
-            ):
+            if not session.active or not session.connected or session.evaluation_active or session.user_turn_active:
                 return
             step = self._workflow.step_by_id(session.step_id)
             if step.is_idle:
@@ -392,11 +422,7 @@ class WorkflowGuide:
                 return
 
             async with session.lock:
-                if (
-                    not session.active
-                    or not session.connected
-                    or session.step_id != step.id
-                ):
+                if not session.active or not session.connected or session.step_id != step.id:
                     return
                 if observation.frame_pts_us <= session.last_frame_pts_us:
                     return
@@ -425,6 +451,15 @@ class WorkflowGuide:
                         update_state,
                         observation_patch,
                     )
+                if updating_complete:
+                    session.step_state = "complete"
+                    logger.debug(
+                        "guide completed state refreshed without step agent pid={} step={} fields={}",
+                        session.participant_id,
+                        step.id,
+                        sorted(observation_patch),
+                    )
+                    return
 
             result = await self._agent.run_step(
                 step=step,
@@ -443,46 +478,19 @@ class WorkflowGuide:
             reminder_notice = ""
             urgent_notice = ""
             async with session.lock:
-                if (
-                    not session.active
-                    or not session.connected
-                    or session.step_id != step.id
-                ):
-                    return
-                if updating_complete and session.ready_step_id != step.id:
-                    return
-                if updating_complete:
-                    complete_fields = step.state_update_fields("complete")
-                    self._merge_context(
-                        session.context,
-                        guarded_patch,
-                        allowed=complete_fields,
-                    )
-                    session.step_state = "complete"
-                    logger.info(
-                        "guide completed state updated pid={} step={} fields={} "
-                        "values={}",
-                        session.participant_id,
-                        step.id,
-                        sorted(complete_fields),
-                        {
-                            name: session.context.get(name)
-                            for name in complete_fields
-                        },
-                    )
+                if not session.active or not session.connected or session.step_id != step.id:
                     return
                 self._merge_context(
                     session.context,
                     guarded_patch,
-                    allowed={field.name for field in step.context_fields},
+                    allowed=step.writable_fields,
                 )
                 if result.assistant_message:
                     session.pending_instruction = result.assistant_message
                     if result.speak:
                         urgent_notice = result.assistant_message
                 logger.debug(
-                    "guide eval result pid={} step={} state={} ready={} patch_keys={} "
-                    "assistant_message={!r} speak={}",
+                    "guide eval result pid={} step={} state={} ready={} patch_keys={} assistant_message={!r} speak={}",
                     session.participant_id,
                     step.id,
                     result.step_state,
@@ -499,10 +507,7 @@ class WorkflowGuide:
                 ):
                     ready_notice = self._mark_ready_for_next(session, step)
                 else:
-                    session.step_state = (
-                        result.step_state
-                        if result.step_state != "complete" else "started"
-                    )
+                    session.step_state = result.step_state if result.step_state != "complete" else "started"
                     reminder_notice = self._reminder_due(session, step)
 
             if urgent_notice and not ready_notice:
@@ -537,6 +542,9 @@ class WorkflowGuide:
         step: WorkflowStep,
         text: str,
         frame_pts_us: int,
+        *,
+        kind: str = "step_monitor",
+        question: str = "",
     ) -> None:
         if not text.strip():
             return
@@ -545,9 +553,13 @@ class WorkflowGuide:
                 "step_id": step.id,
                 "step_name": step.name,
                 "frame_pts_us": frame_pts_us,
+                "observed_at_us": _now_us(),
+                "kind": kind,
                 "caption": text.strip(),
             }
         )
+        if question:
+            session.observation_log[-1]["question"] = question
         logger.debug(
             "vlm observation stored pid={} step={} frame_pts_us={} caption={!r}",
             session.participant_id,
@@ -652,7 +664,7 @@ class WorkflowGuide:
         *,
         force: bool = False,
     ) -> None:
-        text = text.strip()
+        text = speech_text(text)
         if not text or not session.connected:
             return
         if session.user_turn_active:
@@ -718,12 +730,17 @@ class WorkflowGuide:
     ) -> str:
         if not template.strip():
             return fallback
-        return render_template(
-            template,
-            context=session.context,
-            step=step,
-            task=self._workflow.task,
-        ).strip() or fallback
+        return (
+            speech_text(
+                render_template(
+                    template,
+                    context=session.context,
+                    step=step,
+                    task=self._workflow.task,
+                ).strip()
+            )
+            or fallback
+        )
 
     def _record(self, participant_id: str, user: str, assistant: str) -> None:
         turns = self._history.setdefault(participant_id, [])
@@ -860,12 +877,7 @@ def _validated_model_intent(
         return NavigationIntent()
     clean = _normalize_command(text)
     words = set(clean.split())
-    if (
-        intent.intent == "advance"
-        and active
-        and intent.explicit_command
-        and not _looks_like_question(text, clean)
-    ):
+    if intent.intent == "advance" and active and intent.explicit_command and not _looks_like_question(text, clean):
         return intent
     if intent.intent == "start" and not active and words & _START_WORDS:
         return intent
@@ -884,12 +896,8 @@ def _time_question_answer(
     if session is None:
         return ""
     clean = _normalize_command(text)
-    start_time_requested = any(
-        phrase in clean for phrase in _START_TIME_QUERY_PHRASES
-    )
-    if not start_time_requested and not any(
-        phrase in clean for phrase in _TIME_QUERY_PHRASES
-    ):
+    start_time_requested = any(phrase in clean for phrase in _START_TIME_QUERY_PHRASES)
+    if not start_time_requested and not any(phrase in clean for phrase in _TIME_QUERY_PHRASES):
         return ""
     status = workflow.find_timer_status(
         session.context,
@@ -901,25 +909,12 @@ def _time_question_answer(
         if timer_step is None or timer_step.timer is None:
             return ""
         timer = timer_step.timer
-        started_at_us = _positive_context_int(
-            session.context.get(timer.started_at_us_field)
-        )
-        duration_seconds = _positive_context_int(
-            session.context.get(timer.duration_seconds_field)
-        )
-        remaining_requested = any(
-            phrase in clean for phrase in _REMAINING_TIME_PHRASES
-        )
+        started_at_us = _positive_context_int(session.context.get(timer.started_at_us_field))
+        duration_seconds = _positive_context_int(session.context.get(timer.duration_seconds_field))
+        remaining_requested = any(phrase in clean for phrase in _REMAINING_TIME_PHRASES)
         if started_at_us <= 0 and (start_time_requested or remaining_requested):
-            target = (
-                f" The target duration is {_format_duration(duration_seconds)}."
-                if duration_seconds > 0
-                else ""
-            )
-            return (
-                f"The {timer.label} timer has not started because no start time "
-                f"is recorded yet.{target}"
-            )
+            target = f" The target duration is {_format_duration(duration_seconds)}." if duration_seconds > 0 else ""
+            return f"The {timer.label} timer has not started because no start time is recorded yet.{target}"
         return ""
     if start_time_requested:
         started = datetime.fromtimestamp(
@@ -934,17 +929,11 @@ def _time_question_answer(
         if status.expired:
             return f"The {status.label} time is up."
         remaining = _format_duration(status.remaining_seconds)
-        return (
-            f"There is about {remaining} left for {status.label}. "
-            f"About {elapsed} has elapsed out of {target}."
-        )
+        return f"There is about {remaining} left for {status.label}. About {elapsed} has elapsed out of {target}."
     if status.expired:
         return f"About {elapsed} has elapsed. The {status.label} time is up."
     remaining = _format_duration(status.remaining_seconds)
-    return (
-        f"About {elapsed} has elapsed since {status.label} started. "
-        f"There is about {remaining} left."
-    )
+    return f"About {elapsed} has elapsed since {status.label} started. There is about {remaining} left."
 
 
 def _relevant_timer_step(
@@ -974,13 +963,13 @@ def _format_duration(total_seconds: int) -> str:
             return f"{minutes} minute" if minutes == 1 else f"{minutes} minutes"
         minute_text = f"{minutes} minute" if minutes == 1 else f"{minutes} minutes"
         second_text = f"{seconds} second" if seconds == 1 else f"{seconds} seconds"
-        return f"{minute_text} {second_text}"
+        return f"{minute_text} and {second_text}"
     hours, minutes = divmod(minutes, 60)
     hour_text = f"{hours} hour" if hours == 1 else f"{hours} hours"
     if minutes == 0:
         return hour_text
     minute_text = f"{minutes} minute" if minutes == 1 else f"{minutes} minutes"
-    return f"{hour_text} {minute_text}"
+    return f"{hour_text} and {minute_text}"
 
 
 def _apply_vlm_verdict_guards(
@@ -990,11 +979,7 @@ def _apply_vlm_verdict_guards(
     ready_to_advance: bool,
 ) -> tuple[dict[str, Any], bool]:
     verdicts = _parse_vlm_verdicts(observation_text)
-    blocking = {
-        name: value
-        for name, value in verdicts.items()
-        if value in {"no", "unclear"}
-    }
+    blocking = {name: value for name, value in verdicts.items() if value in {"no", "unclear"}}
     if not blocking:
         return context_patch, ready_to_advance
 
@@ -1002,14 +987,11 @@ def _apply_vlm_verdict_guards(
     for key, value in context_patch.items():
         field_token = _tokenize_for_match(str(key))
         contradicted = [
-            f"{name}:{state}"
-            for name, state in blocking.items()
-            if name in field_token and _truthy_patch_value(value)
+            f"{name}:{state}" for name, state in blocking.items() if name in field_token and _truthy_patch_value(value)
         ]
         if contradicted:
             logger.warning(
-                "dropping context update contradicted by VLM verdict step={} field={} "
-                "value={!r} verdicts={}",
+                "dropping context update contradicted by VLM verdict step={} field={} value={!r} verdicts={}",
                 step.id,
                 key,
                 value,
@@ -1032,10 +1014,7 @@ def _apply_vlm_verdict_guards(
 
 
 def _parse_vlm_verdicts(text: str) -> dict[str, str]:
-    return {
-        _tokenize_for_match(match.group(1)): match.group(2).casefold()
-        for match in _VERDICT_RE.finditer(text)
-    }
+    return {_tokenize_for_match(match.group(1)): match.group(2).casefold() for match in _VERDICT_RE.finditer(text)}
 
 
 def _tokenize_for_match(text: str) -> str:
@@ -1068,12 +1047,7 @@ def _looks_like_advance(text: str, workflow: WorkflowDefinition) -> bool:
 
 
 def _looks_like_status_request(clean: str) -> bool:
-    return (
-        "status" in clean.split()
-        or "what step" in clean
-        or "where are we" in clean
-        or "workflow progress" in clean
-    )
+    return "status" in clean.split() or "what step" in clean or "where are we" in clean or "workflow progress" in clean
 
 
 def _contains_negation(text: str) -> bool:

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/guide.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/guide.py
@@ -1,0 +1,1110 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Participant-facing guided workflow orchestration."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import time
+from collections.abc import Awaitable, Callable
+from datetime import datetime
+from typing import Any
+
+from loguru import logger
+
+from .agent import NavigationIntent, WorkflowAgent
+from .vision import FrameUnavailable, StepVision
+from .workflow import (
+    WorkflowDefinition,
+    WorkflowSession,
+    WorkflowStep,
+    render_template,
+)
+
+NoticeFn = Callable[[str, str], Awaitable[None]]
+
+
+class WorkflowGuide:
+    """Owns per-participant sessions for a YAML-defined guided workflow."""
+
+    def __init__(
+        self,
+        *,
+        workflow: WorkflowDefinition,
+        vision: StepVision,
+        agent: WorkflowAgent,
+        notice: NoticeFn,
+    ) -> None:
+        self._workflow = workflow
+        self._vision = vision
+        self._agent = agent
+        self._notice = notice
+        self._sessions: dict[str, WorkflowSession] = {}
+        self._history: dict[str, list[tuple[str, str]]] = {}
+        self._closed = asyncio.Event()
+
+    async def handle_query(
+        self,
+        *,
+        participant_id: str,
+        text: str,
+    ) -> str:
+        clean = text.strip()
+        if not clean:
+            return ""
+
+        session = self._sessions.get(participant_id)
+        if session is not None:
+            session.connected = True
+        step = self._current_step(session)
+        logger.info(
+            "guide query pid={} active={} step={} state={} text={!r}",
+            participant_id,
+            bool(session and session.active),
+            step.id,
+            session.step_state if session is not None else "idle",
+            clean,
+        )
+        if session is not None and session.active:
+            session.user_turn_active = True
+        response = ""
+        deferred_notice = ""
+        intent = NavigationIntent()
+        try:
+            response = _idle_navigation_answer(clean, session, self._workflow)
+            if not response:
+                response = _time_question_answer(clean, session, self._workflow)
+            if not response:
+                intent = _local_intent(
+                    clean,
+                    self._workflow,
+                    active=session is not None and session.active,
+                )
+                if intent is not None:
+                    logger.debug(
+                        "guide local intent pid={} intent={} confidence={}",
+                        participant_id,
+                        intent.intent,
+                        intent.confidence,
+                    )
+                else:
+                    classified = await self._agent.classify_intent(
+                        transcript=clean,
+                        session=session,
+                        current_step=step,
+                        recent_turns=self._history.get(participant_id, []),
+                    )
+                    intent = _validated_model_intent(
+                        clean,
+                        classified,
+                        self._workflow,
+                        active=bool(session and session.active),
+                    )
+                    logger.info(
+                        "guide llm intent pid={} proposed={} accepted={} skip={} confidence={}",
+                        participant_id,
+                        classified.intent,
+                        intent.intent,
+                        intent.skip_requested,
+                        classified.confidence,
+                    )
+
+            if response:
+                logger.info("guide deterministic answer pid={} text={!r}", participant_id, response)
+            elif intent.intent == "stop":
+                response = await self.stop(participant_id)
+            elif intent.intent == "start":
+                response = await self.start(participant_id)
+            elif intent.intent == "status":
+                response = self.status(participant_id)
+            elif intent.intent == "advance":
+                response = await self.advance(
+                    participant_id,
+                    manual=intent.skip_requested,
+                )
+            else:
+                logger.debug("guide answer_user dispatch pid={} step={}", participant_id, step.id)
+                response = await self._agent.answer_user(
+                    transcript=clean,
+                    session=session,
+                    current_step=step,
+                    observation_log=session.observation_log if session is not None else [],
+                    recent_turns=self._history.get(participant_id, []),
+                )
+        finally:
+            if session is not None:
+                session.user_turn_active = False
+                deferred_notice = session.deferred_notice
+                session.deferred_notice = ""
+
+        self._record(participant_id, clean, response)
+        logger.info(
+            "guide response pid={} intent={} text={!r}",
+            participant_id,
+            intent.intent,
+            response,
+        )
+        if deferred_notice and response:
+            logger.info(
+                "guide deferred notice pid={} text={!r}",
+                participant_id,
+                deferred_notice,
+            )
+            await self._notice(participant_id, deferred_notice)
+        return response
+
+    async def start(self, participant_id: str) -> str:
+        step = self._workflow.first_active_step()
+        self._history.pop(participant_id, None)
+        session = WorkflowSession(
+            participant_id=participant_id,
+            step_id=step.id,
+            context=self._workflow.initial_context(),
+        )
+        self._begin_step(session, step)
+        self._sessions[participant_id] = session
+        message = self._message(
+            step.on_enter_message,
+            session=session,
+            step=step,
+            fallback=f"Step {step.id}: {step.name}.",
+        )
+        logger.info("guide start pid={} step={} message={!r}", participant_id, step.id, message)
+        return message
+
+    async def stop(self, participant_id: str) -> str:
+        session = self._sessions.get(participant_id)
+        if session is not None:
+            self._set_idle(session)
+        logger.info("guide stop pid={}", participant_id)
+        return "Guidance stopped."
+
+    async def advance(self, participant_id: str, *, manual: bool = False) -> str:
+        session = self._sessions.get(participant_id)
+        if session is None or not session.active:
+            return "No guided workflow is active."
+        async with session.lock:
+            current = self._workflow.step_by_id(session.step_id)
+            complete = (
+                session.ready_step_id == current.id
+                or self._workflow.advance_when_met(current, session.context)
+            )
+            skipped = not complete
+            applied: dict[str, Any] = {}
+            if skipped:
+                applied = self._workflow.apply_skip_defaults(current, session.context)
+                logger.info(
+                    "guide advance applying skip defaults pid={} step={} fields={}",
+                    participant_id,
+                    current.id,
+                    sorted(applied),
+                )
+            next_step = self._workflow.next_step(current.id)
+            if next_step is None:
+                template = current.on_skip_message if skipped else current.on_complete_message
+                message = self._message(
+                    template,
+                    session=session,
+                    step=current,
+                    fallback=f"{self._workflow.task.get('name', 'Workflow')} is complete.",
+                )
+                logger.info(
+                    "guide complete pid={} step={} skipped={} message={!r}",
+                    participant_id,
+                    current.id,
+                    skipped or manual,
+                    message,
+                )
+                self._set_idle(session)
+                return _advance_prefix(skipped or manual) + message
+
+            self._begin_step(session, next_step)
+            message = self._message(
+                next_step.on_enter_message,
+                session=session,
+                step=next_step,
+                fallback=f"Step {next_step.id}: {next_step.name}.",
+            )
+            logger.info(
+                "guide advance pid={} from_step={} to_step={} skipped={} message={!r}",
+                participant_id,
+                current.id,
+                next_step.id,
+                skipped or manual,
+                message,
+            )
+            return _advance_prefix(skipped or manual) + message
+
+    def status(self, participant_id: str) -> str:
+        session = self._sessions.get(participant_id)
+        if session is None or not session.active:
+            return "No guided workflow is active."
+        step = self._workflow.step_by_id(session.step_id)
+        suffix = (
+            " It is ready; say next when you want to continue."
+            if session.ready_step_id == step.id else ""
+        )
+        return f"On step {step.id}: {step.name}. State: {session.step_state}.{suffix}"
+
+    async def monitor_forever(self) -> None:
+        while not self._closed.is_set():
+            await asyncio.sleep(self._workflow.monitor_interval_s)
+            sessions = list(self._sessions.values())
+            results = await asyncio.gather(
+                *(self._evaluate(session) for session in sessions),
+                return_exceptions=True,
+            )
+            for session, result in zip(sessions, results, strict=True):
+                if isinstance(result, BaseException):
+                    logger.opt(
+                        exception=(type(result), result, result.__traceback__),
+                    ).error(
+                        "guide monitor failed pid={} step={}",
+                        session.participant_id,
+                        session.step_id,
+                    )
+
+    async def release(self, participant_id: str) -> None:
+        self._vision.release(participant_id)
+        session = self._sessions.get(participant_id)
+        if session is not None:
+            session.connected = False
+            session.deferred_notice = ""
+            logger.info(
+                "guide participant disconnected pid={} active={} step={} state={}",
+                participant_id,
+                session.active,
+                session.step_id,
+                session.step_state,
+            )
+
+    async def resume(self, participant_id: str) -> None:
+        session = self._sessions.get(participant_id)
+        if session is None:
+            return
+        session.connected = True
+        logger.info(
+            "guide participant resumed pid={} active={} step={} state={}",
+            participant_id,
+            session.active,
+            session.step_id,
+            session.step_state,
+        )
+
+    async def close(self) -> None:
+        self._closed.set()
+        for participant_id in list(self._sessions):
+            await self.release(participant_id)
+
+    async def _evaluate(self, session: WorkflowSession) -> None:
+        if not session.active or not session.connected:
+            return
+        timer_notice = ""
+        timer_step = False
+        updating_complete = False
+        async with session.lock:
+            if (
+                not session.active
+                or not session.connected
+                or session.evaluation_active
+                or session.user_turn_active
+            ):
+                return
+            step = self._workflow.step_by_id(session.step_id)
+            if step.is_idle:
+                return
+            if session.ready_step_id == step.id:
+                if not step.state_update_fields("complete"):
+                    return
+                updating_complete = True
+            if step.timer is not None:
+                timer_step = True
+                status = self._workflow.timer_status(
+                    step,
+                    session.context,
+                    now_us=_now_us(),
+                )
+                if status is None:
+                    session.step_state = "needs_input"
+                    timer_notice = self._reminder_due(session, step)
+                    logger.warning(
+                        "guide timer waiting for context pid={} step={}",
+                        session.participant_id,
+                        step.id,
+                    )
+                elif status.expired:
+                    self._workflow.mark_timer_complete(step, session.context)
+                    timer_notice = self._mark_ready_for_next(session, step)
+                    logger.info(
+                        "guide timer expired pid={} step={} elapsed_s={} target_s={}",
+                        session.participant_id,
+                        step.id,
+                        status.elapsed_seconds,
+                        status.duration_seconds,
+                    )
+                else:
+                    session.step_state = "started"
+                    logger.debug(
+                        "guide timer active pid={} step={} elapsed_s={} remaining_s={}",
+                        session.participant_id,
+                        step.id,
+                        status.elapsed_seconds,
+                        status.remaining_seconds,
+                    )
+            elif not step.vlm_prompt.strip():
+                logger.error("guide step has neither VLM prompt nor timer step={}", step.id)
+                return
+            if timer_step:
+                pass
+            else:
+                session.evaluation_active = True
+                last_frame_pts_us = session.last_frame_pts_us
+                context_snapshot = dict(session.context)
+                logger.debug(
+                    "guide eval begin pid={} step={} state={} updating_complete={}",
+                    session.participant_id,
+                    step.id,
+                    session.step_state,
+                    updating_complete,
+                )
+        if timer_step:
+            if timer_notice:
+                await self._maybe_notice(session, timer_notice, force=True)
+            return
+        try:
+            try:
+                observation = await self._vision.observe(
+                    session.participant_id,
+                    step,
+                    context_snapshot,
+                    task=self._workflow.task,
+                )
+            except FrameUnavailable:
+                logger.debug("no fresh frame for participant {}", session.participant_id)
+                return
+            except Exception:
+                logger.exception("step VLM observation failed")
+                return
+
+            if observation.frame_pts_us <= last_frame_pts_us:
+                return
+
+            async with session.lock:
+                if (
+                    not session.active
+                    or not session.connected
+                    or session.step_id != step.id
+                ):
+                    return
+                if observation.frame_pts_us <= session.last_frame_pts_us:
+                    return
+                session.last_frame_pts_us = observation.frame_pts_us
+                self._store_observation(
+                    session,
+                    step,
+                    observation.text,
+                    observation.frame_pts_us,
+                )
+                update_state = "complete" if updating_complete else session.step_state
+                observation_patch = step.observation_context_patch(
+                    observation.text,
+                    state=update_state,
+                )
+                self._merge_context(
+                    session.context,
+                    observation_patch,
+                    allowed=step.state_update_fields(update_state),
+                )
+                if observation_patch:
+                    logger.info(
+                        "guide observation state update pid={} step={} state={} values={}",
+                        session.participant_id,
+                        step.id,
+                        update_state,
+                        observation_patch,
+                    )
+
+            result = await self._agent.run_step(
+                step=step,
+                session=session,
+                vlm_observation=observation.text,
+            )
+            guarded_patch, guarded_ready = _apply_vlm_verdict_guards(
+                step,
+                observation.text,
+                result.context_patch,
+                result.ready_to_advance,
+            )
+            guarded_patch.update(observation_patch)
+
+            ready_notice = ""
+            reminder_notice = ""
+            urgent_notice = ""
+            async with session.lock:
+                if (
+                    not session.active
+                    or not session.connected
+                    or session.step_id != step.id
+                ):
+                    return
+                if updating_complete and session.ready_step_id != step.id:
+                    return
+                if updating_complete:
+                    complete_fields = step.state_update_fields("complete")
+                    self._merge_context(
+                        session.context,
+                        guarded_patch,
+                        allowed=complete_fields,
+                    )
+                    session.step_state = "complete"
+                    logger.info(
+                        "guide completed state updated pid={} step={} fields={} "
+                        "values={}",
+                        session.participant_id,
+                        step.id,
+                        sorted(complete_fields),
+                        {
+                            name: session.context.get(name)
+                            for name in complete_fields
+                        },
+                    )
+                    return
+                self._merge_context(
+                    session.context,
+                    guarded_patch,
+                    allowed={field.name for field in step.context_fields},
+                )
+                if result.assistant_message:
+                    session.pending_instruction = result.assistant_message
+                    if result.speak:
+                        urgent_notice = result.assistant_message
+                logger.debug(
+                    "guide eval result pid={} step={} state={} ready={} patch_keys={} "
+                    "assistant_message={!r} speak={}",
+                    session.participant_id,
+                    step.id,
+                    result.step_state,
+                    guarded_ready,
+                    sorted(guarded_patch),
+                    result.assistant_message,
+                    result.speak,
+                )
+
+                if self._workflow.advance_when_met(
+                    step,
+                    session.context,
+                    ready_to_advance=guarded_ready,
+                ):
+                    ready_notice = self._mark_ready_for_next(session, step)
+                else:
+                    session.step_state = (
+                        result.step_state
+                        if result.step_state != "complete" else "started"
+                    )
+                    reminder_notice = self._reminder_due(session, step)
+
+            if urgent_notice and not ready_notice:
+                await self._maybe_notice(session, urgent_notice)
+            if reminder_notice:
+                await self._maybe_notice(session, reminder_notice, force=True)
+            if ready_notice:
+                await self._maybe_notice(session, ready_notice, force=True)
+        finally:
+            async with session.lock:
+                session.evaluation_active = False
+
+    def _merge_context(
+        self,
+        context: dict[str, Any],
+        patch: dict[str, Any],
+        *,
+        allowed: set[str],
+    ) -> None:
+        for key, value in patch.items():
+            if key not in allowed:
+                continue
+            if value is None:
+                continue
+            if isinstance(value, str) and not value.strip():
+                continue
+            context[key] = value
+
+    def _store_observation(
+        self,
+        session: WorkflowSession,
+        step: WorkflowStep,
+        text: str,
+        frame_pts_us: int,
+    ) -> None:
+        if not text.strip():
+            return
+        session.observation_log.append(
+            {
+                "step_id": step.id,
+                "step_name": step.name,
+                "frame_pts_us": frame_pts_us,
+                "caption": text.strip(),
+            }
+        )
+        logger.debug(
+            "vlm observation stored pid={} step={} frame_pts_us={} caption={!r}",
+            session.participant_id,
+            step.id,
+            frame_pts_us,
+            text[:240],
+        )
+        del session.observation_log[:-20]
+
+    def _mark_ready_for_next(
+        self,
+        session: WorkflowSession,
+        step: WorkflowStep,
+    ) -> str:
+        if session.ready_step_id == step.id:
+            return ""
+        session.ready_step_id = step.id
+        session.step_state = "complete"
+        session.pending_instruction = ""
+        session.deferred_notice = ""
+        session.reminder_count = self._workflow.max_reminders_per_step
+        message = self._message(
+            step.on_complete_message,
+            session=session,
+            step=step,
+            fallback=f"Step {step.id}: {step.name} is ready.",
+        )
+        notice = message
+        if self._workflow.next_step(step.id) is not None:
+            notice = f"{message} Say next when you're ready."
+        logger.info(
+            "guide step ready pid={} step={} notice={!r}",
+            session.participant_id,
+            step.id,
+            notice,
+        )
+        if self._workflow.next_step(step.id) is None:
+            self._set_idle(session)
+        return notice
+
+    def _set_idle(self, session: WorkflowSession) -> None:
+        previous_step = session.step_id
+        self._history.pop(session.participant_id, None)
+        session.active = False
+        session.step_id = 0
+        session.context = self._workflow.initial_context()
+        session.last_frame_pts_us = 0
+        session.ready_step_id = None
+        session.step_state = "idle"
+        session.step_started_us = 0
+        session.last_reminder_us = 0
+        session.reminder_count = 0
+        session.pending_instruction = ""
+        session.deferred_notice = ""
+        session.observation_log.clear()
+        logger.info(
+            "guide idle pid={} previous_step={}",
+            session.participant_id,
+            previous_step,
+        )
+
+    def _reminder_due(self, session: WorkflowSession, step: WorkflowStep) -> str:
+        if session.ready_step_id == step.id:
+            return ""
+        if session.reminder_count >= self._workflow.max_reminders_per_step:
+            return ""
+
+        now_us = _now_us()
+        interval_us = int(self._workflow.reminder_interval_s * 1_000_000)
+        if now_us - session.last_reminder_us < interval_us:
+            return ""
+
+        session.reminder_count += 1
+        session.last_reminder_us = now_us
+        session.step_state = "needs_input"
+        if session.pending_instruction.strip():
+            logger.info(
+                "guide reminder due pid={} step={} source=pending text={!r}",
+                session.participant_id,
+                step.id,
+                session.pending_instruction,
+            )
+            return session.pending_instruction
+        message = self._message(
+            step.on_reminder_message or step.on_enter_message,
+            session=session,
+            step=step,
+            fallback=f"Continue step {step.id}: {step.name}.",
+        )
+        logger.info(
+            "guide reminder due pid={} step={} source=yaml text={!r}",
+            session.participant_id,
+            step.id,
+            message,
+        )
+        return message
+
+    async def _maybe_notice(
+        self,
+        session: WorkflowSession,
+        text: str,
+        *,
+        force: bool = False,
+    ) -> None:
+        text = text.strip()
+        if not text or not session.connected:
+            return
+        if session.user_turn_active:
+            session.deferred_notice = text
+            logger.debug(
+                "guide notice deferred pid={} step={} text={!r}",
+                session.participant_id,
+                session.step_id,
+                text,
+            )
+            return
+        now_us = _now_us()
+        min_interval_us = int(self._workflow.min_notice_interval_s * 1_000_000)
+        if not force and now_us - session.last_notice_us < min_interval_us:
+            logger.debug(
+                "guide notice suppressed by interval pid={} step={} text={!r}",
+                session.participant_id,
+                session.step_id,
+                text,
+            )
+            return
+        session.last_notice_us = now_us
+        session.last_notice_text = text
+        logger.info(
+            "guide notice pid={} step={} text={!r}",
+            session.participant_id,
+            session.step_id,
+            text,
+        )
+        await self._notice(session.participant_id, text)
+
+    def _begin_step(self, session: WorkflowSession, step: WorkflowStep) -> None:
+        now_us = _now_us()
+        session.step_id = step.id
+        session.active = True
+        session.last_frame_pts_us = 0
+        session.ready_step_id = None
+        session.step_state = "started"
+        session.step_started_us = now_us
+        session.last_reminder_us = now_us
+        session.reminder_count = 0
+        session.pending_instruction = ""
+        session.deferred_notice = ""
+        logger.info(
+            "guide begin step pid={} step={} name={!r}",
+            session.participant_id,
+            step.id,
+            step.name,
+        )
+
+    def _current_step(self, session: WorkflowSession | None) -> WorkflowStep:
+        if session is not None:
+            return self._workflow.step_by_id(session.step_id)
+        return self._workflow.step_by_id(0)
+
+    def _message(
+        self,
+        template: str,
+        *,
+        session: WorkflowSession,
+        step: WorkflowStep,
+        fallback: str,
+    ) -> str:
+        if not template.strip():
+            return fallback
+        return render_template(
+            template,
+            context=session.context,
+            step=step,
+            task=self._workflow.task,
+        ).strip() or fallback
+
+    def _record(self, participant_id: str, user: str, assistant: str) -> None:
+        turns = self._history.setdefault(participant_id, [])
+        turns.append((user, assistant))
+        del turns[:-4]
+
+
+def _advance_prefix(skipped: bool) -> str:
+    return "Using reasonable defaults and moving on. " if skipped else ""
+
+
+_COMMAND_CLEAN_RE = re.compile(r"[^a-z0-9]+")
+_VERDICT_RE = re.compile(
+    r"^\s*([A-Z][A-Z0-9_ ]+)\s*:\s*(yes|no|unclear)\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+_QUESTION_STARTS = {
+    "what",
+    "when",
+    "where",
+    "why",
+    "how",
+    "can",
+    "could",
+    "should",
+    "do",
+    "does",
+    "did",
+    "is",
+    "are",
+}
+_DEFAULT_ADVANCE_EXAMPLES = (
+    "next",
+    "next step",
+    "continue",
+    "go on",
+    "move on",
+    "proceed",
+    "proceed further",
+    "let us proceed",
+    "lets proceed",
+    "let us proceed further",
+    "lets proceed further",
+    "i am ready",
+    "im ready",
+    "skip",
+    "skip this",
+    "skip this step",
+)
+_NEGATION_WORDS = {"not", "never", "dont", "no"}
+_START_WORDS = {"begin", "guide", "help", "start", "walk"}
+_STOP_WORDS = {"cancel", "end", "quit", "stop"}
+_TIME_QUERY_PHRASES = (
+    "how long",
+    "how much time",
+    "time has passed",
+    "time passed",
+    "time left",
+    "elapsed",
+    "remaining",
+    "longer",
+)
+_START_TIME_QUERY_PHRASES = (
+    "when did",
+    "when was",
+    "what time did",
+    "what time was",
+)
+_REMAINING_TIME_PHRASES = (
+    "how long do i",
+    "how much longer",
+    "need to wait",
+    "still need",
+    "time left",
+    "remaining",
+    "longer",
+)
+
+
+def _idle_navigation_answer(
+    text: str,
+    session: WorkflowSession | None,
+    workflow: WorkflowDefinition,
+) -> str:
+    if session is not None and session.active:
+        return ""
+    clean = _normalize_command(text)
+    words = set(clean.split())
+    if "next" not in words and not _looks_like_advance(text, workflow):
+        return ""
+    idle = workflow.step_by_id(0)
+    start_hint = render_template(
+        idle.on_enter_message,
+        context=workflow.initial_context(),
+        step=idle,
+        task=workflow.task,
+    ).strip()
+    suffix = f" {start_hint}" if start_hint else ""
+    return f"No guided workflow is active; the previous session is finished.{suffix}"
+
+
+def _local_intent(
+    text: str,
+    workflow: WorkflowDefinition,
+    *,
+    active: bool,
+) -> NavigationIntent | None:
+    if _contains_negation(text):
+        return None
+    if active and _matches_any(text, workflow.stop_triggers):
+        return NavigationIntent(intent="stop", confidence=1.0)
+    if _matches_any(text, workflow.status_triggers):
+        return NavigationIntent(intent="status", confidence=1.0)
+    if not active and _matches_any(text, workflow.start_triggers):
+        return NavigationIntent(intent="start", confidence=1.0)
+    if active and _looks_like_advance(text, workflow):
+        return NavigationIntent(
+            intent="advance",
+            skip_requested=_skip_requested(text),
+            explicit_command=True,
+            confidence=0.9,
+        )
+    return None
+
+
+def _validated_model_intent(
+    text: str,
+    intent: NavigationIntent,
+    workflow: WorkflowDefinition,
+    *,
+    active: bool,
+) -> NavigationIntent:
+    if intent.confidence < 0.75 or _contains_negation(text):
+        return NavigationIntent()
+    clean = _normalize_command(text)
+    words = set(clean.split())
+    if (
+        intent.intent == "advance"
+        and active
+        and intent.explicit_command
+        and not _looks_like_question(text, clean)
+    ):
+        return intent
+    if intent.intent == "start" and not active and words & _START_WORDS:
+        return intent
+    if intent.intent == "stop" and active and words & _STOP_WORDS:
+        return intent
+    if intent.intent == "status" and _looks_like_status_request(clean):
+        return intent
+    return NavigationIntent()
+
+
+def _time_question_answer(
+    text: str,
+    session: WorkflowSession | None,
+    workflow: WorkflowDefinition,
+) -> str:
+    if session is None:
+        return ""
+    clean = _normalize_command(text)
+    start_time_requested = any(
+        phrase in clean for phrase in _START_TIME_QUERY_PHRASES
+    )
+    if not start_time_requested and not any(
+        phrase in clean for phrase in _TIME_QUERY_PHRASES
+    ):
+        return ""
+    status = workflow.find_timer_status(
+        session.context,
+        current_step_id=session.step_id,
+        now_us=_now_us(),
+    )
+    if status is None:
+        timer_step = _relevant_timer_step(workflow, session.step_id)
+        if timer_step is None or timer_step.timer is None:
+            return ""
+        timer = timer_step.timer
+        started_at_us = _positive_context_int(
+            session.context.get(timer.started_at_us_field)
+        )
+        duration_seconds = _positive_context_int(
+            session.context.get(timer.duration_seconds_field)
+        )
+        remaining_requested = any(
+            phrase in clean for phrase in _REMAINING_TIME_PHRASES
+        )
+        if started_at_us <= 0 and (start_time_requested or remaining_requested):
+            target = (
+                f" The target duration is {_format_duration(duration_seconds)}."
+                if duration_seconds > 0
+                else ""
+            )
+            return (
+                f"The {timer.label} timer has not started because no start time "
+                f"is recorded yet.{target}"
+            )
+        return ""
+    if start_time_requested:
+        started = datetime.fromtimestamp(
+            status.started_at_us / 1_000_000,
+        ).astimezone()
+        local_time = started.strftime("%I:%M:%S %p %Z").lstrip("0")
+        return f"The {status.label} timer started at {local_time}."
+    elapsed = _format_duration(status.elapsed_seconds)
+    target = _format_duration(status.duration_seconds)
+    remaining_requested = any(phrase in clean for phrase in _REMAINING_TIME_PHRASES)
+    if remaining_requested:
+        if status.expired:
+            return f"The {status.label} time is up."
+        remaining = _format_duration(status.remaining_seconds)
+        return (
+            f"There is about {remaining} left for {status.label}. "
+            f"About {elapsed} has elapsed out of {target}."
+        )
+    if status.expired:
+        return f"About {elapsed} has elapsed. The {status.label} time is up."
+    remaining = _format_duration(status.remaining_seconds)
+    return (
+        f"About {elapsed} has elapsed since {status.label} started. "
+        f"There is about {remaining} left."
+    )
+
+
+def _relevant_timer_step(
+    workflow: WorkflowDefinition,
+    current_step_id: int,
+) -> WorkflowStep | None:
+    timer_steps = [step for step in workflow.steps if step.timer is not None]
+    if not timer_steps:
+        return None
+    return min(timer_steps, key=lambda step: step.id != current_step_id)
+
+
+def _positive_context_int(value: Any) -> int:
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _format_duration(total_seconds: int) -> str:
+    total_seconds = max(0, total_seconds)
+    if total_seconds < 60:
+        return f"{total_seconds} second" if total_seconds == 1 else f"{total_seconds} seconds"
+    minutes, seconds = divmod(total_seconds, 60)
+    if minutes < 60:
+        if seconds == 0:
+            return f"{minutes} minute" if minutes == 1 else f"{minutes} minutes"
+        minute_text = f"{minutes} minute" if minutes == 1 else f"{minutes} minutes"
+        second_text = f"{seconds} second" if seconds == 1 else f"{seconds} seconds"
+        return f"{minute_text} {second_text}"
+    hours, minutes = divmod(minutes, 60)
+    hour_text = f"{hours} hour" if hours == 1 else f"{hours} hours"
+    if minutes == 0:
+        return hour_text
+    minute_text = f"{minutes} minute" if minutes == 1 else f"{minutes} minutes"
+    return f"{hour_text} {minute_text}"
+
+
+def _apply_vlm_verdict_guards(
+    step: WorkflowStep,
+    observation_text: str,
+    context_patch: dict[str, Any],
+    ready_to_advance: bool,
+) -> tuple[dict[str, Any], bool]:
+    verdicts = _parse_vlm_verdicts(observation_text)
+    blocking = {
+        name: value
+        for name, value in verdicts.items()
+        if value in {"no", "unclear"}
+    }
+    if not blocking:
+        return context_patch, ready_to_advance
+
+    guarded: dict[str, Any] = {}
+    for key, value in context_patch.items():
+        field_token = _tokenize_for_match(str(key))
+        contradicted = [
+            f"{name}:{state}"
+            for name, state in blocking.items()
+            if name in field_token and _truthy_patch_value(value)
+        ]
+        if contradicted:
+            logger.warning(
+                "dropping context update contradicted by VLM verdict step={} field={} "
+                "value={!r} verdicts={}",
+                step.id,
+                key,
+                value,
+                contradicted,
+            )
+            continue
+        guarded[key] = value
+
+    rule_field = str(step.advance_when.get("field") or "")
+    rule_token = _tokenize_for_match(rule_field)
+    if ready_to_advance and any(name in rule_token for name in blocking):
+        logger.warning(
+            "blocking ready_to_advance contradicted by VLM verdict step={} field={} verdicts={}",
+            step.id,
+            rule_field,
+            blocking,
+        )
+        ready_to_advance = False
+    return guarded, ready_to_advance
+
+
+def _parse_vlm_verdicts(text: str) -> dict[str, str]:
+    return {
+        _tokenize_for_match(match.group(1)): match.group(2).casefold()
+        for match in _VERDICT_RE.finditer(text)
+    }
+
+
+def _tokenize_for_match(text: str) -> str:
+    return re.sub(r"[^A-Z0-9]+", "_", text.upper()).strip("_")
+
+
+def _truthy_patch_value(value: Any) -> bool:
+    if value is True:
+        return True
+    if isinstance(value, int | float):
+        return value > 0
+    if isinstance(value, str):
+        return bool(value.strip())
+    return bool(value)
+
+
+def _looks_like_advance(text: str, workflow: WorkflowDefinition) -> bool:
+    clean = _normalize_command(text)
+    if not clean or _looks_like_question(text, clean):
+        return False
+    examples = workflow.task.get("navigation_examples", {})
+    configured = ()
+    if isinstance(examples, dict):
+        configured = tuple(str(item) for item in examples.get("advance", ()) or ())
+    for phrase in (*configured, *_DEFAULT_ADVANCE_EXAMPLES):
+        normalized = _normalize_command(phrase)
+        if normalized and (clean == normalized or clean.endswith(f" {normalized}")):
+            return True
+    return False
+
+
+def _looks_like_status_request(clean: str) -> bool:
+    return (
+        "status" in clean.split()
+        or "what step" in clean
+        or "where are we" in clean
+        or "workflow progress" in clean
+    )
+
+
+def _contains_negation(text: str) -> bool:
+    return bool(set(_normalize_command(text).split()) & _NEGATION_WORDS)
+
+
+def _matches_any(text: str, phrases: tuple[str, ...]) -> bool:
+    clean = _normalize_command(text)
+    return any(
+        normalized and (clean == normalized or normalized in clean)
+        for normalized in (_normalize_command(phrase) for phrase in phrases)
+    )
+
+
+def _looks_like_question(original: str, clean: str) -> bool:
+    first = clean.split(" ", 1)[0] if clean else ""
+    return "?" in original or first in _QUESTION_STARTS
+
+
+def _skip_requested(text: str) -> bool:
+    words = _normalize_command(text).split()
+    return "skip" in words or any(word.startswith("default") for word in words)
+
+
+def _normalize_command(text: str) -> str:
+    lowered = text.casefold().replace("'", "").replace("\N{RIGHT SINGLE QUOTATION MARK}", "")
+    return " ".join(_COMMAND_CLEAN_RE.sub(" ", lowered).split())
+
+
+def _now_us() -> int:
+    return time.time_ns() // 1_000
+
+
+__all__ = ["NoticeFn", "WorkflowGuide"]

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/guide.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/guide.py
@@ -9,12 +9,12 @@ import asyncio
 import re
 import time
 from collections.abc import Awaitable, Callable
-from datetime import datetime
 from typing import Any
 
 from loguru import logger
 
 from .agent import NavigationIntent, WorkflowAgent
+from .step_mechanism import CaptionAgentStepMechanism, StepMechanisms
 from .vision import FrameUnavailable, StepVision
 from .workflow import (
     WorkflowDefinition,
@@ -37,11 +37,22 @@ class WorkflowGuide:
         vision: StepVision,
         agent: WorkflowAgent,
         notice: NoticeFn,
+        step_mechanisms: StepMechanisms | None = None,
     ) -> None:
         self._workflow = workflow
         self._vision = vision
         self._agent = agent
         self._notice = notice
+        self._step_mechanisms = step_mechanisms or StepMechanisms(
+            [
+                CaptionAgentStepMechanism(
+                    workflow=workflow,
+                    vision=vision,
+                    agent=agent,
+                )
+            ]
+        )
+        self._step_mechanisms.validate(workflow)
         self._sessions: dict[str, WorkflowSession] = {}
         self._history: dict[str, list[tuple[str, str]]] = {}
         self._closed = asyncio.Event()
@@ -75,8 +86,6 @@ class WorkflowGuide:
         intent = NavigationIntent()
         try:
             response = _idle_navigation_answer(clean, session, self._workflow)
-            if not response:
-                response = _time_question_answer(clean, session, self._workflow)
             if not response:
                 intent = _local_intent(
                     clean,
@@ -336,9 +345,6 @@ class WorkflowGuide:
     async def _evaluate(self, session: WorkflowSession) -> None:
         if not session.active or not session.connected:
             return
-        timer_notice = ""
-        timer_step = False
-        updating_complete = False
         async with session.lock:
             if not session.active or not session.connected or session.evaluation_active or session.user_turn_active:
                 return
@@ -346,143 +352,57 @@ class WorkflowGuide:
             if step.is_idle:
                 return
             if session.ready_step_id == step.id:
-                if not step.state_update_fields("complete"):
-                    return
-                updating_complete = True
-            if step.timer is not None:
-                timer_step = True
-                status = self._workflow.timer_status(
-                    step,
-                    session.context,
-                    now_us=_now_us(),
-                )
-                if status is None:
-                    session.step_state = "needs_input"
-                    timer_notice = self._reminder_due(session, step)
-                    logger.warning(
-                        "guide timer waiting for context pid={} step={}",
-                        session.participant_id,
-                        step.id,
-                    )
-                elif status.expired:
-                    self._workflow.mark_timer_complete(step, session.context)
-                    timer_notice = self._mark_ready_for_next(session, step)
-                    logger.info(
-                        "guide timer expired pid={} step={} elapsed_s={} target_s={}",
-                        session.participant_id,
-                        step.id,
-                        status.elapsed_seconds,
-                        status.duration_seconds,
-                    )
-                else:
-                    session.step_state = "started"
-                    logger.debug(
-                        "guide timer active pid={} step={} elapsed_s={} remaining_s={}",
-                        session.participant_id,
-                        step.id,
-                        status.elapsed_seconds,
-                        status.remaining_seconds,
-                    )
-            elif not step.vlm_prompt.strip():
-                logger.error("guide step has neither VLM prompt nor timer step={}", step.id)
                 return
-            if timer_step:
-                pass
-            else:
-                session.evaluation_active = True
-                last_frame_pts_us = session.last_frame_pts_us
-                context_snapshot = dict(session.context)
-                logger.debug(
-                    "guide eval begin pid={} step={} state={} updating_complete={}",
-                    session.participant_id,
-                    step.id,
-                    session.step_state,
-                    updating_complete,
-                )
-        if timer_step:
-            if timer_notice:
-                await self._maybe_notice(session, timer_notice, force=True)
-            return
+            session.evaluation_active = True
+            last_frame_pts_us = session.last_frame_pts_us
+            context_snapshot = dict(session.context)
+            observation_log = list(session.observation_log)
+            logger.debug(
+                "guide eval begin pid={} step={} state={} mechanism={}",
+                session.participant_id,
+                step.id,
+                session.step_state,
+                step.mechanism,
+            )
         try:
             try:
-                observation = await self._vision.observe(
-                    session.participant_id,
-                    step,
-                    context_snapshot,
-                    task=self._workflow.task,
+                iteration = await self._step_mechanisms.run(
+                    participant_id=session.participant_id,
+                    step=step,
+                    context=context_snapshot,
+                    observation_log=observation_log,
+                    last_frame_pts_us=last_frame_pts_us,
                 )
             except FrameUnavailable:
                 logger.debug("no fresh frame for participant {}", session.participant_id)
                 return
             except Exception:
-                logger.exception("step VLM observation failed")
+                logger.exception("step mechanism failed")
                 return
 
-            if observation.frame_pts_us <= last_frame_pts_us:
+            if iteration is None:
                 return
 
-            async with session.lock:
-                if not session.active or not session.connected or session.step_id != step.id:
-                    return
-                if observation.frame_pts_us <= session.last_frame_pts_us:
-                    return
-                session.last_frame_pts_us = observation.frame_pts_us
-                self._store_observation(
-                    session,
-                    step,
-                    observation.text,
-                    observation.frame_pts_us,
-                )
-                update_state = "complete" if updating_complete else session.step_state
-                observation_patch = step.observation_context_patch(
-                    observation.text,
-                    state=update_state,
-                )
-                self._merge_context(
-                    session.context,
-                    observation_patch,
-                    allowed=step.state_update_fields(update_state),
-                )
-                if observation_patch:
-                    logger.info(
-                        "guide observation state update pid={} step={} state={} values={}",
-                        session.participant_id,
-                        step.id,
-                        update_state,
-                        observation_patch,
-                    )
-                if updating_complete:
-                    session.step_state = "complete"
-                    logger.debug(
-                        "guide completed state refreshed without step agent pid={} step={} fields={}",
-                        session.participant_id,
-                        step.id,
-                        sorted(observation_patch),
-                    )
-                    return
-
-            result = await self._agent.run_step(
-                step=step,
-                session=session,
-                vlm_observation=observation.text,
-            )
-            guarded_patch, guarded_ready = _apply_vlm_verdict_guards(
-                step,
-                observation.text,
-                result.context_patch,
-                result.ready_to_advance,
-            )
-            guarded_patch.update(observation_patch)
-
+            result = iteration.result
             ready_notice = ""
             reminder_notice = ""
             urgent_notice = ""
             async with session.lock:
                 if not session.active or not session.connected or session.step_id != step.id:
                     return
+                if iteration.frame_pts_us is not None:
+                    if iteration.frame_pts_us <= session.last_frame_pts_us:
+                        return
+                    session.last_frame_pts_us = iteration.frame_pts_us
+                    self._store_observation(
+                        session,
+                        step,
+                        iteration.caption,
+                        iteration.frame_pts_us,
+                    )
                 self._merge_context(
                     session.context,
-                    guarded_patch,
+                    result.context_patch,
                     allowed=step.writable_fields,
                 )
                 if result.assistant_message:
@@ -494,8 +414,8 @@ class WorkflowGuide:
                     session.participant_id,
                     step.id,
                     result.step_state,
-                    guarded_ready,
-                    sorted(guarded_patch),
+                    result.ready_to_advance,
+                    sorted(result.context_patch),
                     result.assistant_message,
                     result.speak,
                 )
@@ -503,7 +423,7 @@ class WorkflowGuide:
                 if self._workflow.advance_when_met(
                     step,
                     session.context,
-                    ready_to_advance=guarded_ready,
+                    ready_to_advance=result.ready_to_advance,
                 ):
                     ready_notice = self._mark_ready_for_next(session, step)
                 else:
@@ -753,10 +673,6 @@ def _advance_prefix(skipped: bool) -> str:
 
 
 _COMMAND_CLEAN_RE = re.compile(r"[^a-z0-9]+")
-_VERDICT_RE = re.compile(
-    r"^\s*([A-Z][A-Z0-9_ ]+)\s*:\s*(yes|no|unclear)\b",
-    re.IGNORECASE | re.MULTILINE,
-)
 _QUESTION_STARTS = {
     "what",
     "when",
@@ -793,31 +709,6 @@ _DEFAULT_ADVANCE_EXAMPLES = (
 _NEGATION_WORDS = {"not", "never", "dont", "no"}
 _START_WORDS = {"begin", "guide", "help", "start", "walk"}
 _STOP_WORDS = {"cancel", "end", "quit", "stop"}
-_TIME_QUERY_PHRASES = (
-    "how long",
-    "how much time",
-    "time has passed",
-    "time passed",
-    "time left",
-    "elapsed",
-    "remaining",
-    "longer",
-)
-_START_TIME_QUERY_PHRASES = (
-    "when did",
-    "when was",
-    "what time did",
-    "what time was",
-)
-_REMAINING_TIME_PHRASES = (
-    "how long do i",
-    "how much longer",
-    "need to wait",
-    "still need",
-    "time left",
-    "remaining",
-    "longer",
-)
 
 
 def _idle_navigation_answer(
@@ -886,149 +777,6 @@ def _validated_model_intent(
     if intent.intent == "status" and _looks_like_status_request(clean):
         return intent
     return NavigationIntent()
-
-
-def _time_question_answer(
-    text: str,
-    session: WorkflowSession | None,
-    workflow: WorkflowDefinition,
-) -> str:
-    if session is None:
-        return ""
-    clean = _normalize_command(text)
-    start_time_requested = any(phrase in clean for phrase in _START_TIME_QUERY_PHRASES)
-    if not start_time_requested and not any(phrase in clean for phrase in _TIME_QUERY_PHRASES):
-        return ""
-    status = workflow.find_timer_status(
-        session.context,
-        current_step_id=session.step_id,
-        now_us=_now_us(),
-    )
-    if status is None:
-        timer_step = _relevant_timer_step(workflow, session.step_id)
-        if timer_step is None or timer_step.timer is None:
-            return ""
-        timer = timer_step.timer
-        started_at_us = _positive_context_int(session.context.get(timer.started_at_us_field))
-        duration_seconds = _positive_context_int(session.context.get(timer.duration_seconds_field))
-        remaining_requested = any(phrase in clean for phrase in _REMAINING_TIME_PHRASES)
-        if started_at_us <= 0 and (start_time_requested or remaining_requested):
-            target = f" The target duration is {_format_duration(duration_seconds)}." if duration_seconds > 0 else ""
-            return f"The {timer.label} timer has not started because no start time is recorded yet.{target}"
-        return ""
-    if start_time_requested:
-        started = datetime.fromtimestamp(
-            status.started_at_us / 1_000_000,
-        ).astimezone()
-        local_time = started.strftime("%I:%M:%S %p %Z").lstrip("0")
-        return f"The {status.label} timer started at {local_time}."
-    elapsed = _format_duration(status.elapsed_seconds)
-    target = _format_duration(status.duration_seconds)
-    remaining_requested = any(phrase in clean for phrase in _REMAINING_TIME_PHRASES)
-    if remaining_requested:
-        if status.expired:
-            return f"The {status.label} time is up."
-        remaining = _format_duration(status.remaining_seconds)
-        return f"There is about {remaining} left for {status.label}. About {elapsed} has elapsed out of {target}."
-    if status.expired:
-        return f"About {elapsed} has elapsed. The {status.label} time is up."
-    remaining = _format_duration(status.remaining_seconds)
-    return f"About {elapsed} has elapsed since {status.label} started. There is about {remaining} left."
-
-
-def _relevant_timer_step(
-    workflow: WorkflowDefinition,
-    current_step_id: int,
-) -> WorkflowStep | None:
-    timer_steps = [step for step in workflow.steps if step.timer is not None]
-    if not timer_steps:
-        return None
-    return min(timer_steps, key=lambda step: step.id != current_step_id)
-
-
-def _positive_context_int(value: Any) -> int:
-    try:
-        return max(0, int(value))
-    except (TypeError, ValueError):
-        return 0
-
-
-def _format_duration(total_seconds: int) -> str:
-    total_seconds = max(0, total_seconds)
-    if total_seconds < 60:
-        return f"{total_seconds} second" if total_seconds == 1 else f"{total_seconds} seconds"
-    minutes, seconds = divmod(total_seconds, 60)
-    if minutes < 60:
-        if seconds == 0:
-            return f"{minutes} minute" if minutes == 1 else f"{minutes} minutes"
-        minute_text = f"{minutes} minute" if minutes == 1 else f"{minutes} minutes"
-        second_text = f"{seconds} second" if seconds == 1 else f"{seconds} seconds"
-        return f"{minute_text} and {second_text}"
-    hours, minutes = divmod(minutes, 60)
-    hour_text = f"{hours} hour" if hours == 1 else f"{hours} hours"
-    if minutes == 0:
-        return hour_text
-    minute_text = f"{minutes} minute" if minutes == 1 else f"{minutes} minutes"
-    return f"{hour_text} and {minute_text}"
-
-
-def _apply_vlm_verdict_guards(
-    step: WorkflowStep,
-    observation_text: str,
-    context_patch: dict[str, Any],
-    ready_to_advance: bool,
-) -> tuple[dict[str, Any], bool]:
-    verdicts = _parse_vlm_verdicts(observation_text)
-    blocking = {name: value for name, value in verdicts.items() if value in {"no", "unclear"}}
-    if not blocking:
-        return context_patch, ready_to_advance
-
-    guarded: dict[str, Any] = {}
-    for key, value in context_patch.items():
-        field_token = _tokenize_for_match(str(key))
-        contradicted = [
-            f"{name}:{state}" for name, state in blocking.items() if name in field_token and _truthy_patch_value(value)
-        ]
-        if contradicted:
-            logger.warning(
-                "dropping context update contradicted by VLM verdict step={} field={} value={!r} verdicts={}",
-                step.id,
-                key,
-                value,
-                contradicted,
-            )
-            continue
-        guarded[key] = value
-
-    rule_field = str(step.advance_when.get("field") or "")
-    rule_token = _tokenize_for_match(rule_field)
-    if ready_to_advance and any(name in rule_token for name in blocking):
-        logger.warning(
-            "blocking ready_to_advance contradicted by VLM verdict step={} field={} verdicts={}",
-            step.id,
-            rule_field,
-            blocking,
-        )
-        ready_to_advance = False
-    return guarded, ready_to_advance
-
-
-def _parse_vlm_verdicts(text: str) -> dict[str, str]:
-    return {_tokenize_for_match(match.group(1)): match.group(2).casefold() for match in _VERDICT_RE.finditer(text)}
-
-
-def _tokenize_for_match(text: str) -> str:
-    return re.sub(r"[^A-Z0-9]+", "_", text.upper()).strip("_")
-
-
-def _truthy_patch_value(value: Any) -> bool:
-    if value is True:
-        return True
-    if isinstance(value, int | float):
-        return value > 0
-    if isinstance(value, str):
-        return bool(value.strip())
-    return bool(value)
 
 
 def _looks_like_advance(text: str, workflow: WorkflowDefinition) -> bool:

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/guide.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/guide.py
@@ -14,7 +14,7 @@ from typing import Any
 from loguru import logger
 
 from .agent import NavigationIntent, WorkflowAgent
-from .step_mechanism import CaptionAgentStepMechanism, StepMechanisms
+from .step_mechanism import CaptionAgentStepMechanism, StepEvent, StepMechanisms
 from .vision import FrameUnavailable, StepVision
 from .workflow import (
     WorkflowDefinition,
@@ -135,52 +135,17 @@ class WorkflowGuide:
                     manual=intent.skip_requested,
                 )
             else:
-                logger.debug("guide answer_user dispatch pid={} step={}", participant_id, step.id)
-
-                async def inspect_current_view(question: str) -> dict[str, Any]:
-                    if not hasattr(self._vision, "inspect"):
-                        return {"error": "A live camera view is not available."}
-                    observation = await self._vision.inspect(
-                        participant_id,
-                        question,
-                        step=step,
-                        context=dict(session.context) if session is not None else {},
-                        task=self._workflow.task,
-                    )
-                    observed_at_us = _now_us()
-                    if session is not None:
-                        async with session.lock:
-                            if session.active and session.step_id == step.id:
-                                self._store_observation(
-                                    session,
-                                    step,
-                                    observation.text,
-                                    observation.frame_pts_us,
-                                    kind="visual_question",
-                                    question=question,
-                                )
-                    result = {
-                        "question": question,
-                        "visual_evidence": observation.text,
-                        "frame_pts_us": observation.frame_pts_us,
-                        "observed_at_us": observed_at_us,
-                    }
-                    logger.info(
-                        "guide visual question pid={} step={} question={!r} answer={!r}",
-                        participant_id,
-                        step.id,
-                        question,
-                        observation.text[:500],
-                    )
-                    return result
-
-                response = await self._agent.answer_user(
+                logger.debug(
+                    "guide voice event dispatch pid={} step={} mechanism={}",
+                    participant_id,
+                    step.id,
+                    step.mechanism,
+                )
+                response = await self._handle_voice_event(
+                    participant_id=participant_id,
                     transcript=clean,
                     session=session,
-                    current_step=step,
-                    observation_log=session.observation_log if session is not None else [],
-                    recent_turns=self._history.get(participant_id, []),
-                    visual_query=inspect_current_view,
+                    step=step,
                 )
         finally:
             if session is not None:
@@ -189,7 +154,10 @@ class WorkflowGuide:
                 session.deferred_notice = ""
 
         response = speech_text(response)
-        self._record(participant_id, clean, response)
+        if intent.intent == "answer":
+            self._record(participant_id, clean, response)
+        elif intent.intent in {"start", "advance", "stop"}:
+            self._history.pop(participant_id, None)
         logger.info(
             "guide response pid={} intent={} text={!r}",
             participant_id,
@@ -312,29 +280,28 @@ class WorkflowGuide:
 
     async def release(self, participant_id: str) -> None:
         self._vision.release(participant_id)
-        session = self._sessions.get(participant_id)
+        session = self._sessions.pop(participant_id, None)
+        self._history.pop(participant_id, None)
         if session is not None:
+            previous_step = session.step_id
+            self._set_idle(session)
             session.connected = False
-            session.deferred_notice = ""
             logger.info(
-                "guide participant disconnected pid={} active={} step={} state={}",
+                "guide participant disconnected and cleared pid={} previous_step={}",
                 participant_id,
-                session.active,
-                session.step_id,
-                session.step_state,
+                previous_step,
             )
 
-    async def resume(self, participant_id: str) -> None:
-        session = self._sessions.get(participant_id)
-        if session is None:
-            return
-        session.connected = True
+    async def reset(self, participant_id: str) -> None:
+        """Discard any stale participant state before a new connection."""
+
+        session = self._sessions.pop(participant_id, None)
+        self._history.pop(participant_id, None)
+        if session is not None:
+            self._set_idle(session)
         logger.info(
-            "guide participant resumed pid={} active={} step={} state={}",
+            "guide participant connected with fresh state pid={}",
             participant_id,
-            session.active,
-            session.step_id,
-            session.step_state,
         )
 
     async def close(self) -> None:
@@ -372,6 +339,7 @@ class WorkflowGuide:
                     context=context_snapshot,
                     observation_log=observation_log,
                     last_frame_pts_us=last_frame_pts_us,
+                    event=StepEvent.periodic(step_state=session.step_state),
                 )
             except FrameUnavailable:
                 logger.debug("no fresh frame for participant {}", session.participant_id)
@@ -390,15 +358,18 @@ class WorkflowGuide:
             async with session.lock:
                 if not session.active or not session.connected or session.step_id != step.id:
                     return
-                if iteration.frame_pts_us is not None:
-                    if iteration.frame_pts_us <= session.last_frame_pts_us:
+                monitor_observations = [
+                    observation for observation in iteration.observations if observation.kind == "step_monitor"
+                ]
+                for observation in monitor_observations:
+                    if observation.frame_pts_us <= session.last_frame_pts_us:
                         return
-                    session.last_frame_pts_us = iteration.frame_pts_us
+                    session.last_frame_pts_us = observation.frame_pts_us
                     self._store_observation(
                         session,
                         step,
-                        iteration.caption,
-                        iteration.frame_pts_us,
+                        observation.text,
+                        observation.frame_pts_us,
                     )
                 self._merge_context(
                     session.context,
@@ -439,6 +410,71 @@ class WorkflowGuide:
         finally:
             async with session.lock:
                 session.evaluation_active = False
+
+    async def _handle_voice_event(
+        self,
+        *,
+        participant_id: str,
+        transcript: str,
+        session: WorkflowSession | None,
+        step: WorkflowStep,
+    ) -> str:
+        if session is not None:
+            async with session.lock:
+                context = dict(session.context)
+                observation_log = list(session.observation_log)
+                step_state = session.step_state
+                ready = session.ready_step_id == step.id
+                workflow_active = session.active
+        else:
+            context = self._workflow.initial_context()
+            observation_log = []
+            step_state = "idle"
+            ready = False
+            workflow_active = False
+
+        try:
+            iteration = await self._step_mechanisms.run(
+                participant_id=participant_id,
+                step=step,
+                context=context,
+                observation_log=observation_log,
+                last_frame_pts_us=session.last_frame_pts_us if session is not None else 0,
+                event=StepEvent.voice(
+                    transcript,
+                    recent_turns=self._history.get(participant_id, []),
+                    step_state=step_state,
+                    ready=ready,
+                    workflow_active=workflow_active,
+                ),
+            )
+        except Exception:
+            logger.exception("step mechanism voice event failed")
+            return "I could not answer that just now. Please try again."
+
+        if iteration is None:
+            return "I could not answer that just now. Please try again."
+        if iteration.result.context_patch:
+            logger.warning(
+                "discarding context patch from read-only voice event pid={} step={} keys={}",
+                participant_id,
+                step.id,
+                sorted(iteration.result.context_patch),
+            )
+
+        if session is not None and workflow_active and iteration.observations:
+            async with session.lock:
+                if session.active == workflow_active and session.step_id == step.id:
+                    for observation in iteration.observations:
+                        self._store_observation(
+                            session,
+                            step,
+                            observation.text,
+                            observation.frame_pts_us,
+                            kind=observation.kind,
+                            question=observation.question,
+                        )
+        return iteration.result.assistant_message.strip() or "Done."
 
     def _merge_context(
         self,
@@ -543,6 +579,8 @@ class WorkflowGuide:
 
     def _reminder_due(self, session: WorkflowSession, step: WorkflowStep) -> str:
         if session.ready_step_id == step.id:
+            return ""
+        if self._workflow.condition_met(step.suppress_reminders_when, session.context):
             return ""
         if session.reminder_count >= self._workflow.max_reminders_per_step:
             return ""

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/system.txt
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/system.txt
@@ -5,6 +5,9 @@ details, safety guidance, or facts not already present in context.
 For a question about what is visible right now, call inspect_current_view with
 the wearer's full question. This includes current display readings, labels,
 objects, quantities, color, placement, progress, or visible safety concerns.
+Always make a new inspection for words such as "now," "currently," or "what
+about now," even when an earlier conversation turn or workflow field contains
+a reading. A prior visual answer is historical evidence, not the current view.
 Use get_recent_vlm_observations only when the wearer explicitly asks what was
 seen earlier or historical visual evidence is needed. A previous step caption
 is not a substitute for a fresh inspection.
@@ -13,9 +16,11 @@ timestamp fields in workflow context such as `steeping_started_at_us`.
 Treat the authoritative timer state in the request as final. Never claim that a
 timer has elapsed or completed when its `expired` value is false, and never
 invent a start time when no timer start is recorded.
-Treat workflow context and the latest VLM observation as the current physical
-state. They override older conversation turns and older observations. Never
-repeat an earlier sensor or display reading when a newer reading is available.
+Treat workflow context and the latest step-monitor observation as the newest
+workflow snapshot. They override older workflow observations, but they may be
+stale for a present-tense visual question. Never repeat an earlier sensor or
+display reading without inspecting the current view when the wearer asks for
+the value now.
 
 Keep replies to one or two short sentences of plain spoken prose. Do not use
 Markdown, JSON, field names, raw epoch values, or ISO timestamps. Say units in

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/system.txt
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/system.txt
@@ -1,0 +1,23 @@
+You are a concise smart-glasses guide for a YAML-defined physical workflow.
+Answer the wearer using the current step and workflow context first. Use
+rag_lookup whenever the answer needs task reference information, recipe-like
+details, safety guidance, or facts not already present in context.
+Use get_recent_vlm_observations only when the wearer asks what you saw, asks
+about visual status, or visual evidence is needed to answer.
+Use get_current_time for elapsed-time or timer questions, then compare it with
+timestamp fields in workflow context such as `steeping_started_at_us`.
+Treat the authoritative timer state in the request as final. Never claim that a
+timer has elapsed or completed when its `expired` value is false, and never
+invent a start time when no timer start is recorded.
+Treat workflow context and the latest VLM observation as the current physical
+state. They override older conversation turns and older observations. Never
+repeat an earlier sensor or display reading when a newer reading is available.
+
+Keep replies to one or two short sentences. Do not repeat raw VLM captions or
+internal log entries verbatim. Do not invent visible facts. If the workflow is
+active, anchor the answer to the current step and tell the wearer the immediate
+next action. Do not move steps in an answer; navigation commands are classified
+before this prompt. When the current step is complete, do not request its inputs
+or repeat its instructions; answer the question and mention that the wearer can
+proceed. If the workflow is idle, answer normally and offer to start guidance
+only when the request is about doing the task.

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/system.txt
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/system.txt
@@ -1,5 +1,14 @@
 You are a concise smart-glasses guide for a YAML-defined physical workflow.
-Answer the wearer using the current step and workflow context first. Use
+Answer only the wearer's current request, using the current step and its
+projected context. Do not volunteer a workflow summary, a preview of later
+steps, or brewing instructions the wearer did not ask for. Do not combine the
+current step with a future step. If the wearer asks what to do now, answer only
+with the current step's immediate action. If they explicitly ask what comes
+next, call get_next_workflow_step and use that result exactly; do not infer or
+skip ahead to a later step. Never call that tool for an ordinary question or
+progress report.
+
+Use
 rag_lookup whenever the answer needs task reference information, recipe-like
 details, safety guidance, or facts not already present in context.
 For a question about what is visible right now, call inspect_current_view with
@@ -12,10 +21,12 @@ Use get_recent_vlm_observations only when the wearer explicitly asks what was
 seen earlier or historical visual evidence is needed. A previous step caption
 is not a substitute for a fresh inspection.
 Use get_timer_status for elapsed-time or remaining-time questions, passing the
-recorded start timestamp and duration from workflow context. Treat the tool
-result as authoritative. Never claim that a timer has elapsed or completed when
-its `expired` value is false, and never invent a start time when none is recorded.
-Treat workflow context and the latest step-monitor observation as the newest
+recorded start timestamp and duration from workflow context. Call it again for
+every timer question, including repeated questions such as "how about now."
+Treat only that turn's tool result as authoritative; never reuse a duration from
+an earlier answer. Never claim that a timer has elapsed or completed when its
+`expired` value is false, and never invent a start time when none is recorded.
+Treat current-step context and the latest step-monitor observation as the newest
 workflow snapshot. They override older workflow observations, but they may be
 stale for a present-tense visual question. Never repeat an earlier sensor or
 display reading without inspecting the current view when the wearer asks for
@@ -25,10 +36,10 @@ Keep replies to one or two short sentences of plain spoken prose. Do not use
 Markdown, JSON, field names, raw epoch values, or ISO timestamps. Say units in
 full, such as "degrees Celsius" and "minutes," and render recorded times as
 natural local clock times. Do not repeat raw VLM captions or internal log entries
-verbatim. Do not invent visible facts. If the workflow is active, anchor the
-answer to the current step and give the immediate next action when useful. Do
-not move steps in an answer; navigation commands are classified before this
-prompt. When the current step is complete, do not request its inputs or repeat
-its instructions; answer the question and mention that the wearer can proceed.
-If the workflow is idle, answer normally and offer to start guidance only when
-the request is about doing the task.
+verbatim. Do not invent visible facts. Do not announce the current step unless
+the wearer asks where they are. Do not claim that water is ready from an older
+reading or from a target temperature alone. Do not move steps in an answer;
+navigation commands are classified before this prompt. When the current step is
+complete, do not request its inputs or repeat its instructions; answer only the
+question. If the workflow is idle, answer normally and offer to start guidance
+only when the request is about doing the task.

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/system.txt
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/system.txt
@@ -11,11 +11,10 @@ a reading. A prior visual answer is historical evidence, not the current view.
 Use get_recent_vlm_observations only when the wearer explicitly asks what was
 seen earlier or historical visual evidence is needed. A previous step caption
 is not a substitute for a fresh inspection.
-Use get_current_time for elapsed-time or timer questions, then compare it with
-timestamp fields in workflow context such as `steeping_started_at_us`.
-Treat the authoritative timer state in the request as final. Never claim that a
-timer has elapsed or completed when its `expired` value is false, and never
-invent a start time when no timer start is recorded.
+Use get_timer_status for elapsed-time or remaining-time questions, passing the
+recorded start timestamp and duration from workflow context. Treat the tool
+result as authoritative. Never claim that a timer has elapsed or completed when
+its `expired` value is false, and never invent a start time when none is recorded.
 Treat workflow context and the latest step-monitor observation as the newest
 workflow snapshot. They override older workflow observations, but they may be
 stale for a present-tense visual question. Never repeat an earlier sensor or

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/system.txt
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/system.txt
@@ -2,8 +2,12 @@ You are a concise smart-glasses guide for a YAML-defined physical workflow.
 Answer the wearer using the current step and workflow context first. Use
 rag_lookup whenever the answer needs task reference information, recipe-like
 details, safety guidance, or facts not already present in context.
-Use get_recent_vlm_observations only when the wearer asks what you saw, asks
-about visual status, or visual evidence is needed to answer.
+For a question about what is visible right now, call inspect_current_view with
+the wearer's full question. This includes current display readings, labels,
+objects, quantities, color, placement, progress, or visible safety concerns.
+Use get_recent_vlm_observations only when the wearer explicitly asks what was
+seen earlier or historical visual evidence is needed. A previous step caption
+is not a substitute for a fresh inspection.
 Use get_current_time for elapsed-time or timer questions, then compare it with
 timestamp fields in workflow context such as `steeping_started_at_us`.
 Treat the authoritative timer state in the request as final. Never claim that a
@@ -13,11 +17,14 @@ Treat workflow context and the latest VLM observation as the current physical
 state. They override older conversation turns and older observations. Never
 repeat an earlier sensor or display reading when a newer reading is available.
 
-Keep replies to one or two short sentences. Do not repeat raw VLM captions or
-internal log entries verbatim. Do not invent visible facts. If the workflow is
-active, anchor the answer to the current step and tell the wearer the immediate
-next action. Do not move steps in an answer; navigation commands are classified
-before this prompt. When the current step is complete, do not request its inputs
-or repeat its instructions; answer the question and mention that the wearer can
-proceed. If the workflow is idle, answer normally and offer to start guidance
-only when the request is about doing the task.
+Keep replies to one or two short sentences of plain spoken prose. Do not use
+Markdown, JSON, field names, raw epoch values, or ISO timestamps. Say units in
+full, such as "degrees Celsius" and "minutes," and render recorded times as
+natural local clock times. Do not repeat raw VLM captions or internal log entries
+verbatim. Do not invent visible facts. If the workflow is active, anchor the
+answer to the current step and give the immediate next action when useful. Do
+not move steps in an answer; navigation commands are classified before this
+prompt. When the current step is complete, do not request its inputs or repeat
+its instructions; answer the question and mention that the wearer can proceed.
+If the workflow is idle, answer normally and offer to start guidance only when
+the request is about doing the task.

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/step_mechanism.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/step_mechanism.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reusable execution mechanisms for YAML-defined workflow steps."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from loguru import logger
+
+from .agent import StepAgentResult, WorkflowAgent
+from .vision import StepVision
+from .workflow import WorkflowDefinition, WorkflowStep
+
+
+@dataclass(frozen=True, slots=True)
+class StepIteration:
+    """Output from one mechanism iteration."""
+
+    result: StepAgentResult
+    caption: str = ""
+    frame_pts_us: int | None = None
+
+
+class StepMechanism(Protocol):
+    """A pluggable strategy that produces one step-agent result."""
+
+    name: str
+
+    async def run(
+        self,
+        *,
+        participant_id: str,
+        step: WorkflowStep,
+        context: dict[str, Any],
+        observation_log: list[dict[str, Any]],
+        last_frame_pts_us: int,
+    ) -> StepIteration | None: ...
+
+
+class CaptionAgentStepMechanism:
+    """Optionally caption a frame, then pass all interpretation to the agent."""
+
+    name = "caption_agent"
+
+    def __init__(
+        self,
+        *,
+        workflow: WorkflowDefinition,
+        vision: StepVision,
+        agent: WorkflowAgent,
+    ) -> None:
+        self._workflow = workflow
+        self._vision = vision
+        self._agent = agent
+
+    async def run(
+        self,
+        *,
+        participant_id: str,
+        step: WorkflowStep,
+        context: dict[str, Any],
+        observation_log: list[dict[str, Any]],
+        last_frame_pts_us: int,
+    ) -> StepIteration | None:
+        caption = ""
+        frame_pts_us: int | None = None
+        if step.vlm_prompt.strip():
+            observation = await self._vision.observe(
+                participant_id,
+                step,
+                context,
+                task=self._workflow.task,
+            )
+            if observation.frame_pts_us <= last_frame_pts_us:
+                return None
+            caption = observation.text
+            frame_pts_us = observation.frame_pts_us
+
+        logger.debug(
+            "step mechanism agent begin pid={} step={} mechanism={} has_caption={}",
+            participant_id,
+            step.id,
+            self.name,
+            bool(caption),
+        )
+        result = await self._agent.run_step(
+            step=step,
+            participant_id=participant_id,
+            context=context,
+            observation_log=observation_log,
+            vlm_observation=caption,
+        )
+        return StepIteration(
+            result=result,
+            caption=caption,
+            frame_pts_us=frame_pts_us,
+        )
+
+
+class StepMechanisms:
+    """Resolve YAML mechanism names without coupling the guide to their logic."""
+
+    def __init__(self, mechanisms: list[StepMechanism]) -> None:
+        self._by_name = {mechanism.name: mechanism for mechanism in mechanisms}
+        if len(self._by_name) != len(mechanisms):
+            raise ValueError("step mechanism names must be unique")
+
+    def validate(self, workflow: WorkflowDefinition) -> None:
+        unknown = {
+            step.mechanism
+            for step in workflow.steps
+            if not step.is_idle and step.mechanism not in self._by_name
+        }
+        if unknown:
+            raise ValueError(f"unknown step mechanisms: {', '.join(sorted(unknown))}")
+
+    async def run(
+        self,
+        *,
+        participant_id: str,
+        step: WorkflowStep,
+        context: dict[str, Any],
+        observation_log: list[dict[str, Any]],
+        last_frame_pts_us: int,
+    ) -> StepIteration | None:
+        return await self._by_name[step.mechanism].run(
+            participant_id=participant_id,
+            step=step,
+            context=context,
+            observation_log=observation_log,
+            last_frame_pts_us=last_frame_pts_us,
+        )
+
+
+__all__ = [
+    "CaptionAgentStepMechanism",
+    "StepIteration",
+    "StepMechanism",
+    "StepMechanisms",
+]

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/step_mechanism.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/step_mechanism.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Protocol
+from typing import Any, Literal, Protocol
 
 from loguru import logger
 
@@ -14,14 +14,60 @@ from .agent import StepAgentResult, WorkflowAgent
 from .vision import StepVision
 from .workflow import WorkflowDefinition, WorkflowStep
 
+StepEventKind = Literal["periodic", "voice"]
+
+
+@dataclass(frozen=True, slots=True)
+class StepEvent:
+    """One trigger delivered to the active step mechanism."""
+
+    kind: StepEventKind
+    transcript: str = ""
+    recent_turns: tuple[tuple[str, str], ...] = ()
+    step_state: str = "started"
+    ready: bool = False
+    workflow_active: bool = True
+
+    @classmethod
+    def periodic(cls, *, step_state: str = "started") -> StepEvent:
+        return cls(kind="periodic", step_state=step_state)
+
+    @classmethod
+    def voice(
+        cls,
+        transcript: str,
+        *,
+        recent_turns: list[tuple[str, str]],
+        step_state: str,
+        ready: bool,
+        workflow_active: bool,
+    ) -> StepEvent:
+        return cls(
+            kind="voice",
+            transcript=transcript,
+            recent_turns=tuple(recent_turns),
+            step_state=step_state,
+            ready=ready,
+            workflow_active=workflow_active,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class MechanismObservation:
+    """Visual evidence collected while handling a step event."""
+
+    text: str
+    frame_pts_us: int
+    kind: str = "step_monitor"
+    question: str = ""
+
 
 @dataclass(frozen=True, slots=True)
 class StepIteration:
     """Output from one mechanism iteration."""
 
     result: StepAgentResult
-    caption: str = ""
-    frame_pts_us: int | None = None
+    observations: tuple[MechanismObservation, ...] = ()
 
 
 class StepMechanism(Protocol):
@@ -37,6 +83,7 @@ class StepMechanism(Protocol):
         context: dict[str, Any],
         observation_log: list[dict[str, Any]],
         last_frame_pts_us: int,
+        event: StepEvent,
     ) -> StepIteration | None: ...
 
 
@@ -64,10 +111,21 @@ class CaptionAgentStepMechanism:
         context: dict[str, Any],
         observation_log: list[dict[str, Any]],
         last_frame_pts_us: int,
+        event: StepEvent,
     ) -> StepIteration | None:
+        if event.kind == "voice":
+            return await self._run_voice(
+                participant_id=participant_id,
+                step=step,
+                context=context,
+                observation_log=observation_log,
+                event=event,
+            )
+
         caption = ""
         frame_pts_us: int | None = None
-        if step.vlm_prompt.strip():
+        vision_stopped = self._workflow.condition_met(step.vlm_stop_when, context)
+        if step.vlm_prompt.strip() and not vision_stopped:
             observation = await self._vision.observe(
                 participant_id,
                 step,
@@ -80,11 +138,12 @@ class CaptionAgentStepMechanism:
             frame_pts_us = observation.frame_pts_us
 
         logger.debug(
-            "step mechanism agent begin pid={} step={} mechanism={} has_caption={}",
+            "step mechanism agent begin pid={} step={} mechanism={} has_caption={} vision_stopped={}",
             participant_id,
             step.id,
             self.name,
             bool(caption),
+            vision_stopped,
         )
         result = await self._agent.run_step(
             step=step,
@@ -95,8 +154,71 @@ class CaptionAgentStepMechanism:
         )
         return StepIteration(
             result=result,
-            caption=caption,
-            frame_pts_us=frame_pts_us,
+            observations=(MechanismObservation(caption, frame_pts_us),) if caption and frame_pts_us is not None else (),
+        )
+
+    async def _run_voice(
+        self,
+        *,
+        participant_id: str,
+        step: WorkflowStep,
+        context: dict[str, Any],
+        observation_log: list[dict[str, Any]],
+        event: StepEvent,
+    ) -> StepIteration:
+        observations: list[MechanismObservation] = []
+
+        async def inspect_current_view(question: str) -> dict[str, Any]:
+            if not hasattr(self._vision, "inspect"):
+                return {"error": "A live camera view is not available."}
+            observation = await self._vision.inspect(
+                participant_id,
+                question,
+                step=step,
+                context=context,
+                task=self._workflow.task,
+            )
+            observations.append(
+                MechanismObservation(
+                    text=observation.text,
+                    frame_pts_us=observation.frame_pts_us,
+                    kind="visual_question",
+                    question=question,
+                )
+            )
+            logger.info(
+                "guide visual question pid={} step={} question={!r} answer={!r}",
+                participant_id,
+                step.id,
+                question,
+                observation.text[:500],
+            )
+            return {
+                "question": question,
+                "visual_evidence": observation.text,
+                "frame_pts_us": observation.frame_pts_us,
+            }
+
+        answer = await self._agent.answer_step(
+            transcript=event.transcript,
+            context=context,
+            current_step=step,
+            step_state=event.step_state,
+            ready=event.ready,
+            workflow_active=event.workflow_active,
+            observation_log=observation_log,
+            recent_turns=list(event.recent_turns),
+            visual_query=inspect_current_view,
+        )
+
+        return StepIteration(
+            result=StepAgentResult(
+                context_patch={},
+                step_state=event.step_state,
+                ready_to_advance=event.ready,
+                assistant_message=answer,
+            ),
+            observations=tuple(observations),
         )
 
 
@@ -110,9 +232,7 @@ class StepMechanisms:
 
     def validate(self, workflow: WorkflowDefinition) -> None:
         unknown = {
-            step.mechanism
-            for step in workflow.steps
-            if not step.is_idle and step.mechanism not in self._by_name
+            step.mechanism for step in workflow.steps if not step.is_idle and step.mechanism not in self._by_name
         }
         if unknown:
             raise ValueError(f"unknown step mechanisms: {', '.join(sorted(unknown))}")
@@ -125,18 +245,31 @@ class StepMechanisms:
         context: dict[str, Any],
         observation_log: list[dict[str, Any]],
         last_frame_pts_us: int,
+        event: StepEvent,
     ) -> StepIteration | None:
+        logger.debug(
+            "step event pid={} step={} mechanism={} kind={} state={} ready={}",
+            participant_id,
+            step.id,
+            step.mechanism,
+            event.kind,
+            event.step_state,
+            event.ready,
+        )
         return await self._by_name[step.mechanism].run(
             participant_id=participant_id,
             step=step,
             context=context,
             observation_log=observation_log,
             last_frame_pts_us=last_frame_pts_us,
+            event=event,
         )
 
 
 __all__ = [
     "CaptionAgentStepMechanism",
+    "MechanismObservation",
+    "StepEvent",
     "StepIteration",
     "StepMechanism",
     "StepMechanisms",

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/tools.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/tools.py
@@ -6,13 +6,64 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable, Iterable
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
 from nat.builder.function import Function
 from pydantic import BaseModel
 from xr_ai_models import ToolDef
+
+ToolHandler = Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]
+
+
+@dataclass(frozen=True, slots=True)
+class AgentTool:
+    """A tool definition paired with its handler and effect capability."""
+
+    definition: ToolDef
+    handler: ToolHandler
+    read_only: bool = False
+
+    @property
+    def name(self) -> str:
+        return self.definition.name
+
+
+class ToolCatalog:
+    """Select and invoke tools without embedding tool names in an agent loop."""
+
+    def __init__(self, tools: Iterable[AgentTool] = ()) -> None:
+        self._tools: dict[str, AgentTool] = {}
+        for tool in tools:
+            if tool.name in self._tools:
+                raise ValueError(f"duplicate agent tool: {tool.name}")
+            self._tools[tool.name] = tool
+
+    def select(
+        self,
+        names: Iterable[str] | None = None,
+        *,
+        read_only_only: bool = False,
+    ) -> list[AgentTool]:
+        selected = (
+            list(self._tools.values())
+            if names is None
+            else [self._tools[name] for name in names if name in self._tools]
+        )
+        if read_only_only:
+            selected = [tool for tool in selected if tool.read_only]
+        return selected
+
+    def missing(self, names: Iterable[str]) -> set[str]:
+        return set(names) - self._tools.keys()
+
+    async def invoke(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        tool = self._tools.get(name)
+        if tool is None:
+            return {"error": f"unknown tool: {name}"}
+        return await tool.handler(arguments)
 
 
 class GuideTools:
@@ -24,15 +75,21 @@ class GuideTools:
         *,
         clock: Callable[[], datetime] | None = None,
     ) -> None:
-        matches = [
-            function
-            for function in rag_functions.values()
-            if function.instance_name.endswith("__retrieve")
-        ]
+        matches = [function for function in rag_functions.values() if function.instance_name.endswith("__retrieve")]
         if len(matches) != 1:
             raise ValueError("native RAG group must expose exactly one retrieve function")
         self._rag_retrieve = matches[0]
         self._clock = clock or (lambda: datetime.now().astimezone())
+
+    def agent_tools(self) -> list[AgentTool]:
+        """Return reusable tools with explicit side-effect capabilities."""
+
+        definitions = {tool.name: tool for tool in self.definitions()}
+        return [
+            AgentTool(definitions["rag_lookup"], self._rag_lookup, read_only=True),
+            AgentTool(definitions["get_current_time"], self._get_current_time, read_only=True),
+            AgentTool(definitions["get_timer_status"], self._get_timer_status, read_only=True),
+        ]
 
     def definitions(self) -> list[ToolDef]:
         return [
@@ -44,8 +101,7 @@ class GuideTools:
             ToolDef(
                 name="get_current_time",
                 description=(
-                    "Return the current wall-clock time. Use this before writing a "
-                    "timestamp into workflow context."
+                    "Return the current wall-clock time. Use this before writing a timestamp into workflow context."
                 ),
                 parameters={
                     "type": "object",
@@ -57,8 +113,9 @@ class GuideTools:
                 name="get_timer_status",
                 description=(
                     "Calculate elapsed and remaining wall-clock time from a recorded "
-                    "start timestamp and duration. Use this for timer completion and "
-                    "for user questions about elapsed or remaining time."
+                    "start timestamp and duration. Call this for every timer completion "
+                    "check and every user question about elapsed or remaining time, "
+                    "including repeated questions. Never reuse an earlier result."
                 ),
                 parameters={
                     "type": "object",
@@ -83,18 +140,29 @@ class GuideTools:
         ]
 
     async def invoke(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
-        if name == "rag_lookup":
-            return _plain(await self._rag_retrieve.ainvoke(arguments))
-        if name == "get_current_time":
-            now = self._clock()
-            return {
-                "epoch_us": int(now.timestamp() * 1_000_000),
-                "iso": now.isoformat(timespec="seconds"),
-                "timezone": now.tzname(),
-            }
-        if name == "get_timer_status":
-            return _timer_status(arguments, now=self._clock())
-        return {"error": f"unknown tool: {name}"}
+        handlers: dict[str, ToolHandler] = {
+            "rag_lookup": self._rag_lookup,
+            "get_current_time": self._get_current_time,
+            "get_timer_status": self._get_timer_status,
+        }
+        handler = handlers.get(name)
+        if handler is None:
+            return {"error": f"unknown tool: {name}"}
+        return await handler(arguments)
+
+    async def _rag_lookup(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        return _plain(await self._rag_retrieve.ainvoke(arguments))
+
+    async def _get_current_time(self, _arguments: dict[str, Any]) -> dict[str, Any]:
+        now = self._clock()
+        return {
+            "epoch_us": int(now.timestamp() * 1_000_000),
+            "iso": now.isoformat(timespec="seconds"),
+            "timezone": now.tzname(),
+        }
+
+    async def _get_timer_status(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        return _timer_status(arguments, now=self._clock())
 
 
 def _timer_status(arguments: dict[str, Any], *, now: datetime) -> dict[str, Any]:
@@ -145,4 +213,4 @@ def _plain(value: Any) -> Any:
     return value
 
 
-__all__ = ["GuideTools"]
+__all__ = ["AgentTool", "GuideTools", "ToolCatalog"]

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/tools.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/tools.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tool definitions available to workflow step and answer agents."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from nat.builder.function import Function
+from pydantic import BaseModel
+from xr_ai_models import ToolDef
+
+
+class GuideTools:
+    """General tools that keep the workflow reusable across tasks."""
+
+    def __init__(self, rag_functions: dict[str, Function]) -> None:
+        matches = [
+            function
+            for function in rag_functions.values()
+            if function.instance_name.endswith("__retrieve")
+        ]
+        if len(matches) != 1:
+            raise ValueError("native RAG group must expose exactly one retrieve function")
+        self._rag_retrieve = matches[0]
+
+    def definitions(self) -> list[ToolDef]:
+        return [
+            ToolDef(
+                name="rag_lookup",
+                description=(self._rag_retrieve.description or "").strip(),
+                parameters=self._rag_retrieve.input_schema.model_json_schema(),
+            ),
+            ToolDef(
+                name="get_current_time",
+                description=(
+                    "Return the current wall-clock time. Use this before writing a "
+                    "timestamp into workflow context."
+                ),
+                parameters={
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": False,
+                },
+            ),
+        ]
+
+    async def invoke(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        if name == "rag_lookup":
+            return _plain(await self._rag_retrieve.ainvoke(arguments))
+        if name == "get_current_time":
+            now = datetime.now().astimezone()
+            return {
+                "epoch_us": int(now.timestamp() * 1_000_000),
+                "iso": now.isoformat(timespec="seconds"),
+                "timezone": now.tzname(),
+            }
+        return {"error": f"unknown tool: {name}"}
+
+
+def _plain(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        return value.model_dump(mode="python")
+    if isinstance(value, list):
+        return [_plain(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _plain(item) for key, item in value.items()}
+    return value
+
+
+__all__ = ["GuideTools"]

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/tools.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/tools.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import math
+from collections.abc import Callable
 from datetime import datetime
 from typing import Any
 
@@ -16,7 +18,12 @@ from xr_ai_models import ToolDef
 class GuideTools:
     """General tools that keep the workflow reusable across tasks."""
 
-    def __init__(self, rag_functions: dict[str, Function]) -> None:
+    def __init__(
+        self,
+        rag_functions: dict[str, Function],
+        *,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
         matches = [
             function
             for function in rag_functions.values()
@@ -25,6 +32,7 @@ class GuideTools:
         if len(matches) != 1:
             raise ValueError("native RAG group must expose exactly one retrieve function")
         self._rag_retrieve = matches[0]
+        self._clock = clock or (lambda: datetime.now().astimezone())
 
     def definitions(self) -> list[ToolDef]:
         return [
@@ -45,19 +53,86 @@ class GuideTools:
                     "additionalProperties": False,
                 },
             ),
+            ToolDef(
+                name="get_timer_status",
+                description=(
+                    "Calculate elapsed and remaining wall-clock time from a recorded "
+                    "start timestamp and duration. Use this for timer completion and "
+                    "for user questions about elapsed or remaining time."
+                ),
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "started_at_us": {
+                            "type": "integer",
+                            "description": "Timer start as epoch microseconds.",
+                        },
+                        "duration_seconds": {
+                            "type": "integer",
+                            "description": "Positive timer duration in seconds.",
+                        },
+                        "label": {
+                            "type": "string",
+                            "description": "Optional human-readable timer label.",
+                        },
+                    },
+                    "required": ["started_at_us", "duration_seconds"],
+                    "additionalProperties": False,
+                },
+            ),
         ]
 
     async def invoke(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
         if name == "rag_lookup":
             return _plain(await self._rag_retrieve.ainvoke(arguments))
         if name == "get_current_time":
-            now = datetime.now().astimezone()
+            now = self._clock()
             return {
                 "epoch_us": int(now.timestamp() * 1_000_000),
                 "iso": now.isoformat(timespec="seconds"),
                 "timezone": now.tzname(),
             }
+        if name == "get_timer_status":
+            return _timer_status(arguments, now=self._clock())
         return {"error": f"unknown tool: {name}"}
+
+
+def _timer_status(arguments: dict[str, Any], *, now: datetime) -> dict[str, Any]:
+    try:
+        started_at_us = int(arguments.get("started_at_us") or 0)
+        duration_seconds = int(arguments.get("duration_seconds") or 0)
+    except (TypeError, ValueError):
+        started_at_us = 0
+        duration_seconds = 0
+    label = str(arguments.get("label") or "timer").strip() or "timer"
+    if started_at_us <= 0 or duration_seconds <= 0:
+        return {
+            "label": label,
+            "started": False,
+            "expired": False,
+            "error": "A positive start timestamp and duration are required.",
+        }
+
+    now_us = int(now.timestamp() * 1_000_000)
+    elapsed_us = max(0, now_us - started_at_us)
+    duration_us = duration_seconds * 1_000_000
+    return {
+        "label": label,
+        "started": True,
+        "started_at_us": started_at_us,
+        "started_at_iso": datetime.fromtimestamp(
+            started_at_us / 1_000_000,
+            tz=now.tzinfo,
+        ).isoformat(timespec="seconds"),
+        "now_us": now_us,
+        "duration_seconds": duration_seconds,
+        "elapsed_seconds": elapsed_us // 1_000_000,
+        "remaining_seconds": max(
+            0,
+            math.ceil((duration_us - elapsed_us) / 1_000_000),
+        ),
+        "expired": elapsed_us >= duration_us,
+    }
 
 
 def _plain(value: Any) -> Any:

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/vision.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/vision.py
@@ -56,11 +56,57 @@ class StepVision:
         *,
         task: dict[str, Any],
     ) -> VisualObservation:
+        prompt = render_template(
+            step.vlm_prompt,
+            context=context,
+            step=step,
+            task=task,
+        )
+        return await self._ask_current_frame(
+            participant_id,
+            prompt,
+            purpose=f"step:{step.id}",
+        )
+
+    async def inspect(
+        self,
+        participant_id: str,
+        question: str,
+        *,
+        step: WorkflowStep,
+        context: dict[str, Any],
+        task: dict[str, Any],
+    ) -> VisualObservation:
+        """Answer a wearer-specific visual question from a newly captured frame."""
+
+        prompt = (
+            "Inspect the current camera frame to answer the wearer's question. "
+            "Report only facts visible now, including readable text or display values. "
+            "If the requested object, property, or text is not visible enough to answer, "
+            "say so directly. Do not substitute an older workflow observation or infer "
+            "a hidden state.\n\n"
+            f"Task: {task.get('name', 'guided workflow')}\n"
+            f"Current step: {step.name}\n"
+            f"Wearer's visual question: {question}"
+        )
+        return await self._ask_current_frame(
+            participant_id,
+            prompt,
+            purpose=f"question:{step.id}",
+        )
+
+    async def _ask_current_frame(
+        self,
+        participant_id: str,
+        prompt: str,
+        *,
+        purpose: str,
+    ) -> VisualObservation:
         started = time.perf_counter()
         logger.debug(
-            "vlm frame wait begin pid={} step={} timeout_s={}",
+            "vlm frame wait begin pid={} purpose={} timeout_s={}",
             participant_id,
-            step.id,
+            purpose,
             self._frame_timeout_s,
         )
         try:
@@ -70,24 +116,18 @@ class StepVision:
             raise FrameUnavailable("Camera frame request timed out.") from exc
         frame_elapsed_ms = (time.perf_counter() - started) * 1000
         logger.debug(
-            "vlm frame acquired pid={} step={} frame_pts_us={} elapsed_ms={:.1f}",
+            "vlm frame acquired pid={} purpose={} frame_pts_us={} elapsed_ms={:.1f}",
             participant_id,
-            step.id,
+            purpose,
             frame.pts_us,
             frame_elapsed_ms,
         )
         image = encode_image(frame_to_pil(frame))
-        prompt = render_template(
-            step.vlm_prompt,
-            context=context,
-            step=step,
-            task=task,
-        )
         vlm_started = time.perf_counter()
         logger.debug(
-            "vlm request begin pid={} step={} timeout_s={}",
+            "vlm request begin pid={} purpose={} timeout_s={}",
             participant_id,
-            step.id,
+            purpose,
             self._vlm_timeout_s,
         )
         response = await self._vlm.ask_image(
@@ -98,9 +138,9 @@ class StepVision:
             timeout=self._vlm_timeout_s,
         )
         logger.debug(
-            "vlm request complete pid={} step={} request_ms={:.1f} total_ms={:.1f}",
+            "vlm request complete pid={} purpose={} request_ms={:.1f} total_ms={:.1f}",
             participant_id,
-            step.id,
+            purpose,
             (time.perf_counter() - vlm_started) * 1000,
             (time.perf_counter() - started) * 1000,
         )

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/vision.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/vision.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Live-frame VLM observation loop for YAML workflow steps."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from loguru import logger
+from xr_ai_hub import FrameUnavailable, LiveFrameSource
+from xr_ai_nat.functions.vision._pixels import encode_image, frame_to_pil
+
+from .workflow import WorkflowStep, render_template
+
+
+@dataclass(frozen=True, slots=True)
+class VisualObservation:
+    """One VLM caption tied to a live frame timestamp."""
+
+    text: str
+    frame_pts_us: int
+
+
+class StepVision:
+    """Run a step-specific VLM prompt over the participant's current frame."""
+
+    def __init__(
+        self,
+        *,
+        endpoint: Any,
+        vlm: Any,
+        frame_max_age_s: float,
+        frame_timeout_s: float,
+        vlm_timeout_s: float = 15.0,
+        system_prompt: str = "",
+    ) -> None:
+        self._frames = LiveFrameSource(
+            endpoint,
+            max_age_s=frame_max_age_s,
+            timeout_s=frame_timeout_s,
+        )
+        self._vlm = vlm
+        self._frame_timeout_s = frame_timeout_s
+        self._vlm_timeout_s = vlm_timeout_s
+        self._system_prompt = system_prompt
+
+    async def observe(
+        self,
+        participant_id: str,
+        step: WorkflowStep,
+        context: dict[str, Any],
+        *,
+        task: dict[str, Any],
+    ) -> VisualObservation:
+        started = time.perf_counter()
+        logger.debug(
+            "vlm frame wait begin pid={} step={} timeout_s={}",
+            participant_id,
+            step.id,
+            self._frame_timeout_s,
+        )
+        try:
+            async with asyncio.timeout(self._frame_timeout_s + 1.0):
+                frame = await self._frames.get(participant_id)
+        except TimeoutError as exc:
+            raise FrameUnavailable("Camera frame request timed out.") from exc
+        frame_elapsed_ms = (time.perf_counter() - started) * 1000
+        logger.debug(
+            "vlm frame acquired pid={} step={} frame_pts_us={} elapsed_ms={:.1f}",
+            participant_id,
+            step.id,
+            frame.pts_us,
+            frame_elapsed_ms,
+        )
+        image = encode_image(frame_to_pil(frame))
+        prompt = render_template(
+            step.vlm_prompt,
+            context=context,
+            step=step,
+            task=task,
+        )
+        vlm_started = time.perf_counter()
+        logger.debug(
+            "vlm request begin pid={} step={} timeout_s={}",
+            participant_id,
+            step.id,
+            self._vlm_timeout_s,
+        )
+        response = await self._vlm.ask_image(
+            image,
+            prompt,
+            system_prompt=self._system_prompt,
+            temperature=0.0,
+            timeout=self._vlm_timeout_s,
+        )
+        logger.debug(
+            "vlm request complete pid={} step={} request_ms={:.1f} total_ms={:.1f}",
+            participant_id,
+            step.id,
+            (time.perf_counter() - vlm_started) * 1000,
+            (time.perf_counter() - started) * 1000,
+        )
+        return VisualObservation(text=(response.content or "").strip(), frame_pts_us=frame.pts_us)
+
+    def release(self, participant_id: str) -> None:
+        self._frames.release(participant_id)
+
+
+__all__ = ["FrameUnavailable", "StepVision", "VisualObservation"]

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/workflow.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/workflow.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import asyncio
 import copy
 import json
-import math
 import re
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -18,12 +17,6 @@ from typing import Any
 import yaml
 
 _TEMPLATE_RE = re.compile(r"{{\s*([a-zA-Z0-9_.-]+)(?:\s*\|\s*([a-zA-Z0-9_-]+))?\s*}}")
-_OBSERVATION_FIELD_RE = re.compile(
-    r"^\s*([A-Z][A-Z0-9_ ]+)\s*:\s*(.*?)\s*$",
-    re.IGNORECASE | re.MULTILINE,
-)
-_STEP_STATES = frozenset({"started", "needs_input", "complete"})
-_INVALID_CONTEXT_VALUE = object()
 _TEMPERATURE_RE = re.compile(
     r"(?<![\w.])(-?\d+(?:\.\d+)?)\s*(?:°\s*)?([CF])\b",
     re.IGNORECASE,
@@ -69,38 +62,6 @@ class ContextField:
 
 
 @dataclass(frozen=True, slots=True)
-class TimerSpec:
-    """YAML-defined wall-clock timer for a non-visual workflow step."""
-
-    label: str
-    started_at_us_field: str
-    duration_seconds_field: str
-    completion_field: str
-
-
-@dataclass(frozen=True, slots=True)
-class TimerStatus:
-    """Current timer values derived from workflow context."""
-
-    label: str
-    started_at_us: int
-    duration_seconds: int
-    elapsed_seconds: int
-    remaining_seconds: int
-    expired: bool
-
-
-@dataclass(frozen=True, slots=True)
-class StateUpdateSpec:
-    """Declarative mapping from a structured VLM field to workflow context."""
-
-    context_field: str
-    states: tuple[str, ...]
-    observation_key: str = ""
-    value_map: dict[str, Any] = field(default_factory=dict)
-
-
-@dataclass(frozen=True, slots=True)
 class WorkflowStep:
     """One YAML-configured step in the guided workflow."""
 
@@ -110,13 +71,12 @@ class WorkflowStep:
     vlm_prompt: str
     agent_prompt: str
     context_fields: tuple[ContextField, ...]
+    mechanism: str = "caption_agent"
     read_fields: tuple[str, ...] = ()
     partial_context: bool = False
     advance_when: dict[str, Any] = field(default_factory=dict)
     skip_defaults: dict[str, Any] = field(default_factory=dict)
-    agent_tools: dict[str, dict[str, Any]] = field(default_factory=dict)
-    timer: TimerSpec | None = None
-    state_updates: tuple[StateUpdateSpec, ...] = ()
+    agent_tools: tuple[str, ...] = ()
     on_enter_message: str = ""
     on_reminder_message: str = ""
     on_complete_message: str = ""
@@ -149,39 +109,6 @@ class WorkflowStep:
 
         writes = tuple(item.name for item in self.context_fields)
         return tuple(dict.fromkeys((*self.read_fields, *writes)))
-
-    def state_update_fields(self, state: str) -> set[str]:
-        return {update.context_field for update in self.state_updates if state in update.states}
-
-    def observation_context_patch(
-        self,
-        observation: str,
-        *,
-        state: str,
-    ) -> dict[str, Any]:
-        observed = {
-            _normalize_observation_key(match.group(1)): match.group(2).strip()
-            for match in _OBSERVATION_FIELD_RE.finditer(observation)
-        }
-        field_types = {item.name: item.type for item in self.context_fields}
-        patch: dict[str, Any] = {}
-        for update in self.state_updates:
-            if state not in update.states or not update.observation_key:
-                continue
-            raw_value = observed.get(_normalize_observation_key(update.observation_key))
-            if not raw_value:
-                continue
-            mapped = update.value_map.get(
-                _normalize_observation_value(raw_value),
-                raw_value,
-            )
-            value = _coerce_context_value(
-                mapped,
-                field_types[update.context_field],
-            )
-            if value is not _INVALID_CONTEXT_VALUE:
-                patch[update.context_field] = value
-        return patch
 
 
 @dataclass(slots=True)
@@ -371,54 +298,6 @@ class WorkflowDefinition:
         rule = step.advance_when or {}
         return _rule_met(rule, context) if rule else ready_to_advance
 
-    def timer_status(
-        self,
-        step: WorkflowStep,
-        context: dict[str, Any],
-        *,
-        now_us: int,
-    ) -> TimerStatus | None:
-        spec = step.timer
-        if spec is None:
-            return None
-        started_at_us = _positive_int(_lookup(context, spec.started_at_us_field))
-        duration_seconds = _positive_int(_lookup(context, spec.duration_seconds_field))
-        if started_at_us <= 0 or duration_seconds <= 0:
-            return None
-        elapsed_us = max(0, now_us - started_at_us)
-        duration_us = duration_seconds * 1_000_000
-        return TimerStatus(
-            label=spec.label,
-            started_at_us=started_at_us,
-            duration_seconds=duration_seconds,
-            elapsed_seconds=elapsed_us // 1_000_000,
-            remaining_seconds=max(
-                0,
-                math.ceil((duration_us - elapsed_us) / 1_000_000),
-            ),
-            expired=elapsed_us >= duration_us,
-        )
-
-    def find_timer_status(
-        self,
-        context: dict[str, Any],
-        *,
-        current_step_id: int,
-        now_us: int,
-    ) -> TimerStatus | None:
-        timer_steps = (step for step in self.steps if step.timer is not None)
-        ordered = sorted(timer_steps, key=lambda step: step.id != current_step_id)
-        for step in ordered:
-            status = self.timer_status(step, context, now_us=now_us)
-            if status is not None:
-                return status
-        return None
-
-    def mark_timer_complete(self, step: WorkflowStep, context: dict[str, Any]) -> None:
-        if step.timer is not None:
-            context[step.timer.completion_field] = True
-
-
 def _rule_met(rule: dict[str, Any], context: dict[str, Any]) -> bool:
     all_rules = rule.get("all")
     if isinstance(all_rules, list):
@@ -580,13 +459,12 @@ def _parse_step(
         vlm_prompt=str(raw.get("vlm_prompt") or ""),
         agent_prompt=str(raw.get("agent_prompt") or ""),
         context_fields=context_fields,
+        mechanism=str(raw.get("mechanism") or "caption_agent").strip(),
         read_fields=read_fields,
         partial_context=registry_enabled,
         advance_when=dict(raw.get("advance_when") or {}),
         skip_defaults=dict(raw.get("skip_defaults") or {}),
-        agent_tools=_parse_agent_tools(raw.get("agent_tools") or {}),
-        timer=_parse_timer(raw.get("timer")),
-        state_updates=_parse_state_updates(raw.get("state_updates")),
+        agent_tools=_parse_agent_tools(raw.get("agent_tools") or []),
         on_enter_message=str(raw.get("on_enter_message") or ""),
         on_reminder_message=str(raw.get("on_reminder_message") or ""),
         on_complete_message=str(raw.get("on_complete_message") or ""),
@@ -594,67 +472,13 @@ def _parse_step(
     )
 
 
-def _parse_agent_tools(raw: Any) -> dict[str, dict[str, Any]]:
-    if isinstance(raw, list):
-        return {str(name): {} for name in raw}
-    if not isinstance(raw, dict):
-        raise ValueError("agent_tools must be a mapping or list")
-    tools: dict[str, dict[str, Any]] = {}
-    for name, policy in raw.items():
-        if policy is not None and not isinstance(policy, dict):
-            raise ValueError(f"agent tool policy must be a mapping: {name}")
-        tools[str(name)] = dict(policy or {})
-    return tools
-
-
-def _parse_state_updates(raw: Any) -> tuple[StateUpdateSpec, ...]:
-    if raw is None:
-        return ()
+def _parse_agent_tools(raw: Any) -> tuple[str, ...]:
     if not isinstance(raw, list):
-        raise ValueError("state_updates must be a list")
-    updates: list[StateUpdateSpec] = []
-    for item in raw:
-        if not isinstance(item, dict):
-            raise ValueError("each state_updates entry must be a mapping")
-        context_field = str(item.get("context_field") or "").strip()
-        if not context_field:
-            raise ValueError("state_updates entry must define context_field")
-        raw_states = item.get("states") or ["started", "needs_input"]
-        if not isinstance(raw_states, list) or not raw_states:
-            raise ValueError("state_updates states must be a non-empty list")
-        value_map = item.get("value_map") or {}
-        if not isinstance(value_map, dict):
-            raise ValueError("state_updates value_map must be a mapping")
-        updates.append(
-            StateUpdateSpec(
-                context_field=context_field,
-                states=tuple(str(state).casefold().strip() for state in raw_states),
-                observation_key=str(item.get("observation_key") or "").strip(),
-                value_map={_normalize_observation_value(key): value for key, value in value_map.items()},
-            )
-        )
-    return tuple(updates)
-
-
-def _parse_timer(raw: Any) -> TimerSpec | None:
-    if raw is None:
-        return None
-    if not isinstance(raw, dict):
-        raise ValueError("timer must be a mapping")
-    required = (
-        "started_at_us_field",
-        "duration_seconds_field",
-        "completion_field",
-    )
-    missing = [name for name in required if not str(raw.get(name) or "").strip()]
-    if missing:
-        raise ValueError(f"timer is missing required fields: {', '.join(missing)}")
-    return TimerSpec(
-        label=str(raw.get("label") or "timer").strip(),
-        started_at_us_field=str(raw["started_at_us_field"]),
-        duration_seconds_field=str(raw["duration_seconds_field"]),
-        completion_field=str(raw["completion_field"]),
-    )
+        raise ValueError("agent_tools must be a list of tool names")
+    names = tuple(str(name).strip() for name in raw if str(name).strip())
+    if len(names) != len(set(names)):
+        raise ValueError("agent_tools must not contain duplicate names")
+    return names
 
 
 def _parse_context_fields(raw: Any, *, lazy: bool = False) -> list[ContextField]:
@@ -748,58 +572,16 @@ def _validate_definition(definition: WorkflowDefinition, path: Path) -> None:
             raise ValueError(f"step {step.id} must define description: {path}")
         if not step.agent_prompt.strip():
             raise ValueError(f"step {step.id} must define agent_prompt: {path}")
-        if step.timer is None and not step.vlm_prompt.strip():
-            raise ValueError(f"step {step.id} must define vlm_prompt or timer: {path}")
+        if not step.mechanism:
+            raise ValueError(f"step {step.id} must define a mechanism: {path}")
         if not step.advance_when:
             raise ValueError(f"step {step.id} must define advance_when: {path}")
 
         writable = step.writable_fields
-        available = writable | set(step.read_fields)
         unknown_defaults = set(step.skip_defaults) - writable
         if unknown_defaults:
             names = ", ".join(sorted(unknown_defaults))
             raise ValueError(f"step {step.id} skip_defaults use unknown fields {names}: {path}")
-        unknown_update_fields = {update.context_field for update in step.state_updates} - writable
-        if unknown_update_fields:
-            names = ", ".join(sorted(unknown_update_fields))
-            raise ValueError(f"step {step.id} updates unknown context fields {names}: {path}")
-        invalid_states = {
-            state for update in step.state_updates for state in update.states if state not in _STEP_STATES
-        }
-        if invalid_states:
-            names = ", ".join(sorted(invalid_states))
-            raise ValueError(f"step {step.id} state_updates use invalid states {names}: {path}")
-        if step.state_update_fields("complete") and not step.vlm_prompt.strip():
-            raise ValueError(f"step {step.id} cannot update complete state without a vlm_prompt: {path}")
-        for tool_name, policy in step.agent_tools.items():
-            if not policy.get("auto_invoke"):
-                continue
-            outputs = policy.get("context_outputs")
-            if not isinstance(outputs, dict) or not outputs:
-                raise ValueError(f"step {step.id} automatic tool {tool_name} must define context_outputs: {path}")
-            unknown_outputs = {str(name) for name in outputs.values()} - writable
-            if unknown_outputs:
-                names = ", ".join(sorted(unknown_outputs))
-                raise ValueError(
-                    f"step {step.id} automatic tool {tool_name} uses unknown context fields {names}: {path}"
-                )
-            empty_field = str(policy.get("when_context_empty") or "").strip()
-            if empty_field and empty_field not in available:
-                raise ValueError(
-                    f"step {step.id} automatic tool {tool_name} checks unknown context field {empty_field}: {path}"
-                )
-        if step.timer is not None:
-            timer_fields = {
-                step.timer.started_at_us_field,
-                step.timer.duration_seconds_field,
-                step.timer.completion_field,
-            }
-            unknown_timer_fields = timer_fields - available
-            if unknown_timer_fields:
-                names = ", ".join(sorted(unknown_timer_fields))
-                raise ValueError(f"step {step.id} timer uses unknown fields {names}: {path}")
-            if step.timer.completion_field not in writable:
-                raise ValueError(f"step {step.id} timer completion field must be writable: {path}")
 
 
 def _default_for_type(field_type: str) -> Any:
@@ -810,50 +592,6 @@ def _default_for_type(field_type: str) -> Any:
         "integer": 0,
         "number": 0.0,
     }.get(field_type, "")
-
-
-def _normalize_observation_key(value: Any) -> str:
-    return re.sub(r"[^A-Z0-9]+", "_", str(value).upper()).strip("_")
-
-
-def _normalize_observation_value(value: Any) -> str:
-    if isinstance(value, bool):
-        return "yes" if value else "no"
-    return str(value).casefold().strip()
-
-
-def _coerce_context_value(value: Any, field_type: str) -> Any:
-    if field_type == "string":
-        return str(value)
-    if field_type == "boolean":
-        if isinstance(value, bool):
-            return value
-        normalized = str(value).casefold().strip()
-        if normalized in {"1", "true", "yes", "on"}:
-            return True
-        if normalized in {"0", "false", "no", "off"}:
-            return False
-        return _INVALID_CONTEXT_VALUE
-    if field_type == "integer":
-        try:
-            return int(value)
-        except (TypeError, ValueError):
-            return _INVALID_CONTEXT_VALUE
-    if field_type == "number":
-        try:
-            return float(value)
-        except (TypeError, ValueError):
-            return _INVALID_CONTEXT_VALUE
-    if field_type in {"array", "object"}:
-        decoded = value
-        if isinstance(value, str):
-            try:
-                decoded = json.loads(value)
-            except json.JSONDecodeError:
-                return _INVALID_CONTEXT_VALUE
-        expected_type = list if field_type == "array" else dict
-        return decoded if isinstance(decoded, expected_type) else _INVALID_CONTEXT_VALUE
-    return value
 
 
 def _render_default(value: Any, values: dict[str, Any]) -> Any:
@@ -898,14 +636,6 @@ def _unset_for_skip(value: Any, field: ContextField | None) -> bool:
     return field.default in (None, "", False, 0, 0.0)
 
 
-def _positive_int(value: Any) -> int:
-    try:
-        number = int(value)
-    except (TypeError, ValueError):
-        return 0
-    return max(0, number)
-
-
 def _compare_number(value: Any, expected: Any, comparator: Any) -> bool:
     try:
         left = float(value)
@@ -917,9 +647,6 @@ def _compare_number(value: Any, expected: Any, comparator: Any) -> bool:
 
 __all__ = [
     "ContextField",
-    "StateUpdateSpec",
-    "TimerSpec",
-    "TimerStatus",
     "WorkflowDefinition",
     "WorkflowSession",
     "WorkflowStep",

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/workflow.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/workflow.py
@@ -1,0 +1,762 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Load and evaluate YAML-defined guided workflow steps."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+import math
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_TEMPLATE_RE = re.compile(r"{{\s*([a-zA-Z0-9_.-]+)\s*}}")
+_OBSERVATION_FIELD_RE = re.compile(
+    r"^\s*([A-Z][A-Z0-9_ ]+)\s*:\s*(.*?)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+_STEP_STATES = frozenset({"started", "needs_input", "complete"})
+_INVALID_CONTEXT_VALUE = object()
+
+
+@dataclass(frozen=True, slots=True)
+class ContextField:
+    """One field the step agent should maintain in workflow context."""
+
+    name: str
+    label: str
+    type: str = "string"
+    description: str = ""
+    default: Any = ""
+    required: bool = False
+
+    def schema(self) -> dict[str, Any]:
+        schema_type = self.type if self.type in {
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "array",
+            "object",
+        } else "string"
+        out: dict[str, Any] = {"type": schema_type}
+        if self.description:
+            out["description"] = self.description
+        if self.default not in (None, ""):
+            out["default"] = self.default
+        return out
+
+
+@dataclass(frozen=True, slots=True)
+class TimerSpec:
+    """YAML-defined wall-clock timer for a non-visual workflow step."""
+
+    label: str
+    started_at_us_field: str
+    duration_seconds_field: str
+    completion_field: str
+
+
+@dataclass(frozen=True, slots=True)
+class TimerStatus:
+    """Current timer values derived from workflow context."""
+
+    label: str
+    started_at_us: int
+    duration_seconds: int
+    elapsed_seconds: int
+    remaining_seconds: int
+    expired: bool
+
+
+@dataclass(frozen=True, slots=True)
+class StateUpdateSpec:
+    """Declarative mapping from a structured VLM field to workflow context."""
+
+    context_field: str
+    states: tuple[str, ...]
+    observation_key: str = ""
+    value_map: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowStep:
+    """One YAML-configured step in the guided workflow."""
+
+    id: int
+    name: str
+    description: str
+    vlm_prompt: str
+    agent_prompt: str
+    context_fields: tuple[ContextField, ...]
+    advance_when: dict[str, Any] = field(default_factory=dict)
+    skip_defaults: dict[str, Any] = field(default_factory=dict)
+    agent_tools: dict[str, dict[str, Any]] = field(default_factory=dict)
+    timer: TimerSpec | None = None
+    state_updates: tuple[StateUpdateSpec, ...] = ()
+    on_enter_message: str = ""
+    on_reminder_message: str = ""
+    on_complete_message: str = ""
+    on_skip_message: str = ""
+
+    @property
+    def is_idle(self) -> bool:
+        return self.id == 0
+
+    def context_schema(self) -> dict[str, Any]:
+        required = [field.name for field in self.context_fields if field.required]
+        schema: dict[str, Any] = {
+            "type": "object",
+            "properties": {
+                field.name: field.schema()
+                for field in self.context_fields
+            },
+            "additionalProperties": False,
+        }
+        if required:
+            schema["required"] = required
+        return schema
+
+    def state_update_fields(self, state: str) -> set[str]:
+        return {
+            update.context_field
+            for update in self.state_updates
+            if state in update.states
+        }
+
+    def observation_context_patch(
+        self,
+        observation: str,
+        *,
+        state: str,
+    ) -> dict[str, Any]:
+        observed = {
+            _normalize_observation_key(match.group(1)): match.group(2).strip()
+            for match in _OBSERVATION_FIELD_RE.finditer(observation)
+        }
+        field_types = {item.name: item.type for item in self.context_fields}
+        patch: dict[str, Any] = {}
+        for update in self.state_updates:
+            if state not in update.states or not update.observation_key:
+                continue
+            raw_value = observed.get(
+                _normalize_observation_key(update.observation_key)
+            )
+            if not raw_value:
+                continue
+            mapped = update.value_map.get(
+                _normalize_observation_value(raw_value),
+                raw_value,
+            )
+            value = _coerce_context_value(
+                mapped,
+                field_types[update.context_field],
+            )
+            if value is not _INVALID_CONTEXT_VALUE:
+                patch[update.context_field] = value
+        return patch
+
+
+@dataclass(slots=True)
+class WorkflowSession:
+    """Participant-local workflow state."""
+
+    participant_id: str
+    step_id: int
+    context: dict[str, Any]
+    active: bool = True
+    connected: bool = True
+    last_frame_pts_us: int = 0
+    last_notice_us: int = 0
+    last_notice_text: str = ""
+    ready_step_id: int | None = None
+    step_state: str = "started"
+    step_started_us: int = 0
+    last_reminder_us: int = 0
+    reminder_count: int = 0
+    pending_instruction: str = ""
+    evaluation_active: bool = False
+    user_turn_active: bool = False
+    deferred_notice: str = ""
+    observation_log: list[dict[str, Any]] = field(default_factory=list)
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowDefinition:
+    """Task, step, and runtime settings loaded from YAML."""
+
+    task: dict[str, Any]
+    runtime: dict[str, Any]
+    steps: tuple[WorkflowStep, ...]
+
+    @classmethod
+    def load(cls, path: Path) -> "WorkflowDefinition":
+        with path.open(encoding="utf-8") as stream:
+            raw = yaml.safe_load(stream) or {}
+        if not isinstance(raw, dict):
+            raise ValueError(f"workflow YAML must be a mapping: {path}")
+        raw_steps = raw.get("steps")
+        if not isinstance(raw_steps, list) or not raw_steps:
+            raise ValueError(f"workflow YAML must define a non-empty steps list: {path}")
+        steps = tuple(sorted((_parse_step(item) for item in raw_steps), key=lambda item: item.id))
+        ids = [step.id for step in steps]
+        if len(set(ids)) != len(ids):
+            raise ValueError(f"workflow step IDs must be unique: {path}")
+        if 0 not in ids:
+            raise ValueError(f"workflow must include idle step id 0: {path}")
+        definition = cls(
+            task=dict(raw.get("task") or {}),
+            runtime=dict(raw.get("runtime") or {}),
+            steps=steps,
+        )
+        _validate_definition(definition, path)
+        return definition
+
+    @property
+    def monitor_interval_s(self) -> float:
+        return float(self.runtime.get("monitor_interval_s", 2.0))
+
+    @property
+    def min_notice_interval_s(self) -> float:
+        return float(self.runtime.get("min_notice_interval_s", 8.0))
+
+    @property
+    def reminder_interval_s(self) -> float:
+        return float(self.runtime.get("reminder_interval_s", 30.0))
+
+    @property
+    def max_reminders_per_step(self) -> int:
+        return int(self.runtime.get("max_reminders_per_step", 1))
+
+    @property
+    def navigation_timeout_s(self) -> float:
+        return float(self.runtime.get("navigation_timeout_s", 4.0))
+
+    @property
+    def max_agent_iterations(self) -> int:
+        return int(self.runtime.get("max_agent_iterations", 6))
+
+    @property
+    def start_triggers(self) -> tuple[str, ...]:
+        return tuple(str(item).casefold() for item in self.task.get("start_triggers", ()))
+
+    @property
+    def stop_triggers(self) -> tuple[str, ...]:
+        return tuple(str(item).casefold() for item in self.task.get("stop_triggers", ()))
+
+    @property
+    def status_triggers(self) -> tuple[str, ...]:
+        return tuple(str(item).casefold() for item in self.task.get("status_triggers", ()))
+
+    def step_by_id(self, step_id: int) -> WorkflowStep:
+        for step in self.steps:
+            if step.id == step_id:
+                return step
+        raise KeyError(f"unknown workflow step id: {step_id}")
+
+    def first_active_step(self) -> WorkflowStep:
+        for step in self.steps:
+            if not step.is_idle:
+                return step
+        raise ValueError("workflow has no non-idle steps")
+
+    def next_step(self, step_id: int) -> WorkflowStep | None:
+        active = [step for step in self.steps if not step.is_idle]
+        for index, step in enumerate(active):
+            if step.id == step_id:
+                return active[index + 1] if index + 1 < len(active) else None
+        return None
+
+    def initial_context(self) -> dict[str, Any]:
+        context: dict[str, Any] = {}
+        for step in self.steps:
+            for item in step.context_fields:
+                context.setdefault(item.name, copy.deepcopy(item.default))
+        return context
+
+    def apply_skip_defaults(
+        self,
+        step: WorkflowStep,
+        context: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Apply YAML-authored defaults for fields still missing on manual advance."""
+
+        now = datetime.now().astimezone()
+        values = {
+            "now_us": int(now.timestamp() * 1_000_000),
+            "now_iso": now.isoformat(timespec="seconds"),
+        }
+        applied: dict[str, Any] = {}
+        fields = {item.name: item for item in step.context_fields}
+        for name, value in step.skip_defaults.items():
+            field_name = str(name)
+            if _unset_for_skip(_lookup(context, field_name), fields.get(field_name)):
+                rendered = _render_default(copy.deepcopy(value), values)
+                context[field_name] = rendered
+                applied[field_name] = rendered
+        return applied
+
+    def advance_when_met(
+        self,
+        step: WorkflowStep,
+        context: dict[str, Any],
+        *,
+        ready_to_advance: bool = False,
+    ) -> bool:
+        rule = step.advance_when or {}
+        return _rule_met(rule, context) if rule else ready_to_advance
+
+    def timer_status(
+        self,
+        step: WorkflowStep,
+        context: dict[str, Any],
+        *,
+        now_us: int,
+    ) -> TimerStatus | None:
+        spec = step.timer
+        if spec is None:
+            return None
+        started_at_us = _positive_int(_lookup(context, spec.started_at_us_field))
+        duration_seconds = _positive_int(_lookup(context, spec.duration_seconds_field))
+        if started_at_us <= 0 or duration_seconds <= 0:
+            return None
+        elapsed_us = max(0, now_us - started_at_us)
+        duration_us = duration_seconds * 1_000_000
+        return TimerStatus(
+            label=spec.label,
+            started_at_us=started_at_us,
+            duration_seconds=duration_seconds,
+            elapsed_seconds=elapsed_us // 1_000_000,
+            remaining_seconds=max(
+                0,
+                math.ceil((duration_us - elapsed_us) / 1_000_000),
+            ),
+            expired=elapsed_us >= duration_us,
+        )
+
+    def find_timer_status(
+        self,
+        context: dict[str, Any],
+        *,
+        current_step_id: int,
+        now_us: int,
+    ) -> TimerStatus | None:
+        timer_steps = (step for step in self.steps if step.timer is not None)
+        ordered = sorted(timer_steps, key=lambda step: step.id != current_step_id)
+        for step in ordered:
+            status = self.timer_status(step, context, now_us=now_us)
+            if status is not None:
+                return status
+        return None
+
+    def mark_timer_complete(self, step: WorkflowStep, context: dict[str, Any]) -> None:
+        if step.timer is not None:
+            context[step.timer.completion_field] = True
+
+
+def _rule_met(rule: dict[str, Any], context: dict[str, Any]) -> bool:
+    all_rules = rule.get("all")
+    if isinstance(all_rules, list):
+        return bool(all_rules) and all(
+            isinstance(item, dict) and _rule_met(item, context)
+            for item in all_rules
+        )
+
+    any_rules = rule.get("any")
+    if isinstance(any_rules, list):
+        return bool(any_rules) and any(
+            isinstance(item, dict) and _rule_met(item, context)
+            for item in any_rules
+        )
+
+    field_name = rule.get("field")
+    if field_name:
+        value = _lookup(context, str(field_name))
+        if rule.get("exists") is True:
+            return _present(value)
+        if "equals" in rule:
+            return value == rule["equals"]
+        if "not_equals" in rule:
+            return value != rule["not_equals"]
+        if "gt" in rule:
+            return _compare_number(value, rule["gt"], lambda left, right: left > right)
+        if "gte" in rule:
+            return _compare_number(value, rule["gte"], lambda left, right: left >= right)
+        if "lt" in rule:
+            return _compare_number(value, rule["lt"], lambda left, right: left < right)
+        if "lte" in rule:
+            return _compare_number(value, rule["lte"], lambda left, right: left <= right)
+
+    all_present = rule.get("all_present") or ()
+    if all_present:
+        return all(_present(_lookup(context, str(name))) for name in all_present)
+    any_present = rule.get("any_present") or ()
+    if any_present:
+        return any(_present(_lookup(context, str(name))) for name in any_present)
+    return False
+
+
+def render_template(
+    template: str,
+    *,
+    context: dict[str, Any],
+    step: WorkflowStep | None = None,
+    task: dict[str, Any] | None = None,
+) -> str:
+    """Render simple ``{{field}}`` placeholders from context, step, and task."""
+
+    def replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        if key.startswith("step.") and step is not None:
+            return str(getattr(step, key.removeprefix("step."), ""))
+        if key.startswith("task.") and task is not None:
+            return str(_lookup(task, key.removeprefix("task.")) or "")
+        value = _lookup(context, key)
+        if isinstance(value, dict | list):
+            return json.dumps(value, ensure_ascii=True)
+        return "" if value is None else str(value)
+
+    return _TEMPLATE_RE.sub(replace, template)
+
+
+def context_for_prompt(context: dict[str, Any]) -> str:
+    """Stable JSON rendering used in model prompts."""
+
+    return json.dumps(context, indent=2, sort_keys=True, ensure_ascii=True)
+
+
+def _parse_step(raw: Any) -> WorkflowStep:
+    if not isinstance(raw, dict):
+        raise ValueError(f"workflow step must be a mapping: {raw!r}")
+    step_id = int(raw["id"])
+    return WorkflowStep(
+        id=step_id,
+        name=str(raw.get("name") or f"Step {step_id}"),
+        description=str(raw.get("description") or ""),
+        vlm_prompt=str(raw.get("vlm_prompt") or ""),
+        agent_prompt=str(raw.get("agent_prompt") or ""),
+        context_fields=tuple(_parse_context_fields(raw.get("context_output") or {})),
+        advance_when=dict(raw.get("advance_when") or {}),
+        skip_defaults=dict(raw.get("skip_defaults") or {}),
+        agent_tools=_parse_agent_tools(raw.get("agent_tools") or {}),
+        timer=_parse_timer(raw.get("timer")),
+        state_updates=_parse_state_updates(raw.get("state_updates")),
+        on_enter_message=str(raw.get("on_enter_message") or ""),
+        on_reminder_message=str(raw.get("on_reminder_message") or ""),
+        on_complete_message=str(raw.get("on_complete_message") or ""),
+        on_skip_message=str(raw.get("on_skip_message") or ""),
+    )
+
+
+def _parse_agent_tools(raw: Any) -> dict[str, dict[str, Any]]:
+    if isinstance(raw, list):
+        return {str(name): {} for name in raw}
+    if not isinstance(raw, dict):
+        raise ValueError("agent_tools must be a mapping or list")
+    tools: dict[str, dict[str, Any]] = {}
+    for name, policy in raw.items():
+        if policy is not None and not isinstance(policy, dict):
+            raise ValueError(f"agent tool policy must be a mapping: {name}")
+        tools[str(name)] = dict(policy or {})
+    return tools
+
+
+def _parse_state_updates(raw: Any) -> tuple[StateUpdateSpec, ...]:
+    if raw is None:
+        return ()
+    if not isinstance(raw, list):
+        raise ValueError("state_updates must be a list")
+    updates: list[StateUpdateSpec] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            raise ValueError("each state_updates entry must be a mapping")
+        context_field = str(item.get("context_field") or "").strip()
+        if not context_field:
+            raise ValueError("state_updates entry must define context_field")
+        raw_states = item.get("states") or ["started", "needs_input"]
+        if not isinstance(raw_states, list) or not raw_states:
+            raise ValueError("state_updates states must be a non-empty list")
+        value_map = item.get("value_map") or {}
+        if not isinstance(value_map, dict):
+            raise ValueError("state_updates value_map must be a mapping")
+        updates.append(
+            StateUpdateSpec(
+                context_field=context_field,
+                states=tuple(str(state).casefold().strip() for state in raw_states),
+                observation_key=str(item.get("observation_key") or "").strip(),
+                value_map={
+                    _normalize_observation_value(key): value
+                    for key, value in value_map.items()
+                },
+            )
+        )
+    return tuple(updates)
+
+
+def _parse_timer(raw: Any) -> TimerSpec | None:
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise ValueError("timer must be a mapping")
+    required = (
+        "started_at_us_field",
+        "duration_seconds_field",
+        "completion_field",
+    )
+    missing = [name for name in required if not str(raw.get(name) or "").strip()]
+    if missing:
+        raise ValueError(f"timer is missing required fields: {', '.join(missing)}")
+    return TimerSpec(
+        label=str(raw.get("label") or "timer").strip(),
+        started_at_us_field=str(raw["started_at_us_field"]),
+        duration_seconds_field=str(raw["duration_seconds_field"]),
+        completion_field=str(raw["completion_field"]),
+    )
+
+
+def _parse_context_fields(raw: Any) -> list[ContextField]:
+    if isinstance(raw, dict) and "fields" in raw:
+        raw = raw["fields"]
+    if not isinstance(raw, dict):
+        return []
+    fields: list[ContextField] = []
+    for name, spec in raw.items():
+        if spec is None:
+            spec = {}
+        if not isinstance(spec, dict):
+            spec = {"description": str(spec)}
+        field_type = str(spec.get("type", "string"))
+        default = spec.get("default", _default_for_type(field_type))
+        fields.append(
+            ContextField(
+                name=str(name),
+                label=str(spec.get("label") or name),
+                type=field_type,
+                description=str(spec.get("description") or ""),
+                default=default,
+                required=bool(spec.get("required", False)),
+            )
+        )
+    return fields
+
+
+def _validate_definition(definition: WorkflowDefinition, path: Path) -> None:
+    for key in (
+        "monitor_interval_s",
+        "min_notice_interval_s",
+        "reminder_interval_s",
+        "navigation_timeout_s",
+        "max_agent_iterations",
+    ):
+        if float(definition.runtime.get(key, 1)) <= 0:
+            raise ValueError(f"runtime.{key} must be positive: {path}")
+    if definition.max_reminders_per_step < 0:
+        raise ValueError(f"runtime.max_reminders_per_step cannot be negative: {path}")
+
+    for step in definition.steps:
+        if step.is_idle:
+            continue
+        if not step.description.strip():
+            raise ValueError(f"step {step.id} must define description: {path}")
+        if not step.agent_prompt.strip():
+            raise ValueError(f"step {step.id} must define agent_prompt: {path}")
+        if step.timer is None and not step.vlm_prompt.strip():
+            raise ValueError(f"step {step.id} must define vlm_prompt or timer: {path}")
+        if not step.advance_when:
+            raise ValueError(f"step {step.id} must define advance_when: {path}")
+
+        fields = {field.name for field in step.context_fields}
+        unknown_defaults = set(step.skip_defaults) - fields
+        if unknown_defaults:
+            names = ", ".join(sorted(unknown_defaults))
+            raise ValueError(f"step {step.id} skip_defaults use unknown fields {names}: {path}")
+        unknown_update_fields = {
+            update.context_field for update in step.state_updates
+        } - fields
+        if unknown_update_fields:
+            names = ", ".join(sorted(unknown_update_fields))
+            raise ValueError(
+                f"step {step.id} updates unknown context fields {names}: {path}"
+            )
+        invalid_states = {
+            state
+            for update in step.state_updates
+            for state in update.states
+            if state not in _STEP_STATES
+        }
+        if invalid_states:
+            names = ", ".join(sorted(invalid_states))
+            raise ValueError(
+                f"step {step.id} state_updates use invalid states {names}: {path}"
+            )
+        if step.state_update_fields("complete") and not step.vlm_prompt.strip():
+            raise ValueError(
+                f"step {step.id} cannot update complete state without a "
+                f"vlm_prompt: {path}"
+            )
+        for tool_name, policy in step.agent_tools.items():
+            if not policy.get("auto_invoke"):
+                continue
+            outputs = policy.get("context_outputs")
+            if not isinstance(outputs, dict) or not outputs:
+                raise ValueError(
+                    f"step {step.id} automatic tool {tool_name} must define "
+                    f"context_outputs: {path}"
+                )
+            unknown_outputs = {str(name) for name in outputs.values()} - fields
+            if unknown_outputs:
+                names = ", ".join(sorted(unknown_outputs))
+                raise ValueError(
+                    f"step {step.id} automatic tool {tool_name} uses unknown context "
+                    f"fields {names}: {path}"
+                )
+            empty_field = str(policy.get("when_context_empty") or "").strip()
+            if empty_field and empty_field not in fields:
+                raise ValueError(
+                    f"step {step.id} automatic tool {tool_name} checks unknown context "
+                    f"field {empty_field}: {path}"
+                )
+        if step.timer is not None:
+            timer_fields = {
+                step.timer.started_at_us_field,
+                step.timer.duration_seconds_field,
+                step.timer.completion_field,
+            }
+            unknown_timer_fields = timer_fields - fields
+            if unknown_timer_fields:
+                names = ", ".join(sorted(unknown_timer_fields))
+                raise ValueError(f"step {step.id} timer uses unknown fields {names}: {path}")
+
+
+def _default_for_type(field_type: str) -> Any:
+    return {
+        "boolean": False,
+        "array": [],
+        "object": {},
+        "integer": 0,
+        "number": 0.0,
+    }.get(field_type, "")
+
+
+def _normalize_observation_key(value: Any) -> str:
+    return re.sub(r"[^A-Z0-9]+", "_", str(value).upper()).strip("_")
+
+
+def _normalize_observation_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    return str(value).casefold().strip()
+
+
+def _coerce_context_value(value: Any, field_type: str) -> Any:
+    if field_type == "string":
+        return str(value)
+    if field_type == "boolean":
+        if isinstance(value, bool):
+            return value
+        normalized = str(value).casefold().strip()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+        return _INVALID_CONTEXT_VALUE
+    if field_type == "integer":
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return _INVALID_CONTEXT_VALUE
+    if field_type == "number":
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return _INVALID_CONTEXT_VALUE
+    if field_type in {"array", "object"}:
+        decoded = value
+        if isinstance(value, str):
+            try:
+                decoded = json.loads(value)
+            except json.JSONDecodeError:
+                return _INVALID_CONTEXT_VALUE
+        expected_type = list if field_type == "array" else dict
+        return decoded if isinstance(decoded, expected_type) else _INVALID_CONTEXT_VALUE
+    return value
+
+
+def _render_default(value: Any, values: dict[str, Any]) -> Any:
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped == "{{now_us}}":
+            return values["now_us"]
+        if stripped == "{{now_iso}}":
+            return values["now_iso"]
+        return render_template(value, context=values)
+    if isinstance(value, list):
+        return [_render_default(item, values) for item in value]
+    if isinstance(value, dict):
+        return {key: _render_default(item, values) for key, item in value.items()}
+    return value
+
+
+def _lookup(data: dict[str, Any], dotted: str) -> Any:
+    value: Any = data
+    for part in dotted.split("."):
+        if not isinstance(value, dict) or part not in value:
+            return None
+        value = value[part]
+    return value
+
+
+def _present(value: Any) -> bool:
+    if value is None or value is False:
+        return False
+    if isinstance(value, str) and not value.strip():
+        return False
+    if isinstance(value, list | dict) and not value:
+        return False
+    return True
+
+
+def _unset_for_skip(value: Any, field: ContextField | None) -> bool:
+    if not _present(value):
+        return True
+    if field is None or value != field.default:
+        return False
+    return field.default in (None, "", False, 0, 0.0)
+
+
+def _positive_int(value: Any) -> int:
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, number)
+
+
+def _compare_number(value: Any, expected: Any, comparator: Any) -> bool:
+    try:
+        left = float(value)
+        right = float(expected)
+    except (TypeError, ValueError):
+        return False
+    return bool(comparator(left, right))
+
+
+__all__ = [
+    "ContextField",
+    "StateUpdateSpec",
+    "TimerSpec",
+    "TimerStatus",
+    "WorkflowDefinition",
+    "WorkflowSession",
+    "WorkflowStep",
+    "context_for_prompt",
+    "render_template",
+]

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/workflow.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/workflow.py
@@ -17,13 +17,21 @@ from typing import Any
 
 import yaml
 
-_TEMPLATE_RE = re.compile(r"{{\s*([a-zA-Z0-9_.-]+)\s*}}")
+_TEMPLATE_RE = re.compile(r"{{\s*([a-zA-Z0-9_.-]+)(?:\s*\|\s*([a-zA-Z0-9_-]+))?\s*}}")
 _OBSERVATION_FIELD_RE = re.compile(
     r"^\s*([A-Z][A-Z0-9_ ]+)\s*:\s*(.*?)\s*$",
     re.IGNORECASE | re.MULTILINE,
 )
 _STEP_STATES = frozenset({"started", "needs_input", "complete"})
 _INVALID_CONTEXT_VALUE = object()
+_TEMPERATURE_RE = re.compile(
+    r"(?<![\w.])(-?\d+(?:\.\d+)?)\s*(?:°\s*)?([CF])\b",
+    re.IGNORECASE,
+)
+_ISO_TIMESTAMP_RE = re.compile(
+    r"\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?"
+    r"(?:Z|[+-]\d{2}:\d{2})?\b"
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -36,20 +44,26 @@ class ContextField:
     description: str = ""
     default: Any = ""
     required: bool = False
+    initialize: bool = True
 
     def schema(self) -> dict[str, Any]:
-        schema_type = self.type if self.type in {
-            "string",
-            "number",
-            "integer",
-            "boolean",
-            "array",
-            "object",
-        } else "string"
+        schema_type = (
+            self.type
+            if self.type
+            in {
+                "string",
+                "number",
+                "integer",
+                "boolean",
+                "array",
+                "object",
+            }
+            else "string"
+        )
         out: dict[str, Any] = {"type": schema_type}
         if self.description:
             out["description"] = self.description
-        if self.default not in (None, ""):
+        if self.initialize and self.default not in (None, ""):
             out["default"] = self.default
         return out
 
@@ -96,6 +110,8 @@ class WorkflowStep:
     vlm_prompt: str
     agent_prompt: str
     context_fields: tuple[ContextField, ...]
+    read_fields: tuple[str, ...] = ()
+    partial_context: bool = False
     advance_when: dict[str, Any] = field(default_factory=dict)
     skip_defaults: dict[str, Any] = field(default_factory=dict)
     agent_tools: dict[str, dict[str, Any]] = field(default_factory=dict)
@@ -111,25 +127,31 @@ class WorkflowStep:
         return self.id == 0
 
     def context_schema(self) -> dict[str, Any]:
-        required = [field.name for field in self.context_fields if field.required]
+        required = [field.name for field in self.context_fields if field.required and not self.partial_context]
         schema: dict[str, Any] = {
             "type": "object",
-            "properties": {
-                field.name: field.schema()
-                for field in self.context_fields
-            },
+            "properties": {field.name: field.schema() for field in self.context_fields},
             "additionalProperties": False,
         }
         if required:
             schema["required"] = required
         return schema
 
+    @property
+    def writable_fields(self) -> set[str]:
+        """Context fields this step is allowed to change."""
+
+        return {item.name for item in self.context_fields}
+
+    @property
+    def prompt_fields(self) -> tuple[str, ...]:
+        """Ordered context projection supplied to this step's state agent."""
+
+        writes = tuple(item.name for item in self.context_fields)
+        return tuple(dict.fromkeys((*self.read_fields, *writes)))
+
     def state_update_fields(self, state: str) -> set[str]:
-        return {
-            update.context_field
-            for update in self.state_updates
-            if state in update.states
-        }
+        return {update.context_field for update in self.state_updates if state in update.states}
 
     def observation_context_patch(
         self,
@@ -146,9 +168,7 @@ class WorkflowStep:
         for update in self.state_updates:
             if state not in update.states or not update.observation_key:
                 continue
-            raw_value = observed.get(
-                _normalize_observation_key(update.observation_key)
-            )
+            raw_value = observed.get(_normalize_observation_key(update.observation_key))
             if not raw_value:
                 continue
             mapped = update.value_map.get(
@@ -196,6 +216,8 @@ class WorkflowDefinition:
     task: dict[str, Any]
     runtime: dict[str, Any]
     steps: tuple[WorkflowStep, ...]
+    context_fields: tuple[ContextField, ...] = ()
+    sparse_context: bool = False
 
     @classmethod
     def load(cls, path: Path) -> "WorkflowDefinition":
@@ -206,16 +228,41 @@ class WorkflowDefinition:
         raw_steps = raw.get("steps")
         if not isinstance(raw_steps, list) or not raw_steps:
             raise ValueError(f"workflow YAML must define a non-empty steps list: {path}")
-        steps = tuple(sorted((_parse_step(item) for item in raw_steps), key=lambda item: item.id))
+        raw_context = raw.get("context")
+        has_context_registry = isinstance(raw_context, dict) and "fields" in raw_context
+        registered_fields = _parse_context_fields(raw_context or {}, lazy=True)
+        if has_context_registry:
+            registered_fields = _extend_registry_from_step_writes(
+                registered_fields,
+                raw_steps,
+            )
+        registry = {item.name: item for item in registered_fields}
+        steps = tuple(
+            sorted(
+                (
+                    _parse_step(
+                        item,
+                        registry=registry,
+                        registry_enabled=has_context_registry,
+                    )
+                    for item in raw_steps
+                ),
+                key=lambda item: item.id,
+            )
+        )
         ids = [step.id for step in steps]
         if len(set(ids)) != len(ids):
             raise ValueError(f"workflow step IDs must be unique: {path}")
         if 0 not in ids:
             raise ValueError(f"workflow must include idle step id 0: {path}")
+        if not has_context_registry:
+            registered_fields = list({item.name: item for step in steps for item in step.context_fields}.values())
         definition = cls(
             task=dict(raw.get("task") or {}),
             runtime=dict(raw.get("runtime") or {}),
             steps=steps,
+            context_fields=tuple(registered_fields),
+            sparse_context=has_context_registry,
         )
         _validate_definition(definition, path)
         return definition
@@ -276,11 +323,21 @@ class WorkflowDefinition:
         return None
 
     def initial_context(self) -> dict[str, Any]:
-        context: dict[str, Any] = {}
-        for step in self.steps:
-            for item in step.context_fields:
-                context.setdefault(item.name, copy.deepcopy(item.default))
-        return context
+        return {item.name: copy.deepcopy(item.default) for item in self.context_fields if item.initialize}
+
+    def context_for_step(
+        self,
+        step: WorkflowStep,
+        context: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Return only populated fields that the current step reads or writes."""
+
+        if not self.sparse_context:
+            return dict(context)
+        return {name: copy.deepcopy(context[name]) for name in step.prompt_fields if name in context}
+
+    def field_map(self) -> dict[str, ContextField]:
+        return {item.name: item for item in self.context_fields}
 
     def apply_skip_defaults(
         self,
@@ -295,7 +352,7 @@ class WorkflowDefinition:
             "now_iso": now.isoformat(timespec="seconds"),
         }
         applied: dict[str, Any] = {}
-        fields = {item.name: item for item in step.context_fields}
+        fields = self.field_map()
         for name, value in step.skip_defaults.items():
             field_name = str(name)
             if _unset_for_skip(_lookup(context, field_name), fields.get(field_name)):
@@ -365,17 +422,11 @@ class WorkflowDefinition:
 def _rule_met(rule: dict[str, Any], context: dict[str, Any]) -> bool:
     all_rules = rule.get("all")
     if isinstance(all_rules, list):
-        return bool(all_rules) and all(
-            isinstance(item, dict) and _rule_met(item, context)
-            for item in all_rules
-        )
+        return bool(all_rules) and all(isinstance(item, dict) and _rule_met(item, context) for item in all_rules)
 
     any_rules = rule.get("any")
     if isinstance(any_rules, list):
-        return bool(any_rules) and any(
-            isinstance(item, dict) and _rule_met(item, context)
-            for item in any_rules
-        )
+        return bool(any_rules) and any(isinstance(item, dict) and _rule_met(item, context) for item in any_rules)
 
     field_name = rule.get("field")
     if field_name:
@@ -411,20 +462,86 @@ def render_template(
     step: WorkflowStep | None = None,
     task: dict[str, Any] | None = None,
 ) -> str:
-    """Render simple ``{{field}}`` placeholders from context, step, and task."""
+    """Render context placeholders and optional speech-oriented filters."""
 
     def replace(match: re.Match[str]) -> str:
         key = match.group(1)
+        formatter = (match.group(2) or "").casefold()
         if key.startswith("step.") and step is not None:
-            return str(getattr(step, key.removeprefix("step."), ""))
-        if key.startswith("task.") and task is not None:
-            return str(_lookup(task, key.removeprefix("task.")) or "")
-        value = _lookup(context, key)
-        if isinstance(value, dict | list):
-            return json.dumps(value, ensure_ascii=True)
-        return "" if value is None else str(value)
+            value: Any = getattr(step, key.removeprefix("step."), "")
+        elif key.startswith("task.") and task is not None:
+            value = _lookup(task, key.removeprefix("task."))
+        else:
+            value = _lookup(context, key)
+        return _format_template_value(value, formatter)
 
     return _TEMPLATE_RE.sub(replace, template)
+
+
+def speech_text(text: str) -> str:
+    """Normalize common machine-oriented values for text-to-speech output."""
+
+    def temperature(match: re.Match[str]) -> str:
+        unit = "Celsius" if match.group(2).casefold() == "c" else "Fahrenheit"
+        return f"{match.group(1)} degrees {unit}"
+
+    def timestamp(match: re.Match[str]) -> str:
+        return _spoken_local_time(match.group(0))
+
+    normalized = _TEMPERATURE_RE.sub(temperature, text)
+    normalized = _ISO_TIMESTAMP_RE.sub(timestamp, normalized)
+    normalized = normalized.replace("**", "").replace("__", "").replace("`", "")
+    return re.sub(r"[ \t]+", " ", normalized).strip()
+
+
+def _format_template_value(value: Any, formatter: str) -> str:
+    if value is None:
+        return ""
+    if formatter == "duration":
+        return _spoken_duration(value)
+    if formatter in {"local_time", "time"}:
+        return _spoken_local_time(value)
+    if formatter in {"spoken", "speech", "temperature"}:
+        return speech_text(str(value))
+    if isinstance(value, dict | list):
+        return json.dumps(value, ensure_ascii=True)
+    return str(value)
+
+
+def _spoken_duration(value: Any) -> str:
+    try:
+        total_seconds = max(0, int(value))
+    except (TypeError, ValueError):
+        return ""
+    minutes, seconds = divmod(total_seconds, 60)
+    hours, minutes = divmod(minutes, 60)
+    parts: list[str] = []
+    if hours:
+        parts.append(f"{hours} hour" if hours == 1 else f"{hours} hours")
+    if minutes:
+        parts.append(f"{minutes} minute" if minutes == 1 else f"{minutes} minutes")
+    if seconds or not parts:
+        parts.append(f"{seconds} second" if seconds == 1 else f"{seconds} seconds")
+    if len(parts) == 1:
+        return parts[0]
+    return f"{', '.join(parts[:-1])} and {parts[-1]}"
+
+
+def _spoken_local_time(value: Any) -> str:
+    try:
+        if isinstance(value, int | float) or str(value).isdigit():
+            number = int(value)
+            seconds = number / 1_000_000 if number > 10_000_000_000 else number
+            moment = datetime.fromtimestamp(seconds).astimezone()
+        else:
+            encoded = str(value).replace("Z", "+00:00")
+            moment = datetime.fromisoformat(encoded)
+            if moment.tzinfo is None:
+                moment = moment.astimezone()
+    except (OSError, OverflowError, TypeError, ValueError):
+        return str(value)
+    clock = moment.strftime("%I:%M %p").lstrip("0")
+    return clock.replace("AM", "A.M.").replace("PM", "P.M.")
 
 
 def context_for_prompt(context: dict[str, Any]) -> str:
@@ -433,17 +550,38 @@ def context_for_prompt(context: dict[str, Any]) -> str:
     return json.dumps(context, indent=2, sort_keys=True, ensure_ascii=True)
 
 
-def _parse_step(raw: Any) -> WorkflowStep:
+def _parse_step(
+    raw: Any,
+    *,
+    registry: dict[str, ContextField] | None = None,
+    registry_enabled: bool = False,
+) -> WorkflowStep:
     if not isinstance(raw, dict):
         raise ValueError(f"workflow step must be a mapping: {raw!r}")
     step_id = int(raw["id"])
+    local_fields = tuple(_parse_context_fields(raw.get("context_output") or {}))
+    if registry_enabled:
+        writes = raw.get("writes")
+        if writes is None:
+            write_names = tuple(item.name for item in local_fields)
+        elif isinstance(writes, dict):
+            write_names = tuple(str(name) for name in writes)
+        else:
+            write_names = _parse_field_names(writes, "writes")
+        context_fields = tuple(_registered_field(name, registry or {}, step_id) for name in write_names)
+        read_fields = _parse_field_names(raw.get("reads") or (), "reads")
+    else:
+        context_fields = local_fields
+        read_fields = ()
     return WorkflowStep(
         id=step_id,
         name=str(raw.get("name") or f"Step {step_id}"),
         description=str(raw.get("description") or ""),
         vlm_prompt=str(raw.get("vlm_prompt") or ""),
         agent_prompt=str(raw.get("agent_prompt") or ""),
-        context_fields=tuple(_parse_context_fields(raw.get("context_output") or {})),
+        context_fields=context_fields,
+        read_fields=read_fields,
+        partial_context=registry_enabled,
         advance_when=dict(raw.get("advance_when") or {}),
         skip_defaults=dict(raw.get("skip_defaults") or {}),
         agent_tools=_parse_agent_tools(raw.get("agent_tools") or {}),
@@ -492,10 +630,7 @@ def _parse_state_updates(raw: Any) -> tuple[StateUpdateSpec, ...]:
                 context_field=context_field,
                 states=tuple(str(state).casefold().strip() for state in raw_states),
                 observation_key=str(item.get("observation_key") or "").strip(),
-                value_map={
-                    _normalize_observation_value(key): value
-                    for key, value in value_map.items()
-                },
+                value_map={_normalize_observation_value(key): value for key, value in value_map.items()},
             )
         )
     return tuple(updates)
@@ -522,7 +657,7 @@ def _parse_timer(raw: Any) -> TimerSpec | None:
     )
 
 
-def _parse_context_fields(raw: Any) -> list[ContextField]:
+def _parse_context_fields(raw: Any, *, lazy: bool = False) -> list[ContextField]:
     if isinstance(raw, dict) and "fields" in raw:
         raw = raw["fields"]
     if not isinstance(raw, dict):
@@ -534,7 +669,11 @@ def _parse_context_fields(raw: Any) -> list[ContextField]:
         if not isinstance(spec, dict):
             spec = {"description": str(spec)}
         field_type = str(spec.get("type", "string"))
-        default = spec.get("default", _default_for_type(field_type))
+        initialize = not lazy or "initial" in spec
+        default = spec.get(
+            "initial",
+            spec.get("default", _default_for_type(field_type)),
+        )
         fields.append(
             ContextField(
                 name=str(name),
@@ -543,9 +682,45 @@ def _parse_context_fields(raw: Any) -> list[ContextField]:
                 description=str(spec.get("description") or ""),
                 default=default,
                 required=bool(spec.get("required", False)),
+                initialize=initialize,
             )
         )
     return fields
+
+
+def _extend_registry_from_step_writes(
+    fields: list[ContextField],
+    raw_steps: list[Any],
+) -> list[ContextField]:
+    """Allow a step to declare a new write field inline when convenient."""
+
+    by_name = {item.name: item for item in fields}
+    for raw_step in raw_steps:
+        if not isinstance(raw_step, dict) or not isinstance(raw_step.get("writes"), dict):
+            continue
+        for item in _parse_context_fields(raw_step["writes"], lazy=True):
+            by_name.setdefault(item.name, item)
+    return list(by_name.values())
+
+
+def _parse_field_names(raw: Any, key: str) -> tuple[str, ...]:
+    if not isinstance(raw, list | tuple):
+        raise ValueError(f"step {key} must be a list or mapping")
+    names = tuple(str(item).strip() for item in raw if str(item).strip())
+    if len(names) != len(set(names)):
+        raise ValueError(f"step {key} must not contain duplicate fields")
+    return names
+
+
+def _registered_field(
+    name: str,
+    registry: dict[str, ContextField],
+    step_id: int,
+) -> ContextField:
+    try:
+        return registry[name]
+    except KeyError as exc:
+        raise ValueError(f"step {step_id} references unknown context field {name}") from exc
 
 
 def _validate_definition(definition: WorkflowDefinition, path: Path) -> None:
@@ -561,7 +736,12 @@ def _validate_definition(definition: WorkflowDefinition, path: Path) -> None:
     if definition.max_reminders_per_step < 0:
         raise ValueError(f"runtime.max_reminders_per_step cannot be negative: {path}")
 
+    registered = set(definition.field_map())
     for step in definition.steps:
+        unknown_reads = set(step.read_fields) - registered
+        if unknown_reads:
+            names = ", ".join(sorted(unknown_reads))
+            raise ValueError(f"step {step.id} reads unknown fields {names}: {path}")
         if step.is_idle:
             continue
         if not step.description.strip():
@@ -573,56 +753,40 @@ def _validate_definition(definition: WorkflowDefinition, path: Path) -> None:
         if not step.advance_when:
             raise ValueError(f"step {step.id} must define advance_when: {path}")
 
-        fields = {field.name for field in step.context_fields}
-        unknown_defaults = set(step.skip_defaults) - fields
+        writable = step.writable_fields
+        available = writable | set(step.read_fields)
+        unknown_defaults = set(step.skip_defaults) - writable
         if unknown_defaults:
             names = ", ".join(sorted(unknown_defaults))
             raise ValueError(f"step {step.id} skip_defaults use unknown fields {names}: {path}")
-        unknown_update_fields = {
-            update.context_field for update in step.state_updates
-        } - fields
+        unknown_update_fields = {update.context_field for update in step.state_updates} - writable
         if unknown_update_fields:
             names = ", ".join(sorted(unknown_update_fields))
-            raise ValueError(
-                f"step {step.id} updates unknown context fields {names}: {path}"
-            )
+            raise ValueError(f"step {step.id} updates unknown context fields {names}: {path}")
         invalid_states = {
-            state
-            for update in step.state_updates
-            for state in update.states
-            if state not in _STEP_STATES
+            state for update in step.state_updates for state in update.states if state not in _STEP_STATES
         }
         if invalid_states:
             names = ", ".join(sorted(invalid_states))
-            raise ValueError(
-                f"step {step.id} state_updates use invalid states {names}: {path}"
-            )
+            raise ValueError(f"step {step.id} state_updates use invalid states {names}: {path}")
         if step.state_update_fields("complete") and not step.vlm_prompt.strip():
-            raise ValueError(
-                f"step {step.id} cannot update complete state without a "
-                f"vlm_prompt: {path}"
-            )
+            raise ValueError(f"step {step.id} cannot update complete state without a vlm_prompt: {path}")
         for tool_name, policy in step.agent_tools.items():
             if not policy.get("auto_invoke"):
                 continue
             outputs = policy.get("context_outputs")
             if not isinstance(outputs, dict) or not outputs:
-                raise ValueError(
-                    f"step {step.id} automatic tool {tool_name} must define "
-                    f"context_outputs: {path}"
-                )
-            unknown_outputs = {str(name) for name in outputs.values()} - fields
+                raise ValueError(f"step {step.id} automatic tool {tool_name} must define context_outputs: {path}")
+            unknown_outputs = {str(name) for name in outputs.values()} - writable
             if unknown_outputs:
                 names = ", ".join(sorted(unknown_outputs))
                 raise ValueError(
-                    f"step {step.id} automatic tool {tool_name} uses unknown context "
-                    f"fields {names}: {path}"
+                    f"step {step.id} automatic tool {tool_name} uses unknown context fields {names}: {path}"
                 )
             empty_field = str(policy.get("when_context_empty") or "").strip()
-            if empty_field and empty_field not in fields:
+            if empty_field and empty_field not in available:
                 raise ValueError(
-                    f"step {step.id} automatic tool {tool_name} checks unknown context "
-                    f"field {empty_field}: {path}"
+                    f"step {step.id} automatic tool {tool_name} checks unknown context field {empty_field}: {path}"
                 )
         if step.timer is not None:
             timer_fields = {
@@ -630,10 +794,12 @@ def _validate_definition(definition: WorkflowDefinition, path: Path) -> None:
                 step.timer.duration_seconds_field,
                 step.timer.completion_field,
             }
-            unknown_timer_fields = timer_fields - fields
+            unknown_timer_fields = timer_fields - available
             if unknown_timer_fields:
                 names = ", ".join(sorted(unknown_timer_fields))
                 raise ValueError(f"step {step.id} timer uses unknown fields {names}: {path}")
+            if step.timer.completion_field not in writable:
+                raise ValueError(f"step {step.id} timer completion field must be writable: {path}")
 
 
 def _default_for_type(field_type: str) -> Any:
@@ -759,4 +925,5 @@ __all__ = [
     "WorkflowStep",
     "context_for_prompt",
     "render_template",
+    "speech_text",
 ]

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/workflow.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/workflow.py
@@ -75,6 +75,8 @@ class WorkflowStep:
     read_fields: tuple[str, ...] = ()
     partial_context: bool = False
     advance_when: dict[str, Any] = field(default_factory=dict)
+    vlm_stop_when: dict[str, Any] = field(default_factory=dict)
+    suppress_reminders_when: dict[str, Any] = field(default_factory=dict)
     skip_defaults: dict[str, Any] = field(default_factory=dict)
     agent_tools: tuple[str, ...] = ()
     on_enter_message: str = ""
@@ -298,6 +300,16 @@ class WorkflowDefinition:
         rule = step.advance_when or {}
         return _rule_met(rule, context) if rule else ready_to_advance
 
+    def condition_met(
+        self,
+        rule: dict[str, Any],
+        context: dict[str, Any],
+    ) -> bool:
+        """Evaluate an optional YAML condition against workflow context."""
+
+        return bool(rule) and _rule_met(rule, context)
+
+
 def _rule_met(rule: dict[str, Any], context: dict[str, Any]) -> bool:
     all_rules = rule.get("all")
     if isinstance(all_rules, list):
@@ -463,6 +475,8 @@ def _parse_step(
         read_fields=read_fields,
         partial_context=registry_enabled,
         advance_when=dict(raw.get("advance_when") or {}),
+        vlm_stop_when=dict(raw.get("vlm_stop_when") or {}),
+        suppress_reminders_when=dict(raw.get("suppress_reminders_when") or {}),
         skip_defaults=dict(raw.get("skip_defaults") or {}),
         agent_tools=_parse_agent_tools(raw.get("agent_tools") or []),
         on_enter_message=str(raw.get("on_enter_message") or ""),

--- a/agent-samples/tea-making-sample/yaml/96G_blackwell/embedding_server.yaml
+++ b/agent-samples/tea-making-sample/yaml/96G_blackwell/embedding_server.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Embedding shares the single Blackwell GPU after Omni and STT have started.
+model: nvidia/llama-nemotron-embed-1b-v2
+host: "0.0.0.0"
+port: 8109
+served_model_name: embed
+hf_token: ""
+model_cache: ../../../../models
+cuda_visible_devices: "0"
+max_num_seqs: 32
+tensor_parallel_size: 1
+max_model_len: 8192
+gpu_memory_utilization: 0.05
+enforce_eager: true
+vllm_backend: docker
+vllm_image: nvcr.io/nvidia/vllm:26.04-py3

--- a/agent-samples/tea-making-sample/yaml/96G_blackwell/nemotron_omni_llm_server.yaml
+++ b/agent-samples/tea-making-sample/yaml/96G_blackwell/nemotron_omni_llm_server.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Nemotron-Omni on one 96 GiB RTX Pro Blackwell GPU. The NVFP4 checkpoint is
+# selected automatically. Start this service before STT and embedding so vLLM
+# profiles its memory while the GPU is otherwise empty.
+
+model_blackwell: nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4
+model_ada: nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8
+model_bf16: nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16
+use_bf16: false
+
+host: "0.0.0.0"
+port: 8108
+hf_token: ""
+model_cache: ../../../../models
+cuda_visible_devices: "0"
+
+max_num_seqs: 8
+tensor_parallel_size: 1
+max_model_len: 32768
+# 0.80 x 96 GiB = 76.8 GiB, leaving about 19 GiB for STT, embedding,
+# CUDA context, and request-time multimodal allocations.
+gpu_memory_utilization: 0.80
+enforce_eager: false
+
+video_pruning_rate: 0.5
+video_fps: 2
+video_num_frames: 256
+
+# Let vLLM select an NVFP4-compatible MoE backend. Triton is not supported by
+# the NVFP4 checkpoint in vLLM 0.20.
+vllm_backend: docker
+vllm_image: vllm/vllm-openai:v0.20.0
+extra_pip: []

--- a/agent-samples/tea-making-sample/yaml/96G_blackwell/stt_server.yaml
+++ b/agent-samples/tea-making-sample/yaml/96G_blackwell/stt_server.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# STT shares the single Blackwell GPU with Omni and embedding.
+model: nvidia/parakeet-tdt-0.6b-v3
+device: auto
+cuda_visible_devices: "0"
+port: 8103
+host: "0.0.0.0"
+model_cache: ../../../../models

--- a/agent-samples/tea-making-sample/yaml/dual_48G_ada/embedding_server.yaml
+++ b/agent-samples/tea-making-sample/yaml/dual_48G_ada/embedding_server.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# GPU 1 hosts only the small embedding and STT services.
+model: nvidia/llama-nemotron-embed-1b-v2
+host: "0.0.0.0"
+port: 8109
+served_model_name: embed
+hf_token: ""
+model_cache: ../../../../models
+cuda_visible_devices: "1"
+max_num_seqs: 32
+tensor_parallel_size: 1
+max_model_len: 8192
+# 0.10 x 48 GiB = 4.8 GiB for the 1B pooling model.
+gpu_memory_utilization: 0.10
+enforce_eager: true
+vllm_backend: docker
+vllm_image: nvcr.io/nvidia/vllm:26.04-py3

--- a/agent-samples/tea-making-sample/yaml/dual_48G_ada/nemotron_omni_llm_server.yaml
+++ b/agent-samples/tea-making-sample/yaml/dual_48G_ada/nemotron_omni_llm_server.yaml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Nemotron-Omni uses GPU 0 exclusively on a dual 48 GiB L40/L40S system. The
+# FP8 checkpoint is about 33 GB and is selected automatically for SM89. Keeping
+# tensor parallelism at one avoids reserving most of both GPUs and leaves GPU 1
+# available for STT and embeddings.
+
+model_blackwell: nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4
+model_ada: nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8
+model_bf16: nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16
+use_bf16: false
+
+host: "0.0.0.0"
+port: 8108
+hf_token: ""
+model_cache: ../../../../models
+cuda_visible_devices: "0"
+
+max_num_seqs: 8
+tensor_parallel_size: 1
+max_model_len: 32768
+gpu_memory_utilization: 0.85
+enforce_eager: false
+
+video_pruning_rate: 0.5
+video_fps: 2
+video_num_frames: 256
+
+vllm_backend: docker
+vllm_image: vllm/vllm-openai:v0.20.0
+extra_pip: []

--- a/agent-samples/tea-making-sample/yaml/dual_48G_ada/stt_server.yaml
+++ b/agent-samples/tea-making-sample/yaml/dual_48G_ada/stt_server.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Keep STT on GPU 1 so GPU 0 remains dedicated to FP8 Nemotron-Omni.
+model: nvidia/parakeet-tdt-0.6b-v3
+device: auto
+cuda_visible_devices: "1"
+port: 8103
+host: "0.0.0.0"
+model_cache: ../../../../models

--- a/agent-samples/tea-making-sample/yaml/models.yaml
+++ b/agent-samples/tea-making-sample/yaml/models.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Model roles for the tea-making guided workflow sample.
+
+agent_llm:
+  kind: preset:nemotron_omni
+  base_url: http://localhost:8108
+  default_extras:
+    chat_template_kwargs:
+      enable_thinking: false
+
+vlm:
+  category: vlm
+  kind: openai_compat
+  model_name: llm
+  base_url: http://localhost:8108
+  capabilities:
+    streaming: true
+    vision: true
+  default_extras:
+    chat_template_kwargs:
+      enable_thinking: false
+
+embedding:
+  kind: preset:nemotron_embedding
+  base_url: http://localhost:8109
+
+stt:
+  kind: preset:parakeet_stt
+  base_url: http://localhost:8103
+
+tts:
+  kind: preset:piper_tts
+  base_url: http://localhost:8105

--- a/agent-samples/tea-making-sample/yaml/piper_tts_server.yaml
+++ b/agent-samples/tea-making-sample/yaml/piper_tts_server.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+voice: en_US-lessac-medium
+port: 8105
+use_cuda: false
+model_cache: ../../../models

--- a/agent-samples/tea-making-sample/yaml/rag_service.yaml
+++ b/agent-samples/tea-making-sample/yaml/rag_service.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+endpoint: tcp://0.0.0.0:8340
+documents_dir: ../rag-documents
+models_config: models.yaml
+embedding_role: embedding
+cache_dir: ../../../models/tea-making-rag-cache
+chunk_size: 700
+overlap: 100
+embedding_dim: 768
+batch_size: 16
+min_score: 0.3

--- a/agent-samples/tea-making-sample/yaml/tea_making_worker.yaml
+++ b/agent-samples/tea-making-sample/yaml/tea_making_worker.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Tea-making guided workflow worker configuration.
+# Paths resolve relative to this file's directory.
+
+models_yaml: models.yaml
+voice_gate_yaml: voice_gate.yaml
+workflow_yaml: workflow.yaml
+rag_endpoint: tcp://127.0.0.1:8340
+answer_prompt: ../worker/tea_making_worker/prompts/system.txt
+
+frame_max_age_s: 5.0
+frame_timeout_s: 5.0
+vlm_timeout_s: 15.0
+
+silence_duration: 0.8
+min_speech: 0.15
+silero_threshold: 0.3
+idle_timeout_secs: 0

--- a/agent-samples/tea-making-sample/yaml/voice_gate.yaml
+++ b/agent-samples/tea-making-sample/yaml/voice_gate.yaml
@@ -1,8 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Always-on for a hands-busy guided workflow. Add magic phrases here if the
-# sample should require a wake phrase.
-magic_phrases: []
+# Strict-prefix wake phrases. The matched phrase is removed before the workflow
+# receives the command, so "Agent, help me make tea" becomes
+# "help me make tea".
+magic_phrases:
+  - "agent"
+  - "hey agent"
 listening_chime: false
-followup_grace_s: 60.0
+
+# Require a wake phrase on every utterance; do not accept an ungated follow-up.
+followup_grace_s: 0.0
+
+# Spoken automatically by the shared voice gate when a participant connects.
+welcome_message: >-
+  Welcome to the tea-making guide. To begin, say, "Agent, help me make tea."
+  Start every command with "Agent."

--- a/agent-samples/tea-making-sample/yaml/voice_gate.yaml
+++ b/agent-samples/tea-making-sample/yaml/voice_gate.yaml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Always-on for a hands-busy guided workflow. Add magic phrases here if the
+# sample should require a wake phrase.
+magic_phrases: []
+listening_chime: false
+followup_grace_s: 60.0

--- a/agent-samples/tea-making-sample/yaml/workflow.yaml
+++ b/agent-samples/tea-making-sample/yaml/workflow.yaml
@@ -132,7 +132,8 @@ steps:
     description: Wait for the wearer to ask for guided tea making.
     reads: []
     writes: []
-    on_enter_message: "Say 'help me make tea' when you want to start."
+    on_enter_message: >-
+      Say "Agent, help me make tea" when you want to start a fresh session.
 
   - id: 1
     name: Identify tea information
@@ -158,6 +159,7 @@ steps:
       If no useful label or instructions are visible now, state what is missing.
       Do not guess the tea type from a cup, kettle, or background.
     agent_prompt: |
+      Work only on identifying the tea and its brewing values for this step.
       Extract visible package details first. When the tea type is specific enough,
       call rag_lookup with the tea type plus "water temperature and steep time".
       Prefer package instructions over RAG and record the source briefly.
@@ -167,8 +169,9 @@ steps:
       package value when needed. Set steep_duration_seconds to one timer target;
       for a range, use its lower bound so the wearer can taste before over-steeping.
       Set context_ready only when the tea name, spoken guidance, numeric target,
-      and timer duration are known. Otherwise request a clearer label once the
-      worker's reminder interval is reached.
+      and timer duration are known. Do not describe later physical actions and do
+      not put label-reading status or brewing guidance in assistant_message; the
+      worker owns all ordinary speech.
     agent_tools: [rag_lookup]
     advance_when:
       all:
@@ -201,117 +204,124 @@ steps:
       I still need the tea label or tea bag tag. Hold it in view, or say next if
       you want me to use generic tea defaults.
     on_complete_message: >-
-      I have the details for {{tea_name}}. Use {{tea_temperature | spoken}} and
-      steep it for {{steep_duration_seconds | duration}}. Next, fill the kettle
-      or pot with water.
+      I have the brewing details for {{tea_name}}.
 
   - id: 2
-    name: Fill water and start heating
-    description: Guide the wearer through adding water and starting the heater.
-    reads:
-      - tea_name
-      - tea_temperature
-      - target_temperature_c
+    name: Fill water
+    description: Guide the wearer through adding water to the heating vessel.
+    reads: []
     writes:
       - water_filled
-      - heating_apparatus
-      - water_heating_started
     vlm_prompt: |
-      Monitor the current water-heating setup. Caption only visible evidence:
-      - kettle, pot, cup, faucet, or water container
+      Inspect only whether the heating vessel contains water. Caption current
+      visible evidence:
+      - kettle, pot, or other heating vessel
       - whether water is being added or is visibly present
-      - whether a kettle, stove, hot plate, or electric base appears to be on
-      - unsafe, overfilled, empty, or unstable conditions
+      - unsafe overfilling, an empty vessel, or an unstable vessel
 
       End with:
       WATER_FILLED: yes/no/unclear
-      HEATING_STARTED: yes/no/unclear
     agent_prompt: |
-      Treat water_filled and water_heating_started as action milestones. Set them
-      true only from clear current evidence, and do not erase a completed milestone
-      merely because the vessel later moves out of view. Update heating_apparatus
-      when a more specific current observation is available. If the setup is
-      visibly unsafe, request one brief correction and keep the step incomplete.
-      Mark complete after both milestones are established.
+      Work only on whether water has been added. Do not discuss heating,
+      temperature, tea, or later actions. Set water_filled true only when the
+      latest caption clearly shows water being added or present. Keep the
+      milestone true after it is established. If the vessel is visibly unsafe,
+      return one brief safety correction and keep the step incomplete. Otherwise
+      leave assistant_message empty.
     agent_tools: []
     advance_when:
-      all:
-        - field: water_filled
-          equals: true
-        - field: water_heating_started
-          equals: true
+      field: water_filled
+      equals: true
     skip_defaults:
       water_filled: true
-      heating_apparatus: "assumed kettle or pot"
-      water_heating_started: true
-    on_enter_message: "Fill the kettle or pot with fresh water, then start heating it."
+    on_enter_message: "Fill the kettle or pot with fresh water."
     on_reminder_message: >-
-      I still need to see water in the heating vessel and the heater started.
-      Fill it and turn it on, or say next to continue with that assumed.
-    on_complete_message: >-
-      Water is heating. Wait until it reaches {{tea_temperature | spoken}}.
+      I still need to see water in the kettle or pot. Fill it, or say next to
+      continue with that assumed.
+    on_complete_message: "The heating vessel has water in it."
 
   - id: 3
-    name: Heat water to the target
-    description: Monitor the latest visible reading and boil cues until the water is ready.
+    name: Start heating and reach the target temperature
+    description: Start the heater and monitor current readings until the water reaches the tea target.
     reads:
       - tea_name
       - tea_temperature
       - target_temperature_c
+      - water_filled
     writes:
+      - heating_apparatus
+      - water_heating_started
       - water_temperature_current
       - water_boil_cue
       - water_ready
     vlm_prompt: |
-      Inspect the current water-heating apparatus and any temperature display.
-      Caption only current visible evidence:
+      Inspect only the current water-heating setup. Caption current visible evidence:
+      - kettle, pot, stove, hot plate, or electric base
+      - whether the heater appears to be on
       - exact numeric thermometer, kettle display, or appliance reading
       - steam, rolling boil, small bubbles, or automatic kettle shutoff
+      - immediate safety concerns
 
       Do not decide whether the water suits the tea. Include numbers and units
       exactly as visible. End with:
+      HEATING_STARTED: yes/no/unclear
       TEMPERATURE_READING: <exact current value with units, or not_visible>
       BOIL_CUE: yes/no/unclear
     agent_prompt: |
-      Compare the latest visible reading with target_temperature_c. Replace
-      water_temperature_current on every pass, including with "not visible";
-      it is a live observation, not historical memory. Treat water_boil_cue the
-      same way. Convert a visible Fahrenheit reading for comparison when needed.
+      Work only on starting heat and evaluating the newest temperature caption.
+      Set water_heating_started true only from clear current evidence and keep
+      that action milestone true once established. Update heating_apparatus when
+      the latest caption provides a more specific value.
 
-      Set water_ready true when the current reading reaches the target within a
-      practical brewing tolerance. A clear boil cue is enough only for a target
-      near boiling. For a lower target, a rolling boil means the water needs to
-      cool. Do not use an older reading after a newer one arrives. Once readiness
-      has completed the step, keep that milestone latched while live observation
-      fields may continue changing until the wearer proceeds.
+      Copy
+      TEMPERATURE_READING from the latest caption into
+      water_temperature_current on every pass, including "not visible". Copy
+      BOIL_CUE into water_boil_cue on every pass. Never use either value from
+      current context as evidence for this pass.
+
+      If the latest caption has an exact numeric reading, convert it to Celsius
+      for comparison. Set water_ready true only when that current reading is from
+      2 degrees below through 3 degrees above target_temperature_c. A BOIL_CUE of
+      yes without a numeric reading is enough only when target_temperature_c is
+      at least 98 degrees Celsius. Otherwise leave water_ready unchanged or false.
+      A reading such as 100 degrees Celsius is not ready for an 80-degree target.
+      Do not announce a reading or readiness in assistant_message; the worker
+      owns ordinary speech.
     agent_tools: []
     advance_when:
-      field: water_ready
-      equals: true
+      all:
+        - field: water_heating_started
+          equals: true
+        - field: water_ready
+          equals: true
     skip_defaults:
+      heating_apparatus: "assumed kettle or pot"
+      water_heating_started: true
       water_temperature_current: "assumed ready by wearer request"
       water_boil_cue: "unclear"
       water_ready: true
     on_enter_message: >-
-      Wait for the water. I will watch the current reading and boil cues for the
-      right temperature.
+      Start heating the water and keep the temperature display or kettle in view.
+      The target is {{tea_temperature | spoken}}.
     on_reminder_message: >-
-      I still need a clear boil cue or temperature reading. Keep the kettle or
-      thermometer in view, or say next if the water is ready.
+      I still need to see the heater started and a current temperature reading or
+      boil cue. Keep the setup in view, or say next if the water is ready.
     on_complete_message: >-
-      The water is ready at {{water_temperature_current | spoken}}. Put the tea
-      bag, infuser, or leaves into the water.
+      The water has reached the target temperature.
 
   - id: 4
-    name: Start steeping the tea
-    description: Detect the first moment the tea enters the hot water.
+    name: Steep the tea
+    description: Detect when steeping starts, record the time, and wait for the configured duration.
     reads:
       - tea_name
       - steep_time
       - steep_duration_seconds
+      - steeping_started_at_us
+      - steeping_started_at_iso
     writes:
       - steeping_started_at_us
       - steeping_started_at_iso
+      - steeping_complete
     vlm_prompt: |
       Monitor whether tea leaves, a tea bag, or an infuser enter the hot water.
       Caption only current visible evidence, including whether the tea is outside
@@ -319,57 +329,38 @@ steps:
 
       End with:
       STEEPING_STARTED: yes/no/unclear
-    agent_prompt: |
-      When the latest caption says the tea has entered the hot water and
-      no start timestamp exists, call get_current_time. Copy the tool's epoch_us
-      to steeping_started_at_us and iso to steeping_started_at_iso in the context
-      patch. Never overwrite an existing steeping start timestamp. If steeping
-      has not started, request that the tea be placed in the water only when the
-      worker asks for a delayed reminder.
-    agent_tools: [get_current_time]
-    advance_when:
+    vlm_stop_when:
       field: steeping_started_at_us
       gt: 0
-    skip_defaults:
-      steeping_started_at_us: "{{now_us}}"
-      steeping_started_at_iso: "{{now_iso}}"
-    on_enter_message: "Place the tea bag, infuser, or loose leaves into the hot water."
-    on_reminder_message: >-
-      I still need to see the tea enter the hot water. Put it in now, or say next
-      if steeping has already started.
-    on_complete_message: >-
-      Steeping started at {{steeping_started_at_us | local_time}}. Let {{tea_name}}
-      steep for {{steep_duration_seconds | duration}}.
-
-  - id: 5
-    name: Wait for steeping to finish
-    description: Track elapsed steeping time through an agent tool without VLM captions.
-    reads:
-      - tea_name
-      - steep_time
-      - steep_duration_seconds
-      - steeping_started_at_us
-      - steeping_started_at_iso
-    writes:
-      - steeping_complete
+    suppress_reminders_when:
+      field: steeping_started_at_us
+      gt: 0
     agent_prompt: |
-      On every iteration, call get_timer_status with steeping_started_at_us,
-      steep_duration_seconds, and the label "steeping". Set steeping_complete
-      true only when the tool returns expired true. Otherwise leave it unset and
-      keep the step started. Do not ask the wearer to show the tea or repeat a
-      completed action.
-    agent_tools: [get_timer_status]
+      This step has two focused phases.
+
+      Before steeping_started_at_us exists, use only the latest caption to detect
+      the first immersion. When it clearly says the tea entered the water, call
+      get_current_time and copy epoch_us and iso into the two start fields. Never
+      overwrite an existing start timestamp. Do not start from an unclear caption.
+
+      After steeping_started_at_us exists, call get_timer_status on every
+      iteration with that timestamp, steep_duration_seconds, and label
+      "steeping". Set steeping_complete true only when the fresh tool result says
+      expired true. Otherwise keep it incomplete. Never reuse an earlier timer
+      result. Leave assistant_message empty; the worker owns reminders and the
+      time-up notice.
+    agent_tools: [get_current_time, get_timer_status]
     advance_when:
       field: steeping_complete
       equals: true
     skip_defaults:
       steeping_complete: true
     on_enter_message: >-
-      The tea is steeping. I will tell you when
-      {{steep_duration_seconds | duration}} has elapsed.
+      Place the tea bag, infuser, or loose leaves into the hot water. I will start
+      the {{steep_duration_seconds | duration}} timer when steeping begins.
     on_reminder_message: >-
-      I cannot start the timer without a steeping start time and duration. Say
-      next to skip the timer, or restart guidance to capture them.
+      I still need to see the tea enter the hot water. Put it in now, or say next
+      to skip steeping guidance.
     on_complete_message: >-
       The steeping time is up. Remove the tea bag, infuser, or leaves now.
     on_skip_message: >-

--- a/agent-samples/tea-making-sample/yaml/workflow.yaml
+++ b/agent-samples/tea-making-sample/yaml/workflow.yaml
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# YAML-defined guided workflow. To adapt this sample to a different task,
-# change this file and the files under rag-documents before changing worker code.
+# YAML-defined guided workflow. To adapt this sample to another task, change
+# this file and rag-documents before changing worker code.
 
 task:
   name: tea-making
@@ -45,79 +45,132 @@ runtime:
   min_notice_interval_s: 8.0
   reminder_interval_s: 30.0
   max_reminders_per_step: 1
-  navigation_timeout_s: 4.0
+  navigation_timeout_s: 15.0
   max_agent_iterations: 6
   vlm_system_prompt: >-
     You are a literal visual observer for a smart-glasses workflow. Report only
-    what is visible in the camera frame and visible text you can read. Do not
-    infer hidden actions.
+    what is visible in the current camera frame and visible text you can read.
+    Do not infer hidden actions or reuse details from an earlier frame.
+
+# Context fields are declared once. A session carries populated values between
+# steps, while each step receives only its reads and may patch only its writes.
+# Fields are sparse unless an explicit `initial` value is configured.
+context:
+  fields:
+    tea_name:
+      label: Tea name
+      type: string
+      description: Visible or identified tea name or type.
+    tea_temperature:
+      label: Recommended water temperature
+      type: string
+      description: Natural spoken description of the recommended temperature and source.
+    target_temperature_c:
+      label: Target temperature in Celsius
+      type: number
+      description: Numeric Celsius target used to compare a live water reading.
+    steep_time:
+      label: Recommended steep time
+      type: string
+      description: Natural spoken description of the recommended steeping time and source.
+    steep_duration_seconds:
+      label: Steep timer duration
+      type: integer
+      description: Concrete positive timer target in seconds.
+    other_info:
+      label: Other tea information
+      type: string
+      description: Amount, warnings, caffeine, or useful package notes.
+    tea_guidance_source:
+      label: Tea guidance source
+      type: string
+      description: Brief package or RAG source used for the brewing values.
+    context_ready:
+      label: Tea information ready
+      type: boolean
+      description: True after enough tea information exists to continue.
+    water_filled:
+      label: Water filled
+      type: boolean
+      description: True after water has visibly been added to the heating vessel.
+    heating_apparatus:
+      label: Heating apparatus
+      type: string
+      description: Kettle, pot, stove, or other visible heating device.
+    water_heating_started:
+      label: Water heating started
+      type: boolean
+      description: True after visible evidence that heating has started.
+    water_temperature_current:
+      label: Current water temperature
+      type: string
+      description: Latest visible reading, or not visible; this value is mutable.
+    water_boil_cue:
+      label: Current boil cue
+      type: string
+      description: Latest yes, no, or unclear visual boil cue; this value is mutable.
+    water_ready:
+      label: Water ready
+      type: boolean
+      description: Agent-derived milestone that the water suits the identified tea.
+    steeping_started_at_us:
+      label: Steeping start timestamp
+      type: integer
+      description: Epoch microsecond timestamp returned by get_current_time.
+    steeping_started_at_iso:
+      label: Steeping start local time
+      type: string
+      description: Local ISO timestamp retained for logs and tool reasoning.
+    steeping_complete:
+      label: Steeping complete
+      type: boolean
+      description: True when the steeping timer expires or the wearer skips it.
 
 steps:
   - id: 0
     name: Idle
     description: Wait for the wearer to ask for guided tea making.
-    context_output:
-      fields: {}
+    reads: []
+    writes: []
     on_enter_message: "Say 'help me make tea' when you want to start."
 
   - id: 1
     name: Identify tea information
     description: Identify the tea type and gather brewing guidance.
+    reads: []
+    writes:
+      - tea_name
+      - tea_temperature
+      - target_temperature_c
+      - steep_time
+      - steep_duration_seconds
+      - other_info
+      - tea_guidance_source
+      - context_ready
     vlm_prompt: |
-      Caption the tea information visible in the frame.
+      Caption the tea information visible in the current frame.
       Focus on:
-      - tea name or type from package, tag, tin, sachet, or loose-leaf label
+      - tea name or type from a package, tag, tin, sachet, or loose-leaf label
       - printed water temperature, steep time, amount, and serving instructions
       - whether the tea appears to be bagged or loose leaf
-      - any warnings, caffeine information, or "do not boil" style instructions
+      - warnings, caffeine information, or "do not boil" instructions
 
-      If no useful tea label or instructions are visible, say exactly what is
-      missing. Do not guess the tea type from the cup, kettle, or background.
+      If no useful label or instructions are visible now, state what is missing.
+      Do not guess the tea type from a cup, kettle, or background.
     agent_prompt: |
-      Extract visible tea details first. If the tea name or type is specific
-      enough, call rag_lookup with that tea type plus "temperature steep time".
-      Prefer package instructions over RAG when both are present.
+      Extract visible package details first. When the tea type is specific enough,
+      call rag_lookup with the tea type plus "water temperature and steep time".
+      Prefer package instructions over RAG and record the source briefly.
 
-      Set steep_duration_seconds to a concrete timer target. For a printed or
-      retrieved range, use its lower bound so the wearer can taste or remove the
-      tea before it over-steeps. Set context_ready true only when tea_name,
-      tea_temperature, steep_time, and steep_duration_seconds are all known.
-      If information is missing, set step_state to needs_input and ask the
-      wearer to show the label, tag, or package more clearly.
+      Keep tea_temperature and steep_time as natural spoken phrases. Also set
+      target_temperature_c to one numeric Celsius target. Convert a Fahrenheit
+      package value when needed. Set steep_duration_seconds to one timer target;
+      for a range, use its lower bound so the wearer can taste before over-steeping.
+      Set context_ready only when the tea name, spoken guidance, numeric target,
+      and timer duration are known. Otherwise request a clearer label once the
+      worker's reminder interval is reached.
     agent_tools:
       rag_lookup: {}
-    context_output:
-      fields:
-        tea_name:
-          label: Tea name
-          type: string
-          description: Visible or inferred tea name/type, preferring package text.
-        tea_temperature:
-          label: Tea temperature
-          type: string
-          description: Recommended water temperature with source.
-        steep_time:
-          label: Steep time
-          type: string
-          description: Recommended steeping time with source.
-        steep_duration_seconds:
-          label: Steep timer duration
-          type: integer
-          default: 0
-          description: Concrete positive timer target in seconds.
-        other_info:
-          label: Other info
-          type: string
-          description: Amount, warnings, caffeine, or package notes.
-        rag_retrieval:
-          label: RAG retrieval
-          type: string
-          description: Brief summary of RAG facts used for this tea.
-        context_ready:
-          label: Context ready
-          type: boolean
-          description: True when enough tea info exists for the next step.
-          default: false
     advance_when:
       all:
         - field: context_ready
@@ -126,21 +179,21 @@ steps:
           exists: true
         - field: tea_temperature
           exists: true
-        - field: steep_time
-          exists: true
+        - field: target_temperature_c
+          gt: 0
         - field: steep_duration_seconds
           gt: 0
     skip_defaults:
       tea_name: "generic tea"
       tea_temperature: >-
-        about 200 F / 93 C; use 175 F / 80 C if the wearer knows it is green
-        or white tea
+        about 93 degrees Celsius; use about 80 degrees Celsius if you know it is
+        green or white tea
+      target_temperature_c: 93
       steep_time: >-
-        3 to 5 minutes; use 2 to 3 minutes if the wearer knows it is green or
-        white tea
+        3 to 5 minutes; use 2 to 3 minutes if you know it is green or white tea
       steep_duration_seconds: 180
-      other_info: "Defaults applied because the wearer advanced before tea identification completed."
-      rag_retrieval: "Generic fallback tea guidance."
+      other_info: "Generic defaults were used because tea identification was skipped."
+      tea_guidance_source: "generic fallback guidance"
       context_ready: true
     on_enter_message: >-
       First, show me the tea label or tea bag tag so I can read the brewing
@@ -149,63 +202,39 @@ steps:
       I still need the tea label or tea bag tag. Hold it in view, or say next if
       you want me to use generic tea defaults.
     on_complete_message: >-
-      I have the tea details: {{tea_name}}, {{tea_temperature}}, steep for
-      {{steep_time}}. Fill the kettle or pot with water next.
+      I have the details for {{tea_name}}. Use {{tea_temperature | spoken}} and
+      steep it for {{steep_duration_seconds | duration}}. Next, fill the kettle
+      or pot with water.
 
   - id: 2
     name: Fill water and start heating
     description: Guide the wearer through adding water and starting the heater.
+    reads:
+      - tea_name
+      - tea_temperature
+      - target_temperature_c
+    writes:
+      - water_filled
+      - heating_apparatus
+      - water_heating_started
     vlm_prompt: |
-      Monitor what the wearer is doing for the water-heating step.
-      Caption only visible evidence:
+      Monitor the current water-heating setup. Caption only visible evidence:
       - kettle, pot, cup, faucet, or water container
-      - whether water is being added or already present
-      - whether the kettle, stove, hot plate, or electric base appears on
-      - whether the setup looks unsafe, overfilled, empty, or unstable
+      - whether water is being added or is visibly present
+      - whether a kettle, stove, hot plate, or electric base appears to be on
+      - unsafe, overfilled, empty, or unstable conditions
 
-      Include a concise verdict line:
+      End with:
       WATER_FILLED: yes/no/unclear
       HEATING_STARTED: yes/no/unclear
     agent_prompt: |
-      Preserve the tea information already in context. Update water_filled when
-      the VLM sees water being added or water present in the kettle/pot. Update
-      heating_apparatus with the visible device. Set water_heating_started true
-      only when there is visible evidence that heat has started.
-
-      If the setup appears unsafe, speak a brief correction and do not mark the
-      step complete. Mark ready once heating has clearly started.
+      Treat water_filled and water_heating_started as action milestones. Set them
+      true only from clear current evidence, and do not erase a completed milestone
+      merely because the vessel later moves out of view. Update heating_apparatus
+      when a more specific current observation is available. If the setup is
+      visibly unsafe, request one brief correction and keep the step incomplete.
+      Mark complete after both milestones are established.
     agent_tools: []
-    context_output:
-      fields:
-        tea_name:
-          label: Tea name
-          type: string
-        tea_temperature:
-          label: Tea temperature
-          type: string
-        steep_time:
-          label: Steep time
-          type: string
-        other_info:
-          label: Other info
-          type: string
-        rag_retrieval:
-          label: RAG retrieval
-          type: string
-        water_filled:
-          label: Water filled
-          type: boolean
-          default: false
-          description: True when water is visibly in the heating vessel.
-        heating_apparatus:
-          label: Heating apparatus
-          type: string
-          description: Kettle, pot, stove, microwave-safe cup, or other device.
-        water_heating_started:
-          label: Water heating started
-          type: boolean
-          default: false
-          description: True when the water-heating device is visibly on or heating.
     advance_when:
       all:
         - field: water_filled
@@ -220,36 +249,42 @@ steps:
     on_reminder_message: >-
       I still need to see water in the heating vessel and the heater started.
       Fill it and turn it on, or say next to continue with that assumed.
-    on_complete_message: "Water is heating. Now wait until it reaches {{tea_temperature}}."
+    on_complete_message: >-
+      Water is heating. Wait until it reaches {{tea_temperature | spoken}}.
 
   - id: 3
-    name: Wait for water to boil
-    description: Monitor the heating vessel and any visible temperature reading.
+    name: Heat water to the target
+    description: Monitor the latest visible reading and boil cues until the water is ready.
+    reads:
+      - tea_name
+      - tea_temperature
+      - target_temperature_c
+    writes:
+      - water_temperature_current
+      - water_boil_cue
+      - water_ready
     vlm_prompt: |
-      Monitor the water-heating apparatus and any temperature reading.
-      Caption only visible evidence:
-      - numeric thermometer, kettle display, or appliance temperature setting
-      - steam, rolling boil, small bubbles, kettle shutoff, or other boil cues
-      - whether water appears ready for {{tea_name}} given target {{tea_temperature}}
+      Inspect the current water-heating apparatus and any temperature display.
+      Caption only current visible evidence:
+      - exact numeric thermometer, kettle display, or appliance reading
+      - steam, rolling boil, small bubbles, or automatic kettle shutoff
 
-      Include visible numbers with units exactly as seen. If no thermometer or
-      display is visible, say that the temperature reading is not visible.
-      End with both structured lines:
-      TEMPERATURE_READING: <exact visible value with units, or not_visible>
-      WATER_READY: yes/no/unclear
+      Do not decide whether the water suits the tea. Include numbers and units
+      exactly as visible. End with:
+      TEMPERATURE_READING: <exact current value with units, or not_visible>
+      BOIL_CUE: yes/no/unclear
     agent_prompt: |
-      Preserve tea information. Use the target tea_temperature to decide if the
-      water is ready. Prefer an actual visible temperature reading. For black,
-      herbal, or pu-erh style boiling-water teas, boiling or kettle shutoff is
-      enough. For green or white tea, do not treat a rolling boil as ready
-      unless the target says boiling; ask the wearer to let it cool.
+      Compare the latest visible reading with target_temperature_c. Replace
+      water_temperature_current on every pass, including with "not visible";
+      it is a live observation, not historical memory. Treat water_boil_cue the
+      same way. Convert a visible Fahrenheit reading for comparison when needed.
 
-      water_temperature_current is a live value, not historical memory. On every
-      pass, set it from the latest TEMPERATURE_READING line. Replace an older
-      value whenever the reading changes. If the latest reading is not_visible,
-      set it to "not visible" instead of carrying forward an older number. Boil
-      cues may set it to "boiling" only when they are visible in the latest
-      observation. Mark ready only when the water is ready for this tea.
+      Set water_ready true when the current reading reaches the target within a
+      practical brewing tolerance. A clear boil cue is enough only for a target
+      near boiling. For a lower target, a rolling boil means the water needs to
+      cool. Do not use an older reading after a newer one arrives. Once readiness
+      has completed the step, keep that milestone latched while live observation
+      fields may continue changing until the wearer proceeds.
     agent_tools: []
     state_updates:
       - context_field: water_temperature_current
@@ -257,73 +292,48 @@ steps:
         states: [started, needs_input, complete]
         value_map:
           not_visible: "not visible"
-      - context_field: water_ready
-        observation_key: WATER_READY
+      - context_field: water_boil_cue
+        observation_key: BOIL_CUE
         states: [started, needs_input, complete]
-        value_map:
-          "yes": true
-          "no": false
-          unclear: false
-    context_output:
-      fields:
-        tea_name:
-          label: Tea name
-          type: string
-        tea_temperature:
-          label: Tea temperature
-          type: string
-        steep_time:
-          label: Steep time
-          type: string
-        other_info:
-          label: Other info
-          type: string
-        rag_retrieval:
-          label: RAG retrieval
-          type: string
-        water_temperature_current:
-          label: Current water temperature
-          type: string
-          description: Latest visible reading or current boil evidence, never an older reading.
-        water_ready:
-          label: Water ready
-          type: boolean
-          default: false
-          description: True when the water is suitable for this tea.
     advance_when:
       field: water_ready
       equals: true
     skip_defaults:
       water_temperature_current: "assumed ready by wearer request"
+      water_boil_cue: "unclear"
       water_ready: true
-    on_enter_message: "Wait for the water. I will watch for the right temperature or boil cues."
+    on_enter_message: >-
+      Wait for the water. I will watch the current reading and boil cues for the
+      right temperature.
     on_reminder_message: >-
-      I am still waiting for visible boil cues or a temperature reading. Keep the
-      kettle or thermometer in view, or say next if the water is ready.
+      I still need a clear boil cue or temperature reading. Keep the kettle or
+      thermometer in view, or say next if the water is ready.
     on_complete_message: >-
-      The water is ready: {{water_temperature_current}}. Put the tea bag or
-      leaves into the water.
+      The water is ready at {{water_temperature_current | spoken}}. Put the tea
+      bag, infuser, or leaves into the water.
 
   - id: 4
-    name: Steeping the tea
-    description: Detect the moment tea first starts steeping.
+    name: Start steeping the tea
+    description: Detect the first moment the tea enters the hot water.
+    reads:
+      - tea_name
+      - steep_time
+      - steep_duration_seconds
+    writes:
+      - steeping_started_at_us
+      - steeping_started_at_iso
     vlm_prompt: |
-      Monitor whether tea leaves or a tea bag are being put into the hot water.
-      Caption only visible evidence:
-      - tea bag, infuser, loose leaves, or strainer
-      - whether it is outside the cup/pot, entering the water, or already immersed
-      - the first clear sign that steeping has started
+      Monitor whether tea leaves, a tea bag, or an infuser enter the hot water.
+      Caption only current visible evidence, including whether the tea is outside
+      the vessel, entering the water, or already immersed.
 
-      Include a concise verdict line:
+      End with:
       STEEPING_STARTED: yes/no/unclear
     agent_prompt: |
-      Preserve tea information. When the VLM indicates the tea bag, infuser, or
-      leaves first entered the hot water and steeping_started_at_us is empty,
-      call get_current_time before writing the timestamp. Set
-      steeping_started_at_us and steeping_started_at_iso from that tool result.
-
-      If tea is not yet in the water, ask the wearer to place it in the cup or
-      pot. Do not overwrite an existing steeping timestamp.
+      When the latest VLM verdict first says the tea has entered the hot water and
+      no start timestamp exists, capture the time. Never overwrite an existing
+      steeping start timestamp. If steeping has not started, request that the tea
+      be placed in the water only when the worker asks for a delayed reminder.
     agent_tools:
       get_current_time:
         vlm_verdict: STEEPING_STARTED
@@ -333,99 +343,50 @@ steps:
         context_outputs:
           epoch_us: steeping_started_at_us
           iso: steeping_started_at_iso
-    context_output:
-      fields:
-        tea_name:
-          label: Tea name
-          type: string
-        tea_temperature:
-          label: Tea temperature
-          type: string
-        steep_time:
-          label: Steep time
-          type: string
-        other_info:
-          label: Other info
-          type: string
-        rag_retrieval:
-          label: RAG retrieval
-          type: string
-        steeping_started_at_us:
-          label: Timestamp of when tea was first steeped
-          type: integer
-          default: 0
-          description: Epoch microsecond timestamp from get_current_time.
-        steeping_started_at_iso:
-          label: Steeping started local time
-          type: string
-          description: Local ISO timestamp from get_current_time.
     advance_when:
       field: steeping_started_at_us
       gt: 0
     skip_defaults:
       steeping_started_at_us: "{{now_us}}"
       steeping_started_at_iso: "{{now_iso}}"
-    on_enter_message: >-
-      Place the tea bag, infuser, or loose leaves into the hot water.
+    on_enter_message: "Place the tea bag, infuser, or loose leaves into the hot water."
     on_reminder_message: >-
-      I still need to see the tea bag, infuser, or leaves enter the hot water.
-      Put them in now, or say next if steeping has already started.
+      I still need to see the tea enter the hot water. Put it in now, or say next
+      if steeping has already started.
     on_complete_message: >-
-      Steeping started at {{steeping_started_at_iso}}. Let {{tea_name}} steep
-      for {{steep_time}}.
+      Steeping started at {{steeping_started_at_us | local_time}}. Let {{tea_name}}
+      steep for {{steep_duration_seconds | duration}}.
 
   - id: 5
     name: Wait for steeping to finish
-    description: Track elapsed steeping time without running the VLM.
+    description: Track elapsed steeping time without periodic VLM captions.
+    reads:
+      - tea_name
+      - steep_time
+      - steep_duration_seconds
+      - steeping_started_at_us
+      - steeping_started_at_iso
+    writes:
+      - steeping_complete
     agent_prompt: |
-      The visual work is complete. Use the timer fields in context when answering
-      questions. Report elapsed and remaining time directly, and never ask the
-      wearer to show the tea or repeat a completed action.
+      Use the authoritative timer state when answering questions. Report elapsed
+      and remaining time in natural spoken language. Do not ask the wearer to show
+      the tea or repeat a completed action. A fresh visual question can still use
+      the general live-view inspection tool even though periodic captions are off.
     agent_tools: []
     timer:
       label: steeping
       started_at_us_field: steeping_started_at_us
       duration_seconds_field: steep_duration_seconds
       completion_field: steeping_complete
-    context_output:
-      fields:
-        tea_name:
-          label: Tea name
-          type: string
-        tea_temperature:
-          label: Tea temperature
-          type: string
-        steep_time:
-          label: Steep time
-          type: string
-        steep_duration_seconds:
-          label: Steep timer duration
-          type: integer
-          default: 0
-        other_info:
-          label: Other info
-          type: string
-        rag_retrieval:
-          label: RAG retrieval
-          type: string
-        steeping_started_at_us:
-          label: Timestamp of when tea was first steeped
-          type: integer
-          default: 0
-        steeping_started_at_iso:
-          label: Steeping started local time
-          type: string
-        steeping_complete:
-          label: Steeping complete
-          type: boolean
-          default: false
     advance_when:
       field: steeping_complete
       equals: true
     skip_defaults:
       steeping_complete: true
     on_enter_message: >-
-      The tea is steeping. I will tell you when {{steep_time}} has elapsed.
+      The tea is steeping. I will tell you when
+      {{steep_duration_seconds | duration}} has elapsed.
     on_reminder_message: >-
       I cannot start the timer without a steeping start time and duration. Say
       next to skip the timer, or restart guidance to capture them.

--- a/agent-samples/tea-making-sample/yaml/workflow.yaml
+++ b/agent-samples/tea-making-sample/yaml/workflow.yaml
@@ -169,8 +169,7 @@ steps:
       Set context_ready only when the tea name, spoken guidance, numeric target,
       and timer duration are known. Otherwise request a clearer label once the
       worker's reminder interval is reached.
-    agent_tools:
-      rag_lookup: {}
+    agent_tools: [rag_lookup]
     advance_when:
       all:
         - field: context_ready
@@ -286,15 +285,6 @@ steps:
       has completed the step, keep that milestone latched while live observation
       fields may continue changing until the wearer proceeds.
     agent_tools: []
-    state_updates:
-      - context_field: water_temperature_current
-        observation_key: TEMPERATURE_READING
-        states: [started, needs_input, complete]
-        value_map:
-          not_visible: "not visible"
-      - context_field: water_boil_cue
-        observation_key: BOIL_CUE
-        states: [started, needs_input, complete]
     advance_when:
       field: water_ready
       equals: true
@@ -330,19 +320,13 @@ steps:
       End with:
       STEEPING_STARTED: yes/no/unclear
     agent_prompt: |
-      When the latest VLM verdict first says the tea has entered the hot water and
-      no start timestamp exists, capture the time. Never overwrite an existing
-      steeping start timestamp. If steeping has not started, request that the tea
-      be placed in the water only when the worker asks for a delayed reminder.
-    agent_tools:
-      get_current_time:
-        vlm_verdict: STEEPING_STARTED
-        equals: "yes"
-        auto_invoke: true
-        when_context_empty: steeping_started_at_us
-        context_outputs:
-          epoch_us: steeping_started_at_us
-          iso: steeping_started_at_iso
+      When the latest caption says the tea has entered the hot water and
+      no start timestamp exists, call get_current_time. Copy the tool's epoch_us
+      to steeping_started_at_us and iso to steeping_started_at_iso in the context
+      patch. Never overwrite an existing steeping start timestamp. If steeping
+      has not started, request that the tea be placed in the water only when the
+      worker asks for a delayed reminder.
+    agent_tools: [get_current_time]
     advance_when:
       field: steeping_started_at_us
       gt: 0
@@ -359,7 +343,7 @@ steps:
 
   - id: 5
     name: Wait for steeping to finish
-    description: Track elapsed steeping time without periodic VLM captions.
+    description: Track elapsed steeping time through an agent tool without VLM captions.
     reads:
       - tea_name
       - steep_time
@@ -369,16 +353,12 @@ steps:
     writes:
       - steeping_complete
     agent_prompt: |
-      Use the authoritative timer state when answering questions. Report elapsed
-      and remaining time in natural spoken language. Do not ask the wearer to show
-      the tea or repeat a completed action. A fresh visual question can still use
-      the general live-view inspection tool even though periodic captions are off.
-    agent_tools: []
-    timer:
-      label: steeping
-      started_at_us_field: steeping_started_at_us
-      duration_seconds_field: steep_duration_seconds
-      completion_field: steeping_complete
+      On every iteration, call get_timer_status with steeping_started_at_us,
+      steep_duration_seconds, and the label "steeping". Set steeping_complete
+      true only when the tool returns expired true. Otherwise leave it unset and
+      keep the step started. Do not ask the wearer to show the tea or repeat a
+      completed action.
+    agent_tools: [get_timer_status]
     advance_when:
       field: steeping_complete
       equals: true

--- a/agent-samples/tea-making-sample/yaml/workflow.yaml
+++ b/agent-samples/tea-making-sample/yaml/workflow.yaml
@@ -1,0 +1,435 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# YAML-defined guided workflow. To adapt this sample to a different task,
+# change this file and the files under rag-documents before changing worker code.
+
+task:
+  name: tea-making
+  assistant_name: Tea guide
+  start_triggers:
+    - "make tea"
+    - "making tea"
+    - "start tea"
+    - "start making tea"
+    - "guide me through tea"
+    - "walk me through tea"
+    - "help me make tea"
+  stop_triggers:
+    - "stop guidance"
+    - "stop guide"
+    - "cancel guidance"
+    - "cancel tea"
+  navigation_examples:
+    advance:
+      - "next"
+      - "next step"
+      - "continue"
+      - "go on"
+      - "move on"
+      - "keep going"
+      - "let's proceed further"
+      - "I'm ready"
+      - "skip this step"
+    question:
+      - "what is the next step?"
+      - "can I proceed?"
+      - "what should I do now?"
+  status_triggers:
+    - "status"
+    - "where are we"
+    - "what step"
+
+runtime:
+  monitor_interval_s: 2.0
+  min_notice_interval_s: 8.0
+  reminder_interval_s: 30.0
+  max_reminders_per_step: 1
+  navigation_timeout_s: 4.0
+  max_agent_iterations: 6
+  vlm_system_prompt: >-
+    You are a literal visual observer for a smart-glasses workflow. Report only
+    what is visible in the camera frame and visible text you can read. Do not
+    infer hidden actions.
+
+steps:
+  - id: 0
+    name: Idle
+    description: Wait for the wearer to ask for guided tea making.
+    context_output:
+      fields: {}
+    on_enter_message: "Say 'help me make tea' when you want to start."
+
+  - id: 1
+    name: Identify tea information
+    description: Identify the tea type and gather brewing guidance.
+    vlm_prompt: |
+      Caption the tea information visible in the frame.
+      Focus on:
+      - tea name or type from package, tag, tin, sachet, or loose-leaf label
+      - printed water temperature, steep time, amount, and serving instructions
+      - whether the tea appears to be bagged or loose leaf
+      - any warnings, caffeine information, or "do not boil" style instructions
+
+      If no useful tea label or instructions are visible, say exactly what is
+      missing. Do not guess the tea type from the cup, kettle, or background.
+    agent_prompt: |
+      Extract visible tea details first. If the tea name or type is specific
+      enough, call rag_lookup with that tea type plus "temperature steep time".
+      Prefer package instructions over RAG when both are present.
+
+      Set steep_duration_seconds to a concrete timer target. For a printed or
+      retrieved range, use its lower bound so the wearer can taste or remove the
+      tea before it over-steeps. Set context_ready true only when tea_name,
+      tea_temperature, steep_time, and steep_duration_seconds are all known.
+      If information is missing, set step_state to needs_input and ask the
+      wearer to show the label, tag, or package more clearly.
+    agent_tools:
+      rag_lookup: {}
+    context_output:
+      fields:
+        tea_name:
+          label: Tea name
+          type: string
+          description: Visible or inferred tea name/type, preferring package text.
+        tea_temperature:
+          label: Tea temperature
+          type: string
+          description: Recommended water temperature with source.
+        steep_time:
+          label: Steep time
+          type: string
+          description: Recommended steeping time with source.
+        steep_duration_seconds:
+          label: Steep timer duration
+          type: integer
+          default: 0
+          description: Concrete positive timer target in seconds.
+        other_info:
+          label: Other info
+          type: string
+          description: Amount, warnings, caffeine, or package notes.
+        rag_retrieval:
+          label: RAG retrieval
+          type: string
+          description: Brief summary of RAG facts used for this tea.
+        context_ready:
+          label: Context ready
+          type: boolean
+          description: True when enough tea info exists for the next step.
+          default: false
+    advance_when:
+      all:
+        - field: context_ready
+          equals: true
+        - field: tea_name
+          exists: true
+        - field: tea_temperature
+          exists: true
+        - field: steep_time
+          exists: true
+        - field: steep_duration_seconds
+          gt: 0
+    skip_defaults:
+      tea_name: "generic tea"
+      tea_temperature: >-
+        about 200 F / 93 C; use 175 F / 80 C if the wearer knows it is green
+        or white tea
+      steep_time: >-
+        3 to 5 minutes; use 2 to 3 minutes if the wearer knows it is green or
+        white tea
+      steep_duration_seconds: 180
+      other_info: "Defaults applied because the wearer advanced before tea identification completed."
+      rag_retrieval: "Generic fallback tea guidance."
+      context_ready: true
+    on_enter_message: >-
+      First, show me the tea label or tea bag tag so I can read the brewing
+      instructions.
+    on_reminder_message: >-
+      I still need the tea label or tea bag tag. Hold it in view, or say next if
+      you want me to use generic tea defaults.
+    on_complete_message: >-
+      I have the tea details: {{tea_name}}, {{tea_temperature}}, steep for
+      {{steep_time}}. Fill the kettle or pot with water next.
+
+  - id: 2
+    name: Fill water and start heating
+    description: Guide the wearer through adding water and starting the heater.
+    vlm_prompt: |
+      Monitor what the wearer is doing for the water-heating step.
+      Caption only visible evidence:
+      - kettle, pot, cup, faucet, or water container
+      - whether water is being added or already present
+      - whether the kettle, stove, hot plate, or electric base appears on
+      - whether the setup looks unsafe, overfilled, empty, or unstable
+
+      Include a concise verdict line:
+      WATER_FILLED: yes/no/unclear
+      HEATING_STARTED: yes/no/unclear
+    agent_prompt: |
+      Preserve the tea information already in context. Update water_filled when
+      the VLM sees water being added or water present in the kettle/pot. Update
+      heating_apparatus with the visible device. Set water_heating_started true
+      only when there is visible evidence that heat has started.
+
+      If the setup appears unsafe, speak a brief correction and do not mark the
+      step complete. Mark ready once heating has clearly started.
+    agent_tools: []
+    context_output:
+      fields:
+        tea_name:
+          label: Tea name
+          type: string
+        tea_temperature:
+          label: Tea temperature
+          type: string
+        steep_time:
+          label: Steep time
+          type: string
+        other_info:
+          label: Other info
+          type: string
+        rag_retrieval:
+          label: RAG retrieval
+          type: string
+        water_filled:
+          label: Water filled
+          type: boolean
+          default: false
+          description: True when water is visibly in the heating vessel.
+        heating_apparatus:
+          label: Heating apparatus
+          type: string
+          description: Kettle, pot, stove, microwave-safe cup, or other device.
+        water_heating_started:
+          label: Water heating started
+          type: boolean
+          default: false
+          description: True when the water-heating device is visibly on or heating.
+    advance_when:
+      all:
+        - field: water_filled
+          equals: true
+        - field: water_heating_started
+          equals: true
+    skip_defaults:
+      water_filled: true
+      heating_apparatus: "assumed kettle or pot"
+      water_heating_started: true
+    on_enter_message: "Fill the kettle or pot with fresh water, then start heating it."
+    on_reminder_message: >-
+      I still need to see water in the heating vessel and the heater started.
+      Fill it and turn it on, or say next to continue with that assumed.
+    on_complete_message: "Water is heating. Now wait until it reaches {{tea_temperature}}."
+
+  - id: 3
+    name: Wait for water to boil
+    description: Monitor the heating vessel and any visible temperature reading.
+    vlm_prompt: |
+      Monitor the water-heating apparatus and any temperature reading.
+      Caption only visible evidence:
+      - numeric thermometer, kettle display, or appliance temperature setting
+      - steam, rolling boil, small bubbles, kettle shutoff, or other boil cues
+      - whether water appears ready for {{tea_name}} given target {{tea_temperature}}
+
+      Include visible numbers with units exactly as seen. If no thermometer or
+      display is visible, say that the temperature reading is not visible.
+      End with both structured lines:
+      TEMPERATURE_READING: <exact visible value with units, or not_visible>
+      WATER_READY: yes/no/unclear
+    agent_prompt: |
+      Preserve tea information. Use the target tea_temperature to decide if the
+      water is ready. Prefer an actual visible temperature reading. For black,
+      herbal, or pu-erh style boiling-water teas, boiling or kettle shutoff is
+      enough. For green or white tea, do not treat a rolling boil as ready
+      unless the target says boiling; ask the wearer to let it cool.
+
+      water_temperature_current is a live value, not historical memory. On every
+      pass, set it from the latest TEMPERATURE_READING line. Replace an older
+      value whenever the reading changes. If the latest reading is not_visible,
+      set it to "not visible" instead of carrying forward an older number. Boil
+      cues may set it to "boiling" only when they are visible in the latest
+      observation. Mark ready only when the water is ready for this tea.
+    agent_tools: []
+    state_updates:
+      - context_field: water_temperature_current
+        observation_key: TEMPERATURE_READING
+        states: [started, needs_input, complete]
+        value_map:
+          not_visible: "not visible"
+      - context_field: water_ready
+        observation_key: WATER_READY
+        states: [started, needs_input, complete]
+        value_map:
+          "yes": true
+          "no": false
+          unclear: false
+    context_output:
+      fields:
+        tea_name:
+          label: Tea name
+          type: string
+        tea_temperature:
+          label: Tea temperature
+          type: string
+        steep_time:
+          label: Steep time
+          type: string
+        other_info:
+          label: Other info
+          type: string
+        rag_retrieval:
+          label: RAG retrieval
+          type: string
+        water_temperature_current:
+          label: Current water temperature
+          type: string
+          description: Latest visible reading or current boil evidence, never an older reading.
+        water_ready:
+          label: Water ready
+          type: boolean
+          default: false
+          description: True when the water is suitable for this tea.
+    advance_when:
+      field: water_ready
+      equals: true
+    skip_defaults:
+      water_temperature_current: "assumed ready by wearer request"
+      water_ready: true
+    on_enter_message: "Wait for the water. I will watch for the right temperature or boil cues."
+    on_reminder_message: >-
+      I am still waiting for visible boil cues or a temperature reading. Keep the
+      kettle or thermometer in view, or say next if the water is ready.
+    on_complete_message: >-
+      The water is ready: {{water_temperature_current}}. Put the tea bag or
+      leaves into the water.
+
+  - id: 4
+    name: Steeping the tea
+    description: Detect the moment tea first starts steeping.
+    vlm_prompt: |
+      Monitor whether tea leaves or a tea bag are being put into the hot water.
+      Caption only visible evidence:
+      - tea bag, infuser, loose leaves, or strainer
+      - whether it is outside the cup/pot, entering the water, or already immersed
+      - the first clear sign that steeping has started
+
+      Include a concise verdict line:
+      STEEPING_STARTED: yes/no/unclear
+    agent_prompt: |
+      Preserve tea information. When the VLM indicates the tea bag, infuser, or
+      leaves first entered the hot water and steeping_started_at_us is empty,
+      call get_current_time before writing the timestamp. Set
+      steeping_started_at_us and steeping_started_at_iso from that tool result.
+
+      If tea is not yet in the water, ask the wearer to place it in the cup or
+      pot. Do not overwrite an existing steeping timestamp.
+    agent_tools:
+      get_current_time:
+        vlm_verdict: STEEPING_STARTED
+        equals: "yes"
+        auto_invoke: true
+        when_context_empty: steeping_started_at_us
+        context_outputs:
+          epoch_us: steeping_started_at_us
+          iso: steeping_started_at_iso
+    context_output:
+      fields:
+        tea_name:
+          label: Tea name
+          type: string
+        tea_temperature:
+          label: Tea temperature
+          type: string
+        steep_time:
+          label: Steep time
+          type: string
+        other_info:
+          label: Other info
+          type: string
+        rag_retrieval:
+          label: RAG retrieval
+          type: string
+        steeping_started_at_us:
+          label: Timestamp of when tea was first steeped
+          type: integer
+          default: 0
+          description: Epoch microsecond timestamp from get_current_time.
+        steeping_started_at_iso:
+          label: Steeping started local time
+          type: string
+          description: Local ISO timestamp from get_current_time.
+    advance_when:
+      field: steeping_started_at_us
+      gt: 0
+    skip_defaults:
+      steeping_started_at_us: "{{now_us}}"
+      steeping_started_at_iso: "{{now_iso}}"
+    on_enter_message: >-
+      Place the tea bag, infuser, or loose leaves into the hot water.
+    on_reminder_message: >-
+      I still need to see the tea bag, infuser, or leaves enter the hot water.
+      Put them in now, or say next if steeping has already started.
+    on_complete_message: >-
+      Steeping started at {{steeping_started_at_iso}}. Let {{tea_name}} steep
+      for {{steep_time}}.
+
+  - id: 5
+    name: Wait for steeping to finish
+    description: Track elapsed steeping time without running the VLM.
+    agent_prompt: |
+      The visual work is complete. Use the timer fields in context when answering
+      questions. Report elapsed and remaining time directly, and never ask the
+      wearer to show the tea or repeat a completed action.
+    agent_tools: []
+    timer:
+      label: steeping
+      started_at_us_field: steeping_started_at_us
+      duration_seconds_field: steep_duration_seconds
+      completion_field: steeping_complete
+    context_output:
+      fields:
+        tea_name:
+          label: Tea name
+          type: string
+        tea_temperature:
+          label: Tea temperature
+          type: string
+        steep_time:
+          label: Steep time
+          type: string
+        steep_duration_seconds:
+          label: Steep timer duration
+          type: integer
+          default: 0
+        other_info:
+          label: Other info
+          type: string
+        rag_retrieval:
+          label: RAG retrieval
+          type: string
+        steeping_started_at_us:
+          label: Timestamp of when tea was first steeped
+          type: integer
+          default: 0
+        steeping_started_at_iso:
+          label: Steeping started local time
+          type: string
+        steeping_complete:
+          label: Steeping complete
+          type: boolean
+          default: false
+    advance_when:
+      field: steeping_complete
+      equals: true
+    skip_defaults:
+      steeping_complete: true
+    on_enter_message: >-
+      The tea is steeping. I will tell you when {{steep_time}} has elapsed.
+    on_reminder_message: >-
+      I cannot start the timer without a steeping start time and duration. Say
+      next to skip the timer, or restart guidance to capture them.
+    on_complete_message: >-
+      The steeping time is up. Remove the tea bag, infuser, or leaves now.
+    on_skip_message: >-
+      Steeping timer skipped. Remove the tea when it reaches your preferred strength.

--- a/agent-samples/tea-making-sample/yaml/xr_media_hub.yaml
+++ b/agent-samples/tea-making-sample/yaml/xr_media_hub.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+api_key: devkey
+api_secret: devsecret-xr-livekit-prototype-2026
+room_name: xr-room
+
+lk_port_ws: 7880
+lk_port_tcp: 7881
+lk_port_udp: 7882
+
+enable_web_server: true
+web_server_port: 8080
+web_client_dir: ../../../client-samples/web
+
+enable_token_server: true

--- a/agent-sdk/xr-ai-nat/xr_ai_nat/functions/rag/_client.py
+++ b/agent-sdk/xr-ai-nat/xr_ai_nat/functions/rag/_client.py
@@ -47,6 +47,7 @@ class RAGHealthResult(BaseModel):
     ready: bool
     document_count: int
     chunk_count: int
+    corpus_id: str | None = None
 
 
 class RAGClient:

--- a/ai-services/llm/nemotron_omni/nemotron_omni_llm_server.yaml
+++ b/ai-services/llm/nemotron_omni/nemotron_omni_llm_server.yaml
@@ -40,14 +40,19 @@ video_pruning_rate: 0.5   # fraction of redundant video tokens to drop
 video_fps:          2     # FPS for video sampling
 video_num_frames:   256   # max frames per video clip
 
-# vLLM runtime — pip-installed vllm (default) or NGC docker container.
+# RTX Pro Blackwell currently requires the Triton MoE backend. Leave unset on
+# platforms where vLLM's automatic backend selection is supported.
+# moe_backend: triton
+
+# vLLM runtime — pip-installed vllm or a Docker container.
 #   pip     — vllm CLI from this wrapper's venv (today's behavior)
-#   docker  — `docker run nvcr.io/nvidia/vllm:<tag> vllm serve …`
+#   docker  — `docker run vllm/vllm-openai:<tag> vllm serve …`
 # Both honor the same config keys above; only the runtime hosting vllm differs.
 # docker mode requires Docker Engine + NVIDIA Container Toolkit and a
-# `docker login nvcr.io` (or NGC_API_KEY in the environment).
+# compatible NVIDIA driver.
 vllm_backend: docker
 
-# Container image used when vllm_backend: docker.  Override to pin a different
-# tag, an internal mirror, or a custom build.
-vllm_image: nvcr.io/nvidia/vllm:26.04-py3
+# Nemotron-3-Nano-Omni requires vLLM 0.20.0 or newer. The prior NGC 26.04
+# image contained vLLM 0.19.0 and rejected its architecture before loading.
+vllm_image: vllm/vllm-openai:v0.20.0
+extra_pip: []

--- a/ai-services/llm/nemotron_omni/nemotron_omni_llm_server/__main__.py
+++ b/ai-services/llm/nemotron_omni/nemotron_omni_llm_server/__main__.py
@@ -28,15 +28,14 @@ Config keys (nemotron_omni_llm_server.yaml)
     video_pruning_rate:       float  --video-pruning-rate (default: 0.5).
     video_fps:                int    FPS for video input sampling (default: 2).
     video_num_frames:         int    Max frames per video (default: 256).
+    moe_backend:              str    Optional vLLM MoE backend (for example,
+                                     "triton" on RTX Pro Blackwell).
     vllm_backend:             str    "pip" (default) or "docker".
-    vllm_image:               str    NGC image when vllm_backend=docker
-                                     (default: nvcr.io/nvidia/vllm:26.04-py3).
-    extra_pip:                list   Pip packages installed into the NGC
-                                     container before `vllm serve` runs
-                                     (docker backend only; default:
-                                     ["mamba-ssm", "causal-conv1d"] since
-                                     Nemotron-Omni's hybrid SSM backbone
-                                     requires both at model-load time).
+    vllm_image:               str    Image when vllm_backend=docker (default:
+                                     vllm/vllm-openai:v0.20.0, the minimum
+                                     version supporting this architecture).
+    extra_pip:                list   Optional packages installed before
+                                     `vllm serve` (docker backend only).
 """
 import json
 import os
@@ -44,7 +43,6 @@ import os
 from loguru import logger
 from xr_ai_logging import setup_logging
 from xr_ai_vllm import (
-    DEFAULT_IMAGE,
     gpu_compute_major,
     load_config,
     resolve_model_cache,
@@ -67,6 +65,7 @@ _DEFAULT_EAGER   = False
 _DEFAULT_PRUNE   = 0.5
 _DEFAULT_FPS     = 2
 _DEFAULT_FRAMES  = 256
+_DEFAULT_IMAGE   = "vllm/vllm-openai:v0.20.0"
 
 _CONTAINER_NAME = "xr-ai-vllm-nemotron-omni-llm-server"
 
@@ -108,14 +107,10 @@ def run() -> None:
     prune_rate    = float(cfg.get("video_pruning_rate", _DEFAULT_PRUNE))
     video_fps     = int(cfg.get("video_fps",        _DEFAULT_FPS))
     video_frames  = int(cfg.get("video_num_frames", _DEFAULT_FRAMES))
+    moe_backend   = cfg.get("moe_backend")
     backend       = cfg.get("vllm_backend",         "pip")
-    image         = cfg.get("vllm_image",           DEFAULT_IMAGE)
-    # Nemotron-Omni's hybrid SSM/Transformer backbone imports `mamba_ssm`
-    # at model-load time, and `causal_conv1d` is its required CUDA-kernel
-    # peer dep. Neither ships in the NGC vLLM image, so we install both
-    # into the container before `vllm serve` runs. Configurable via YAML
-    # for users who want to pin specific versions or add more wheels.
-    extra_pip     = cfg.get("extra_pip", ["mamba-ssm", "causal-conv1d"])
+    image         = cfg.get("vllm_image",           _DEFAULT_IMAGE)
+    extra_pip     = cfg.get("extra_pip", [])
 
     media_io_kwargs = json.dumps({"video": {"fps": video_fps, "num_frames": video_frames}})
 
@@ -135,6 +130,8 @@ def run() -> None:
     ]
     if use_kv_fp8:
         extra_serve_args += ["--kv-cache-dtype", "fp8"]
+    if moe_backend:
+        extra_serve_args += ["--moe-backend", str(moe_backend)]
     if enforce_eager:
         extra_serve_args.append("--enforce-eager")
 

--- a/ai-services/llm/nemotron_omni/pyproject.toml
+++ b/ai-services/llm/nemotron_omni/pyproject.toml
@@ -10,7 +10,7 @@ name = "nemotron-omni-llm-server"
 version = "0.1.0"
 requires-python = ">=3.11,<3.13"
 dependencies = [
-    "vllm>=0.12.0",
+    "vllm>=0.20.0",
     "pyyaml>=6.0",
     "hf-transfer>=0.1.4",
     "xr-ai-logging",

--- a/docs/ai-services.md
+++ b/docs/ai-services.md
@@ -321,7 +321,11 @@ port → PID → SIGTERM/SIGKILL path. Same UX for both.
   OpenAI-compatible HTTP contract as the other LLM servers — swap the port to
   swap backends. Hosting backend is selectable per YAML (see *Choosing the
   vLLM runtime*); runs foreground in both pip and docker modes (no
-  cross-restart persistence).
+  cross-restart persistence). This architecture requires vLLM 0.20.0 or newer;
+  the Docker configuration therefore uses `vllm/vllm-openai:v0.20.0` rather
+  than the repository-wide NGC default. The optional `moe_backend` YAML key is
+  forwarded as `--moe-backend`; use `triton` for the current RTX Pro Blackwell
+  compatibility path.
 - **stt-server** loads parakeet-tdt-0.6b-v3 via NeMo ASR in-process.
   English-only; `language` / `temperature` form fields are accepted but ignored.
 - **tts/magpie** loads magpie_tts_multilingual_357m via NeMo TTS in-process.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -39,6 +39,36 @@ the 8B held is freed. The standalone `ai-services/llm/llama_nemotron` server
 and its `xr-ai-models` preset remain available for samples that want a small
 dedicated model.
 
+### 2026-08-03 — Tea making selects a hardware-specific GPU layout
+
+The tea-making launcher now uses the shared GPU detector to select explicit
+single-96-GiB-Blackwell or dual-48-GiB-Ada service YAMLs. On Blackwell, NVFP4
+Omni starts first with bounded room for colocated STT and embedding, and the
+RTX Pro profile selects Triton for the current MoE compatibility requirement.
+On dual L40/L40S, FP8 Omni owns GPU 0 while STT and embedding use GPU 1. This
+prevents independently launched vLLM services from reserving the same L40 and
+preserves the sample's one-command startup on both target systems.
+
+### 2026-08-03 — Nemotron Omni pins its minimum supported vLLM runtime
+
+Nemotron-3-Nano-Omni declares the `NemotronH_Nano_Omni_Reasoning_V3`
+architecture, which vLLM 0.19 rejects before remote model code can load. The
+Omni service now pins `vllm/vllm-openai:v0.20.0`, removes the obsolete
+model-side Mamba package installation, and requires vLLM 0.20 for pip mode.
+The shared Docker runner explicitly selects `/bin/bash` so images with their
+own `vllm serve` entrypoint can execute setup commands correctly. Its container
+fingerprint version changed so stopped containers created with the old command
+are recreated instead of reused. The GPU smoke test is required to pass rather
+than treating the architecture failure as expected.
+
+### 2026-08-03 — Persistent vLLM containers track launch configuration
+
+Docker-backed vLLM containers carry a fingerprint of their image, model
+arguments, environment, GPU selection, and cache mount. A stopped container is
+reused only when that fingerprint matches the current request; otherwise it is
+recreated so YAML changes such as GPU memory utilization take effect. Healthy
+running containers remain reusable to preserve hot model weights.
+
 ### 2026-08-03 — Native RAG uses a typed service boundary
 
 Dense document retrieval is a reusable `rag-service` capability exposed to

--- a/docs/source/components/ai-services.md
+++ b/docs/source/components/ai-services.md
@@ -307,7 +307,11 @@ port → PID → SIGTERM/SIGKILL path. Same UX for both.
   OpenAI-compatible HTTP contract as the other LLM servers — swap the port to
   swap backends. Hosting backend is selectable per YAML (refer to *Choosing the
   vLLM runtime*); runs foreground in both pip and docker modes (no
-  cross-restart persistence).
+  cross-restart persistence). This architecture requires vLLM 0.20.0 or newer;
+  the Docker configuration therefore uses `vllm/vllm-openai:v0.20.0` rather
+  than the repository-wide NGC default. The optional `moe_backend` YAML key is
+  forwarded as `--moe-backend`; use `triton` for the current RTX Pro Blackwell
+  compatibility path.
 - **stt-server** loads parakeet-tdt-0.6b-v3 via NeMo ASR in-process.
   English-only; the `language` and `temperature` form fields are accepted but ignored.
 - **tts/magpie** loads magpie_tts_multilingual_357m via NeMo TTS in-process.

--- a/services/rag-service/rag_service/__main__.py
+++ b/services/rag-service/rag_service/__main__.py
@@ -16,6 +16,7 @@ from xr_ai_nat.functions._service.rpc import RPCServer
 
 from .index import DenseIndex
 from .service import RAGService
+from .startup import corpus_metadata, reusable_client
 
 
 def _resolve(path: str, config_path: Path) -> Path:
@@ -24,6 +25,23 @@ def _resolve(path: str, config_path: Path) -> Path:
 
 
 async def _serve(config: dict, config_path: Path, ready_file: Path | None) -> None:
+    address = str(config.get("endpoint", "tcp://0.0.0.0:8340"))
+    documents_dir = _resolve(str(config["documents_dir"]), config_path)
+    existing = await reusable_client(address, documents_dir)
+    if existing is not None:
+        logger.info("rag-service already running at {} - reusing", address)
+        if ready_file is not None:
+            ready_file.touch()
+        try:
+            while True:
+                await asyncio.sleep(2.0)
+                if not await existing.health():
+                    raise RuntimeError(
+                        f"reused RAG service at {address} became unavailable"
+                    )
+        finally:
+            await existing.close()
+
     models_path = _resolve(str(config["models_config"]), config_path)
     models = load_models_config(models_path)
     embedder = make_embedding(models, str(config.get("embedding_role", "embedding")))
@@ -31,7 +49,7 @@ async def _serve(config: dict, config_path: Path, ready_file: Path | None) -> No
         if not await embedder.health():
             raise RuntimeError("embedding service is not healthy")
         index = await DenseIndex.build(
-            _resolve(str(config["documents_dir"]), config_path),
+            documents_dir,
             embedder,
             cache_dir=_resolve(str(config.get("cache_dir", ".rag-cache")), config_path),
             chunk_size=int(config.get("chunk_size", 900)),
@@ -46,14 +64,14 @@ async def _serve(config: dict, config_path: Path, ready_file: Path | None) -> No
             ),
             min_score=float(config.get("min_score", 0.3)),
         )
-        address = str(config.get("endpoint", "tcp://0.0.0.0:8340"))
+        _, corpus_id = corpus_metadata(documents_dir)
         logger.info(
             "rag-service rpc={} documents={} chunks={}",
             address,
             len(index.documents),
             len(index.chunks),
         )
-        await RPCServer(address, RAGService(index).dispatch).serve(
+        await RPCServer(address, RAGService(index, corpus_id=corpus_id).dispatch).serve(
             ready=ready_file.touch if ready_file else None
         )
     finally:

--- a/services/rag-service/rag_service/index.py
+++ b/services/rag-service/rag_service/index.py
@@ -114,10 +114,7 @@ class DenseIndex:
             raise ValueError("overlap must be non-negative and smaller than chunk_size")
         if embedding_dim <= 0 or batch_size <= 0:
             raise ValueError("embedding_dim and batch_size must be positive")
-        paths = sorted(
-            path for path in documents_dir.rglob("*")
-            if path.is_file() and path.suffix.lower() in {".md", ".txt"}
-        )
+        paths = find_document_paths(documents_dir)
         documents = [str(path.relative_to(documents_dir)) for path in paths]
         chunks = [
             Chunk(source=source, text=part)
@@ -205,6 +202,15 @@ class DenseIndex:
             }
             for index in indices
         ]
+
+
+def find_document_paths(documents_dir: Path) -> list[Path]:
+    """Return supported corpus files in stable source-name order."""
+    return sorted(
+        path
+        for path in documents_dir.rglob("*")
+        if path.is_file() and path.suffix.lower() in {".md", ".txt"}
+    )
 
 
 def _normalize(vectors: np.ndarray) -> np.ndarray:

--- a/services/rag-service/rag_service/service.py
+++ b/services/rag-service/rag_service/service.py
@@ -9,8 +9,9 @@ from .index import DenseIndex
 
 
 class RAGService:
-    def __init__(self, index: DenseIndex) -> None:
+    def __init__(self, index: DenseIndex, *, corpus_id: str | None = None) -> None:
         self._index = index
+        self._corpus_id = corpus_id
 
     async def dispatch(self, method: str, arguments: dict) -> dict:
         if method == "retrieve":
@@ -32,9 +33,12 @@ class RAGService:
         if method == "list_documents":
             return {"documents": self._index.documents}
         if method == "get_health":
-            return {
+            result: dict[str, object] = {
                 "ready": await self._index.health(),
                 "document_count": len(self._index.documents),
                 "chunk_count": len(self._index.chunks),
             }
+            if self._corpus_id is not None:
+                result["corpus_id"] = self._corpus_id
+            return result
         raise ValueError(f"unknown method: {method}")

--- a/services/rag-service/rag_service/startup.py
+++ b/services/rag-service/rag_service/startup.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Idempotent startup helpers for a local RAG service."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from urllib.parse import urlsplit
+
+from loguru import logger
+from xr_ai_nat.functions.rag._client import RAGClient
+
+from .index import find_document_paths
+
+
+def connect_endpoint(bind_endpoint: str) -> str:
+    """Convert a wildcard TCP bind endpoint into a local connect endpoint."""
+    parsed = urlsplit(bind_endpoint)
+    if parsed.scheme != "tcp" or parsed.hostname not in {"0.0.0.0", "*", "::"}:
+        return bind_endpoint
+    if parsed.port is None:
+        raise ValueError(f"TCP endpoint does not include a port: {bind_endpoint}")
+    return f"tcp://127.0.0.1:{parsed.port}"
+
+
+def corpus_metadata(documents_dir: Path) -> tuple[list[str], str]:
+    """Return source names and a stable content fingerprint for a corpus."""
+    paths = find_document_paths(documents_dir)
+    names = [str(path.relative_to(documents_dir)) for path in paths]
+    digest = hashlib.sha256()
+    for path, name in zip(paths, names, strict=True):
+        digest.update(name.encode())
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return names, digest.hexdigest()
+
+
+async def reusable_client(
+    bind_endpoint: str,
+    documents_dir: Path,
+) -> RAGClient | None:
+    """Return a client when a compatible RAG service already owns the endpoint."""
+    endpoint = connect_endpoint(bind_endpoint)
+    client = RAGClient(endpoint, timeout_s=2.0)
+    try:
+        health = await client.get_health()
+        remote_documents = (await client.list_documents()).documents
+    except Exception as exc:
+        logger.debug("no reusable RAG service at {}: {}", endpoint, exc)
+        await client.close()
+        return None
+
+    expected_documents, expected_corpus_id = corpus_metadata(documents_dir)
+    if remote_documents != expected_documents:
+        await client.close()
+        raise RuntimeError(
+            f"RAG endpoint {bind_endpoint} is already serving a different document set; "
+            "stop that service or configure a different endpoint"
+        )
+    if health.corpus_id is not None and health.corpus_id != expected_corpus_id:
+        await client.close()
+        raise RuntimeError(
+            f"RAG endpoint {bind_endpoint} is already serving older document contents; "
+            "stop that service so the index can be rebuilt"
+        )
+    if not health.ready:
+        await client.close()
+        raise RuntimeError(
+            f"RAG endpoint {bind_endpoint} is already occupied by an unhealthy RAG service; "
+            "stop that service before restarting"
+        )
+    return client

--- a/tests/test_gpu_llm_servers.py
+++ b/tests/test_gpu_llm_servers.py
@@ -330,29 +330,6 @@ async def test_nemotron3_nano_persistent(tmp_path: Path) -> None:
 # ── test 3: nemotron_omni multimodal ────────────────────────────────────────
 
 
-# Nemotron-3-Nano-Omni-30B's `config.json` declares architecture
-# `NemotronH_Nano_Omni_Reasoning_V3`, which is not yet in the vLLM
-# 0.19.0 model registry shipped by `nvcr.io/nvidia/vllm:26.04-py3` —
-# `--trust-remote-code` (already passed) does not help because the
-# registry lookup happens before remote-code dispatch.  Two ways out:
-# (a) bump `DEFAULT_IMAGE` to an NGC tag whose vLLM has registered the
-# arch, or (b) pin a newer vllm wheel via extra_pip (defeats the point
-# of the prebuilt container).  Neither is in scope for this PR.  Keep
-# the test running (not skipped) so the next nightly catches the fix
-# automatically; `strict=False` so an upstream image bump doesn't
-# break this suite on the day the fix lands.
-@pytest.mark.xfail(
-    reason="vLLM 0.19.0 in nvcr.io/nvidia/vllm:26.04-py3 does not register "
-           "the NemotronH_Nano_Omni_Reasoning_V3 architecture, so startup "
-           "fails in create_model_config (config.json arch check) — before "
-           "any model code loads. The test config below sets extra_pip=[] so "
-           "this guaranteed failure no longer pays the ~16 min mamba-ssm / "
-           "causal-conv1d CUDA-kernel compile it never reaches. When vLLM "
-           "registers the arch, the failure mode shifts to a mamba_ssm "
-           "ImportError at model load — that's the signal to restore extra_pip "
-           "(and bump DEFAULT_IMAGE) and run this for real.",
-    strict=False,
-)
 async def test_nemotron_omni_multimodal(tmp_path: Path) -> None:
     if shutil.which("uv") is None:
         pytest.skip("uv not on PATH")
@@ -377,12 +354,9 @@ async def test_nemotron_omni_multimodal(tmp_path: Path) -> None:
         "video_pruning_rate":     0.5,
         "video_fps":              2,
         "video_num_frames":       8,
-        # docker backend: nvcc + flashinfer are pre-built in the NGC image.
+        # Nemotron Omni's architecture was added in vLLM 0.20.0.
         "vllm_backend":           "docker",
-        # This test xfails at the vLLM arch check (see the xfail reason),
-        # which runs before any model code imports mamba_ssm. Skip the
-        # default mamba-ssm/causal-conv1d source build — it's a ~16 min
-        # CUDA-kernel compile this guaranteed failure never reaches.
+        "vllm_image":             "vllm/vllm-openai:v0.20.0",
         "extra_pip":              [],
     }
     cfg_yaml = tmp_path / "nemotron_omni_llm_server.yaml"

--- a/tests/test_launcher_stack.py
+++ b/tests/test_launcher_stack.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import pytest
 
@@ -139,6 +140,93 @@ class TestRunStackShutdownContract:
 
         # Clean exit preserves the persist set so the container outlives us.
         assert stub_stack["no_kill"] == {"vlm"}
+
+
+class TestLauncherOwnership:
+    def test_matches_only_owned_orphan_wrapper(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(_stack.tempfile, "tempdir", str(tmp_path))
+        base = tmp_path / "sample"
+        config = base / "yaml" / "hub.yaml"
+        project = tmp_path / "server-runtime"
+        ready = tmp_path / "xr-ai-old" / "hub.ready"
+        process = _stack.Process(
+            "hub",
+            project,
+            "xr_media_hub",
+            config=config,
+        )
+        argv = [
+            "uv",
+            "run",
+            "--quiet",
+            "--project",
+            str(project),
+            "xr_media_hub",
+            "--config",
+            str(config),
+            "--ready-file",
+            str(ready),
+        ]
+
+        assert _stack._abandoned_process_name(argv, [process], base) == "hub"
+
+        outside = [*argv]
+        outside[outside.index("--config") + 1] = str(tmp_path / "other" / "hub.yaml")
+        assert _stack._abandoned_process_name(outside, [process], base) is None
+
+        persistent = _stack.Process(
+            "hub",
+            project,
+            "xr_media_hub",
+            config=config,
+            launch_mode="persist",
+        )
+        assert _stack._abandoned_process_name(argv, [persistent], base) is None
+
+    def test_finds_only_parentless_matching_process_groups(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(_stack.tempfile, "tempdir", str(tmp_path))
+        base = tmp_path / "sample"
+        config = base / "yaml" / "worker.yaml"
+        project = base / "worker"
+        ready = tmp_path / "xr-ai-old" / "worker.ready"
+        process = _stack.Process("worker", project, "worker", config=config)
+        proc_root = tmp_path / "proc"
+        orphan = proc_root / "101"
+        child = proc_root / "102"
+        orphan.mkdir(parents=True)
+        child.mkdir()
+        argv = [
+            "uv",
+            "run",
+            "--project",
+            str(project),
+            "worker",
+            "--config",
+            str(config),
+            "--ready-file",
+            str(ready),
+        ]
+        (orphan / "status").write_text("PPid:\t1\n")
+        (orphan / "cmdline").write_bytes(b"\0".join(value.encode() for value in argv))
+        (child / "status").write_text("PPid:\t101\n")
+        (child / "cmdline").write_bytes(b"\0".join(value.encode() for value in argv))
+        monkeypatch.setattr(_stack.os, "getpgid", lambda pid: {101: 201}[pid])
+        monkeypatch.setattr(_stack.os, "getpgrp", lambda: 999)
+
+        assert _stack._find_abandoned_process_groups(
+            [process], base, proc_root=proc_root
+        ) == {201: {"worker"}}
+
+    def test_stack_lock_rejects_concurrent_launcher(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(_stack.tempfile, "tempdir", str(tmp_path))
+        first = _stack._acquire_stack_lock(Path("sample"))
+        try:
+            with pytest.raises(RuntimeError, match="already running"):
+                _stack._acquire_stack_lock(Path("sample"))
+        finally:
+            _stack._release_stack_lock(first)
+
+
 class TestStripConflictingCudnn:
     """LD_LIBRARY_PATH sanitization so a host cuDNN can't shadow the venv one."""
 

--- a/tests/test_rag_service.py
+++ b/tests/test_rag_service.py
@@ -12,6 +12,7 @@ from nat.builder.workflow_builder import WorkflowBuilder
 from pydantic import ValidationError
 from rag_service import DenseIndex, RAGService
 from rag_service.index import _chunk_text
+from rag_service.startup import connect_endpoint, corpus_metadata, reusable_client
 from xr_ai_nat.functions._service.rpc import RPCServer
 from xr_ai_nat.functions.rag import RAGFunctionsConfig, RetrieveRequest, RetrieveResult
 
@@ -201,3 +202,51 @@ async def test_native_function_group_uses_typed_contracts(tmp_path) -> None:
 def test_retrieve_request_rejects_blank_query() -> None:
     with pytest.raises(ValidationError, match="query must not be blank"):
         RetrieveRequest(query="  ")
+
+
+def test_startup_metadata_and_wildcard_endpoint(tmp_path) -> None:
+    documents = tmp_path / "documents"
+    documents.mkdir()
+    (documents / "guide.md").write_text("Make tea carefully.")
+
+    names, first_id = corpus_metadata(documents)
+    assert names == ["guide.md"]
+    assert connect_endpoint("tcp://0.0.0.0:8340") == "tcp://127.0.0.1:8340"
+    assert connect_endpoint("ipc:///tmp/rag") == "ipc:///tmp/rag"
+
+    (documents / "guide.md").write_text("Updated tea guidance.")
+    assert corpus_metadata(documents)[1] != first_id
+
+
+@pytest.mark.parametrize("publish_corpus_id", [False, True])
+async def test_reuses_compatible_running_service(tmp_path, publish_corpus_id) -> None:
+    documents = tmp_path / "documents"
+    documents.mkdir()
+    (documents / "guide.md").write_text("Reset the task before starting again.")
+    corpus_id = corpus_metadata(documents)[1]
+    index = await DenseIndex.build(
+        documents,
+        _Embedding(),
+        cache_dir=tmp_path / "cache",
+        embedding_dim=3,
+    )
+    endpoint = f"ipc:///tmp/rag-reuse-{uuid.uuid4().hex}"
+    server = RPCServer(
+        endpoint,
+        RAGService(
+            index,
+            corpus_id=corpus_id if publish_corpus_id else None,
+        ).dispatch,
+    )
+    task = asyncio.create_task(server.serve())
+    await asyncio.sleep(0.02)
+    client = None
+    try:
+        client = await reusable_client(endpoint, documents)
+        assert client is not None
+        assert await client.health()
+    finally:
+        if client is not None:
+            await client.close()
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)

--- a/tests/test_tea_making_sample.py
+++ b/tests/test_tea_making_sample.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import importlib.util
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -23,12 +24,14 @@ sys.path.insert(0, str(_OMNI_DIR))
 from nemotron_omni_llm_server import __main__ as omni_server_module  # noqa: E402
 from tea_making_worker import agent as agent_module  # noqa: E402
 from tea_making_worker import guide as guide_module  # noqa: E402
+from tea_making_worker import tools as tools_module  # noqa: E402
 from tea_making_worker.agent import (  # noqa: E402
     NavigationIntent,
     StepAgentResult,
     WorkflowAgent,
 )
 from tea_making_worker.guide import WorkflowGuide  # noqa: E402
+from tea_making_worker.step_mechanism import StepIteration, StepMechanisms  # noqa: E402
 from tea_making_worker.workflow import (  # noqa: E402
     WorkflowDefinition,
     WorkflowSession,
@@ -49,7 +52,7 @@ def _workflow() -> WorkflowDefinition:
     return WorkflowDefinition.load(_SAMPLE_DIR / "yaml" / "workflow.yaml")
 
 
-def test_shipped_workflow_uses_omni_native_rag_and_timer_only_step_five() -> None:
+def test_shipped_workflow_uses_omni_native_rag_and_one_step_mechanism() -> None:
     workflow = _workflow()
     models = yaml.safe_load((_SAMPLE_DIR / "yaml" / "models.yaml").read_text())
     worker = yaml.safe_load((_SAMPLE_DIR / "yaml" / "tea_making_worker.yaml").read_text())
@@ -96,20 +99,14 @@ def test_shipped_workflow_uses_omni_native_rag_and_timer_only_step_five() -> Non
 
     assert not (_SAMPLE_DIR / "yaml" / "rag.yaml").exists()
     assert not (_WORKER_DIR / "tea_making_worker" / "rag.py").exists()
-    assert step_five.timer is not None
+    assert {step.mechanism for step in workflow.steps if not step.is_idle} == {
+        "caption_agent"
+    }
     assert step_five.vlm_prompt == ""
-    assert step_five.timer.completion_field == "steeping_complete"
+    assert step_five.agent_tools == ("get_timer_status",)
+    assert workflow.step_by_id(4).agent_tools == ("get_current_time",)
     step_three = workflow.step_by_id(3)
-    state_updates = {update.context_field: update for update in step_three.state_updates}
-    assert set(state_updates) == {"water_temperature_current", "water_boil_cue"}
-    assert state_updates["water_temperature_current"].observation_key == ("TEMPERATURE_READING")
-    assert state_updates["water_temperature_current"].states == (
-        "started",
-        "needs_input",
-        "complete",
-    )
-    assert state_updates["water_boil_cue"].observation_key == "BOIL_CUE"
-    assert "water_ready" not in state_updates
+    assert step_three.agent_tools == ()
     assert "water_temperature_current" in {field.name for field in step_three.context_fields}
     assert workflow.sparse_context is True
     assert workflow.initial_context() == {}
@@ -173,7 +170,7 @@ def test_omni_server_forwards_configured_moe_backend(monkeypatch, tmp_path: Path
     assert serve_args[backend_index + 1] == "triton"
 
 
-async def test_state_updates_are_driven_by_arbitrary_workflow_yaml(
+async def test_caption_agent_mechanism_applies_changing_agent_patches(
     tmp_path: Path,
 ) -> None:
     workflow_path = tmp_path / "workflow.yaml"
@@ -193,21 +190,9 @@ async def test_state_updates_are_driven_by_arbitrary_workflow_yaml(
                         "id": 1,
                         "name": "Read instrument",
                         "description": "Read an arbitrary instrument.",
+                        "mechanism": "caption_agent",
                         "vlm_prompt": ("End with PRESSURE_READING and ALARM_ACTIVE lines."),
                         "agent_prompt": "Interpret the latest instrument reading.",
-                        "state_updates": [
-                            {
-                                "context_field": "pressure_kpa",
-                                "observation_key": "PRESSURE_READING",
-                                "states": ["started", "complete"],
-                            },
-                            {
-                                "context_field": "alarm_active",
-                                "observation_key": "ALARM_ACTIVE",
-                                "states": ["started", "complete"],
-                                "value_map": {"yes": True, "no": False},
-                            },
-                        ],
                         "context_output": {
                             "fields": {
                                 "pressure_kpa": {
@@ -255,39 +240,14 @@ async def test_state_updates_are_driven_by_arbitrary_workflow_yaml(
     )
 
     workflow = WorkflowDefinition.load(workflow_path)
-    step = workflow.step_by_id(1)
-
-    assert step.observation_context_patch(
-        "Visible display.\nPRESSURE_READING: 42.5\nALARM_ACTIVE: yes",
-        state="started",
-    ) == {"pressure_kpa": 42.5, "alarm_active": True}
-    assert step.observation_context_patch(
-        "PRESSURE_READING: 44.0\nALARM_ACTIVE: no",
-        state="complete",
-    ) == {"pressure_kpa": 44.0, "alarm_active": False}
-    assert (
-        step.observation_context_patch(
-            "PRESSURE_READING: 45.0\nALARM_ACTIVE: yes",
-            state="needs_input",
-        )
-        == {}
-    )
-    assert (
-        step.observation_context_patch(
-            "PRESSURE_READING: unavailable\nALARM_ACTIVE: unclear",
-            state="started",
-        )
-        == {}
-    )
-
     observations = iter(
         [
             SimpleNamespace(
-                text="PRESSURE_READING: 42.5\nALARM_ACTIVE: yes",
+                text="PRESSURE_READING: 42.5\nALARM_ACTIVE: no",
                 frame_pts_us=1,
             ),
             SimpleNamespace(
-                text="PRESSURE_READING: 44.0\nALARM_ACTIVE: no",
+                text="PRESSURE_READING: 44.0\nALARM_ACTIVE: yes",
                 frame_pts_us=2,
             ),
         ]
@@ -303,11 +263,16 @@ async def test_state_updates_are_driven_by_arbitrary_workflow_yaml(
             return None
 
     class _Agent:
-        async def run_step(self, *, session, **_kwargs):
-            agent_contexts.append(dict(session.context))
+        async def run_step(self, *, context, vlm_observation, **_kwargs):
+            agent_contexts.append(dict(context))
+            is_complete = "ALARM_ACTIVE: yes" in vlm_observation
             return StepAgentResult(
-                context_patch={"pressure_kpa": 1.0, "alarm_active": True},
-                step_state="started",
+                context_patch={
+                    "pressure_kpa": 44.0 if is_complete else 42.5,
+                    "alarm_active": is_complete,
+                },
+                step_state="complete" if is_complete else "started",
+                ready_to_advance=is_complete,
             )
 
     async def notice(participant_id: str, text: str) -> None:
@@ -323,26 +288,102 @@ async def test_state_updates_are_driven_by_arbitrary_workflow_yaml(
         participant_id="alice",
         step_id=1,
         context=workflow.initial_context(),
+        last_reminder_us=guide_module._now_us(),  # noqa: SLF001
     )
 
     await guide._evaluate(session)  # noqa: SLF001
 
-    assert agent_contexts[0]["pressure_kpa"] == 42.5
-    assert agent_contexts[0]["alarm_active"] is True
+    assert agent_contexts[0]["pressure_kpa"] == 0
+    assert agent_contexts[0]["alarm_active"] is False
     assert session.context["pressure_kpa"] == 42.5
+    assert session.context["alarm_active"] is False
+    assert session.ready_step_id is None
+
+    await guide._evaluate(session)  # noqa: SLF001
+
+    assert agent_contexts[1]["pressure_kpa"] == 42.5
+    assert agent_contexts[1]["alarm_active"] is False
+    assert session.context["pressure_kpa"] == 44.0
     assert session.context["alarm_active"] is True
     assert session.ready_step_id == 1
     assert session.step_state == "complete"
     assert len(notices) == 1
 
+
+async def test_workflow_can_inject_a_different_step_mechanism(tmp_path: Path) -> None:
+    workflow_path = tmp_path / "workflow.yaml"
+    workflow_path.write_text(
+        yaml.safe_dump(
+            {
+                "task": {"name": "custom-mechanism"},
+                "steps": [
+                    {"id": 0, "name": "Idle", "description": "Wait."},
+                    {
+                        "id": 1,
+                        "name": "Custom step",
+                        "description": "Run custom logic.",
+                        "mechanism": "scripted",
+                        "agent_prompt": "This prompt belongs to the custom mechanism.",
+                        "context_output": {
+                            "fields": {"done": {"type": "boolean", "default": False}}
+                        },
+                        "advance_when": {"field": "done", "equals": True},
+                    },
+                    {
+                        "id": 2,
+                        "name": "Later custom step",
+                        "description": "Keep the first step from being final.",
+                        "mechanism": "scripted",
+                        "agent_prompt": "Not evaluated in this test.",
+                        "context_output": {
+                            "fields": {"finished": {"type": "boolean", "default": False}}
+                        },
+                        "advance_when": {"field": "finished", "equals": True},
+                    },
+                ],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    workflow = WorkflowDefinition.load(workflow_path)
+    calls: list[int] = []
+
+    class _ScriptedMechanism:
+        name = "scripted"
+
+        async def run(self, *, step, **_kwargs):
+            calls.append(step.id)
+            return StepIteration(
+                result=StepAgentResult(
+                    context_patch={"done": True},
+                    step_state="complete",
+                    ready_to_advance=True,
+                )
+            )
+
+    async def notice(_participant_id: str, _text: str) -> None:
+        return None
+
+    guide = WorkflowGuide(
+        workflow=workflow,
+        vision=SimpleNamespace(release=lambda _participant_id: None),
+        agent=SimpleNamespace(),
+        notice=notice,
+        step_mechanisms=StepMechanisms([_ScriptedMechanism()]),
+    )
+    session = WorkflowSession(
+        participant_id="alice",
+        step_id=1,
+        context=workflow.initial_context(),
+    )
+
     await guide._evaluate(session)  # noqa: SLF001
 
-    assert len(agent_contexts) == 1
-    assert session.context["pressure_kpa"] == 44.0
-    assert session.context["alarm_active"] is False
+    assert calls == [1]
+    assert session.context["done"] is True
     assert session.ready_step_id == 1
     assert session.step_state == "complete"
-    assert len(notices) == 1
 
 
 def test_sparse_context_carries_values_with_projected_reads_and_partial_writes(
@@ -386,13 +427,6 @@ def test_sparse_context_carries_values_with_projected_reads_and_partial_writes(
                         "writes": {
                             "live_value": {"type": "number", "required": True},
                         },
-                        "state_updates": [
-                            {
-                                "context_field": "live_value",
-                                "observation_key": "LIVE_VALUE",
-                                "states": ["started", "needs_input"],
-                            }
-                        ],
                         "advance_when": {"field": "live_value", "gte": 10},
                     },
                 ],
@@ -417,14 +451,8 @@ def test_sparse_context_carries_values_with_projected_reads_and_partial_writes(
     }
     assert set(step.context_schema()["properties"]) == {"live_value"}
     assert "required" not in step.context_schema()
-    assert step.observation_context_patch(
-        "LIVE_VALUE: 9.5",
-        state="started",
-    ) == {"live_value": 9.5}
-    assert step.observation_context_patch(
-        "LIVE_VALUE: 11.0",
-        state="needs_input",
-    ) == {"live_value": 11.0}
+    assert step.mechanism == "caption_agent"
+    assert step.agent_tools == ()
 
 
 def test_templates_and_response_normalization_are_speech_friendly() -> None:
@@ -614,33 +642,32 @@ def test_step_four_skip_replaces_zero_timestamp_with_current_time() -> None:
     assert context["steeping_started_at_iso"]
 
 
-def test_vlm_yes_policy_accepts_yaml_boolean_and_string_values() -> None:
-    observation = "tea bag, entering the water\n\nSTEEPING_STARTED: yes"
-
-    assert agent_module._tool_policy_met(  # noqa: SLF001
-        {"vlm_verdict": "STEEPING_STARTED", "equals": True},
-        observation,
-    )
-    assert agent_module._tool_policy_met(  # noqa: SLF001
-        {"vlm_verdict": "STEEPING_STARTED", "equals": "yes"},
-        observation,
-    )
-
-
-async def test_vlm_yes_automatically_captures_steeping_start_time() -> None:
+async def test_step_agent_calls_time_tool_to_capture_steeping_start() -> None:
     workflow = _workflow()
     step = workflow.step_by_id(4)
-    captured_messages: list = []
+    model_calls: list[list] = []
     tool_calls: list[tuple[str, dict]] = []
 
     class _Llm:
         async def chat(self, messages, **_kwargs):
-            captured_messages.extend(messages)
+            model_calls.append(list(messages))
+            if len(model_calls) == 1:
+                return SimpleNamespace(
+                    content="",
+                    tool_calls=[
+                        ToolCall(
+                            id="time-1",
+                            name="get_current_time",
+                            arguments="{}",
+                        )
+                    ],
+                )
             return SimpleNamespace(
                 content=(
-                    '{"context":{"steeping_started_at_us":0,'
-                    '"steeping_started_at_iso":""},"ready_to_advance":false,'
-                    '"step_state":"started","assistant_message":"","speak":false}'
+                    '{"context":{"steeping_started_at_us":1785798780376000,'
+                    '"steeping_started_at_iso":"2026-08-03T16:13:00-07:00"},'
+                    '"ready_to_advance":true,"step_state":"complete",'
+                    '"assistant_message":"","speak":false}'
                 ),
                 tool_calls=[],
             )
@@ -663,22 +690,18 @@ async def test_vlm_yes_automatically_captures_steeping_start_time() -> None:
         workflow=workflow,
         answer_prompt=(_WORKER_DIR / "tea_making_worker" / "prompts" / "system.txt"),
     )
-    session = WorkflowSession(
-        participant_id="alice",
-        step_id=4,
-        context=workflow.initial_context(),
-    )
-
     result = await agent.run_step(
         step=step,
-        session=session,
+        participant_id="alice",
+        context=workflow.initial_context(),
+        observation_log=[],
         vlm_observation="tea bag, entering the water\n\nSTEEPING_STARTED: yes",
     )
 
     assert tool_calls == [("get_current_time", {})]
     assert result.context_patch["steeping_started_at_us"] == 1_785_798_780_376_000
     assert result.context_patch["steeping_started_at_iso"] == ("2026-08-03T16:13:00-07:00")
-    assert "1785798780376000" in captured_messages[1].content
+    assert '"epoch_us": 1785798780376000' in model_calls[1][-1].content
 
 
 def test_navigation_eval_cases_require_explicit_movement_language() -> None:
@@ -700,86 +723,188 @@ def test_navigation_eval_cases_require_explicit_movement_language() -> None:
         assert actual.intent == case["expected_intent"], case["utterance"]
 
 
-def test_timer_question_eval_cases_report_elapsed_or_remaining(monkeypatch) -> None:
+async def test_timer_tool_reports_elapsed_remaining_and_expiration() -> None:
+    now = datetime(2026, 8, 3, 16, 13, tzinfo=timezone(timedelta(hours=-7)))
+
+    class _Rag:
+        instance_name = "test__retrieve"
+
+    guide_tools = tools_module.GuideTools({"retrieve": _Rag()}, clock=lambda: now)
+    started_at_us = int((now - timedelta(seconds=65)).timestamp() * 1_000_000)
+
+    active = await guide_tools.invoke(
+        "get_timer_status",
+        {
+            "started_at_us": started_at_us,
+            "duration_seconds": 180,
+            "label": "steeping",
+        },
+    )
+
+    assert active["elapsed_seconds"] == 65
+    assert active["remaining_seconds"] == 115
+    assert active["expired"] is False
+
+    guide_tools._clock = lambda: now + timedelta(seconds=120)  # noqa: SLF001
+    expired = await guide_tools.invoke(
+        "get_timer_status",
+        {"started_at_us": started_at_us, "duration_seconds": 180},
+    )
+    assert expired["remaining_seconds"] == 0
+    assert expired["expired"] is True
+
+
+async def test_timer_tool_rejects_a_missing_start_time() -> None:
+    class _Rag:
+        instance_name = "test__retrieve"
+
+    guide_tools = tools_module.GuideTools({"retrieve": _Rag()})
+    status = await guide_tools.invoke(
+        "get_timer_status",
+        {"started_at_us": 0, "duration_seconds": 180},
+    )
+
+    assert status["started"] is False
+    assert status["expired"] is False
+    assert "positive start timestamp" in status["error"]
+
+
+async def test_step_agent_uses_timer_tool_to_complete_no_caption_step() -> None:
     workflow = _workflow()
-    now_us = 10_000_000_000
+    step = workflow.step_by_id(5)
+    model_calls: list[list] = []
+    tool_calls: list[tuple[str, dict]] = []
+
+    class _Llm:
+        async def chat(self, messages, **_kwargs):
+            model_calls.append(list(messages))
+            if len(model_calls) == 1:
+                return SimpleNamespace(
+                    content="",
+                    tool_calls=[
+                        ToolCall(
+                            id="timer-1",
+                            name="get_timer_status",
+                            arguments=(
+                                '{"started_at_us":1785798780000000,'
+                                '"duration_seconds":180,"label":"steeping"}'
+                            ),
+                        )
+                    ],
+                )
+            return SimpleNamespace(
+                content=(
+                    '{"context":{"steeping_complete":true},'
+                    '"ready_to_advance":true,"step_state":"complete",'
+                    '"assistant_message":"","speak":false}'
+                ),
+                tool_calls=[],
+            )
+
+    class _Tools:
+        def definitions(self):
+            return [SimpleNamespace(name="get_timer_status")]
+
+        async def invoke(self, name, arguments):
+            tool_calls.append((name, arguments))
+            return {
+                "label": "steeping",
+                "elapsed_seconds": 181,
+                "remaining_seconds": 0,
+                "expired": True,
+            }
+
+    agent = WorkflowAgent(
+        llm=_Llm(),
+        tools=_Tools(),
+        workflow=workflow,
+        answer_prompt=(_WORKER_DIR / "tea_making_worker" / "prompts" / "system.txt"),
+    )
     context = workflow.initial_context()
     context.update(
-        steeping_started_at_us=now_us - 65_000_000,
+        steeping_started_at_us=1_785_798_780_000_000,
+        steep_duration_seconds=180,
+    )
+
+    result = await agent.run_step(
+        step=step,
+        participant_id="alice",
+        context=context,
+        observation_log=[],
+        vlm_observation="",
+    )
+
+    assert tool_calls[0][0] == "get_timer_status"
+    assert result.context_patch == {"steeping_complete": True}
+    assert result.ready_to_advance is True
+    assert '"expired": true' in model_calls[1][-1].content
+
+
+async def test_answer_agent_uses_timer_tool_for_remaining_time_question() -> None:
+    workflow = _workflow()
+    step = workflow.step_by_id(5)
+    calls = 0
+
+    class _Llm:
+        async def chat(self, _messages, **_kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return SimpleNamespace(
+                    content="",
+                    tool_calls=[
+                        ToolCall(
+                            id="timer-answer-1",
+                            name="get_timer_status",
+                            arguments=(
+                                '{"started_at_us":1785798780000000,'
+                                '"duration_seconds":180,"label":"steeping"}'
+                            ),
+                        )
+                    ],
+                )
+            return SimpleNamespace(
+                content="About one minute and fifty-five seconds remain.",
+                tool_calls=[],
+            )
+
+    class _Tools:
+        def definitions(self):
+            return [SimpleNamespace(name="get_timer_status")]
+
+        async def invoke(self, _name, _arguments):
+            return {
+                "elapsed_seconds": 65,
+                "remaining_seconds": 115,
+                "expired": False,
+            }
+
+    agent = WorkflowAgent(
+        llm=_Llm(),
+        tools=_Tools(),
+        workflow=workflow,
+        answer_prompt=(_WORKER_DIR / "tea_making_worker" / "prompts" / "system.txt"),
+    )
+    context = workflow.initial_context()
+    context.update(
+        steeping_started_at_us=1_785_798_780_000_000,
         steep_duration_seconds=180,
     )
     session = WorkflowSession(participant_id="alice", step_id=5, context=context)
-    cases = yaml.safe_load((_SAMPLE_DIR / "eval" / "cases.yaml").read_text())
-    monkeypatch.setattr(guide_module, "_now_us", lambda: now_us)
 
-    for case in cases["timer_questions"]:
-        answer = guide_module._time_question_answer(  # noqa: SLF001
-            case["utterance"],
-            session,
-            workflow,
-        )
-        if case["expected"] == "elapsed":
-            assert "1 minute and 5 seconds" in answer
-        else:
-            assert "1 minute and 55 seconds" in answer
-            assert "left" in answer
-
-    monkeypatch.setattr(guide_module, "_now_us", lambda: now_us + 120_000_000)
-    assert "time is up" in guide_module._time_question_answer(  # noqa: SLF001
-        "How much longer do I need to wait?",
-        session,
-        workflow,
+    answer = await agent.answer_user(
+        transcript="How long do I still need to wait?",
+        session=session,
+        current_step=step,
+        observation_log=[],
+        recent_turns=[],
     )
 
-
-def test_timer_questions_do_not_invent_a_missing_start_time() -> None:
-    workflow = _workflow()
-    context = workflow.initial_context()
-    context["steep_duration_seconds"] = 180
-    session = WorkflowSession(participant_id="alice", step_id=4, context=context)
-
-    remaining = guide_module._time_question_answer(  # noqa: SLF001
-        "How long do I have remaining?",
-        session,
-        workflow,
-    )
-    started = guide_module._time_question_answer(  # noqa: SLF001
-        "When did I steep the tea?",
-        session,
-        workflow,
-    )
-
-    assert "has not started" in remaining
-    assert "3 minutes" in remaining
-    assert "no start time is recorded" in started
+    assert calls == 2
+    assert answer == "About one minute and fifty-five seconds remain."
 
 
-def test_timer_start_time_question_uses_recorded_timestamp(monkeypatch) -> None:
-    workflow = _workflow()
-    started_at_us = 1_785_798_780_000_000
-    context = workflow.initial_context()
-    context.update(
-        steeping_started_at_us=started_at_us,
-        steep_duration_seconds=180,
-    )
-    session = WorkflowSession(participant_id="alice", step_id=5, context=context)
-    monkeypatch.setattr(
-        guide_module,
-        "_now_us",
-        lambda: started_at_us + 30_000_000,
-    )
-
-    answer = guide_module._time_question_answer(  # noqa: SLF001
-        "When did I steep the tea?",
-        session,
-        workflow,
-    )
-
-    assert "timer started at" in answer
-    assert "time is up" not in answer
-
-
-async def test_timer_step_expires_without_calling_vision_or_step_agent() -> None:
+async def test_no_caption_timer_step_runs_agent_and_finishes_workflow() -> None:
     workflow = _workflow()
     now_us = guide_module._now_us()  # noqa: SLF001
     context = workflow.initial_context()
@@ -788,6 +913,7 @@ async def test_timer_step_expires_without_calling_vision_or_step_agent() -> None
         steep_duration_seconds=180,
     )
     notices: list[tuple[str, str]] = []
+    agent_calls: list[str] = []
 
     class _Vision:
         async def observe(self, *_args, **_kwargs):
@@ -797,8 +923,13 @@ async def test_timer_step_expires_without_calling_vision_or_step_agent() -> None
             return None
 
     class _Agent:
-        async def run_step(self, *_args, **_kwargs):
-            raise AssertionError("timer-only step must not invoke the step agent")
+        async def run_step(self, *, vlm_observation, **_kwargs):
+            agent_calls.append(vlm_observation)
+            return StepAgentResult(
+                context_patch={"steeping_complete": True},
+                step_state="complete",
+                ready_to_advance=True,
+            )
 
     async def notice(participant_id: str, text: str) -> None:
         notices.append((participant_id, text))
@@ -813,6 +944,7 @@ async def test_timer_step_expires_without_calling_vision_or_step_agent() -> None
 
     await guide._evaluate(session)  # noqa: SLF001
 
+    assert agent_calls == [""]
     assert session.active is False
     assert session.step_id == 0
     assert session.step_state == "idle"
@@ -856,58 +988,6 @@ async def test_completed_step_does_not_repeat_guidance_or_recheck_vision() -> No
     await guide._evaluate(session)  # noqa: SLF001
 
     assert session.step_state == "complete"
-    assert notices == []
-
-
-async def test_completed_water_step_silently_updates_observed_state() -> None:
-    workflow = _workflow()
-    notices: list[tuple[str, str]] = []
-
-    class _Vision:
-        async def observe(self, *_args, **_kwargs):
-            return SimpleNamespace(
-                text="TEMPERATURE_READING: 75 C\nBOIL_CUE: no",
-                frame_pts_us=2_000_000,
-            )
-
-        def release(self, _participant_id: str) -> None:
-            return None
-
-    class _Agent:
-        async def run_step(self, *_args, **_kwargs):
-            raise AssertionError("completed live updates must not invoke the step agent")
-
-    async def notice(participant_id: str, text: str) -> None:
-        notices.append((participant_id, text))
-
-    guide = WorkflowGuide(
-        workflow=workflow,
-        vision=_Vision(),
-        agent=_Agent(),
-        notice=notice,
-    )
-    context = workflow.initial_context()
-    context.update(
-        tea_name="Aged Earl Grey",
-        water_temperature_current="59 C",
-        water_ready=True,
-    )
-    session = WorkflowSession(
-        participant_id="alice",
-        step_id=3,
-        context=context,
-        ready_step_id=3,
-        step_state="complete",
-    )
-
-    await guide._evaluate(session)  # noqa: SLF001
-
-    assert session.context["water_temperature_current"] == "75 C"
-    assert session.context["water_ready"] is True
-    assert session.context["water_boil_cue"] == "no"
-    assert session.context["tea_name"] == "Aged Earl Grey"
-    assert session.step_state == "complete"
-    assert session.ready_step_id == 3
     assert notices == []
 
 

--- a/tests/test_tea_making_sample.py
+++ b/tests/test_tea_making_sample.py
@@ -12,7 +12,8 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import yaml
-from xr_ai_models import ToolCall
+from xr_ai_models import ToolCall, ToolDef
+from xr_ai_voicegate import VoiceGate, load_voice_gate_config
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _SAMPLE_DIR = _REPO_ROOT / "agent-samples" / "tea-making-sample"
@@ -31,7 +32,11 @@ from tea_making_worker.agent import (  # noqa: E402
     WorkflowAgent,
 )
 from tea_making_worker.guide import WorkflowGuide  # noqa: E402
-from tea_making_worker.step_mechanism import StepIteration, StepMechanisms  # noqa: E402
+from tea_making_worker.step_mechanism import (  # noqa: E402
+    StepEvent,
+    StepIteration,
+    StepMechanisms,
+)
 from tea_making_worker.workflow import (  # noqa: E402
     WorkflowDefinition,
     WorkflowSession,
@@ -56,7 +61,7 @@ def test_shipped_workflow_uses_omni_native_rag_and_one_step_mechanism() -> None:
     workflow = _workflow()
     models = yaml.safe_load((_SAMPLE_DIR / "yaml" / "models.yaml").read_text())
     worker = yaml.safe_load((_SAMPLE_DIR / "yaml" / "tea_making_worker.yaml").read_text())
-    step_five = workflow.step_by_id(5)
+    final_step = workflow.step_by_id(4)
 
     assert models["agent_llm"]["kind"] == "preset:nemotron_omni"
     assert models["embedding"]["kind"] == "preset:nemotron_embedding"
@@ -102,19 +107,81 @@ def test_shipped_workflow_uses_omni_native_rag_and_one_step_mechanism() -> None:
     assert {step.mechanism for step in workflow.steps if not step.is_idle} == {
         "caption_agent"
     }
-    assert step_five.vlm_prompt == ""
-    assert step_five.agent_tools == ("get_timer_status",)
-    assert workflow.step_by_id(4).agent_tools == ("get_current_time",)
+    assert final_step.vlm_prompt
+    assert final_step.agent_tools == ("get_current_time", "get_timer_status")
+    assert final_step.vlm_stop_when == {
+        "field": "steeping_started_at_us",
+        "gt": 0,
+    }
+    assert final_step.suppress_reminders_when == final_step.vlm_stop_when
+    assert workflow.next_step(final_step.id) is None
+    assert workflow.step_by_id(2).writable_fields == {"water_filled"}
     step_three = workflow.step_by_id(3)
     assert step_three.agent_tools == ()
     assert "water_temperature_current" in {field.name for field in step_three.context_fields}
+    assert "water_heating_started" in step_three.writable_fields
     assert workflow.sparse_context is True
     assert workflow.initial_context() == {}
     assert step_three.read_fields == (
         "tea_name",
         "tea_temperature",
         "target_temperature_c",
+        "water_filled",
     )
+    full_context = {
+        "tea_name": "green tea",
+        "water_filled": True,
+        "water_temperature_current": "80 C",
+        "steeping_started_at_us": 123,
+        "steeping_complete": False,
+    }
+    assert set(workflow.context_for_step(workflow.step_by_id(2), full_context)) == {
+        "water_filled"
+    }
+    assert "steeping_started_at_us" not in workflow.context_for_step(step_three, full_context)
+    assert "water_temperature_current" not in workflow.context_for_step(final_step, full_context)
+
+
+async def test_tea_voice_gate_requires_a_wake_phrase_on_every_utterance() -> None:
+    config = load_voice_gate_config(_SAMPLE_DIR / "yaml" / "voice_gate.yaml")
+    queries: list[tuple[str, str, bool]] = []
+    dropped: list[tuple[str, str]] = []
+
+    async def on_query(participant_id: str, text: str, fresh_match: bool) -> None:
+        queries.append((participant_id, text, fresh_match))
+
+    async def on_stop(_participant_id: str) -> None:
+        return None
+
+    async def on_drop(participant_id: str, text: str) -> None:
+        dropped.append((participant_id, text))
+
+    gate = VoiceGate(
+        config,
+        audio_sink=SimpleNamespace(),
+        tts=SimpleNamespace(),
+    )
+    gate.bind(on_query=on_query, on_stop=on_stop, on_drop=on_drop)
+
+    await gate.feed("alice", "help me make tea")
+    await gate.feed("alice", "Agent, help me make tea")
+    await gate.feed("alice", "next")
+    await gate.feed("alice", "Hey agent, next")
+    await gate.feed("alice", "Agent, cancel tea")
+
+    assert config.magic_phrases == ("agent", "hey agent")
+    assert config.followup_grace_s == 0.0
+    assert "Agent, help me make tea" in config.welcome_message
+    assert gate.format_phrase_help() == config.welcome_message
+    assert queries == [
+        ("alice", "help me make tea", True),
+        ("alice", "next", True),
+        ("alice", "cancel tea", True),
+    ]
+    assert dropped == [
+        ("alice", "help me make tea"),
+        ("alice", "next"),
+    ]
 
 
 def test_launcher_selects_hardware_specific_model_configs() -> None:
@@ -478,7 +545,7 @@ def test_templates_and_response_normalization_are_speech_friendly() -> None:
 
 async def test_answer_agent_can_inspect_a_fresh_view_for_visual_questions() -> None:
     workflow = _workflow()
-    step = workflow.step_by_id(5)
+    step = workflow.step_by_id(4)
     model_calls: list[list] = []
     visual_questions: list[str] = []
 
@@ -523,7 +590,7 @@ async def test_answer_agent_can_inspect_a_fresh_view_for_visual_questions() -> N
     )
     session = WorkflowSession(
         participant_id="alice",
-        step_id=5,
+        step_id=4,
         context={"steeping_started_at_us": 1, "steep_duration_seconds": 180},
     )
 
@@ -581,7 +648,7 @@ async def test_guide_logs_fresh_visual_answers_and_normalizes_them_for_speech() 
         async def classify_intent(self, **_kwargs):
             return NavigationIntent(intent="answer", confidence=0.99)
 
-        async def answer_user(self, *, transcript, visual_query, **_kwargs):
+        async def answer_step(self, *, transcript, visual_query, **_kwargs):
             evidence = await visual_query(transcript)
             assert evidence["visual_evidence"] == "The kettle display reads 82 C."
             return "It reads 82 C."
@@ -597,7 +664,7 @@ async def test_guide_logs_fresh_visual_answers_and_normalizes_them_for_speech() 
     )
     session = WorkflowSession(
         participant_id="alice",
-        step_id=5,
+        step_id=4,
         context={"steeping_started_at_us": 1, "steep_duration_seconds": 180},
     )
     guide._sessions["alice"] = session  # noqa: SLF001
@@ -611,6 +678,206 @@ async def test_guide_logs_fresh_visual_answers_and_normalizes_them_for_speech() 
     assert response == "It reads 82 degrees Celsius."
     assert session.observation_log[-1]["kind"] == "visual_question"
     assert session.observation_log[-1]["question"] == ("What does the kettle display show now?")
+
+
+async def test_voice_event_runs_through_mechanism_without_mutating_state() -> None:
+    workflow = _workflow()
+    events: list[StepEvent] = []
+
+    class _Mechanism:
+        name = "caption_agent"
+
+        async def run(self, *, event, **_kwargs):
+            events.append(event)
+            return StepIteration(
+                result=StepAgentResult(
+                    context_patch={"tea_name": "incorrect mutation"},
+                    assistant_message="Hold the label closer to the camera.",
+                )
+            )
+
+    class _Agent:
+        async def classify_intent(self, **_kwargs):
+            return NavigationIntent(intent="answer", confidence=0.99)
+
+    async def notice(_participant_id: str, _text: str) -> None:
+        return None
+
+    guide = WorkflowGuide(
+        workflow=workflow,
+        vision=SimpleNamespace(release=lambda _participant_id: None),
+        agent=_Agent(),
+        notice=notice,
+        step_mechanisms=StepMechanisms([_Mechanism()]),
+    )
+    session = WorkflowSession(
+        participant_id="alice",
+        step_id=1,
+        context=workflow.initial_context(),
+    )
+    guide._sessions["alice"] = session  # noqa: SLF001
+
+    response = await guide.handle_query(
+        participant_id="alice",
+        text="Can you read this label?",
+    )
+
+    assert response == "Hold the label closer to the camera."
+    assert len(events) == 1
+    assert events[0].kind == "voice"
+    assert events[0].transcript == "Can you read this label?"
+    assert "tea_name" not in session.context
+
+
+async def test_answer_prompt_is_scoped_without_future_step_state() -> None:
+    workflow = _workflow()
+    step = workflow.step_by_id(1)
+    captured: list = []
+
+    class _Llm:
+        async def chat(self, messages, **_kwargs):
+            captured.extend(messages)
+            return SimpleNamespace(content="Show me the tea label.", tool_calls=[])
+
+    class _Tools:
+        def definitions(self):
+            return []
+
+    agent = WorkflowAgent(
+        llm=_Llm(),
+        tools=_Tools(),
+        workflow=workflow,
+        answer_prompt=(_WORKER_DIR / "tea_making_worker" / "prompts" / "system.txt"),
+    )
+    session = WorkflowSession(
+        participant_id="alice",
+        step_id=1,
+        context={
+            "tea_name": "green tea",
+            "steeping_started_at_us": 1_785_798_780_000_000,
+            "steeping_complete": True,
+        },
+    )
+
+    await agent.answer_user(
+        transcript="What should I do now?",
+        session=session,
+        current_step=step,
+        observation_log=[],
+        recent_turns=[],
+    )
+
+    prompt = captured[-1].content
+    assert "[Current-step context only]" in prompt
+    assert '"tea_name": "green tea"' in prompt
+    assert "steeping_started_at_us" not in prompt
+    assert "steeping_complete" not in prompt
+    assert "navigation_examples" not in prompt
+    assert "name=Fill water" not in prompt
+    assert "name=Steep the tea" not in prompt
+
+
+async def test_answer_next_step_tool_is_grounded_in_workflow_yaml() -> None:
+    workflow = _workflow()
+    step = workflow.step_by_id(1)
+    model_calls: list[list] = []
+
+    class _Llm:
+        async def chat(self, messages, **_kwargs):
+            model_calls.append(list(messages))
+            if len(model_calls) == 1:
+                return SimpleNamespace(
+                    content="",
+                    tool_calls=[
+                        ToolCall(
+                            id="next-1",
+                            name="get_next_workflow_step",
+                            arguments="{}",
+                        )
+                    ],
+                )
+            return SimpleNamespace(
+                content="Next, fill the kettle or pot with water.",
+                tool_calls=[],
+            )
+
+    class _Tools:
+        def definitions(self):
+            return []
+
+    agent = WorkflowAgent(
+        llm=_Llm(),
+        tools=_Tools(),
+        workflow=workflow,
+        answer_prompt=(_WORKER_DIR / "tea_making_worker" / "prompts" / "system.txt"),
+    )
+    session = WorkflowSession(
+        participant_id="alice",
+        step_id=1,
+        context={"tea_name": "green tea"},
+    )
+
+    answer = await agent.answer_user(
+        transcript="What comes next?",
+        session=session,
+        current_step=step,
+        observation_log=[],
+        recent_turns=[],
+    )
+
+    assert answer == "Next, fill the kettle or pot with water."
+    tool_result = model_calls[1][-1].content
+    assert '"name": "Fill water"' in tool_result
+    assert "Steep the tea" not in tool_result
+
+
+async def test_answer_agent_receives_only_read_only_tools() -> None:
+    workflow = _workflow()
+    offered: list[str] = []
+
+    async def invoke(_arguments):
+        return {"ok": True}
+
+    class _Tools:
+        def agent_tools(self):
+            return [
+                tools_module.AgentTool(
+                    ToolDef(name="read_sensor", description="Read.", parameters={}),
+                    invoke,
+                    read_only=True,
+                ),
+                tools_module.AgentTool(
+                    ToolDef(name="change_device", description="Write.", parameters={}),
+                    invoke,
+                    read_only=False,
+                ),
+            ]
+
+    class _Llm:
+        async def chat(self, _messages, **kwargs):
+            offered.extend(tool.name for tool in kwargs["tools"])
+            return SimpleNamespace(content="The sensor is available.", tool_calls=[])
+
+    agent = WorkflowAgent(
+        llm=_Llm(),
+        tools=_Tools(),
+        workflow=workflow,
+        answer_prompt=(_WORKER_DIR / "tea_making_worker" / "prompts" / "system.txt"),
+    )
+
+    await agent.answer_user(
+        transcript="Can you check the sensor?",
+        session=None,
+        current_step=workflow.step_by_id(0),
+        observation_log=[],
+        recent_turns=[],
+    )
+
+    assert "read_sensor" in offered
+    assert "change_device" not in offered
+    assert "get_recent_vlm_observations" in offered
+    assert "inspect_current_view" in offered
+    assert "get_next_workflow_step" in offered
 
 
 def test_yaml_completion_rule_cannot_be_bypassed_by_model_readiness() -> None:
@@ -630,16 +897,16 @@ def test_yaml_completion_rule_cannot_be_bypassed_by_model_readiness() -> None:
     assert workflow.advance_when_met(step, context)
 
 
-def test_step_four_skip_replaces_zero_timestamp_with_current_time() -> None:
+def test_final_step_skip_completes_without_inventing_a_start_time() -> None:
     workflow = _workflow()
     step = workflow.step_by_id(4)
     context = workflow.initial_context()
 
     applied = workflow.apply_skip_defaults(step, context)
 
-    assert applied.keys() == {"steeping_started_at_us", "steeping_started_at_iso"}
-    assert context["steeping_started_at_us"] > 0
-    assert context["steeping_started_at_iso"]
+    assert applied == {"steeping_complete": True}
+    assert "steeping_started_at_us" not in context
+    assert "steeping_started_at_iso" not in context
 
 
 async def test_step_agent_calls_time_tool_to_capture_steeping_start() -> None:
@@ -666,7 +933,7 @@ async def test_step_agent_calls_time_tool_to_capture_steeping_start() -> None:
                 content=(
                     '{"context":{"steeping_started_at_us":1785798780376000,'
                     '"steeping_started_at_iso":"2026-08-03T16:13:00-07:00"},'
-                    '"ready_to_advance":true,"step_state":"complete",'
+                    '"ready_to_advance":false,"step_state":"started",'
                     '"assistant_message":"","speak":false}'
                 ),
                 tool_calls=[],
@@ -674,7 +941,10 @@ async def test_step_agent_calls_time_tool_to_capture_steeping_start() -> None:
 
     class _Tools:
         def definitions(self):
-            return [SimpleNamespace(name="get_current_time")]
+            return [
+                SimpleNamespace(name="get_current_time"),
+                SimpleNamespace(name="get_timer_status"),
+            ]
 
         async def invoke(self, name, arguments):
             tool_calls.append((name, arguments))
@@ -701,6 +971,7 @@ async def test_step_agent_calls_time_tool_to_capture_steeping_start() -> None:
     assert tool_calls == [("get_current_time", {})]
     assert result.context_patch["steeping_started_at_us"] == 1_785_798_780_376_000
     assert result.context_patch["steeping_started_at_iso"] == ("2026-08-03T16:13:00-07:00")
+    assert result.ready_to_advance is False
     assert '"epoch_us": 1785798780376000' in model_calls[1][-1].content
 
 
@@ -771,7 +1042,7 @@ async def test_timer_tool_rejects_a_missing_start_time() -> None:
 
 async def test_step_agent_uses_timer_tool_to_complete_no_caption_step() -> None:
     workflow = _workflow()
-    step = workflow.step_by_id(5)
+    step = workflow.step_by_id(4)
     model_calls: list[list] = []
     tool_calls: list[tuple[str, dict]] = []
 
@@ -842,13 +1113,15 @@ async def test_step_agent_uses_timer_tool_to_complete_no_caption_step() -> None:
 
 async def test_answer_agent_uses_timer_tool_for_remaining_time_question() -> None:
     workflow = _workflow()
-    step = workflow.step_by_id(5)
+    step = workflow.step_by_id(4)
     calls = 0
+    model_calls: list[list] = []
 
     class _Llm:
-        async def chat(self, _messages, **_kwargs):
+        async def chat(self, messages, **_kwargs):
             nonlocal calls
             calls += 1
+            model_calls.append(list(messages))
             if calls == 1:
                 return SimpleNamespace(
                     content="",
@@ -869,15 +1142,25 @@ async def test_answer_agent_uses_timer_tool_for_remaining_time_question() -> Non
             )
 
     class _Tools:
-        def definitions(self):
-            return [SimpleNamespace(name="get_timer_status")]
-
-        async def invoke(self, _name, _arguments):
+        async def timer_status(self, _arguments):
             return {
                 "elapsed_seconds": 65,
                 "remaining_seconds": 115,
                 "expired": False,
             }
+
+        def agent_tools(self):
+            return [
+                tools_module.AgentTool(
+                    ToolDef(
+                        name="get_timer_status",
+                        description="Read timer status.",
+                        parameters={},
+                    ),
+                    self.timer_status,
+                    read_only=True,
+                )
+            ]
 
     agent = WorkflowAgent(
         llm=_Llm(),
@@ -890,21 +1173,26 @@ async def test_answer_agent_uses_timer_tool_for_remaining_time_question() -> Non
         steeping_started_at_us=1_785_798_780_000_000,
         steep_duration_seconds=180,
     )
-    session = WorkflowSession(participant_id="alice", step_id=5, context=context)
+    session = WorkflowSession(participant_id="alice", step_id=4, context=context)
 
     answer = await agent.answer_user(
         transcript="How long do I still need to wait?",
         session=session,
         current_step=step,
         observation_log=[],
-        recent_turns=[],
+        recent_turns=[
+            ("How much time has elapsed?", "One minute and five seconds have elapsed."),
+        ],
     )
 
     assert calls == 2
     assert answer == "About one minute and fifty-five seconds remain."
+    prompt = model_calls[0][-1].content
+    assert "How much time has elapsed?" in prompt
+    assert "One minute and five seconds" not in prompt
 
 
-async def test_no_caption_timer_step_runs_agent_and_finishes_workflow() -> None:
+async def test_merged_steeping_step_stops_vision_and_finishes_workflow() -> None:
     workflow = _workflow()
     now_us = guide_module._now_us()  # noqa: SLF001
     context = workflow.initial_context()
@@ -917,7 +1205,7 @@ async def test_no_caption_timer_step_runs_agent_and_finishes_workflow() -> None:
 
     class _Vision:
         async def observe(self, *_args, **_kwargs):
-            raise AssertionError("timer-only step must not invoke the VLM")
+            raise AssertionError("merged timer phase must not invoke the VLM")
 
         def release(self, _participant_id: str) -> None:
             return None
@@ -940,7 +1228,12 @@ async def test_no_caption_timer_step_runs_agent_and_finishes_workflow() -> None:
         agent=_Agent(),
         notice=notice,
     )
-    session = WorkflowSession(participant_id="alice", step_id=5, context=context)
+    session = WorkflowSession(participant_id="alice", step_id=4, context=context)
+    step = workflow.step_by_id(4)
+
+    assert workflow.condition_met(step.vlm_stop_when, context)
+    assert guide._reminder_due(session, step) == ""  # noqa: SLF001
+    assert session.reminder_count == 0
 
     await guide._evaluate(session)  # noqa: SLF001
 
@@ -951,6 +1244,57 @@ async def test_no_caption_timer_step_runs_agent_and_finishes_workflow() -> None:
     assert session.ready_step_id is None
     assert "steeping_complete" not in session.context
     assert notices == [("alice", "The steeping time is up. Remove the tea bag, infuser, or leaves now.")]
+
+
+async def test_merged_steeping_step_observes_until_start_is_recorded() -> None:
+    workflow = _workflow()
+    captions: list[str] = []
+    notices: list[str] = []
+
+    class _Vision:
+        async def observe(self, *_args, **_kwargs):
+            return SimpleNamespace(
+                text="The tea bag is immersed.\nSTEEPING_STARTED: yes",
+                frame_pts_us=10,
+            )
+
+        def release(self, _participant_id: str) -> None:
+            return None
+
+    class _Agent:
+        async def run_step(self, *, vlm_observation, **_kwargs):
+            captions.append(vlm_observation)
+            return StepAgentResult(
+                context_patch={
+                    "steeping_started_at_us": 1_785_798_780_376_000,
+                    "steeping_started_at_iso": "2026-08-03T16:13:00-07:00",
+                },
+                step_state="started",
+            )
+
+    async def notice(_participant_id: str, text: str) -> None:
+        notices.append(text)
+
+    guide = WorkflowGuide(
+        workflow=workflow,
+        vision=_Vision(),
+        agent=_Agent(),
+        notice=notice,
+    )
+    session = WorkflowSession(
+        participant_id="alice",
+        step_id=4,
+        context={"steep_duration_seconds": 180},
+        last_reminder_us=0,
+    )
+
+    await guide._evaluate(session)  # noqa: SLF001
+
+    assert captions == ["The tea bag is immersed.\nSTEEPING_STARTED: yes"]
+    assert session.context["steeping_started_at_us"] == 1_785_798_780_376_000
+    assert session.ready_step_id is None
+    assert session.reminder_count == 0
+    assert notices == []
 
 
 async def test_completed_step_does_not_repeat_guidance_or_recheck_vision() -> None:
@@ -991,7 +1335,7 @@ async def test_completed_step_does_not_repeat_guidance_or_recheck_vision() -> No
     assert notices == []
 
 
-async def test_participant_reconnect_preserves_active_workflow_state() -> None:
+async def test_disconnect_and_reconnect_clear_workflow_state() -> None:
     workflow = _workflow()
 
     class _Vision:
@@ -1015,22 +1359,30 @@ async def test_participant_reconnect_preserves_active_workflow_state() -> None:
     session.context["tea_name"] = "green tea"
     session.step_id = 4
     session.step_state = "needs_input"
+    session.observation_log.append({"caption": "old evidence"})
+    guide._history["alice"] = [("old request", "old answer")]  # noqa: SLF001
 
     await guide.release("alice")
 
-    assert session.active is True
+    assert "alice" not in guide._sessions  # noqa: SLF001
+    assert "alice" not in guide._history  # noqa: SLF001
+    assert session.active is False
     assert session.connected is False
-    assert session.step_id == 4
-    assert session.context["tea_name"] == "green tea"
+    assert session.step_id == 0
+    assert session.context == workflow.initial_context()
+    assert session.observation_log == []
 
-    await guide.resume("alice")
+    await guide.reset("alice")
+    restarted_message = await guide.start("alice")
+    restarted = guide._sessions["alice"]  # noqa: SLF001
 
-    assert session.active is True
-    assert session.connected is True
-    assert session.step_id == 4
+    assert "show me the tea label" in restarted_message.lower()
+    assert restarted is not session
+    assert restarted.step_id == 1
+    assert restarted.context == workflow.initial_context()
 
 
-async def test_final_advance_resets_to_idle_and_restart_uses_fresh_context() -> None:
+async def test_next_on_incomplete_final_step_resets_and_restarts_fresh() -> None:
     workflow = _workflow()
 
     class _Vision:
@@ -1050,21 +1402,20 @@ async def test_final_advance_resets_to_idle_and_restart_uses_fresh_context() -> 
     context.update(
         tea_name="green tea",
         steeping_started_at_us=123,
-        steeping_complete=True,
     )
     session = WorkflowSession(
         participant_id="alice",
-        step_id=5,
+        step_id=4,
         context=context,
-        ready_step_id=5,
-        step_state="complete",
+        step_state="started",
         observation_log=[{"caption": "old evidence"}],
     )
     guide._sessions["alice"] = session  # noqa: SLF001
 
     response = await guide.advance("alice")
 
-    assert "steeping time is up" in response.lower()
+    assert "using reasonable defaults" in response.lower()
+    assert "timer skipped" in response.lower()
     assert session.active is False
     assert session.step_id == 0
     assert session.step_state == "idle"
@@ -1078,6 +1429,49 @@ async def test_final_advance_resets_to_idle_and_restart_uses_fresh_context() -> 
     assert restarted.active is True
     assert restarted.step_id == 1
     assert "tea_name" not in restarted.context
+
+
+async def test_cancel_clears_active_state_before_a_fresh_restart() -> None:
+    workflow = _workflow()
+
+    class _Vision:
+        def release(self, _participant_id: str) -> None:
+            return None
+
+    async def notice(_participant_id: str, _text: str) -> None:
+        return None
+
+    guide = WorkflowGuide(
+        workflow=workflow,
+        vision=_Vision(),
+        agent=SimpleNamespace(),
+        notice=notice,
+    )
+    await guide.start("alice")
+    old_session = guide._sessions["alice"]  # noqa: SLF001
+    old_session.step_id = 3
+    old_session.context.update(
+        tea_name="black tea",
+        water_filled=True,
+        water_temperature_current="90 C",
+    )
+    old_session.observation_log.append({"caption": "old evidence"})
+    guide._history["alice"] = [("old request", "old answer")]  # noqa: SLF001
+
+    response = await guide.handle_query(participant_id="alice", text="cancel tea")
+
+    assert response == "Guidance stopped."
+    assert old_session.active is False
+    assert old_session.step_id == 0
+    assert old_session.context == workflow.initial_context()
+    assert old_session.observation_log == []
+    assert "alice" not in guide._history  # noqa: SLF001
+
+    await guide.start("alice")
+    restarted = guide._sessions["alice"]  # noqa: SLF001
+    assert restarted is not old_session
+    assert restarted.step_id == 1
+    assert restarted.context == workflow.initial_context()
 
 
 def test_start_making_tea_trigger_starts_only_while_idle() -> None:
@@ -1183,7 +1577,7 @@ async def test_answer_agent_receives_completed_step_state_and_yaml_procedure() -
     assert "ready=True" in prompt
 
 
-async def test_answer_agent_prioritizes_latest_step_monitor_over_old_turns() -> None:
+async def test_answer_prompt_omits_old_assistant_measurements() -> None:
     workflow = _workflow()
     step = workflow.step_by_id(3)
     captured: list = []
@@ -1235,7 +1629,8 @@ async def test_answer_agent_prioritizes_latest_step_monitor_over_old_turns() -> 
     )
 
     prompt = captured[-1].content
-    assert prompt.index("The water is currently 59 C.") < prompt.index("[Workflow snapshot]")
+    assert "The water is currently 59 C." not in prompt
+    assert "What is the temperature?" in prompt
     assert '"water_temperature_current": "100 C"' in prompt
     assert "TEMPERATURE_READING: 100 C" in prompt
     assert (

--- a/tests/test_tea_making_sample.py
+++ b/tests/test_tea_making_sample.py
@@ -513,6 +513,27 @@ async def test_answer_agent_can_inspect_a_fresh_view_for_visual_questions() -> N
     assert '"visual_evidence": "The kettle display reads 82 C."' in (model_calls[1][-1].content)
 
 
+def test_visual_question_answer_is_not_reused_as_current_step_observation() -> None:
+    observation_log = [
+        {
+            "step_id": 3,
+            "kind": "step_monitor",
+            "caption": "WATER_TEMPERATURE: 35 C",
+        },
+        {
+            "step_id": 3,
+            "kind": "visual_question",
+            "question": "What temperature is it now?",
+            "caption": "The display reads 37 C.",
+        },
+    ]
+
+    latest = agent_module._latest_step_observation(observation_log, 3)  # noqa: SLF001
+
+    assert "35 C" in latest
+    assert "37 C" not in latest
+
+
 async def test_guide_logs_fresh_visual_answers_and_normalizes_them_for_speech() -> None:
     workflow = _workflow()
     inspected: list[str] = []
@@ -1082,7 +1103,7 @@ async def test_answer_agent_receives_completed_step_state_and_yaml_procedure() -
     assert "ready=True" in prompt
 
 
-async def test_answer_agent_prioritizes_latest_visual_state_over_old_turns() -> None:
+async def test_answer_agent_prioritizes_latest_step_monitor_over_old_turns() -> None:
     workflow = _workflow()
     step = workflow.step_by_id(3)
     captured: list = []
@@ -1134,13 +1155,13 @@ async def test_answer_agent_prioritizes_latest_visual_state_over_old_turns() -> 
     )
 
     prompt = captured[-1].content
-    assert prompt.index("The water is currently 59 C.") < prompt.index("[Authoritative current state]")
+    assert prompt.index("The water is currently 59 C.") < prompt.index("[Workflow snapshot]")
     assert '"water_temperature_current": "100 C"' in prompt
     assert "TEMPERATURE_READING: 100 C" in prompt
     assert (
         "TEMPERATURE_READING: 59 C"
         not in prompt.split(
-            "[Latest VLM observation]",
+            "[Latest step-monitor observation]",
             maxsplit=1,
         )[1]
     )

--- a/tests/test_tea_making_sample.py
+++ b/tests/test_tea_making_sample.py
@@ -1,0 +1,957 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused contracts for the YAML-driven tea-making sample."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SAMPLE_DIR = _REPO_ROOT / "agent-samples" / "tea-making-sample"
+_WORKER_DIR = _SAMPLE_DIR / "worker"
+_OMNI_DIR = _REPO_ROOT / "ai-services" / "llm" / "nemotron_omni"
+sys.path.insert(0, str(_WORKER_DIR))
+sys.path.insert(0, str(_OMNI_DIR))
+
+from nemotron_omni_llm_server import __main__ as omni_server_module  # noqa: E402
+from tea_making_worker import agent as agent_module  # noqa: E402
+from tea_making_worker import guide as guide_module  # noqa: E402
+from tea_making_worker.agent import (  # noqa: E402
+    NavigationIntent,
+    StepAgentResult,
+    WorkflowAgent,
+)
+from tea_making_worker.guide import WorkflowGuide  # noqa: E402
+from tea_making_worker.workflow import (  # noqa: E402
+    WorkflowDefinition,
+    WorkflowSession,
+)
+
+_MAIN_SPEC = importlib.util.spec_from_file_location(
+    "tea_making_sample_main",
+    _SAMPLE_DIR / "main.py",
+)
+assert _MAIN_SPEC is not None and _MAIN_SPEC.loader is not None
+sample_main_module = importlib.util.module_from_spec(_MAIN_SPEC)
+_MAIN_SPEC.loader.exec_module(sample_main_module)
+
+
+def _workflow() -> WorkflowDefinition:
+    return WorkflowDefinition.load(_SAMPLE_DIR / "yaml" / "workflow.yaml")
+
+
+def test_shipped_workflow_uses_omni_native_rag_and_timer_only_step_five() -> None:
+    workflow = _workflow()
+    models = yaml.safe_load((_SAMPLE_DIR / "yaml" / "models.yaml").read_text())
+    worker = yaml.safe_load(
+        (_SAMPLE_DIR / "yaml" / "tea_making_worker.yaml").read_text()
+    )
+    step_five = workflow.step_by_id(5)
+
+    assert models["agent_llm"]["kind"] == "preset:nemotron_omni"
+    assert models["embedding"]["kind"] == "preset:nemotron_embedding"
+    assert worker["rag_endpoint"] == "tcp://127.0.0.1:8340"
+    assert worker["vlm_timeout_s"] == 15.0
+
+    for profile in ("96G_blackwell", "dual_48G_ada"):
+        profile_dir = _SAMPLE_DIR / "yaml" / profile
+        embedding = yaml.safe_load((profile_dir / "embedding_server.yaml").read_text())
+        omni = yaml.safe_load(
+            (profile_dir / "nemotron_omni_llm_server.yaml").read_text()
+        )
+        stt = yaml.safe_load((profile_dir / "stt_server.yaml").read_text())
+
+        assert omni["vllm_image"] == "vllm/vllm-openai:v0.20.0"
+        assert omni["extra_pip"] == []
+        assert omni["max_num_seqs"] <= 8
+        assert omni["max_model_len"] <= 32768
+        assert omni["tensor_parallel_size"] == 1
+        assert stt["cuda_visible_devices"] in {"0", "1"}
+        assert embedding["cuda_visible_devices"] in {"0", "1"}
+
+    blackwell_dir = _SAMPLE_DIR / "yaml" / "96G_blackwell"
+    blackwell_omni = yaml.safe_load(
+        (blackwell_dir / "nemotron_omni_llm_server.yaml").read_text()
+    )
+    blackwell_embedding = yaml.safe_load(
+        (blackwell_dir / "embedding_server.yaml").read_text()
+    )
+    assert blackwell_omni["cuda_visible_devices"] == "0"
+    assert blackwell_omni["gpu_memory_utilization"] <= 0.80
+    assert "moe_backend" not in blackwell_omni
+    assert blackwell_embedding["cuda_visible_devices"] == "0"
+    assert blackwell_embedding["gpu_memory_utilization"] <= 0.05
+    assert (
+        blackwell_omni["gpu_memory_utilization"]
+        + blackwell_embedding["gpu_memory_utilization"]
+        < 0.86
+    )
+
+    ada_dir = _SAMPLE_DIR / "yaml" / "dual_48G_ada"
+    ada_omni = yaml.safe_load(
+        (ada_dir / "nemotron_omni_llm_server.yaml").read_text()
+    )
+    ada_embedding = yaml.safe_load((ada_dir / "embedding_server.yaml").read_text())
+    ada_stt = yaml.safe_load((ada_dir / "stt_server.yaml").read_text())
+    assert ada_omni["cuda_visible_devices"] == "0"
+    assert ada_omni["gpu_memory_utilization"] <= 0.85
+    assert ada_embedding["cuda_visible_devices"] == "1"
+    assert ada_embedding["gpu_memory_utilization"] <= 0.10
+    assert ada_stt["cuda_visible_devices"] == "1"
+
+    assert not (_SAMPLE_DIR / "yaml" / "rag.yaml").exists()
+    assert not (_WORKER_DIR / "tea_making_worker" / "rag.py").exists()
+    assert step_five.timer is not None
+    assert step_five.vlm_prompt == ""
+    assert step_five.timer.completion_field == "steeping_complete"
+    step_three = workflow.step_by_id(3)
+    state_updates = {
+        update.context_field: update for update in step_three.state_updates
+    }
+    assert set(state_updates) == {"water_temperature_current", "water_ready"}
+    assert state_updates["water_temperature_current"].observation_key == (
+        "TEMPERATURE_READING"
+    )
+    assert state_updates["water_temperature_current"].states == (
+        "started",
+        "needs_input",
+        "complete",
+    )
+    assert state_updates["water_ready"].value_map == {
+        "yes": True,
+        "no": False,
+        "unclear": False,
+    }
+    assert "water_temperature_current" in {
+        field.name for field in step_three.context_fields
+    }
+
+
+def test_launcher_selects_hardware_specific_model_configs() -> None:
+    for detected, expected in (
+        ("96G_blackwell", "96G_blackwell"),
+        ("dual_48G_ada", "dual_48G_ada"),
+        ("spark", "96G_blackwell"),
+    ):
+        processes = sample_main_module._build_processes(detected)
+        by_name = {process.name: process for process in processes}
+
+        assert processes[0].name == "omni"
+        assert by_name["omni"].config == (
+            f"yaml/{expected}/nemotron_omni_llm_server.yaml"
+        )
+        assert by_name["stt"].config == f"yaml/{expected}/stt_server.yaml"
+        assert by_name["embedding"].config == (
+            f"yaml/{expected}/embedding_server.yaml"
+        )
+
+
+def test_omni_server_forwards_configured_moe_backend(monkeypatch, tmp_path: Path) -> None:
+    captured: dict = {}
+    config = {
+        "cuda_visible_devices": "0",
+        "moe_backend": "triton",
+        "vllm_backend": "docker",
+    }
+
+    monkeypatch.setattr(omni_server_module, "setup_logging", lambda *_: None)
+    monkeypatch.setattr(
+        omni_server_module,
+        "load_config",
+        lambda: (config, tmp_path, None),
+    )
+    monkeypatch.setattr(
+        omni_server_module,
+        "resolve_model_cache",
+        lambda *_args, **_kwargs: tmp_path,
+    )
+    monkeypatch.setattr(
+        omni_server_module,
+        "setup_hf_env",
+        lambda *_args, **_kwargs: "0",
+    )
+    monkeypatch.setattr(omni_server_module, "gpu_compute_major", lambda: 12)
+    monkeypatch.setattr(
+        omni_server_module,
+        "serve",
+        lambda **kwargs: captured.update(kwargs),
+    )
+
+    omni_server_module.run()
+
+    serve_args = captured["extra_serve_args"]
+    backend_index = serve_args.index("--moe-backend")
+    assert serve_args[backend_index + 1] == "triton"
+
+
+async def test_state_updates_are_driven_by_arbitrary_workflow_yaml(
+    tmp_path: Path,
+) -> None:
+    workflow_path = tmp_path / "workflow.yaml"
+    workflow_path.write_text(
+        yaml.safe_dump(
+            {
+                "task": {"name": "equipment-check"},
+                "runtime": {},
+                "steps": [
+                    {
+                        "id": 0,
+                        "name": "Idle",
+                        "description": "Wait.",
+                        "context_output": {"fields": {}},
+                    },
+                    {
+                        "id": 1,
+                        "name": "Read instrument",
+                        "description": "Read an arbitrary instrument.",
+                        "vlm_prompt": (
+                            "End with PRESSURE_READING and ALARM_ACTIVE lines."
+                        ),
+                        "agent_prompt": "Interpret the latest instrument reading.",
+                        "state_updates": [
+                            {
+                                "context_field": "pressure_kpa",
+                                "observation_key": "PRESSURE_READING",
+                                "states": ["started", "complete"],
+                            },
+                            {
+                                "context_field": "alarm_active",
+                                "observation_key": "ALARM_ACTIVE",
+                                "states": ["started", "complete"],
+                                "value_map": {"yes": True, "no": False},
+                            },
+                        ],
+                        "context_output": {
+                            "fields": {
+                                "pressure_kpa": {
+                                    "label": "Pressure",
+                                    "type": "number",
+                                    "default": 0,
+                                },
+                                "alarm_active": {
+                                    "label": "Alarm active",
+                                    "type": "boolean",
+                                    "default": False,
+                                },
+                            }
+                        },
+                        "advance_when": {
+                            "field": "alarm_active",
+                            "equals": True,
+                        },
+                    },
+                    {
+                        "id": 2,
+                        "name": "Finish check",
+                        "description": "Finish the equipment check.",
+                        "vlm_prompt": "Observe whether the check is finished.",
+                        "agent_prompt": "Set finished from visible evidence.",
+                        "context_output": {
+                            "fields": {
+                                "finished": {
+                                    "label": "Finished",
+                                    "type": "boolean",
+                                    "default": False,
+                                }
+                            }
+                        },
+                        "advance_when": {
+                            "field": "finished",
+                            "equals": True,
+                        },
+                    },
+                ],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    workflow = WorkflowDefinition.load(workflow_path)
+    step = workflow.step_by_id(1)
+
+    assert step.observation_context_patch(
+        "Visible display.\nPRESSURE_READING: 42.5\nALARM_ACTIVE: yes",
+        state="started",
+    ) == {"pressure_kpa": 42.5, "alarm_active": True}
+    assert step.observation_context_patch(
+        "PRESSURE_READING: 44.0\nALARM_ACTIVE: no",
+        state="complete",
+    ) == {"pressure_kpa": 44.0, "alarm_active": False}
+    assert step.observation_context_patch(
+        "PRESSURE_READING: 45.0\nALARM_ACTIVE: yes",
+        state="needs_input",
+    ) == {}
+    assert step.observation_context_patch(
+        "PRESSURE_READING: unavailable\nALARM_ACTIVE: unclear",
+        state="started",
+    ) == {}
+
+    observations = iter(
+        [
+            SimpleNamespace(
+                text="PRESSURE_READING: 42.5\nALARM_ACTIVE: yes",
+                frame_pts_us=1,
+            ),
+            SimpleNamespace(
+                text="PRESSURE_READING: 44.0\nALARM_ACTIVE: no",
+                frame_pts_us=2,
+            ),
+        ]
+    )
+    agent_contexts: list[dict] = []
+    notices: list[tuple[str, str]] = []
+
+    class _Vision:
+        async def observe(self, *_args, **_kwargs):
+            return next(observations)
+
+        def release(self, _participant_id: str) -> None:
+            return None
+
+    class _Agent:
+        async def run_step(self, *, session, **_kwargs):
+            agent_contexts.append(dict(session.context))
+            return StepAgentResult(
+                context_patch={"pressure_kpa": 1.0, "alarm_active": True},
+                step_state="started",
+            )
+
+    async def notice(participant_id: str, text: str) -> None:
+        notices.append((participant_id, text))
+
+    guide = WorkflowGuide(
+        workflow=workflow,
+        vision=_Vision(),
+        agent=_Agent(),
+        notice=notice,
+    )
+    session = WorkflowSession(
+        participant_id="alice",
+        step_id=1,
+        context=workflow.initial_context(),
+    )
+
+    await guide._evaluate(session)  # noqa: SLF001
+
+    assert agent_contexts[0]["pressure_kpa"] == 42.5
+    assert agent_contexts[0]["alarm_active"] is True
+    assert session.context["pressure_kpa"] == 42.5
+    assert session.context["alarm_active"] is True
+    assert session.ready_step_id == 1
+    assert session.step_state == "complete"
+    assert len(notices) == 1
+
+    await guide._evaluate(session)  # noqa: SLF001
+
+    assert agent_contexts[1]["pressure_kpa"] == 44.0
+    assert agent_contexts[1]["alarm_active"] is False
+    assert session.context["pressure_kpa"] == 44.0
+    assert session.context["alarm_active"] is False
+    assert session.ready_step_id == 1
+    assert session.step_state == "complete"
+    assert len(notices) == 1
+
+
+def test_yaml_completion_rule_cannot_be_bypassed_by_model_readiness() -> None:
+    workflow = _workflow()
+    step = workflow.step_by_id(1)
+    context = workflow.initial_context()
+
+    assert not workflow.advance_when_met(step, context, ready_to_advance=True)
+    context.update(
+        tea_name="green tea",
+        tea_temperature="175 F",
+        steep_time="2 minutes",
+        steep_duration_seconds=120,
+        context_ready=True,
+    )
+    assert workflow.advance_when_met(step, context)
+
+
+def test_step_four_skip_replaces_zero_timestamp_with_current_time() -> None:
+    workflow = _workflow()
+    step = workflow.step_by_id(4)
+    context = workflow.initial_context()
+
+    applied = workflow.apply_skip_defaults(step, context)
+
+    assert applied.keys() == {"steeping_started_at_us", "steeping_started_at_iso"}
+    assert context["steeping_started_at_us"] > 0
+    assert context["steeping_started_at_iso"]
+
+
+def test_vlm_yes_policy_accepts_yaml_boolean_and_string_values() -> None:
+    observation = "tea bag, entering the water\n\nSTEEPING_STARTED: yes"
+
+    assert agent_module._tool_policy_met(  # noqa: SLF001
+        {"vlm_verdict": "STEEPING_STARTED", "equals": True},
+        observation,
+    )
+    assert agent_module._tool_policy_met(  # noqa: SLF001
+        {"vlm_verdict": "STEEPING_STARTED", "equals": "yes"},
+        observation,
+    )
+
+
+async def test_vlm_yes_automatically_captures_steeping_start_time() -> None:
+    workflow = _workflow()
+    step = workflow.step_by_id(4)
+    captured_messages: list = []
+    tool_calls: list[tuple[str, dict]] = []
+
+    class _Llm:
+        async def chat(self, messages, **_kwargs):
+            captured_messages.extend(messages)
+            return SimpleNamespace(
+                content=(
+                    '{"context":{"steeping_started_at_us":0,'
+                    '"steeping_started_at_iso":""},"ready_to_advance":false,'
+                    '"step_state":"started","assistant_message":"","speak":false}'
+                ),
+                tool_calls=[],
+            )
+
+    class _Tools:
+        def definitions(self):
+            return [SimpleNamespace(name="get_current_time")]
+
+        async def invoke(self, name, arguments):
+            tool_calls.append((name, arguments))
+            return {
+                "epoch_us": 1_785_798_780_376_000,
+                "iso": "2026-08-03T16:13:00-07:00",
+                "timezone": "PDT",
+            }
+
+    agent = WorkflowAgent(
+        llm=_Llm(),
+        tools=_Tools(),
+        workflow=workflow,
+        answer_prompt=(
+            _WORKER_DIR / "tea_making_worker" / "prompts" / "system.txt"
+        ),
+    )
+    session = WorkflowSession(
+        participant_id="alice",
+        step_id=4,
+        context=workflow.initial_context(),
+    )
+
+    result = await agent.run_step(
+        step=step,
+        session=session,
+        vlm_observation="tea bag, entering the water\n\nSTEEPING_STARTED: yes",
+    )
+
+    assert tool_calls == [("get_current_time", {})]
+    assert result.context_patch["steeping_started_at_us"] == 1_785_798_780_376_000
+    assert result.context_patch["steeping_started_at_iso"] == (
+        "2026-08-03T16:13:00-07:00"
+    )
+    assert "1785798780376000" in captured_messages[1].content
+
+
+def test_navigation_eval_cases_require_explicit_movement_language() -> None:
+    workflow = _workflow()
+    cases = yaml.safe_load((_SAMPLE_DIR / "eval" / "cases.yaml").read_text())
+
+    for case in cases["navigation"]:
+        proposed = NavigationIntent(
+            intent=case["proposed_intent"],
+            explicit_command=case["explicit_command"],
+            confidence=0.95,
+        )
+        actual = guide_module._validated_model_intent(  # noqa: SLF001
+            case["utterance"],
+            proposed,
+            workflow,
+            active=True,
+        )
+        assert actual.intent == case["expected_intent"], case["utterance"]
+
+
+def test_timer_question_eval_cases_report_elapsed_or_remaining(monkeypatch) -> None:
+    workflow = _workflow()
+    now_us = 10_000_000_000
+    context = workflow.initial_context()
+    context.update(
+        steeping_started_at_us=now_us - 65_000_000,
+        steep_duration_seconds=180,
+    )
+    session = WorkflowSession(participant_id="alice", step_id=5, context=context)
+    cases = yaml.safe_load((_SAMPLE_DIR / "eval" / "cases.yaml").read_text())
+    monkeypatch.setattr(guide_module, "_now_us", lambda: now_us)
+
+    for case in cases["timer_questions"]:
+        answer = guide_module._time_question_answer(  # noqa: SLF001
+            case["utterance"],
+            session,
+            workflow,
+        )
+        if case["expected"] == "elapsed":
+            assert "1 minute 5 seconds" in answer
+        else:
+            assert "1 minute 55 seconds" in answer
+            assert "left" in answer
+
+    monkeypatch.setattr(guide_module, "_now_us", lambda: now_us + 120_000_000)
+    assert "time is up" in guide_module._time_question_answer(  # noqa: SLF001
+        "How much longer do I need to wait?",
+        session,
+        workflow,
+    )
+
+
+def test_timer_questions_do_not_invent_a_missing_start_time() -> None:
+    workflow = _workflow()
+    context = workflow.initial_context()
+    context["steep_duration_seconds"] = 180
+    session = WorkflowSession(participant_id="alice", step_id=4, context=context)
+
+    remaining = guide_module._time_question_answer(  # noqa: SLF001
+        "How long do I have remaining?",
+        session,
+        workflow,
+    )
+    started = guide_module._time_question_answer(  # noqa: SLF001
+        "When did I steep the tea?",
+        session,
+        workflow,
+    )
+
+    assert "has not started" in remaining
+    assert "3 minutes" in remaining
+    assert "no start time is recorded" in started
+
+
+def test_timer_start_time_question_uses_recorded_timestamp(monkeypatch) -> None:
+    workflow = _workflow()
+    started_at_us = 1_785_798_780_000_000
+    context = workflow.initial_context()
+    context.update(
+        steeping_started_at_us=started_at_us,
+        steep_duration_seconds=180,
+    )
+    session = WorkflowSession(participant_id="alice", step_id=5, context=context)
+    monkeypatch.setattr(
+        guide_module,
+        "_now_us",
+        lambda: started_at_us + 30_000_000,
+    )
+
+    answer = guide_module._time_question_answer(  # noqa: SLF001
+        "When did I steep the tea?",
+        session,
+        workflow,
+    )
+
+    assert "timer started at" in answer
+    assert "time is up" not in answer
+
+
+async def test_timer_step_expires_without_calling_vision_or_step_agent() -> None:
+    workflow = _workflow()
+    now_us = guide_module._now_us()  # noqa: SLF001
+    context = workflow.initial_context()
+    context.update(
+        steeping_started_at_us=now_us - 181_000_000,
+        steep_duration_seconds=180,
+    )
+    notices: list[tuple[str, str]] = []
+
+    class _Vision:
+        async def observe(self, *_args, **_kwargs):
+            raise AssertionError("timer-only step must not invoke the VLM")
+
+        def release(self, _participant_id: str) -> None:
+            return None
+
+    class _Agent:
+        async def run_step(self, *_args, **_kwargs):
+            raise AssertionError("timer-only step must not invoke the step agent")
+
+    async def notice(participant_id: str, text: str) -> None:
+        notices.append((participant_id, text))
+
+    guide = WorkflowGuide(
+        workflow=workflow,
+        vision=_Vision(),
+        agent=_Agent(),
+        notice=notice,
+    )
+    session = WorkflowSession(participant_id="alice", step_id=5, context=context)
+
+    await guide._evaluate(session)  # noqa: SLF001
+
+    assert session.active is False
+    assert session.step_id == 0
+    assert session.step_state == "idle"
+    assert session.ready_step_id is None
+    assert session.context["steeping_complete"] is False
+    assert notices == [
+        ("alice", "The steeping time is up. Remove the tea bag, infuser, or leaves now.")
+    ]
+
+
+async def test_completed_step_does_not_repeat_guidance_or_recheck_vision() -> None:
+    workflow = _workflow()
+    notices: list[tuple[str, str]] = []
+
+    class _Vision:
+        async def observe(self, *_args, **_kwargs):
+            raise AssertionError("completed step must not invoke the VLM")
+
+        def release(self, _participant_id: str) -> None:
+            return None
+
+    class _Agent:
+        async def run_step(self, *_args, **_kwargs):
+            raise AssertionError("completed step must not invoke the step agent")
+
+    async def notice(participant_id: str, text: str) -> None:
+        notices.append((participant_id, text))
+
+    guide = WorkflowGuide(
+        workflow=workflow,
+        vision=_Vision(),
+        agent=_Agent(),
+        notice=notice,
+    )
+    session = WorkflowSession(
+        participant_id="alice",
+        step_id=1,
+        context=workflow.initial_context(),
+        ready_step_id=1,
+        step_state="complete",
+    )
+
+    await guide._evaluate(session)  # noqa: SLF001
+
+    assert session.step_state == "complete"
+    assert notices == []
+
+
+async def test_completed_water_step_silently_updates_observed_state() -> None:
+    workflow = _workflow()
+    notices: list[tuple[str, str]] = []
+
+    class _Vision:
+        async def observe(self, *_args, **_kwargs):
+            return SimpleNamespace(
+                text="TEMPERATURE_READING: 75 C\nWATER_READY: no",
+                frame_pts_us=2_000_000,
+            )
+
+        def release(self, _participant_id: str) -> None:
+            return None
+
+    class _Agent:
+        async def run_step(self, *_args, **_kwargs):
+            return StepAgentResult(
+                context_patch={
+                    "water_temperature_current": "59 C",
+                    "water_ready": True,
+                    "tea_name": "must not replace existing context",
+                },
+                step_state="started",
+                assistant_message="This must stay silent.",
+                speak=True,
+            )
+
+    async def notice(participant_id: str, text: str) -> None:
+        notices.append((participant_id, text))
+
+    guide = WorkflowGuide(
+        workflow=workflow,
+        vision=_Vision(),
+        agent=_Agent(),
+        notice=notice,
+    )
+    context = workflow.initial_context()
+    context.update(
+        tea_name="Aged Earl Grey",
+        water_temperature_current="59 C",
+        water_ready=True,
+    )
+    session = WorkflowSession(
+        participant_id="alice",
+        step_id=3,
+        context=context,
+        ready_step_id=3,
+        step_state="complete",
+    )
+
+    await guide._evaluate(session)  # noqa: SLF001
+
+    assert session.context["water_temperature_current"] == "75 C"
+    assert session.context["water_ready"] is False
+    assert session.context["tea_name"] == "Aged Earl Grey"
+    assert session.step_state == "complete"
+    assert session.ready_step_id == 3
+    assert notices == []
+
+
+async def test_participant_reconnect_preserves_active_workflow_state() -> None:
+    workflow = _workflow()
+
+    class _Vision:
+        async def observe(self, *_args, **_kwargs):
+            raise AssertionError("no observation expected")
+
+        def release(self, _participant_id: str) -> None:
+            return None
+
+    async def notice(_participant_id: str, _text: str) -> None:
+        return None
+
+    guide = WorkflowGuide(
+        workflow=workflow,
+        vision=_Vision(),
+        agent=SimpleNamespace(),
+        notice=notice,
+    )
+    await guide.start("alice")
+    session = guide._sessions["alice"]  # noqa: SLF001
+    session.context["tea_name"] = "green tea"
+    session.step_id = 4
+    session.step_state = "needs_input"
+
+    await guide.release("alice")
+
+    assert session.active is True
+    assert session.connected is False
+    assert session.step_id == 4
+    assert session.context["tea_name"] == "green tea"
+
+    await guide.resume("alice")
+
+    assert session.active is True
+    assert session.connected is True
+    assert session.step_id == 4
+
+
+async def test_final_advance_resets_to_idle_and_restart_uses_fresh_context() -> None:
+    workflow = _workflow()
+
+    class _Vision:
+        def release(self, _participant_id: str) -> None:
+            return None
+
+    async def notice(_participant_id: str, _text: str) -> None:
+        return None
+
+    guide = WorkflowGuide(
+        workflow=workflow,
+        vision=_Vision(),
+        agent=SimpleNamespace(),
+        notice=notice,
+    )
+    context = workflow.initial_context()
+    context.update(
+        tea_name="green tea",
+        steeping_started_at_us=123,
+        steeping_complete=True,
+    )
+    session = WorkflowSession(
+        participant_id="alice",
+        step_id=5,
+        context=context,
+        ready_step_id=5,
+        step_state="complete",
+        observation_log=[{"caption": "old evidence"}],
+    )
+    guide._sessions["alice"] = session  # noqa: SLF001
+
+    response = await guide.advance("alice")
+
+    assert "steeping time is up" in response.lower()
+    assert session.active is False
+    assert session.step_id == 0
+    assert session.step_state == "idle"
+    assert session.context["tea_name"] == ""
+    assert session.context["steeping_started_at_us"] == 0
+    assert session.observation_log == []
+
+    assert guide.status("alice") == "No guided workflow is active."
+    await guide.start("alice")
+    restarted = guide._sessions["alice"]  # noqa: SLF001
+    assert restarted.active is True
+    assert restarted.step_id == 1
+    assert restarted.context["tea_name"] == ""
+
+
+def test_start_making_tea_trigger_starts_only_while_idle() -> None:
+    workflow = _workflow()
+
+    idle_intent = guide_module._local_intent(  # noqa: SLF001
+        "Start making tea",
+        workflow,
+        active=False,
+    )
+    active_intent = guide_module._local_intent(  # noqa: SLF001
+        "Start making tea",
+        workflow,
+        active=True,
+    )
+
+    assert idle_intent is not None
+    assert idle_intent.intent == "start"
+    assert active_intent is None
+
+
+async def test_next_after_completed_session_stays_idle_without_agent_call() -> None:
+    workflow = _workflow()
+
+    class _Agent:
+        async def classify_intent(self, *_args, **_kwargs):
+            raise AssertionError("idle next must not invoke the classifier")
+
+        async def answer_user(self, *_args, **_kwargs):
+            raise AssertionError("idle next must not invoke the answer agent")
+
+    class _Vision:
+        def release(self, _participant_id: str) -> None:
+            return None
+
+    async def notice(_participant_id: str, _text: str) -> None:
+        return None
+
+    guide = WorkflowGuide(
+        workflow=workflow,
+        vision=_Vision(),
+        agent=_Agent(),
+        notice=notice,
+    )
+    guide._sessions["alice"] = WorkflowSession(  # noqa: SLF001
+        participant_id="alice",
+        step_id=0,
+        context=workflow.initial_context(),
+        active=False,
+        step_state="idle",
+    )
+
+    response = await guide.handle_query(participant_id="alice", text="Next.")
+
+    assert "previous session is finished" in response
+    assert "help me make tea" in response
+    assert guide.status("alice") == "No guided workflow is active."
+
+
+async def test_answer_agent_receives_completed_step_state_and_yaml_procedure() -> None:
+    workflow = _workflow()
+    step = workflow.step_by_id(1)
+    captured: list = []
+
+    class _Llm:
+        async def chat(self, messages, **_kwargs):
+            captured.extend(messages)
+            return SimpleNamespace(content="You can proceed.", tool_calls=[])
+
+    class _Tools:
+        def definitions(self):
+            return []
+
+        async def invoke(self, _name, _arguments):
+            raise AssertionError("no tool call expected")
+
+    agent = WorkflowAgent(
+        llm=_Llm(),
+        tools=_Tools(),
+        workflow=workflow,
+        answer_prompt=(
+            _WORKER_DIR / "tea_making_worker" / "prompts" / "system.txt"
+        ),
+    )
+    session = WorkflowSession(
+        participant_id="alice",
+        step_id=1,
+        context=workflow.initial_context(),
+        ready_step_id=1,
+        step_state="complete",
+    )
+
+    await agent.answer_user(
+        transcript="What happens now?",
+        session=session,
+        current_step=step,
+        observation_log=[],
+        recent_turns=[],
+    )
+
+    prompt = captured[-1].content
+    assert "[Step procedure]" in prompt
+    assert step.agent_prompt in prompt
+    assert "state=complete" in prompt
+    assert "ready=True" in prompt
+
+
+async def test_answer_agent_prioritizes_latest_visual_state_over_old_turns() -> None:
+    workflow = _workflow()
+    step = workflow.step_by_id(3)
+    captured: list = []
+
+    class _Llm:
+        async def chat(self, messages, **_kwargs):
+            captured.extend(messages)
+            return SimpleNamespace(content="The latest reading is 100 C.", tool_calls=[])
+
+    class _Tools:
+        def definitions(self):
+            return []
+
+    agent = WorkflowAgent(
+        llm=_Llm(),
+        tools=_Tools(),
+        workflow=workflow,
+        answer_prompt=(
+            _WORKER_DIR / "tea_making_worker" / "prompts" / "system.txt"
+        ),
+    )
+    context = workflow.initial_context()
+    context.update(water_temperature_current="100 C", water_ready=True)
+    session = WorkflowSession(
+        participant_id="alice",
+        step_id=3,
+        context=context,
+        ready_step_id=3,
+        step_state="complete",
+    )
+
+    await agent.answer_user(
+        transcript="What is the temperature of the water?",
+        session=session,
+        current_step=step,
+        observation_log=[
+            {
+                "step_id": 3,
+                "frame_pts_us": 1,
+                "caption": "TEMPERATURE_READING: 59 C\nWATER_READY: no",
+            },
+            {
+                "step_id": 3,
+                "frame_pts_us": 2,
+                "caption": "TEMPERATURE_READING: 100 C\nWATER_READY: yes",
+            },
+        ],
+        recent_turns=[
+            ("What is the temperature?", "The water is currently 59 C."),
+        ],
+    )
+
+    prompt = captured[-1].content
+    assert prompt.index("The water is currently 59 C.") < prompt.index(
+        "[Authoritative current state]"
+    )
+    assert '"water_temperature_current": "100 C"' in prompt
+    assert "TEMPERATURE_READING: 100 C" in prompt
+    assert "TEMPERATURE_READING: 59 C" not in prompt.split(
+        "[Latest VLM observation]",
+        maxsplit=1,
+    )[1]

--- a/tests/test_tea_making_sample.py
+++ b/tests/test_tea_making_sample.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import yaml
+from xr_ai_models import ToolCall
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _SAMPLE_DIR = _REPO_ROOT / "agent-samples" / "tea-making-sample"
@@ -31,6 +32,8 @@ from tea_making_worker.guide import WorkflowGuide  # noqa: E402
 from tea_making_worker.workflow import (  # noqa: E402
     WorkflowDefinition,
     WorkflowSession,
+    render_template,
+    speech_text,
 )
 
 _MAIN_SPEC = importlib.util.spec_from_file_location(
@@ -49,9 +52,7 @@ def _workflow() -> WorkflowDefinition:
 def test_shipped_workflow_uses_omni_native_rag_and_timer_only_step_five() -> None:
     workflow = _workflow()
     models = yaml.safe_load((_SAMPLE_DIR / "yaml" / "models.yaml").read_text())
-    worker = yaml.safe_load(
-        (_SAMPLE_DIR / "yaml" / "tea_making_worker.yaml").read_text()
-    )
+    worker = yaml.safe_load((_SAMPLE_DIR / "yaml" / "tea_making_worker.yaml").read_text())
     step_five = workflow.step_by_id(5)
 
     assert models["agent_llm"]["kind"] == "preset:nemotron_omni"
@@ -62,9 +63,7 @@ def test_shipped_workflow_uses_omni_native_rag_and_timer_only_step_five() -> Non
     for profile in ("96G_blackwell", "dual_48G_ada"):
         profile_dir = _SAMPLE_DIR / "yaml" / profile
         embedding = yaml.safe_load((profile_dir / "embedding_server.yaml").read_text())
-        omni = yaml.safe_load(
-            (profile_dir / "nemotron_omni_llm_server.yaml").read_text()
-        )
+        omni = yaml.safe_load((profile_dir / "nemotron_omni_llm_server.yaml").read_text())
         stt = yaml.safe_load((profile_dir / "stt_server.yaml").read_text())
 
         assert omni["vllm_image"] == "vllm/vllm-openai:v0.20.0"
@@ -76,27 +75,17 @@ def test_shipped_workflow_uses_omni_native_rag_and_timer_only_step_five() -> Non
         assert embedding["cuda_visible_devices"] in {"0", "1"}
 
     blackwell_dir = _SAMPLE_DIR / "yaml" / "96G_blackwell"
-    blackwell_omni = yaml.safe_load(
-        (blackwell_dir / "nemotron_omni_llm_server.yaml").read_text()
-    )
-    blackwell_embedding = yaml.safe_load(
-        (blackwell_dir / "embedding_server.yaml").read_text()
-    )
+    blackwell_omni = yaml.safe_load((blackwell_dir / "nemotron_omni_llm_server.yaml").read_text())
+    blackwell_embedding = yaml.safe_load((blackwell_dir / "embedding_server.yaml").read_text())
     assert blackwell_omni["cuda_visible_devices"] == "0"
     assert blackwell_omni["gpu_memory_utilization"] <= 0.80
     assert "moe_backend" not in blackwell_omni
     assert blackwell_embedding["cuda_visible_devices"] == "0"
     assert blackwell_embedding["gpu_memory_utilization"] <= 0.05
-    assert (
-        blackwell_omni["gpu_memory_utilization"]
-        + blackwell_embedding["gpu_memory_utilization"]
-        < 0.86
-    )
+    assert blackwell_omni["gpu_memory_utilization"] + blackwell_embedding["gpu_memory_utilization"] < 0.86
 
     ada_dir = _SAMPLE_DIR / "yaml" / "dual_48G_ada"
-    ada_omni = yaml.safe_load(
-        (ada_dir / "nemotron_omni_llm_server.yaml").read_text()
-    )
+    ada_omni = yaml.safe_load((ada_dir / "nemotron_omni_llm_server.yaml").read_text())
     ada_embedding = yaml.safe_load((ada_dir / "embedding_server.yaml").read_text())
     ada_stt = yaml.safe_load((ada_dir / "stt_server.yaml").read_text())
     assert ada_omni["cuda_visible_devices"] == "0"
@@ -111,26 +100,24 @@ def test_shipped_workflow_uses_omni_native_rag_and_timer_only_step_five() -> Non
     assert step_five.vlm_prompt == ""
     assert step_five.timer.completion_field == "steeping_complete"
     step_three = workflow.step_by_id(3)
-    state_updates = {
-        update.context_field: update for update in step_three.state_updates
-    }
-    assert set(state_updates) == {"water_temperature_current", "water_ready"}
-    assert state_updates["water_temperature_current"].observation_key == (
-        "TEMPERATURE_READING"
-    )
+    state_updates = {update.context_field: update for update in step_three.state_updates}
+    assert set(state_updates) == {"water_temperature_current", "water_boil_cue"}
+    assert state_updates["water_temperature_current"].observation_key == ("TEMPERATURE_READING")
     assert state_updates["water_temperature_current"].states == (
         "started",
         "needs_input",
         "complete",
     )
-    assert state_updates["water_ready"].value_map == {
-        "yes": True,
-        "no": False,
-        "unclear": False,
-    }
-    assert "water_temperature_current" in {
-        field.name for field in step_three.context_fields
-    }
+    assert state_updates["water_boil_cue"].observation_key == "BOIL_CUE"
+    assert "water_ready" not in state_updates
+    assert "water_temperature_current" in {field.name for field in step_three.context_fields}
+    assert workflow.sparse_context is True
+    assert workflow.initial_context() == {}
+    assert step_three.read_fields == (
+        "tea_name",
+        "tea_temperature",
+        "target_temperature_c",
+    )
 
 
 def test_launcher_selects_hardware_specific_model_configs() -> None:
@@ -143,13 +130,9 @@ def test_launcher_selects_hardware_specific_model_configs() -> None:
         by_name = {process.name: process for process in processes}
 
         assert processes[0].name == "omni"
-        assert by_name["omni"].config == (
-            f"yaml/{expected}/nemotron_omni_llm_server.yaml"
-        )
+        assert by_name["omni"].config == (f"yaml/{expected}/nemotron_omni_llm_server.yaml")
         assert by_name["stt"].config == f"yaml/{expected}/stt_server.yaml"
-        assert by_name["embedding"].config == (
-            f"yaml/{expected}/embedding_server.yaml"
-        )
+        assert by_name["embedding"].config == (f"yaml/{expected}/embedding_server.yaml")
 
 
 def test_omni_server_forwards_configured_moe_backend(monkeypatch, tmp_path: Path) -> None:
@@ -210,9 +193,7 @@ async def test_state_updates_are_driven_by_arbitrary_workflow_yaml(
                         "id": 1,
                         "name": "Read instrument",
                         "description": "Read an arbitrary instrument.",
-                        "vlm_prompt": (
-                            "End with PRESSURE_READING and ALARM_ACTIVE lines."
-                        ),
+                        "vlm_prompt": ("End with PRESSURE_READING and ALARM_ACTIVE lines."),
                         "agent_prompt": "Interpret the latest instrument reading.",
                         "state_updates": [
                             {
@@ -284,14 +265,20 @@ async def test_state_updates_are_driven_by_arbitrary_workflow_yaml(
         "PRESSURE_READING: 44.0\nALARM_ACTIVE: no",
         state="complete",
     ) == {"pressure_kpa": 44.0, "alarm_active": False}
-    assert step.observation_context_patch(
-        "PRESSURE_READING: 45.0\nALARM_ACTIVE: yes",
-        state="needs_input",
-    ) == {}
-    assert step.observation_context_patch(
-        "PRESSURE_READING: unavailable\nALARM_ACTIVE: unclear",
-        state="started",
-    ) == {}
+    assert (
+        step.observation_context_patch(
+            "PRESSURE_READING: 45.0\nALARM_ACTIVE: yes",
+            state="needs_input",
+        )
+        == {}
+    )
+    assert (
+        step.observation_context_patch(
+            "PRESSURE_READING: unavailable\nALARM_ACTIVE: unclear",
+            state="started",
+        )
+        == {}
+    )
 
     observations = iter(
         [
@@ -350,13 +337,231 @@ async def test_state_updates_are_driven_by_arbitrary_workflow_yaml(
 
     await guide._evaluate(session)  # noqa: SLF001
 
-    assert agent_contexts[1]["pressure_kpa"] == 44.0
-    assert agent_contexts[1]["alarm_active"] is False
+    assert len(agent_contexts) == 1
     assert session.context["pressure_kpa"] == 44.0
     assert session.context["alarm_active"] is False
     assert session.ready_step_id == 1
     assert session.step_state == "complete"
     assert len(notices) == 1
+
+
+def test_sparse_context_carries_values_with_projected_reads_and_partial_writes(
+    tmp_path: Path,
+) -> None:
+    workflow_path = tmp_path / "workflow.yaml"
+    workflow_path.write_text(
+        yaml.safe_dump(
+            {
+                "task": {"name": "instrument-guide"},
+                "context": {
+                    "fields": {
+                        "durable_fact": {"type": "string"},
+                    }
+                },
+                "steps": [
+                    {
+                        "id": 0,
+                        "name": "Idle",
+                        "description": "Wait.",
+                        "reads": [],
+                        "writes": [],
+                    },
+                    {
+                        "id": 1,
+                        "name": "Identify",
+                        "description": "Identify the instrument.",
+                        "vlm_prompt": "Read its label.",
+                        "agent_prompt": "Store the identified instrument.",
+                        "reads": [],
+                        "writes": ["durable_fact"],
+                        "advance_when": {"field": "durable_fact", "exists": True},
+                    },
+                    {
+                        "id": 2,
+                        "name": "Measure",
+                        "description": "Read the changing measurement.",
+                        "vlm_prompt": "End with LIVE_VALUE.",
+                        "agent_prompt": "Use the newest reading.",
+                        "reads": ["durable_fact"],
+                        "writes": {
+                            "live_value": {"type": "number", "required": True},
+                        },
+                        "state_updates": [
+                            {
+                                "context_field": "live_value",
+                                "observation_key": "LIVE_VALUE",
+                                "states": ["started", "needs_input"],
+                            }
+                        ],
+                        "advance_when": {"field": "live_value", "gte": 10},
+                    },
+                ],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    workflow = WorkflowDefinition.load(workflow_path)
+    step = workflow.step_by_id(2)
+    context = {
+        "durable_fact": "pressure gauge",
+        "live_value": 8.0,
+        "unrelated_internal_value": "do not expose",
+    }
+
+    assert workflow.initial_context() == {}
+    assert workflow.context_for_step(step, context) == {
+        "durable_fact": "pressure gauge",
+        "live_value": 8.0,
+    }
+    assert set(step.context_schema()["properties"]) == {"live_value"}
+    assert "required" not in step.context_schema()
+    assert step.observation_context_patch(
+        "LIVE_VALUE: 9.5",
+        state="started",
+    ) == {"live_value": 9.5}
+    assert step.observation_context_patch(
+        "LIVE_VALUE: 11.0",
+        state="needs_input",
+    ) == {"live_value": 11.0}
+
+
+def test_templates_and_response_normalization_are_speech_friendly() -> None:
+    workflow = _workflow()
+    step = workflow.step_by_id(4)
+    rendered = render_template(
+        ("Started at {{started | local_time}} for {{seconds | duration}} using {{temperature | spoken}}."),
+        context={
+            "started": "2026-08-03T16:13:00-07:00",
+            "seconds": 185,
+            "temperature": "93 C",
+        },
+        step=step,
+        task=workflow.task,
+    )
+
+    assert "2026-08-03" not in rendered
+    assert "4:13 P.M." in rendered
+    assert "3 minutes and 5 seconds" in rendered
+    assert "93 degrees Celsius" in rendered
+    assert speech_text("Heat to 175°F, not 80 C.") == ("Heat to 175 degrees Fahrenheit, not 80 degrees Celsius.")
+
+
+async def test_answer_agent_can_inspect_a_fresh_view_for_visual_questions() -> None:
+    workflow = _workflow()
+    step = workflow.step_by_id(5)
+    model_calls: list[list] = []
+    visual_questions: list[str] = []
+
+    class _Llm:
+        async def chat(self, messages, **_kwargs):
+            model_calls.append(list(messages))
+            if len(model_calls) == 1:
+                return SimpleNamespace(
+                    content="",
+                    tool_calls=[
+                        ToolCall(
+                            id="visual-1",
+                            name="inspect_current_view",
+                            arguments=('{"question":"What temperature is the kettle showing now?"}'),
+                        )
+                    ],
+                )
+            return SimpleNamespace(
+                content="The kettle currently shows 82 degrees Celsius.",
+                tool_calls=[],
+            )
+
+    class _Tools:
+        def definitions(self):
+            return []
+
+        async def invoke(self, _name, _arguments):
+            raise AssertionError("no non-visual tool call expected")
+
+    async def visual_query(question: str) -> dict:
+        visual_questions.append(question)
+        return {
+            "visual_evidence": "The kettle display reads 82 C.",
+            "frame_pts_us": 123,
+        }
+
+    agent = WorkflowAgent(
+        llm=_Llm(),
+        tools=_Tools(),
+        workflow=workflow,
+        answer_prompt=_WORKER_DIR / "tea_making_worker" / "prompts" / "system.txt",
+    )
+    session = WorkflowSession(
+        participant_id="alice",
+        step_id=5,
+        context={"steeping_started_at_us": 1, "steep_duration_seconds": 180},
+    )
+
+    answer = await agent.answer_user(
+        transcript="What temperature is the kettle showing now?",
+        session=session,
+        current_step=step,
+        observation_log=[],
+        recent_turns=[],
+        visual_query=visual_query,
+    )
+
+    assert visual_questions == ["What temperature is the kettle showing now?"]
+    assert answer == "The kettle currently shows 82 degrees Celsius."
+    assert '"visual_evidence": "The kettle display reads 82 C."' in (model_calls[1][-1].content)
+
+
+async def test_guide_logs_fresh_visual_answers_and_normalizes_them_for_speech() -> None:
+    workflow = _workflow()
+    inspected: list[str] = []
+
+    class _Vision:
+        async def inspect(self, _participant_id, question, **_kwargs):
+            inspected.append(question)
+            return SimpleNamespace(
+                text="The kettle display reads 82 C.",
+                frame_pts_us=321,
+            )
+
+        def release(self, _participant_id: str) -> None:
+            return None
+
+    class _Agent:
+        async def classify_intent(self, **_kwargs):
+            return NavigationIntent(intent="answer", confidence=0.99)
+
+        async def answer_user(self, *, transcript, visual_query, **_kwargs):
+            evidence = await visual_query(transcript)
+            assert evidence["visual_evidence"] == "The kettle display reads 82 C."
+            return "It reads 82 C."
+
+    async def notice(_participant_id: str, _text: str) -> None:
+        return None
+
+    guide = WorkflowGuide(
+        workflow=workflow,
+        vision=_Vision(),
+        agent=_Agent(),
+        notice=notice,
+    )
+    session = WorkflowSession(
+        participant_id="alice",
+        step_id=5,
+        context={"steeping_started_at_us": 1, "steep_duration_seconds": 180},
+    )
+    guide._sessions["alice"] = session  # noqa: SLF001
+
+    response = await guide.handle_query(
+        participant_id="alice",
+        text="What does the kettle display show now?",
+    )
+
+    assert inspected == ["What does the kettle display show now?"]
+    assert response == "It reads 82 degrees Celsius."
+    assert session.observation_log[-1]["kind"] == "visual_question"
+    assert session.observation_log[-1]["question"] == ("What does the kettle display show now?")
 
 
 def test_yaml_completion_rule_cannot_be_bypassed_by_model_readiness() -> None:
@@ -368,6 +573,7 @@ def test_yaml_completion_rule_cannot_be_bypassed_by_model_readiness() -> None:
     context.update(
         tea_name="green tea",
         tea_temperature="175 F",
+        target_temperature_c=80,
         steep_time="2 minutes",
         steep_duration_seconds=120,
         context_ready=True,
@@ -434,9 +640,7 @@ async def test_vlm_yes_automatically_captures_steeping_start_time() -> None:
         llm=_Llm(),
         tools=_Tools(),
         workflow=workflow,
-        answer_prompt=(
-            _WORKER_DIR / "tea_making_worker" / "prompts" / "system.txt"
-        ),
+        answer_prompt=(_WORKER_DIR / "tea_making_worker" / "prompts" / "system.txt"),
     )
     session = WorkflowSession(
         participant_id="alice",
@@ -452,9 +656,7 @@ async def test_vlm_yes_automatically_captures_steeping_start_time() -> None:
 
     assert tool_calls == [("get_current_time", {})]
     assert result.context_patch["steeping_started_at_us"] == 1_785_798_780_376_000
-    assert result.context_patch["steeping_started_at_iso"] == (
-        "2026-08-03T16:13:00-07:00"
-    )
+    assert result.context_patch["steeping_started_at_iso"] == ("2026-08-03T16:13:00-07:00")
     assert "1785798780376000" in captured_messages[1].content
 
 
@@ -496,9 +698,9 @@ def test_timer_question_eval_cases_report_elapsed_or_remaining(monkeypatch) -> N
             workflow,
         )
         if case["expected"] == "elapsed":
-            assert "1 minute 5 seconds" in answer
+            assert "1 minute and 5 seconds" in answer
         else:
-            assert "1 minute 55 seconds" in answer
+            assert "1 minute and 55 seconds" in answer
             assert "left" in answer
 
     monkeypatch.setattr(guide_module, "_now_us", lambda: now_us + 120_000_000)
@@ -594,10 +796,8 @@ async def test_timer_step_expires_without_calling_vision_or_step_agent() -> None
     assert session.step_id == 0
     assert session.step_state == "idle"
     assert session.ready_step_id is None
-    assert session.context["steeping_complete"] is False
-    assert notices == [
-        ("alice", "The steeping time is up. Remove the tea bag, infuser, or leaves now.")
-    ]
+    assert "steeping_complete" not in session.context
+    assert notices == [("alice", "The steeping time is up. Remove the tea bag, infuser, or leaves now.")]
 
 
 async def test_completed_step_does_not_repeat_guidance_or_recheck_vision() -> None:
@@ -645,7 +845,7 @@ async def test_completed_water_step_silently_updates_observed_state() -> None:
     class _Vision:
         async def observe(self, *_args, **_kwargs):
             return SimpleNamespace(
-                text="TEMPERATURE_READING: 75 C\nWATER_READY: no",
+                text="TEMPERATURE_READING: 75 C\nBOIL_CUE: no",
                 frame_pts_us=2_000_000,
             )
 
@@ -654,16 +854,7 @@ async def test_completed_water_step_silently_updates_observed_state() -> None:
 
     class _Agent:
         async def run_step(self, *_args, **_kwargs):
-            return StepAgentResult(
-                context_patch={
-                    "water_temperature_current": "59 C",
-                    "water_ready": True,
-                    "tea_name": "must not replace existing context",
-                },
-                step_state="started",
-                assistant_message="This must stay silent.",
-                speak=True,
-            )
+            raise AssertionError("completed live updates must not invoke the step agent")
 
     async def notice(participant_id: str, text: str) -> None:
         notices.append((participant_id, text))
@@ -691,7 +882,8 @@ async def test_completed_water_step_silently_updates_observed_state() -> None:
     await guide._evaluate(session)  # noqa: SLF001
 
     assert session.context["water_temperature_current"] == "75 C"
-    assert session.context["water_ready"] is False
+    assert session.context["water_ready"] is True
+    assert session.context["water_boil_cue"] == "no"
     assert session.context["tea_name"] == "Aged Earl Grey"
     assert session.step_state == "complete"
     assert session.ready_step_id == 3
@@ -775,8 +967,8 @@ async def test_final_advance_resets_to_idle_and_restart_uses_fresh_context() -> 
     assert session.active is False
     assert session.step_id == 0
     assert session.step_state == "idle"
-    assert session.context["tea_name"] == ""
-    assert session.context["steeping_started_at_us"] == 0
+    assert "tea_name" not in session.context
+    assert "steeping_started_at_us" not in session.context
     assert session.observation_log == []
 
     assert guide.status("alice") == "No guided workflow is active."
@@ -784,7 +976,7 @@ async def test_final_advance_resets_to_idle_and_restart_uses_fresh_context() -> 
     restarted = guide._sessions["alice"]  # noqa: SLF001
     assert restarted.active is True
     assert restarted.step_id == 1
-    assert restarted.context["tea_name"] == ""
+    assert "tea_name" not in restarted.context
 
 
 def test_start_making_tea_trigger_starts_only_while_idle() -> None:
@@ -865,9 +1057,7 @@ async def test_answer_agent_receives_completed_step_state_and_yaml_procedure() -
         llm=_Llm(),
         tools=_Tools(),
         workflow=workflow,
-        answer_prompt=(
-            _WORKER_DIR / "tea_making_worker" / "prompts" / "system.txt"
-        ),
+        answer_prompt=(_WORKER_DIR / "tea_making_worker" / "prompts" / "system.txt"),
     )
     session = WorkflowSession(
         participant_id="alice",
@@ -910,9 +1100,7 @@ async def test_answer_agent_prioritizes_latest_visual_state_over_old_turns() -> 
         llm=_Llm(),
         tools=_Tools(),
         workflow=workflow,
-        answer_prompt=(
-            _WORKER_DIR / "tea_making_worker" / "prompts" / "system.txt"
-        ),
+        answer_prompt=(_WORKER_DIR / "tea_making_worker" / "prompts" / "system.txt"),
     )
     context = workflow.initial_context()
     context.update(water_temperature_current="100 C", water_ready=True)
@@ -946,12 +1134,13 @@ async def test_answer_agent_prioritizes_latest_visual_state_over_old_turns() -> 
     )
 
     prompt = captured[-1].content
-    assert prompt.index("The water is currently 59 C.") < prompt.index(
-        "[Authoritative current state]"
-    )
+    assert prompt.index("The water is currently 59 C.") < prompt.index("[Authoritative current state]")
     assert '"water_temperature_current": "100 C"' in prompt
     assert "TEMPERATURE_READING: 100 C" in prompt
-    assert "TEMPERATURE_READING: 59 C" not in prompt.split(
-        "[Latest VLM observation]",
-        maxsplit=1,
-    )[1]
+    assert (
+        "TEMPERATURE_READING: 59 C"
+        not in prompt.split(
+            "[Latest VLM observation]",
+            maxsplit=1,
+        )[1]
+    )

--- a/tests/test_vllm_docker.py
+++ b/tests/test_vllm_docker.py
@@ -6,15 +6,20 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from xr_ai_vllm._docker import (
     _already_logged_in,
+    _config_fingerprint,
     _registry_for,
     build_run_argv,
+    container_config_matches,
     container_exists,
     container_running,
     pid_on_port,
+)
+from xr_ai_vllm._docker import (
+    run as run_docker,
 )
 
 
@@ -99,6 +104,27 @@ class TestBuildRunArgv:
         idx = argv.index("--label")
         assert argv[idx + 1] == "xr-ai-vllm.port=8100"
 
+    def test_config_fingerprint_label_set(self, tmp_path):
+        kwargs = self._base_kwargs(tmp_path)
+        argv = build_run_argv(**kwargs)
+        labels = [
+            argv[index + 1]
+            for index, value in enumerate(argv)
+            if value == "--label"
+        ]
+        fingerprint = _fingerprint_for_kwargs(kwargs)
+        assert f"xr-ai-vllm.config={fingerprint}" in labels
+
+    def test_config_fingerprint_changes_with_vllm_args(self, tmp_path):
+        kwargs = self._base_kwargs(tmp_path)
+        first = _fingerprint_for_kwargs(kwargs)
+        kwargs["vllm_argv"] = [
+            *kwargs["vllm_argv"],
+            "--gpu-memory-utilization",
+            "0.05",
+        ]
+        assert _fingerprint_for_kwargs(kwargs) != first
+
     def test_network_host(self, tmp_path):
         argv = build_run_argv(**self._base_kwargs(tmp_path))
         assert "--network" in argv
@@ -152,10 +178,23 @@ class TestBuildRunArgv:
         argv = build_run_argv(**self._base_kwargs(tmp_path))
         assert "nvcr.io/nvidia/vllm:26.04-py3" in argv
 
+    def test_shell_entrypoint_overrides_image_entrypoint(self, tmp_path):
+        kwargs = self._base_kwargs(tmp_path)
+        kwargs["image"] = "vllm/vllm-openai:v0.20.0"
+
+        argv = build_run_argv(**kwargs)
+
+        entrypoint_index = argv.index("--entrypoint")
+        image_index = argv.index("vllm/vllm-openai:v0.20.0")
+        assert argv[entrypoint_index + 1] == "/bin/bash"
+        assert entrypoint_index < image_index
+        assert argv[image_index + 1] == "-c"
+        assert "vllm serve my-model" in argv[image_index + 2]
+
     def test_no_extra_pip_runs_only_hf_transfer_install(self, tmp_path):
         argv = build_run_argv(**self._base_kwargs(tmp_path))
-        # bash -c "<install>... && vllm serve ..." — the install is the last
-        # argv entry; with no extra_pip there must be exactly one pip line.
+        # /bin/bash -c "<install>... && vllm serve ..." — the install is the
+        # last argv entry; with no extra_pip there must be exactly one pip line.
         bash_cmd = argv[-1]
         assert bash_cmd.count("pip install ") == 1
         assert "hf_transfer" in bash_cmd
@@ -189,9 +228,158 @@ class TestContainerHelpers:
         ):
             assert not container_running("some-name")
 
+    def test_container_config_matches_label(self):
+        labels = json.dumps({"xr-ai-vllm.config": "expected"})
+        with patch(
+            "xr_ai_vllm._docker.subprocess.check_output",
+            return_value=labels,
+        ):
+            assert container_config_matches("some-name", "expected")
+
+    def test_container_config_rejects_missing_label(self):
+        with patch(
+            "xr_ai_vllm._docker.subprocess.check_output",
+            return_value="{}",
+        ):
+            assert not container_config_matches("some-name", "expected")
+
     def test_pid_on_port_returns_none_when_tools_missing(self):
         with patch(
             "xr_ai_vllm._docker.subprocess.check_output",
             side_effect=FileNotFoundError,
         ):
             assert pid_on_port(8100) is None
+
+
+class TestRun:
+    def test_reuses_healthy_running_container_when_config_matches(self, tmp_path):
+        ready_file = tmp_path / "ready"
+        with (
+            patch("xr_ai_vllm._docker._docker_available", return_value=True),
+            patch("xr_ai_vllm._docker._lifecycle.health_ok", return_value=True),
+            patch("xr_ai_vllm._docker.container_running", return_value=True),
+            patch("xr_ai_vllm._docker.container_config_matches", return_value=True),
+            patch("xr_ai_vllm._docker._lifecycle.idle_until_stopped") as idle,
+            patch("xr_ai_vllm._docker.subprocess.Popen") as popen,
+            patch("xr_ai_vllm._docker.signal.signal"),
+        ):
+            run_docker(
+                image="image:latest",
+                container_name="xr-ai-vllm-test",
+                log_prefix="test",
+                vllm_argv=["vllm", "serve", "model"],
+                host="0.0.0.0",
+                port=8109,
+                model_cache=tmp_path,
+                hf_token=None,
+                cuda_visible_devices=None,
+                extra_env=None,
+                extra_pip=None,
+                ready_file=ready_file,
+            )
+
+        assert ready_file.exists()
+        idle.assert_called_once()
+        popen.assert_not_called()
+
+    def test_recreates_healthy_running_container_when_config_changed(self, tmp_path):
+        process = MagicMock()
+        process.poll.return_value = None
+        with (
+            patch("xr_ai_vllm._docker._docker_available", return_value=True),
+            patch("xr_ai_vllm._docker._lifecycle.health_ok", return_value=True),
+            patch("xr_ai_vllm._docker.container_running", return_value=True),
+            patch("xr_ai_vllm._docker.container_exists", return_value=False),
+            patch("xr_ai_vllm._docker.container_config_matches", return_value=False),
+            patch("xr_ai_vllm._docker.stop_container", return_value=True) as stop,
+            patch("xr_ai_vllm._docker.remove_container", return_value=True) as remove,
+            patch("xr_ai_vllm._docker._maybe_ngc_login"),
+            patch(
+                "xr_ai_vllm._docker.build_run_argv",
+                return_value=["docker", "run"],
+            ),
+            patch("xr_ai_vllm._docker.subprocess.Popen", return_value=process) as popen,
+            patch(
+                "xr_ai_vllm._docker._start_log_streamer",
+                return_value=(None, None),
+            ),
+            patch("xr_ai_vllm._docker._lifecycle.wait_until_healthy"),
+            patch("xr_ai_vllm._docker._lifecycle.idle_until_stopped"),
+            patch("xr_ai_vllm._docker.signal.signal"),
+        ):
+            run_docker(
+                image="image:latest",
+                container_name="xr-ai-vllm-test",
+                log_prefix="test",
+                vllm_argv=["vllm", "serve", "model"],
+                host="0.0.0.0",
+                port=8109,
+                model_cache=tmp_path,
+                hf_token=None,
+                cuda_visible_devices=None,
+                extra_env=None,
+                extra_pip=None,
+                ready_file=None,
+            )
+
+        stop.assert_called_once_with("xr-ai-vllm-test", timeout_s=10)
+        remove.assert_called_once_with("xr-ai-vllm-test")
+        popen.assert_called_once_with(["docker", "run"], start_new_session=True)
+
+    def test_recreates_stopped_container_when_config_changed(self, tmp_path):
+        process = MagicMock()
+        process.poll.return_value = None
+        with (
+            patch("xr_ai_vllm._docker._docker_available", return_value=True),
+            patch("xr_ai_vllm._docker._lifecycle.health_ok", return_value=False),
+            patch("xr_ai_vllm._docker.container_exists", return_value=True),
+            patch("xr_ai_vllm._docker.container_running", return_value=False),
+            patch(
+                "xr_ai_vllm._docker.container_config_matches",
+                return_value=False,
+            ),
+            patch("xr_ai_vllm._docker.remove_container", return_value=True) as remove,
+            patch("xr_ai_vllm._docker._maybe_ngc_login"),
+            patch(
+                "xr_ai_vllm._docker.build_run_argv",
+                return_value=["docker", "run"],
+            ),
+            patch("xr_ai_vllm._docker.subprocess.Popen", return_value=process) as popen,
+            patch(
+                "xr_ai_vllm._docker._start_log_streamer",
+                return_value=(None, None),
+            ),
+            patch("xr_ai_vllm._docker._lifecycle.wait_until_healthy"),
+            patch("xr_ai_vllm._docker._lifecycle.idle_until_stopped"),
+            patch("xr_ai_vllm._docker.signal.signal"),
+        ):
+            run_docker(
+                image="image:latest",
+                container_name="xr-ai-vllm-test",
+                log_prefix="test",
+                vllm_argv=["vllm", "serve", "model"],
+                host="0.0.0.0",
+                port=8109,
+                model_cache=tmp_path,
+                hf_token=None,
+                cuda_visible_devices=None,
+                extra_env=None,
+                extra_pip=None,
+                ready_file=None,
+            )
+
+        remove.assert_called_once_with("xr-ai-vllm-test")
+        popen.assert_called_once_with(["docker", "run"], start_new_session=True)
+
+
+def _fingerprint_for_kwargs(kwargs: dict) -> str:
+    return _config_fingerprint(
+        image=kwargs["image"],
+        port=kwargs["port"],
+        model_cache=kwargs["model_cache"],
+        hf_token=kwargs["hf_token"],
+        cuda_visible_devices=kwargs["cuda_visible_devices"],
+        extra_env=kwargs["extra_env"],
+        extra_pip=kwargs["extra_pip"],
+        vllm_argv=kwargs["vllm_argv"],
+    )

--- a/tests/test_voice_pipeline.py
+++ b/tests/test_voice_pipeline.py
@@ -21,7 +21,7 @@ import gc
 import io
 import wave
 import warnings
-from typing import Any, AsyncIterator, Sequence
+from typing import Any, AsyncIterator, Callable, Sequence
 
 import numpy as np
 import pytest
@@ -97,6 +97,7 @@ async def _run_chain(
     sends: Sequence[Frame],
     settle_s: float = 0.1,
     per_send_delay_s: float = 0.0,
+    settle_until: Callable[[_CaptureSink], bool] | None = None,
 ) -> _CaptureSink:
     """Build a Pipeline(processors), start a PipelineWorker, feed
     ``sends`` through the worker's downstream queue, then drain with an
@@ -107,7 +108,8 @@ async def _run_chain(
     ``per_send_delay_s`` introduces a sleep between queued frames so
     earlier ones can start executing before the next arrives — useful
     for interruption tests that need a previous frame to actually start
-    work before the interrupt lands.
+    work before the interrupt lands. ``settle_until`` can replace the
+    fixed delay with an observable completion condition.
     """
     sink = _CaptureSink()
     pipeline = Pipeline([*processors, sink])
@@ -127,7 +129,19 @@ async def _run_chain(
             await worker.queue_frame(f)
             if i < len(sends) - 1 and per_send_delay_s:
                 await asyncio.sleep(per_send_delay_s)
-        await asyncio.sleep(settle_s)
+        if settle_until is None:
+            await asyncio.sleep(settle_s)
+        else:
+            async def wait_for_condition() -> None:
+                while not settle_until(sink):
+                    await asyncio.sleep(0.01)
+
+            try:
+                await asyncio.wait_for(wait_for_condition(), timeout=settle_s)
+            except TimeoutError:
+                # Let the caller's domain-specific assertion report what was
+                # missing instead of replacing it with a generic timeout.
+                pass
         await worker.queue_frame(EndFrame())
 
     await asyncio.gather(runner.run(), drive())
@@ -507,7 +521,14 @@ async def test_vad_stt_stop_probe_emits_interruption_on_stop_match(monkeypatch):
 
     frame = InputAudioRawFrame(audio=b"\x00\x00" * 320, sample_rate=16000, num_channels=1)
     frame.transport_source = "web-client"
-    sink = await _run_chain(proc, sends=[frame], settle_s=0.2)
+    sink = await _run_chain(
+        proc,
+        sends=[frame],
+        settle_s=1.0,
+        settle_until=lambda capture: any(
+            isinstance(item, UserStoppedSpeakingFrame) for item in capture.frames
+        ),
+    )
 
     kinds = [type(f).__name__ for f in sink.frames]
     assert "InterruptionFrame"        in kinds

--- a/utils/xr-ai-launcher/xr_ai_launcher/_stack.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/_stack.py
@@ -20,11 +20,13 @@ The stack is declared as a sequence of ``Process`` or ``Parallel`` items:
 
 For each process the launcher:
 
-  1. Resolves the project directory and YAML config from the sample root.
-  2. Spawns ``uv run --project <dir> <command> --config <yaml> --ready-file <f>``.
-  3. Waits for the process to create *<f>* (the ready file), printing a
+  1. Locks the sample root and cleans up launcher-owned process groups orphaned
+     by an earlier abnormal exit.
+  2. Resolves the project directory and YAML config from the sample root.
+  3. Spawns ``uv run --project <dir> <command> --config <yaml> --ready-file <f>``.
+  4. Waits for the process to create *<f>* (the ready file), printing a
      progress line every five seconds so slow starts remain visible.
-  4. Once all processes are ready, monitors them: any exit triggers a
+  5. Once all processes are ready, monitors them: any exit triggers a
      graceful shutdown of the rest.
 
 Each process is responsible for creating its own ready file at the moment it
@@ -34,6 +36,7 @@ the IPC socket connects, after the HTTP server starts listening, etc.
 from __future__ import annotations
 
 import glob
+import hashlib
 import logging
 import os
 import re
@@ -46,7 +49,7 @@ import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Sequence, Union
+from typing import Sequence, TextIO, Union
 
 from ._credentials import load_credentials
 
@@ -123,6 +126,183 @@ class Parallel:
 
     def __init__(self, processes: Sequence[Process]) -> None:
         object.__setattr__(self, "processes", tuple(processes))
+
+
+def _all_processes(
+    processes: Sequence[Union[Process, Parallel]],
+) -> list[Process]:
+    return [
+        process
+        for item in processes
+        for process in (item.processes if isinstance(item, Parallel) else [item])
+    ]
+
+
+def _acquire_stack_lock(base: Path) -> TextIO | None:
+    """Prevent two launchers from managing the same sample concurrently."""
+    try:
+        import fcntl
+    except ImportError:  # pragma: no cover - flock is available on supported Linux hosts
+        return None
+
+    sample = str(base.resolve())
+    key = hashlib.sha256(sample.encode()).hexdigest()[:16]
+    lock_path = Path(tempfile.gettempdir()) / f"xr-ai-launcher-{key}.lock"
+    handle = lock_path.open("a+", encoding="utf-8")
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError as exc:
+        handle.seek(0)
+        owner = handle.read().strip() or "owner unknown"
+        handle.close()
+        raise RuntimeError(
+            f"Another launcher is already running for {sample} ({owner})"
+        ) from exc
+    handle.seek(0)
+    handle.truncate()
+    handle.write(f"pid={os.getpid()}")
+    handle.flush()
+    return handle
+
+
+def _release_stack_lock(handle: TextIO | None) -> None:
+    if handle is None:
+        return
+    try:
+        import fcntl
+
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    finally:
+        handle.close()
+
+
+def _argument(argv: list[str], name: str) -> str | None:
+    try:
+        return argv[argv.index(name) + 1]
+    except (ValueError, IndexError):
+        return None
+
+
+def _abandoned_process_name(
+    argv: list[str],
+    processes: Sequence[Union[Process, Parallel]],
+    base: Path,
+) -> str | None:
+    """Match an orphaned launcher wrapper proven to belong to this sample."""
+    if len(argv) < 2 or Path(argv[0]).name != "uv" or argv[1] != "run":
+        return None
+
+    ready_value = _argument(argv, "--ready-file")
+    config_value = _argument(argv, "--config")
+    project_value = _argument(argv, "--project")
+    if ready_value is None or config_value is None or project_value is None:
+        return None
+
+    ready_parent = Path(ready_value).parent
+    temp_root = Path(tempfile.gettempdir()).resolve()
+    if (
+        ready_parent.parent.resolve() != temp_root
+        or not ready_parent.name.startswith("xr-ai-")
+    ):
+        return None
+
+    resolved_base = base.resolve()
+    if not Path(config_value).resolve().is_relative_to(resolved_base):
+        return None
+
+    resolved_project = Path(project_value).resolve()
+    for process in _all_processes(processes):
+        if process.launch_mode != "own" or process.config is None:
+            continue
+        if Path(config_value).name != Path(process.config).name:
+            continue
+        if (
+            resolved_project == (resolved_base / process.project).resolve()
+            and process.command in argv
+        ):
+            return process.name
+    return None
+
+
+def _parent_pid(status_path: Path) -> int | None:
+    for line in status_path.read_text().splitlines():
+        if line.startswith("PPid:"):
+            return int(line.split()[1])
+    return None
+
+
+def _find_abandoned_process_groups(
+    processes: Sequence[Union[Process, Parallel]],
+    base: Path,
+    *,
+    proc_root: Path = Path("/proc"),
+) -> dict[int, set[str]]:
+    groups: dict[int, set[str]] = {}
+    if not proc_root.is_dir():
+        return groups
+    for entry in proc_root.iterdir():
+        if not entry.name.isdigit():
+            continue
+        pid = int(entry.name)
+        try:
+            if _parent_pid(entry / "status") != 1:
+                continue
+            argv = [
+                value.decode(errors="replace")
+                for value in (entry / "cmdline").read_bytes().split(b"\0")
+                if value
+            ]
+            name = _abandoned_process_name(argv, processes, base)
+            if name is None:
+                continue
+            pgid = os.getpgid(pid)
+        except (FileNotFoundError, PermissionError, ProcessLookupError, ValueError):
+            continue
+        if pgid != os.getpgrp():
+            groups.setdefault(pgid, set()).add(name)
+    return groups
+
+
+def _process_group_alive(pgid: int) -> bool:
+    try:
+        os.killpg(pgid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+def _cleanup_abandoned_processes(
+    processes: Sequence[Union[Process, Parallel]],
+    base: Path,
+) -> None:
+    groups = _find_abandoned_process_groups(processes, base)
+    if not groups:
+        return
+    for pgid, names in groups.items():
+        log.warning(
+            "Stopping abandoned process group %s from an earlier %s launch",
+            pgid,
+            ", ".join(sorted(names)),
+        )
+        try:
+            os.killpg(pgid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+
+    deadline = time.monotonic() + _STOP_TIMEOUT
+    remaining = set(groups)
+    while remaining and time.monotonic() < deadline:
+        remaining = {pgid for pgid in remaining if _process_group_alive(pgid)}
+        if remaining:
+            time.sleep(0.1)
+    for pgid in remaining:
+        log.warning("Force-killing abandoned process group %s", pgid)
+        try:
+            os.killpg(pgid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
 
 
 # ── subprocess helpers ─────────────────────────────────────────────────────────
@@ -423,6 +603,12 @@ def run_stack(
     instead — useful for launchers whose processes are all ``launch_mode="persist"``
     and should outlive the orchestrator (e.g. ``model-servers``).
 
+    Only one launcher may manage a given resolved *base* at a time. Before
+    spawning, the launcher also stops parentless ``own`` process groups whose
+    command, project, config, and launcher readiness path prove that they came
+    from an abandoned run of this sample. ``persist`` and ``reuse`` processes
+    are never selected by this cleanup.
+
     *base* is the sample root — all relative paths in ``Process.project``
     and ``Process.config`` are resolved against it::
 
@@ -442,15 +628,28 @@ def run_stack(
         def run() -> None:
             run_stack(PROCESSES, _BASE)
     """
+    lock = _acquire_stack_lock(base)
+    try:
+        _cleanup_abandoned_processes(processes, base)
+        _run_stack_unlocked(processes, base, exit_after_ready=exit_after_ready)
+    finally:
+        _release_stack_lock(lock)
+
+
+def _run_stack_unlocked(
+    processes: Sequence[Union[Process, Parallel]],
+    base: Path,
+    *,
+    exit_after_ready: bool = False,
+) -> None:
     load_credentials()
 
     # "persist" and "reuse" processes are left running on shutdown.
     # "reuse" processes are not spawned at all — assumed already running.
     _no_kill: set[str] = {
-        p.name
-        for item in processes
-        for p in (item.processes if isinstance(item, Parallel) else [item])
-        if p.launch_mode in ("persist", "reuse")
+        process.name
+        for process in _all_processes(processes)
+        if process.launch_mode in ("persist", "reuse")
     }
 
     launched: dict[str, subprocess.Popen] = {}

--- a/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
@@ -17,6 +17,7 @@ are not overwritten.
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -34,6 +35,40 @@ log = logging.getLogger(__name__)
 
 _DOCKER_CONFIG = Path.home() / ".docker" / "config.json"
 _LOGIN_DONE: set[str] = set()
+_CONFIG_LABEL = "xr-ai-vllm.config"
+_RUNNER_CONFIG_VERSION = 2
+
+
+def _config_fingerprint(
+    *,
+    image: str,
+    port: int,
+    model_cache: Path,
+    hf_token: str | None,
+    cuda_visible_devices: str | None,
+    extra_env: dict[str, str] | None,
+    extra_pip: list[str] | None,
+    vllm_argv: list[str],
+) -> str:
+    """Return a stable digest for options baked into a Docker container."""
+
+    payload = {
+        "runner_config_version": _RUNNER_CONFIG_VERSION,
+        "image": image,
+        "port": port,
+        "model_cache": str(model_cache),
+        "hf_token": hf_token or "",
+        "cuda_visible_devices": cuda_visible_devices or "all",
+        "extra_env": extra_env or {},
+        "extra_pip": extra_pip or [],
+        "vllm_argv": vllm_argv,
+    }
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
 
 
 # ── docker run argv builder ──────────────────────────────────────────────────
@@ -61,10 +96,21 @@ def build_run_argv(
     """
     argv: list[str] = ["docker", "run"]
     argv += ["--name", container_name]
+    fingerprint = _config_fingerprint(
+        image=image,
+        port=port,
+        model_cache=model_cache,
+        hf_token=hf_token,
+        cuda_visible_devices=cuda_visible_devices,
+        extra_env=extra_env,
+        extra_pip=extra_pip,
+        vllm_argv=vllm_argv,
+    )
     # Label lets container_on_port find this container by port without the
     # caller needing to know the container name — implementation detail stays
     # inside this module.
     argv += ["--label", f"xr-ai-vllm.port={port}"]
+    argv += ["--label", f"{_CONFIG_LABEL}={fingerprint}"]
     argv += ["--network", "host"]
     # vLLM workers communicate via /dev/shm; the default 64 MiB tmpfs is too
     # small for the KV cache shards.  --ipc host gives them the host's larger
@@ -97,7 +143,10 @@ def build_run_argv(
         argv += ["-e", f"{key}={val}"]
 
     argv += ["-v", f"{model_cache}:{model_cache}"]
-
+    # Some images, including vllm/vllm-openai, define `vllm serve` as their
+    # entrypoint. Override it so the setup commands below are interpreted by a
+    # shell instead of being passed as arguments to that image entrypoint.
+    argv += ["--entrypoint", "/bin/bash"]
     argv.append(image)
     # Install hf_transfer before starting vLLM — the NGC image doesn't ship it
     # but HF_HUB_ENABLE_HF_TRANSFER=1 will error if it's missing.
@@ -113,7 +162,7 @@ def build_run_argv(
             f"pip install -q --no-build-isolation {shlex.join(extra_pip)}"
         )
     install_cmds.append(shlex.join(vllm_argv))
-    argv += ["bash", "-c", " && ".join(install_cmds)]
+    argv += ["-c", " && ".join(install_cmds)]
     return argv
 
 
@@ -157,6 +206,25 @@ def container_running(name: str) -> bool:
         return bool(out)
     except (FileNotFoundError, subprocess.CalledProcessError):
         return False
+
+
+def container_config_matches(name: str, fingerprint: str) -> bool:
+    """Return whether a container was created from the requested config."""
+
+    try:
+        out = subprocess.check_output(
+            ["docker", "inspect", "--format", "{{json .Config.Labels}}", name],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+        labels = json.loads(out)
+    except (
+        FileNotFoundError,
+        subprocess.CalledProcessError,
+        json.JSONDecodeError,
+    ):
+        return False
+    return isinstance(labels, dict) and labels.get(_CONFIG_LABEL) == fingerprint
 
 
 def remove_container(name: str) -> bool:
@@ -437,22 +505,58 @@ def run(
     signal.signal(signal.SIGINT,  _on_signal)
     signal.signal(signal.SIGTERM, _on_signal)
 
+    fingerprint = _config_fingerprint(
+        image=image,
+        port=port,
+        model_cache=model_cache,
+        hf_token=hf_token,
+        cuda_visible_devices=cuda_visible_devices,
+        extra_env=extra_env,
+        extra_pip=extra_pip,
+        vllm_argv=vllm_argv,
+    )
+
     # Reuse a container that survived a wrapper restart (weight persistence).
     if _lifecycle.health_ok(health_url):
+        managed_container = container_running(container_name)
+        if not managed_container or container_config_matches(container_name, fingerprint):
+            print(
+                f"[{log_prefix}] vLLM already running on port {port} — reusing",
+                flush=True,
+            )
+            if ready_file:
+                ready_file.touch()
+            signal.signal(signal.SIGINT,  orig_int)
+            signal.signal(signal.SIGTERM, orig_term)
+            _lifecycle.idle_until_stopped(health_url, log_prefix)
+            return
+
         print(
-            f"[{log_prefix}] vLLM already running on port {port} — reusing",
+            f"[{log_prefix}] Running container config changed; recreating {container_name}",
             flush=True,
         )
-        if ready_file:
-            ready_file.touch()
-        signal.signal(signal.SIGINT,  orig_int)
-        signal.signal(signal.SIGTERM, orig_term)
-        _lifecycle.idle_until_stopped(health_url, log_prefix)
-        return
+        if not stop_container(container_name, timeout_s=10) or not remove_container(
+            container_name
+        ):
+            log.error("could not replace running container %s", container_name)
+            sys.exit(2)
 
-    if container_exists(container_name) and not container_running(container_name):
-        # Stopped container already has hf_transfer installed — restart it
-        # rather than running a fresh image (avoids reinstalling every time).
+    stopped_container = container_exists(container_name) and not container_running(
+        container_name
+    )
+    if stopped_container and not container_config_matches(container_name, fingerprint):
+        print(
+            f"[{log_prefix}] Container config changed; recreating {container_name}",
+            flush=True,
+        )
+        if not remove_container(container_name):
+            log.error("could not remove stale container %s", container_name)
+            sys.exit(2)
+        stopped_container = False
+
+    if stopped_container:
+        # The stopped container matches the requested config and already has
+        # hf_transfer installed, so it is safe to restart without reinstalling.
         print(
             f"[{log_prefix}] Restarting stopped container {container_name}",
             flush=True,

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/config.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/config.py
@@ -28,17 +28,21 @@ class VoiceGateConfig:
                            because the chime is an audible "I heard you"
                            cue that most consumers want by default;
                            opt out explicitly with ``listening_chime: false``.
+    ``welcome_message``  — optional participant-joined speech. When empty, the
+                           gate generates its standard wake-phrase help.
     """
     magic_phrases:    tuple[str, ...] = ()
     followup_grace_s: float           = 5.0
     listening_chime:  bool            = True
+    welcome_message:  str             = ""
 
 
 def load_voice_gate_config(path: pathlib.Path) -> VoiceGateConfig:
     """Load + parse a voice_gate YAML file into a :class:`VoiceGateConfig`.
 
     Schema: a top-level mapping with keys ``magic_phrases`` (list[str] or
-    bare str), ``listening_chime`` (bool), ``followup_grace_s`` (float).
+    bare str), ``listening_chime`` (bool), ``followup_grace_s`` (float), and
+    optional ``welcome_message`` (str).
     Missing file or empty file → returns the dataclass defaults (gate
     disabled / always-on). ``magic_phrases: null`` and trailing whitespace
     in phrases are normalized the same way the inline-block parser did.
@@ -58,6 +62,7 @@ def load_voice_gate_config(path: pathlib.Path) -> VoiceGateConfig:
         magic_phrases    = phrases,
         followup_grace_s = float(raw.get("followup_grace_s", 5.0)),
         listening_chime  = bool(raw.get("listening_chime", True)),
+        welcome_message  = str(raw.get("welcome_message") or "").strip(),
     )
 
 

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/gate.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/gate.py
@@ -304,9 +304,12 @@ class VoiceGate:
 
     def format_phrase_help(self) -> str | None:
         """Return a sentence fragment telling the user how to address the
-        agent given the configured phrases. ``None`` when no phrases are
-        configured (the caller picks a generic greeting). The wording
+        agent. An explicit welcome message takes precedence. ``None`` when
+        neither a welcome nor phrases are configured. The generated wording
         carries over from the original ``_greet`` implementation."""
+        welcome = self._cfg.welcome_message.strip()
+        if welcome:
+            return welcome
         phrases = list(self._cfg.magic_phrases)
         if not phrases:
             return None


### PR DESCRIPTION
## Summary

- add the native embedding-backed RAG service and model integration from PR #335
- add a YAML-driven `tea-making-sample` using Nemotron-Omni for visual observation and agent reasoning
- support semantic step navigation, internal VLM evidence, per-step context, RAG questions, reconnect-safe state, and steeping timers
- add launcher memory/container lifecycle fixes needed to run Omni and the embedding service together

## Behavior

- steps never auto-advance except terminal timer completion; the user controls progression and may skip with reasonable defaults
- completed steps stay quiet, while missing information produces at most the configured delayed reminder
- the final step announces when steeping is complete, clears workflow state, and returns the guide to idle
- a new phrase such as `start making tea` begins a fresh session at step 1

## Testing

```text
uv run pytest -q test_tea_making_sample.py test_rag_service.py test_models_config.py test_models_openai_compat.py test_models_protocols.py test_vllm_docker.py
116 passed
```

This branch is a single DCO-signed commit based directly on current `NVIDIA/xr-ai:main` (`ba582de`).
