### PR TITLE
Add selectable Nemotron Omni model-server stack

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -560,10 +560,13 @@ run this first to warm up model weights before starting any demo sample.
 |---|---|---|---|
 | Orchestrator | `model-servers` | `xr-ai-launcher`, `xr-ai-logging`, `xr-ai-vllm` (for `--stop`) | — |
 
-Starts stt-server (8103), nemotron3-nano-llm-server (8107, `persistent=True`),
-vlm-server (8100, `persistent=True`), and embedding-server (8109,
-`persistent=True`). The vLLM servers survive launcher restarts; use `--stop`
-to shut them down.
+The default `--vlm-llm-stack` starts stt-server (8103),
+nemotron3-nano-llm-server (8107, `persistent=True`), and vlm-server (8100,
+`persistent=True`), plus embedding-server (8109, `persistent=True`).
+`--omni-stack` replaces Nano and Cosmos with nemotron-omni-llm-server (8108,
+`persistent=True`) while retaining stt-server and embedding-server. The stacks
+are mutually exclusive; `--stop` shuts down every model-server port without
+selecting one.
 GPU profiles: `dual_48G_ada`, `spark`, `96G_blackwell` (auto-detected).
 
 ### xr-render-demo  (agent-samples/xr-render-demo/)

--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ tens of minutes).  On subsequent runs the containers restart in under a minute.
 The default `--vlm-llm-stack` starts Nemotron-3 Nano (8107), Cosmos (8100),
 STT (8103), and embeddings (8109). Use `--omni-stack` to replace Nano and
 Cosmos with Nemotron-3 Nano Omni (8108); STT and embeddings remain available.
+On `dual_48G_ada`, the default stack places Cosmos and embeddings on GPU 0;
+the Omni stack places Omni on GPU 0 and embeddings on GPU 1.
 Switching stacks stops the incompatible persistent models first and aborts if
 they cannot be stopped, avoiding GPU overcommit.
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,16 @@ GPU profiles are auto-detected (`dual_48G_ada` / `spark` / `96G_blackwell`).
 On first run each model downloads from HuggingFace (~50 GB total; can take
 tens of minutes).  On subsequent runs the containers restart in under a minute.
 
+The default `--vlm-llm-stack` starts Nemotron-3 Nano (8107), Cosmos (8100),
+STT (8103), and embeddings (8109). Use `--omni-stack` to replace Nano and
+Cosmos with Nemotron-3 Nano Omni (8108); STT and embeddings remain available.
+Switching stacks stops the incompatible persistent models first and aborts if
+they cannot be stopped, avoiding GPU overcommit.
+
+```bash
+uv run model_servers --omni-stack
+```
+
 The default models are public, so no HuggingFace token is required.  Set
 `HF_TOKEN` to lift download rate limits / speed, or to use a gated model — see
 [`docs/credentials.md`](docs/credentials.md).  The launcher won't prompt; it
@@ -165,6 +175,8 @@ To stop all model servers when done:
 ```bash
 uv run model_servers --stop
 ```
+
+`--stop` always stops both stack variants, so it takes no stack-selection flag.
 
 ### Simple VLM example (vision Q&A over voice + text)
 

--- a/agent-samples/model-servers/main.py
+++ b/agent-samples/model-servers/main.py
@@ -2,17 +2,23 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-model-servers orchestrator — starts the shared AI inference servers and exits.
+model-servers orchestrator — starts one shared AI inference stack and exits.
 
 All servers are launch_mode="persist" so they keep running after this
 process exits.  Model weights stay hot across stack restarts.
 
 Servers started
 ---------------
-  stt        — nvidia/parakeet-tdt-0.6b-v3        port 8103  (NeMo ASR)
-  agent-llm  — NVIDIA-Nemotron-3-Nano-30B-A3B      port 8107  (vLLM)
-  vlm        — nvidia/Cosmos-Reason1-7B            port 8100  (vLLM)
-  embedding  — nvidia/llama-nemotron-embed-1b-v2   port 8109  (vLLM)
+  default / --vlm-llm-stack
+    stt        — nvidia/parakeet-tdt-0.6b-v3        port 8103  (NeMo ASR)
+    agent-llm  — NVIDIA-Nemotron-3-Nano-30B-A3B     port 8107  (vLLM)
+    vlm        — nvidia/Cosmos-Reason1-7B           port 8100  (vLLM)
+    embedding  — nvidia/llama-nemotron-embed-1b-v2  port 8109  (vLLM)
+
+  --omni-stack
+    stt        — nvidia/parakeet-tdt-0.6b-v3        port 8103  (NeMo ASR)
+    omni       — Nemotron-3-Nano-Omni-30B-A3B       port 8108  (vLLM)
+    embedding  — nvidia/llama-nemotron-embed-1b-v2  port 8109  (vLLM)
 
 How to run:
     uv run --project agent-samples/model-servers model_servers
@@ -29,26 +35,56 @@ from xr_ai_logging import setup_logging
 from xr_ai_vllm import stop_persistent_servers
 
 _BASE = Path(__file__).resolve().parent
+_STOP_SERVICES = [
+    ("stt", 8103),
+    ("agent-llm", 8107),
+    ("vlm", 8100),
+    ("omni", 8108),
+    ("embedding", 8109),
+]
+_INCOMPATIBLE_STACK_SERVICES = {
+    "vlm-llm": [("agent-llm", 8107), ("vlm", 8100)],
+    "omni": [("omni", 8108)],
+}
 
 # agent-llm (Nemotron-30B) loads first on single-GPU profiles so its
 # FlashInfer MoE JIT compilation runs with the full GPU free.  The compiled
 # kernels are cached after the first run (~3-8 min).
-def _build_processes() -> list[Process]:
-    """Detect the GPU profile and return the per-profile process list."""
+def _build_processes(stack: str = "vlm-llm") -> list[Process]:
+    """Return the selected shared model stack for the detected GPU profile."""
     ai = f"yaml/{detect_gpu_config()}"
+    stt = Process(
+        "stt", "../../ai-services/stt-server", "stt_server",
+        config=f"{ai}/stt_server.yaml",
+        launch_mode="persist", port=8103,
+    )
+    embedding = Process(
+        "embedding", "../../ai-services/embedding-server", "embedding_server",
+        config=f"{ai}/embedding_server.yaml",
+        launch_mode="persist", port=8109,
+    )
+    if stack == "omni":
+        return [
+            stt,
+            Process(
+                "omni", "../../ai-services/llm/nemotron_omni",
+                "nemotron_omni_llm_server",
+                config=f"{ai}/nemotron_omni_llm_server.yaml",
+                launch_mode="persist", port=8108,
+            ),
+            embedding,
+        ]
+    if stack != "vlm-llm":
+        raise ValueError(f"unknown model stack: {stack}")
     return [
-        Process("stt",       "../../ai-services/stt-server",         "stt_server",
-                config=f"{ai}/stt_server.yaml",
-                launch_mode="persist", port=8103),
+        stt,
         Process("agent-llm", "../../ai-services/llm/nemotron3_nano", "nemotron3_nano_llm_server",
                 config=f"{ai}/nemotron3_nano_llm_server.yaml",
                 launch_mode="persist", port=8107),
         Process("vlm",       "../../ai-services/vlm-server",         "vlm_server",
                 config=f"{ai}/vlm_server.yaml",
                 launch_mode="persist", port=8100),
-        Process("embedding", "../../ai-services/embedding-server", "embedding_server",
-                config=f"{ai}/embedding_server.yaml",
-                launch_mode="persist", port=8109),
+        embedding,
     ]
 
 
@@ -56,21 +92,36 @@ def _stop_models() -> None:
     # Surface docker/ss/lsof failures so operators see why --stop aborted
     # instead of a silent traceback exit.
     try:
-        stop_persistent_servers([
-            (p.name, p.port)
-            for p in _build_processes()
-            if p.launch_mode == "persist" and p.port is not None
-        ])
+        stop_persistent_servers(_STOP_SERVICES)
     except Exception as exc:
         print(f"model-servers: failed to stop persistent servers: {exc}", flush=True)
+
+
+def _stop_incompatible_stack(stack: str) -> None:
+    """Free GPU capacity held by the other mutually exclusive model stack."""
+    incompatible = _INCOMPATIBLE_STACK_SERVICES["vlm-llm" if stack == "omni" else "omni"]
+    if not stop_persistent_servers(incompatible):
+        raise RuntimeError("could not stop incompatible persistent model stack")
 
 
 def run() -> None:
     setup_logging("orchestrator", namespace="model-servers")
 
     p = argparse.ArgumentParser(add_help=False)
-    p.add_argument("--stop", action="store_true",
-                   help="Stop any persisted vLLM model servers and exit.")
+    mode = p.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--stop", action="store_true",
+        help="Stop every persisted model-server stack and exit.",
+    )
+    mode.add_argument(
+        "--omni-stack", action="store_const", const="omni", dest="stack",
+        help="Start Nemotron-3-Nano-Omni with STT instead of the VLM + LLM stack.",
+    )
+    mode.add_argument(
+        "--vlm-llm-stack", action="store_const", const="vlm-llm", dest="stack",
+        help="Start the default Nemotron-3-Nano + Cosmos VLM stack.",
+    )
+    p.set_defaults(stack="vlm-llm")
     ns, _ = p.parse_known_args()
 
     if ns.stop:
@@ -81,7 +132,8 @@ def run() -> None:
     # rate limits / download speed and is required only for gated models.
     # Warn instead of prompting; see docs/credentials.md.
     warn_if_missing("HF_TOKEN")
-    run_stack(_build_processes(), _BASE, exit_after_ready=True)
+    _stop_incompatible_stack(ns.stack)
+    run_stack(_build_processes(ns.stack), _BASE, exit_after_ready=True)
 
 
 if __name__ == "__main__":

--- a/agent-samples/model-servers/main.py
+++ b/agent-samples/model-servers/main.py
@@ -53,6 +53,9 @@ _INCOMPATIBLE_STACK_SERVICES = {
 def _build_processes(stack: str = "vlm-llm") -> list[Process]:
     """Return the selected shared model stack for the detected GPU profile."""
     ai = f"yaml/{detect_gpu_config()}"
+    embedding_config = f"{ai}/embedding_server_{stack.replace('-', '_')}.yaml"
+    if not (_BASE / embedding_config).exists():
+        embedding_config = f"{ai}/embedding_server.yaml"
     stt = Process(
         "stt", "../../ai-services/stt-server", "stt_server",
         config=f"{ai}/stt_server.yaml",
@@ -60,7 +63,7 @@ def _build_processes(stack: str = "vlm-llm") -> list[Process]:
     )
     embedding = Process(
         "embedding", "../../ai-services/embedding-server", "embedding_server",
-        config=f"{ai}/embedding_server.yaml",
+        config=embedding_config,
         launch_mode="persist", port=8109,
     )
     if stack == "omni":

--- a/agent-samples/model-servers/yaml/96G_blackwell/nemotron_omni_llm_server.yaml
+++ b/agent-samples/model-servers/yaml/96G_blackwell/nemotron_omni_llm_server.yaml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Nemotron-3-Nano-Omni — single Blackwell 96 GB.
+# NVFP4 is selected automatically. This standalone Omni stack leaves the
+# remainder of the GPU for STT, rendering, and runtime overhead.
+
+host: "0.0.0.0"
+port: 8108
+hf_token: ""
+model_cache: ../../../../models
+
+max_num_seqs: 8
+tensor_parallel_size: 1
+max_model_len: 32768
+gpu_memory_utilization: 0.35
+enforce_eager: false
+
+video_pruning_rate: 0.5
+video_fps: 2
+video_num_frames: 64
+# RTX Pro Blackwell requires Triton for this MoE architecture.
+moe_backend: triton
+
+vllm_backend: docker
+vllm_image: vllm/vllm-openai:v0.20.0
+extra_pip: []

--- a/agent-samples/model-servers/yaml/dual_48G_ada/embedding_server_omni.yaml
+++ b/agent-samples/model-servers/yaml/dual_48G_ada/embedding_server_omni.yaml
@@ -6,7 +6,7 @@ host: "0.0.0.0"
 port: 8109
 served_model_name: embed
 model_cache: ../../../../models
-cuda_visible_devices: "0"
+cuda_visible_devices: "1"
 max_num_seqs: 32
 max_model_len: 8192
 gpu_memory_utilization: 0.08

--- a/agent-samples/model-servers/yaml/dual_48G_ada/nemotron_omni_llm_server.yaml
+++ b/agent-samples/model-servers/yaml/dual_48G_ada/nemotron_omni_llm_server.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Nemotron-3-Nano-Omni — dual 48 GB Ada configuration.
+# FP8 Omni occupies GPU 0; the shared STT configuration uses GPU 1.
+
+host: "0.0.0.0"
+port: 8108
+hf_token: ""
+model_cache: ../../../../models
+
+cuda_visible_devices: "0"
+max_num_seqs: 8
+tensor_parallel_size: 1
+max_model_len: 32768
+gpu_memory_utilization: 0.78
+enforce_eager: false
+
+video_pruning_rate: 0.5
+video_fps: 2
+video_num_frames: 64
+
+vllm_backend: docker
+vllm_image: vllm/vllm-openai:v0.20.0
+extra_pip: []

--- a/agent-samples/model-servers/yaml/spark/nemotron_omni_llm_server.yaml
+++ b/agent-samples/model-servers/yaml/spark/nemotron_omni_llm_server.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Nemotron-3-Nano-Omni — DGX Spark (GB10).
+# The NVFP4 model shares physical HBM with STT and the runtime, so retain the
+# conservative allocation used by the standard Nano stack.
+
+host: "0.0.0.0"
+port: 8108
+hf_token: ""
+model_cache: ../../../../models
+
+max_num_seqs: 8
+tensor_parallel_size: 1
+max_model_len: 32768
+gpu_memory_utilization: 0.25
+enforce_eager: false
+
+video_pruning_rate: 0.5
+video_fps: 2
+video_num_frames: 64
+
+vllm_backend: docker
+vllm_image: vllm/vllm-openai:v0.20.0
+extra_pip: []

--- a/ai-services/llm/nemotron_omni/nemotron_omni_llm_server/__main__.py
+++ b/ai-services/llm/nemotron_omni/nemotron_omni_llm_server/__main__.py
@@ -6,8 +6,8 @@ nemotron_omni_llm_server — vLLM launcher for Nemotron-3-Nano-Omni-30B-A3B-Reas
 
 Omni multimodal model (text + video). Selects the weight quantisation based
 on GPU compute capability and dispatches through ``xr_ai_vllm.serve`` to either
-the pip-installed ``vllm`` CLI or the NGC ``nvcr.io/nvidia/vllm`` docker
-container (per ``vllm_backend`` in YAML).
+the pip-installed ``vllm`` CLI or a configured vLLM Docker image (per
+``vllm_backend`` in YAML).
 
 Config keys (nemotron_omni_llm_server.yaml)
 -------------------------------------------
@@ -28,10 +28,11 @@ Config keys (nemotron_omni_llm_server.yaml)
     video_pruning_rate:       float  --video-pruning-rate (default: 0.5).
     video_fps:                int    FPS for video input sampling (default: 2).
     video_num_frames:         int    Max frames per video (default: 256).
+    moe_backend:              str    Optional vLLM MoE backend.
     vllm_backend:             str    "pip" (default) or "docker".
-    vllm_image:               str    NGC image when vllm_backend=docker
+    vllm_image:               str    Docker image when vllm_backend=docker
                                      (default: nvcr.io/nvidia/vllm:26.04-py3).
-    extra_pip:                list   Pip packages installed into the NGC
+    extra_pip:                list   Pip packages installed into the Docker
                                      container before `vllm serve` runs
                                      (docker backend only; default:
                                      ["mamba-ssm", "causal-conv1d"] since
@@ -108,6 +109,7 @@ def run() -> None:
     prune_rate    = float(cfg.get("video_pruning_rate", _DEFAULT_PRUNE))
     video_fps     = int(cfg.get("video_fps",        _DEFAULT_FPS))
     video_frames  = int(cfg.get("video_num_frames", _DEFAULT_FRAMES))
+    moe_backend   = cfg.get("moe_backend")
     backend       = cfg.get("vllm_backend",         "pip")
     image         = cfg.get("vllm_image",           DEFAULT_IMAGE)
     # Nemotron-Omni's hybrid SSM/Transformer backbone imports `mamba_ssm`
@@ -135,12 +137,14 @@ def run() -> None:
     ]
     if use_kv_fp8:
         extra_serve_args += ["--kv-cache-dtype", "fp8"]
+    if moe_backend:
+        extra_serve_args += ["--moe-backend", str(moe_backend)]
     if enforce_eager:
         extra_serve_args.append("--enforce-eager")
 
     serve(
         backend=backend,
-        persistent=False,
+        persistent=True,
         image=image,
         container_name=_CONTAINER_NAME,
         log_prefix="nemotron_omni",

--- a/docs/ai-services.md
+++ b/docs/ai-services.md
@@ -189,9 +189,9 @@ exposes `/v1/health`.
 ## vLLM model persistence
 
 The persistent vLLM-backed servers (`vlm_server`, `llama_nemotron_llm_server`,
-`nemotron3_nano_llm_server`, `embedding_server`) **survive stack restarts by design**.
-`nemotron_omni_llm_server` is foreground (dies with the wrapper). Each
-persistent wrapper script checks its health endpoint before spawning vLLM:
+`nemotron3_nano_llm_server`, `nemotron_omni_llm_server`, `embedding_server`)
+**survive stack restarts by design**. Each persistent wrapper script checks its
+health endpoint before spawning vLLM:
 
 - **Already running** → touch the ready file immediately, then idle. Stack is
   ready in seconds; no model reload.
@@ -272,12 +272,10 @@ Existing `~/.docker/config.json` entries take priority and are not overwritten.
   `xr-ai-vllm-llama-nemotron-llm-server`,
   `xr-ai-vllm-nemotron3-nano-llm-server`,
   `xr-ai-vllm-nemotron-omni-llm-server`.
-- Persistence parity: `vlm_server`, `llama_nemotron_llm_server`, and
-  `nemotron3_nano_llm_server` run detached (`docker run -d --rm --name …`) so
-  the container survives stack restarts, mirroring their pip-mode
-  `start_new_session=True` behavior. `nemotron_omni_llm_server` runs
-  foreground (container exits with the wrapper) — same as its pip-mode
-  semantics.
+- Persistence parity: `vlm_server`, `llama_nemotron_llm_server`,
+  `nemotron3_nano_llm_server`, and `nemotron_omni_llm_server` launch their
+  Docker processes in separate sessions, so they survive launcher shutdowns
+  like their pip-mode `start_new_session=True` counterparts.
 
 ### Cleanup
 
@@ -320,8 +318,7 @@ port → PID → SIGTERM/SIGKILL path. Same UX for both.
   `use_bf16: true` for highest quality at the largest VRAM cost. Same
   OpenAI-compatible HTTP contract as the other LLM servers — swap the port to
   swap backends. Hosting backend is selectable per YAML (see *Choosing the
-  vLLM runtime*); runs foreground in both pip and docker modes (no
-  cross-restart persistence).
+  vLLM runtime*); persists across stack restarts in both pip and docker modes.
 - **stt-server** loads parakeet-tdt-0.6b-v3 via NeMo ASR in-process.
   English-only; `language` / `temperature` form fields are accepted but ignored.
 - **tts/magpie** loads magpie_tts_multilingual_357m via NeMo TTS in-process.

--- a/docs/ai-services.md
+++ b/docs/ai-services.md
@@ -279,10 +279,11 @@ Existing `~/.docker/config.json` entries take priority and are not overwritten.
 
 ### Cleanup
 
-`uv run xr_render_demo --stop` works for both modes. The cleanup path probes
-`/health` first; for docker mode it then runs `docker stop <container_name>`
-(escalating to `docker kill` after 20 s); for pip mode it falls back to the
-port → PID → SIGTERM/SIGKILL path. Same UX for both.
+`uv run xr_render_demo --stop` works for both modes. Cleanup locates labelled
+Docker containers before inspecting ports, then stops them with `docker stop`
+(escalating to `docker kill` after 20 s). Pip-mode processes carry an
+`xr-ai-vllm` ownership marker; unknown listeners and failed inspection abort
+cleanup without sending a signal.
 
 ## Per-server notes
 

--- a/docs/ai-services.md
+++ b/docs/ai-services.md
@@ -209,11 +209,12 @@ vLLM keeps running.
 uv run xr_render_demo --stop
 ```
 
-This hits each model server's `/health` endpoint, then either runs
-`docker stop <container_name>` (docker-mode servers) or finds the listening
-PID via `ss`/`lsof` and sends `SIGTERM` (pip-mode), escalating to
-`docker kill` / `SIGKILL` after 20 s. It is safe to run while the stack is
-down — processes/containers that are not running are silently skipped.
+Cleanup locates labelled Docker containers before inspecting ports, then
+stops them with `docker stop` (escalating to `docker kill` after 20 s).
+Pip-mode processes must carry the `XR_AI_VLLM_MANAGED` and
+`XR_AI_VLLM_PORT` ownership markers before cleanup sends `SIGTERM` or
+`SIGKILL`. Unknown listeners and failed inspection abort cleanup without
+sending a signal; absent servers are silently skipped.
 
 The target ports and container names are defined in `_PERSISTENT_SERVERS` in
 `main.py` and match the defaults in the per-profile YAML files. Update that
@@ -284,6 +285,11 @@ Docker containers before inspecting ports, then stops them with `docker stop`
 (escalating to `docker kill` after 20 s). Pip-mode processes carry an
 `xr-ai-vllm` ownership marker; unknown listeners and failed inspection abort
 cleanup without sending a signal.
+
+Pip-mode vLLM processes started before the ownership markers were introduced
+cannot be identified safely. After upgrading, stop each unmarked process
+manually once; subsequent launches include the markers and support managed
+cleanup.
 
 ## Per-server notes
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,15 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-08-04 — Model servers select one multimodal stack
+
+`model_servers` defaults to the separate Nemotron-3 Nano and Cosmos services,
+with `--omni-stack` selecting Nemotron-3 Nano Omni instead. The launcher keeps
+STT and embeddings in both layouts and persists Omni like the other shared
+vLLM services, so the launcher can exit after readiness without unloading
+weights. `--stop` cleans every stack-specific port without requiring the
+original selection.
+
 ### 2026-08-03 — Spoken text must carry terminal punctuation
 
 The TTS stage batches on sentence-final punctuation and flushes trailing

--- a/docs/source/components/ai-services.md
+++ b/docs/source/components/ai-services.md
@@ -265,10 +265,11 @@ Existing `~/.docker/config.json` entries take priority and are not overwritten.
 
 ### Cleanup
 
-`uv run xr_render_demo --stop` works for both modes. The cleanup path probes
-`/health` first; for docker mode it then runs `docker stop <container_name>`
-(escalating to `docker kill` after 20 s); for pip mode it falls back to the
-port → PID → SIGTERM/SIGKILL path. Same UX for both.
+`uv run xr_render_demo --stop` works for both modes. Cleanup locates labelled
+Docker containers before inspecting ports, then stops them with `docker stop`
+(escalating to `docker kill` after 20 s). Pip-mode processes carry an
+`xr-ai-vllm` ownership marker; unknown listeners and failed inspection abort
+cleanup without sending a signal.
 
 ## Per-server notes
 

--- a/docs/source/components/ai-services.md
+++ b/docs/source/components/ai-services.md
@@ -180,9 +180,9 @@ exposes `/v1/health`.
 ## vLLM model persistence
 
 The persistent vLLM-backed servers (`vlm_server`, `llama_nemotron_llm_server`,
-`nemotron3_nano_llm_server`, `embedding_server`) **survive stack restarts by design**.
-`nemotron_omni_llm_server` is foreground (dies with the wrapper). Each
-persistent wrapper script checks its health endpoint before spawning vLLM:
+`nemotron3_nano_llm_server`, `nemotron_omni_llm_server`, `embedding_server`)
+**survive stack restarts by design**. Each persistent wrapper script checks its
+health endpoint before spawning vLLM:
 
 - **Already running** → touch the ready file immediately, then idle. Stack is
   ready in seconds; no model reload.
@@ -258,12 +258,10 @@ Existing `~/.docker/config.json` entries take priority and are not overwritten.
   `xr-ai-vllm-llama-nemotron-llm-server`,
   `xr-ai-vllm-nemotron3-nano-llm-server`,
   `xr-ai-vllm-nemotron-omni-llm-server`.
-- Persistence parity: `vlm_server`, `llama_nemotron_llm_server`, and
-  `nemotron3_nano_llm_server` run detached (`docker run -d --rm --name …`) so
-  the container survives stack restarts, mirroring their pip-mode
-  `start_new_session=True` behavior. `nemotron_omni_llm_server` runs
-  foreground (container exits with the wrapper) — same as its pip-mode
-  semantics.
+- Persistence parity: `vlm_server`, `llama_nemotron_llm_server`,
+  `nemotron3_nano_llm_server`, and `nemotron_omni_llm_server` launch their
+  Docker processes in separate sessions, so they survive launcher shutdowns
+  like their pip-mode `start_new_session=True` counterparts.
 
 ### Cleanup
 
@@ -306,8 +304,7 @@ port → PID → SIGTERM/SIGKILL path. Same UX for both.
   `use_bf16: true` for highest quality at the largest VRAM cost. Same
   OpenAI-compatible HTTP contract as the other LLM servers — swap the port to
   swap backends. Hosting backend is selectable per YAML (refer to *Choosing the
-  vLLM runtime*); runs foreground in both pip and docker modes (no
-  cross-restart persistence).
+  vLLM runtime*); persists across stack restarts in both pip and docker modes.
 - **stt-server** loads parakeet-tdt-0.6b-v3 via NeMo ASR in-process.
   English-only; the `language` and `temperature` form fields are accepted but ignored.
 - **tts/magpie** loads magpie_tts_multilingual_357m via NeMo TTS in-process.

--- a/docs/source/components/ai-services.md
+++ b/docs/source/components/ai-services.md
@@ -200,11 +200,12 @@ vLLM keeps running.
 uv run xr_render_demo --stop
 ```
 
-This hits each model server's `/health` endpoint, then either runs
-`docker stop <container_name>` (docker-mode servers) or finds the listening
-PID via `ss` or `lsof` and sends `SIGTERM` (pip-mode), escalating to
-`docker kill` or `SIGKILL` after 20 s. It is safe to run while the stack is
-down — processes and containers that are not running are silently skipped.
+Cleanup locates labelled Docker containers before inspecting ports, then
+stops them with `docker stop` (escalating to `docker kill` after 20 s).
+Pip-mode processes must carry the `XR_AI_VLLM_MANAGED` and
+`XR_AI_VLLM_PORT` ownership markers before cleanup sends `SIGTERM` or
+`SIGKILL`. Unknown listeners and failed inspection abort cleanup without
+sending a signal; absent servers are silently skipped.
 
 The target ports and container names match the defaults in the per-profile YAML files.
 
@@ -270,6 +271,11 @@ Docker containers before inspecting ports, then stops them with `docker stop`
 (escalating to `docker kill` after 20 s). Pip-mode processes carry an
 `xr-ai-vllm` ownership marker; unknown listeners and failed inspection abort
 cleanup without sending a signal.
+
+Pip-mode vLLM processes started before the ownership markers were introduced
+cannot be identified safely. After upgrading, stop each unmarked process
+manually once; subsequent launches include the markers and support managed
+cleanup.
 
 ## Per-server notes
 

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -29,6 +29,16 @@ are presets for common configurations; to run on a different GPU, refer to
 On first run each model downloads from HuggingFace (~50 GB total; can take
 tens of minutes). On subsequent runs the containers restart in under a minute.
 
+The default `--vlm-llm-stack` starts Nemotron-3 Nano (8107), Cosmos (8100),
+STT (8103), and embeddings (8109). Use `--omni-stack` to replace Nano and
+Cosmos with Nemotron-3 Nano Omni (8108); STT and embeddings remain available.
+Switching stacks stops the incompatible persistent models first and aborts if
+they cannot be stopped, avoiding GPU overcommit.
+
+```bash
+uv run model_servers --omni-stack
+```
+
 The default models are public, so no HuggingFace token is required. Set
 `HF_TOKEN` to lift download rate limits and speed, or to use a gated model: refer
 to the credentials guide. The launcher won't prompt; it prints a one-line notice
@@ -39,6 +49,8 @@ To stop all model servers when done:
 ```bash
 uv run model_servers --stop
 ```
+
+`--stop` always stops both stack variants, so it takes no stack-selection flag.
 
 ## Simple VLM example (vision Q&A over voice + text)
 

--- a/tests/test_model_servers.py
+++ b/tests/test_model_servers.py
@@ -47,6 +47,28 @@ def test_omni_stack_replaces_nano_and_cosmos(monkeypatch: pytest.MonkeyPatch) ->
     assert str(processes[1].config) == "yaml/dual_48G_ada/nemotron_omni_llm_server.yaml"
 
 
+@pytest.mark.parametrize(
+    ("stack", "config_name", "gpu"),
+    [
+        ("vlm-llm", "embedding_server.yaml", "0"),
+        ("omni", "embedding_server_omni.yaml", "1"),
+    ],
+)
+def test_dual_ada_embedding_follows_stack_gpu_layout(
+    monkeypatch: pytest.MonkeyPatch,
+    stack: str,
+    config_name: str,
+    gpu: str,
+) -> None:
+    monkeypatch.setattr(_model_servers, "detect_gpu_config", lambda: "dual_48G_ada")
+
+    process = next(p for p in _model_servers._build_processes(stack) if p.name == "embedding")
+    config_path = _REPO_ROOT / "agent-samples/model-servers" / str(process.config)
+
+    assert config_path.name == config_name
+    assert yaml.safe_load(config_path.read_text())["cuda_visible_devices"] == gpu
+
+
 @pytest.mark.parametrize("profile", ["96G_blackwell", "dual_48G_ada", "spark"])
 def test_omni_profiles_select_supported_vllm_images(profile: str) -> None:
     profile_path = (

--- a/tests/test_model_servers.py
+++ b/tests/test_model_servers.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the shared model-server stack selector."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_MAIN_PATH = _REPO_ROOT / "agent-samples/model-servers/main.py"
+_SPEC = importlib.util.spec_from_file_location("model_servers_main", _MAIN_PATH)
+assert _SPEC and _SPEC.loader
+_model_servers = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_model_servers)
+
+_OMNI_PATH = (
+    _REPO_ROOT
+    / "ai-services/llm/nemotron_omni/nemotron_omni_llm_server/__main__.py"
+)
+_OMNI_SPEC = importlib.util.spec_from_file_location("nemotron_omni_main", _OMNI_PATH)
+assert _OMNI_SPEC and _OMNI_SPEC.loader
+_omni = importlib.util.module_from_spec(_OMNI_SPEC)
+_OMNI_SPEC.loader.exec_module(_omni)
+
+
+def test_default_stack_uses_nano_and_cosmos(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_model_servers, "detect_gpu_config", lambda: "spark")
+
+    processes = _model_servers._build_processes()
+
+    assert [process.name for process in processes] == ["stt", "agent-llm", "vlm", "embedding"]
+    assert [process.port for process in processes] == [8103, 8107, 8100, 8109]
+
+
+def test_omni_stack_replaces_nano_and_cosmos(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_model_servers, "detect_gpu_config", lambda: "dual_48G_ada")
+
+    processes = _model_servers._build_processes("omni")
+
+    assert [process.name for process in processes] == ["stt", "omni", "embedding"]
+    assert [process.port for process in processes] == [8103, 8108, 8109]
+    assert str(processes[1].config) == "yaml/dual_48G_ada/nemotron_omni_llm_server.yaml"
+
+
+@pytest.mark.parametrize("profile", ["96G_blackwell", "dual_48G_ada", "spark"])
+def test_omni_profiles_select_supported_vllm_images(profile: str) -> None:
+    profile_path = (
+        _REPO_ROOT
+        / "agent-samples/model-servers/yaml"
+        / profile
+        / "nemotron_omni_llm_server.yaml"
+    )
+
+    config = yaml.safe_load(profile_path.read_text())
+
+    assert config["vllm_backend"] == "docker"
+    assert config["vllm_image"] == "vllm/vllm-openai:v0.20.0"
+    assert config["extra_pip"] == []
+    if profile == "96G_blackwell":
+        assert config["moe_backend"] == "triton"
+    else:
+        assert "moe_backend" not in config
+
+
+def test_stop_cleans_every_stack(monkeypatch: pytest.MonkeyPatch) -> None:
+    stopped: list[tuple[str, int]] = []
+    monkeypatch.setattr(
+        _model_servers,
+        "stop_persistent_servers",
+        lambda services: stopped.extend(services) or True,
+    )
+
+    _model_servers._stop_models()
+
+    assert stopped == [
+        ("stt", 8103),
+        ("agent-llm", 8107),
+        ("vlm", 8100),
+        ("omni", 8108),
+        ("embedding", 8109),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("stack", "expected"),
+    [
+        ("omni", [("agent-llm", 8107), ("vlm", 8100)]),
+        ("vlm-llm", [("omni", 8108)]),
+    ],
+)
+def test_starting_stack_stops_incompatible_persistent_models(
+    monkeypatch: pytest.MonkeyPatch,
+    stack: str,
+    expected: list[tuple[str, int]],
+) -> None:
+    stopped: list[tuple[str, int]] = []
+    monkeypatch.setattr(
+        _model_servers,
+        "stop_persistent_servers",
+        lambda services: stopped.extend(services) or True,
+    )
+
+    _model_servers._stop_incompatible_stack(stack)
+
+    assert stopped == expected
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [([], "vlm-llm"), (["--vlm-llm-stack"], "vlm-llm"), (["--omni-stack"], "omni")],
+)
+def test_cli_selects_requested_stack(
+    monkeypatch: pytest.MonkeyPatch,
+    argv: list[str],
+    expected: str,
+) -> None:
+    selected: list[str] = []
+    monkeypatch.setattr(_model_servers, "setup_logging", lambda *_a, **_k: None)
+    monkeypatch.setattr(_model_servers, "warn_if_missing", lambda *_a, **_k: None)
+    monkeypatch.setattr(_model_servers, "_stop_incompatible_stack", lambda _stack: None)
+    monkeypatch.setattr(_model_servers, "_build_processes", lambda stack: selected.append(stack) or [])
+    monkeypatch.setattr(_model_servers, "run_stack", lambda *_a, **_k: None)
+    monkeypatch.setattr(sys, "argv", ["model_servers", *argv])
+
+    _model_servers.run()
+
+    assert selected == [expected]
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected_stopped"),
+    [
+        (["--omni-stack"], [("agent-llm", 8107), ("vlm", 8100)]),
+        (["--vlm-llm-stack"], [("omni", 8108)]),
+    ],
+)
+def test_cli_stops_incompatible_stack_before_starting(
+    monkeypatch: pytest.MonkeyPatch,
+    argv: list[str],
+    expected_stopped: list[tuple[str, int]],
+) -> None:
+    calls: list[object] = []
+    monkeypatch.setattr(_model_servers, "setup_logging", lambda *_a, **_k: None)
+    monkeypatch.setattr(_model_servers, "warn_if_missing", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        _model_servers,
+        "stop_persistent_servers",
+        lambda services: calls.append(list(services)) or True,
+    )
+    monkeypatch.setattr(_model_servers, "_build_processes", lambda _stack: [])
+    monkeypatch.setattr(_model_servers, "run_stack", lambda *_a, **_k: calls.append("run"))
+    monkeypatch.setattr(sys, "argv", ["model_servers", *argv])
+
+    _model_servers.run()
+
+    assert calls == [expected_stopped, "run"]
+
+
+def test_cli_aborts_when_incompatible_stack_cannot_stop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started: list[bool] = []
+    monkeypatch.setattr(_model_servers, "setup_logging", lambda *_a, **_k: None)
+    monkeypatch.setattr(_model_servers, "warn_if_missing", lambda *_a, **_k: None)
+    monkeypatch.setattr(_model_servers, "stop_persistent_servers", lambda _services: False)
+    monkeypatch.setattr(_model_servers, "run_stack", lambda *_a, **_k: started.append(True))
+    monkeypatch.setattr(sys, "argv", ["model_servers", "--omni-stack"])
+
+    with pytest.raises(RuntimeError, match="could not stop incompatible"):
+        _model_servers.run()
+
+    assert started == []
+
+
+def test_omni_forwards_configured_moe_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(_omni, "setup_logging", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        _omni,
+        "load_config",
+        lambda: ({"moe_backend": "triton"}, Path("."), None),
+    )
+    monkeypatch.setattr(_omni, "resolve_model_cache", lambda *_a, **_k: Path("models"))
+    monkeypatch.setattr(_omni, "setup_hf_env", lambda *_a, **_k: None)
+    monkeypatch.setattr(_omni, "gpu_compute_major", lambda: 10)
+    monkeypatch.setattr(_omni, "serve", lambda **kwargs: captured.update(kwargs))
+
+    _omni.run()
+
+    args = captured["extra_serve_args"]
+    assert args[args.index("--moe-backend") + 1] == "triton"
+
+
+def test_stop_needs_no_stack_selection(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(_model_servers, "setup_logging", lambda *_a, **_k: None)
+    monkeypatch.setattr(_model_servers, "_stop_models", lambda: calls.append("stop"))
+    monkeypatch.setattr(sys, "argv", ["model_servers", "--stop"])
+
+    _model_servers.run()
+
+    assert calls == ["stop"]

--- a/tests/test_vllm_stop.py
+++ b/tests/test_vllm_stop.py
@@ -9,14 +9,58 @@ import xr_ai_vllm
 
 def test_stop_fails_closed_when_listener_discovery_fails(monkeypatch) -> None:
     monkeypatch.setattr(xr_ai_vllm._docker, "container_on_port_checked", lambda _port: (None, True))
-    monkeypatch.setattr(xr_ai_vllm._docker, "pid_on_port_checked", lambda _port: (None, False))
+    monkeypatch.setattr(xr_ai_vllm._docker, "pid_on_port_checked", lambda _port: (None, False, False))
 
     assert not xr_ai_vllm.stop_persistent_servers([("omni", 8108)])
 
 
 def test_stop_does_not_signal_unidentified_listener(monkeypatch) -> None:
     monkeypatch.setattr(xr_ai_vllm._docker, "container_on_port_checked", lambda _port: (None, True))
-    monkeypatch.setattr(xr_ai_vllm._docker, "pid_on_port_checked", lambda _port: (1234, True))
+    monkeypatch.setattr(xr_ai_vllm._docker, "pid_on_port_checked", lambda _port: (1234, True, True))
     monkeypatch.setattr(xr_ai_vllm._docker, "is_xr_ai_server_process", lambda *_args: False)
 
     assert not xr_ai_vllm.stop_persistent_servers([("omni", 8108)])
+
+
+def test_stop_container_without_visible_host_pid(monkeypatch) -> None:
+    stopped: list[str] = []
+    monkeypatch.setattr(xr_ai_vllm._docker, "container_on_port_checked", lambda _port: ("omni", True))
+    monkeypatch.setattr(xr_ai_vllm._docker, "pid_on_port_checked", lambda _port: (None, True, False))
+    monkeypatch.setattr(xr_ai_vllm._docker, "stop_container", lambda name: stopped.append(name) or True)
+    monkeypatch.setattr(xr_ai_vllm._docker, "remove_container", lambda _name: True)
+
+    assert xr_ai_vllm.stop_persistent_servers([("omni", 8108)])
+    assert stopped == ["omni"]
+
+
+def test_stop_fails_closed_for_listener_without_visible_pid(monkeypatch) -> None:
+    monkeypatch.setattr(xr_ai_vllm._docker, "container_on_port_checked", lambda _port: (None, True))
+    monkeypatch.setattr(xr_ai_vllm._docker, "pid_on_port_checked", lambda _port: (None, True, True))
+
+    assert not xr_ai_vllm.stop_persistent_servers([("omni", 8108)])
+
+
+def test_stop_does_not_signal_external_vllm_process(tmp_path, monkeypatch) -> None:
+    proc_root = tmp_path / "proc" / "1234"
+    proc_root.mkdir(parents=True)
+    (proc_root / "cmdline").write_text("vllm\0serve\0external-model")
+    (proc_root / "environ").write_bytes(b"PATH=/bin\0")
+    monkeypatch.setattr(xr_ai_vllm._docker, "Path", lambda _path: proc_root / _path.rsplit("/", 1)[-1])
+    monkeypatch.setattr(xr_ai_vllm._docker, "container_on_port_checked", lambda _port: (None, True))
+    monkeypatch.setattr(xr_ai_vllm._docker, "pid_on_port_checked", lambda _port: (1234, True, True))
+    monkeypatch.setattr(xr_ai_vllm.os, "kill", lambda *_args: (_ for _ in ()).throw(AssertionError()))
+
+    assert not xr_ai_vllm.stop_persistent_servers([("omni", 8108)])
+
+
+def test_pip_ownership_marker_matches_service_port(tmp_path, monkeypatch) -> None:
+    proc_root = tmp_path / "proc" / "1234"
+    proc_root.mkdir(parents=True)
+    (proc_root / "cmdline").write_text("vllm\0serve\0model")
+    (proc_root / "environ").write_bytes(
+        b"XR_AI_VLLM_MANAGED=1\0XR_AI_VLLM_PORT=8108\0"
+    )
+    monkeypatch.setattr(xr_ai_vllm._docker, "Path", lambda _path: proc_root / _path.rsplit("/", 1)[-1])
+
+    assert xr_ai_vllm._docker.is_xr_ai_server_process(1234, "omni", 8108)
+    assert not xr_ai_vllm._docker.is_xr_ai_server_process(1234, "omni", 8107)

--- a/tests/test_vllm_stop.py
+++ b/tests/test_vllm_stop.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Safety tests for persistent-server cleanup discovery."""
+from __future__ import annotations
+
+import xr_ai_vllm
+
+
+def test_stop_fails_closed_when_listener_discovery_fails(monkeypatch) -> None:
+    monkeypatch.setattr(xr_ai_vllm._docker, "container_on_port_checked", lambda _port: (None, True))
+    monkeypatch.setattr(xr_ai_vllm._docker, "pid_on_port_checked", lambda _port: (None, False))
+
+    assert not xr_ai_vllm.stop_persistent_servers([("omni", 8108)])
+
+
+def test_stop_does_not_signal_unidentified_listener(monkeypatch) -> None:
+    monkeypatch.setattr(xr_ai_vllm._docker, "container_on_port_checked", lambda _port: (None, True))
+    monkeypatch.setattr(xr_ai_vllm._docker, "pid_on_port_checked", lambda _port: (1234, True))
+    monkeypatch.setattr(xr_ai_vllm._docker, "is_xr_ai_server_process", lambda *_args: False)
+
+    assert not xr_ai_vllm.stop_persistent_servers([("omni", 8108)])

--- a/utils/xr-ai-vllm/xr_ai_vllm/__init__.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/__init__.py
@@ -43,7 +43,6 @@ from __future__ import annotations
 
 import logging
 import os
-import urllib.request
 from pathlib import Path
 
 from . import _docker, _pip
@@ -149,36 +148,41 @@ def serve(
 
 def stop_persistent_servers(
     services: list[tuple[str, int]],
-) -> None:
-    """Stop persisted servers; safe to call when nothing is running.
+) -> bool:
+    """Stop persisted servers and report whether every discovered server stopped.
 
     *services* is a list of ``(label, port)`` tuples.  For each entry:
 
-    1. Probe ``http://127.0.0.1:<port>/health``. Skip if not reachable.
-    2. Look for a docker container labelled ``xr-ai-vllm.port=<port>``
+    1. Look for a docker container labelled ``xr-ai-vllm.port=<port>``
        (stamped at start time by the vLLM wrapper) and ``docker stop`` it.
-    3. Fall back to port → pid → SIGTERM → SIGKILL for pip-mode vLLM or
+    2. Fall back to port → pid → SIGTERM → SIGKILL for pip-mode vLLM or
        in-process servers (e.g. STT).
 
-    Output is print-style with ``[<label>] …`` prefixes.
+    A missing listener is already stopped. Output is print-style with
+    ``[<label>] …`` prefixes. Discovery errors and listeners that are not
+    identified as xr-ai services fail closed without sending a signal.
     """
     import signal
     import time
 
+    success = True
     found = False
     for label, port in services:
-        try:
-            with urllib.request.urlopen(
-                f"http://127.0.0.1:{port}/health", timeout=2
-            ) as r:
-                if r.status != 200:
-                    continue
-        except Exception:
+        pid, pid_checked = _docker.pid_on_port_checked(port)
+        if not pid_checked:
+            print(f"  [{label}] cannot inspect :{port} ownership — not stopping", flush=True)
+            success = False
+            continue
+        if pid is None:
+            continue
+
+        container_name, container_checked = _docker.container_on_port_checked(port)
+        if not container_checked:
+            print(f"  [{label}] cannot inspect :{port} ownership — not stopping", flush=True)
+            success = False
             continue
 
         found = True
-
-        container_name = _docker.container_on_port(port)
         if container_name:
             print(f"  [{label}] stopping container {container_name}…", flush=True)
             if _docker.stop_container(container_name):
@@ -203,12 +207,14 @@ def stop_persistent_servers(
             else:
                 print(f"  [{label}] docker stop failed — check `docker ps -a`",
                       flush=True)
+                success = False
             continue
 
-        pid = _docker.pid_on_port(port)
-        if pid is None:
-            print(f"  [{label}] running on :{port} but no PID found — "
-                  f"kill manually", flush=True)
+        assert pid is not None
+        if not _docker.is_xr_ai_server_process(pid, label):
+            print(f"  [{label}] listener on :{port} is not an xr-ai server — not stopping",
+                  flush=True)
+            success = False
             continue
 
         print(f"  [{label}] stopping (pid={pid}, port={port})…", flush=True)
@@ -224,11 +230,20 @@ def stop_persistent_servers(
             else:
                 print(f"  [{label}] force-killing", flush=True)
                 os.kill(pid, signal.SIGKILL)
+                try:
+                    os.kill(pid, 0)
+                except ProcessLookupError:
+                    print(f"  [{label}] stopped", flush=True)
+                else:
+                    print(f"  [{label}] still running after SIGKILL", flush=True)
+                    success = False
         except ProcessLookupError:
             print(f"  [{label}] already gone", flush=True)
 
     if not found:
         print("  No persistent servers found running.", flush=True)
+
+    return success
 
 
 __all__ = [

--- a/utils/xr-ai-vllm/xr_ai_vllm/__init__.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/__init__.py
@@ -158,8 +158,8 @@ def stop_persistent_servers(
     2. Fall back to port → pid → SIGTERM → SIGKILL for pip-mode vLLM or
        in-process servers (e.g. STT).
 
-    A missing listener is already stopped. Output is print-style with
-    ``[<label>] …`` prefixes. Discovery errors and listeners that are not
+    A missing container and listener is already stopped. Output is print-style
+    with ``[<label>] …`` prefixes. Discovery errors and listeners that are not
     identified as xr-ai services fail closed without sending a signal.
     """
     import signal
@@ -168,22 +168,14 @@ def stop_persistent_servers(
     success = True
     found = False
     for label, port in services:
-        pid, pid_checked = _docker.pid_on_port_checked(port)
-        if not pid_checked:
-            print(f"  [{label}] cannot inspect :{port} ownership — not stopping", flush=True)
-            success = False
-            continue
-        if pid is None:
-            continue
-
         container_name, container_checked = _docker.container_on_port_checked(port)
         if not container_checked:
             print(f"  [{label}] cannot inspect :{port} ownership — not stopping", flush=True)
             success = False
             continue
 
-        found = True
         if container_name:
+            found = True
             print(f"  [{label}] stopping container {container_name}…", flush=True)
             if _docker.stop_container(container_name):
                 # Remove the container so the next launch goes through a full
@@ -210,8 +202,17 @@ def stop_persistent_servers(
                 success = False
             continue
 
+        pid, pid_checked, listening = _docker.pid_on_port_checked(port)
+        if not pid_checked or (listening and pid is None):
+            print(f"  [{label}] cannot inspect :{port} ownership — not stopping", flush=True)
+            success = False
+            continue
+        if not listening:
+            continue
+
         assert pid is not None
-        if not _docker.is_xr_ai_server_process(pid, label):
+        found = True
+        if not _docker.is_xr_ai_server_process(pid, label, port):
             print(f"  [{label}] listener on :{port} is not an xr-ai server — not stopping",
                   flush=True)
             success = False

--- a/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
@@ -559,12 +559,12 @@ def container_on_port(port: int) -> str | None:
     return container
 
 
-def pid_on_port_checked(port: int) -> tuple[int | None, bool]:
-    """Return the listening PID and whether a listener inspection succeeded.
+def pid_on_port_checked(port: int) -> tuple[int | None, bool, bool]:
+    """Return the listening PID, inspection status, and listener presence.
 
     Tries `ss` first (always present on modern Linux), falls back to `lsof`.
-    A tool reporting no listener is a successful inspection; unavailable or
-    failing tools leave the result unknown.
+    A listener without a visible PID is still reported so callers fail closed
+    instead of mistaking an uninspectable listener for an unused port.
     """
     try:
         out = subprocess.check_output(
@@ -574,8 +574,8 @@ def pid_on_port_checked(port: int) -> tuple[int | None, bool]:
         )
         m = re.search(r"pid=(\d+)", out)
         if m:
-            return int(m.group(1)), True
-        return None, True
+            return int(m.group(1)), True, True
+        return None, True, bool(out.strip())
     except (FileNotFoundError, subprocess.CalledProcessError):
         pass
     try:
@@ -585,21 +585,21 @@ def pid_on_port_checked(port: int) -> tuple[int | None, bool]:
             stderr=subprocess.DEVNULL,
         ).strip()
         if out:
-            return int(out.splitlines()[0]), True
-        return None, True
+            return int(out.splitlines()[0]), True, True
+        return None, True, False
     except subprocess.CalledProcessError:
-        return None, True
+        return None, True, False
     except FileNotFoundError:
-        return None, False
+        return None, False, False
 
 
 def pid_on_port(port: int) -> int | None:
     """Return the pid listening on *port* (any v4/v6 socket), or None."""
-    pid, _ = pid_on_port_checked(port)
+    pid, _, _ = pid_on_port_checked(port)
     return pid
 
 
-def is_xr_ai_server_process(pid: int, label: str) -> bool:
+def is_xr_ai_server_process(pid: int, label: str, port: int) -> bool:
     """Return whether *pid* has the expected xr-ai server command line."""
     try:
         command = Path(f"/proc/{pid}/cmdline").read_text(errors="replace")
@@ -607,4 +607,11 @@ def is_xr_ai_server_process(pid: int, label: str) -> bool:
         return False
     if label == "stt":
         return "stt_server" in command
-    return "vllm" in command
+    try:
+        environment = Path(f"/proc/{pid}/environ").read_bytes()
+    except OSError:
+        return False
+    return (
+        b"XR_AI_VLLM_MANAGED=1\0" in environment
+        and f"XR_AI_VLLM_PORT={port}\0".encode() in environment
+    )

--- a/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
@@ -528,13 +528,8 @@ def run(
 _CONTAINER_PREFIX = "xr-ai-vllm-"
 
 
-def container_on_port(port: int) -> str | None:
-    """Return the name of a running xr-ai-vllm container serving *port*, or None.
-
-    ``docker ps --filter publish=<port>`` silently misses ``--network host``
-    containers.  We label each container with ``xr-ai-vllm.port=<port>`` at
-    run time and filter by that label here instead.
-    """
+def container_on_port_checked(port: int) -> tuple[str | None, bool]:
+    """Return a labelled container and whether Docker discovery succeeded."""
     try:
         out = subprocess.check_output(
             ["docker", "ps",
@@ -544,17 +539,32 @@ def container_on_port(port: int) -> str | None:
             stderr=subprocess.DEVNULL,
         ).strip()
         names = out.splitlines()
-        return names[0] if names else None
-    except (FileNotFoundError, subprocess.CalledProcessError):
-        return None
+        return (names[0] if names else None), True
+    except FileNotFoundError:
+        # Without the Docker CLI, a local Docker container cannot be managed;
+        # pip-mode ownership is still established from the listener process.
+        return None, True
+    except subprocess.CalledProcessError:
+        return None, False
 
 
-def pid_on_port(port: int) -> int | None:
-    """Return the pid listening on *port* (any v4/v6 socket), or None.
+def container_on_port(port: int) -> str | None:
+    """Return the name of a running xr-ai-vllm container serving *port*, or None.
+
+    ``docker ps --filter publish=<port>`` silently misses ``--network host``
+    containers.  We label each container with ``xr-ai-vllm.port=<port>`` at
+    run time and filter by that label here instead.
+    """
+    container, _ = container_on_port_checked(port)
+    return container
+
+
+def pid_on_port_checked(port: int) -> tuple[int | None, bool]:
+    """Return the listening PID and whether a listener inspection succeeded.
 
     Tries `ss` first (always present on modern Linux), falls back to `lsof`.
-    Used by the stop helper to send SIGTERM to the vLLM process (pip or docker
-    with --network host — both are visible to ss(8) on the host).
+    A tool reporting no listener is a successful inspection; unavailable or
+    failing tools leave the result unknown.
     """
     try:
         out = subprocess.check_output(
@@ -564,8 +574,9 @@ def pid_on_port(port: int) -> int | None:
         )
         m = re.search(r"pid=(\d+)", out)
         if m:
-            return int(m.group(1))
-    except Exception:
+            return int(m.group(1)), True
+        return None, True
+    except (FileNotFoundError, subprocess.CalledProcessError):
         pass
     try:
         out = subprocess.check_output(
@@ -574,7 +585,26 @@ def pid_on_port(port: int) -> int | None:
             stderr=subprocess.DEVNULL,
         ).strip()
         if out:
-            return int(out.splitlines()[0])
-    except Exception:
-        pass
-    return None
+            return int(out.splitlines()[0]), True
+        return None, True
+    except subprocess.CalledProcessError:
+        return None, True
+    except FileNotFoundError:
+        return None, False
+
+
+def pid_on_port(port: int) -> int | None:
+    """Return the pid listening on *port* (any v4/v6 socket), or None."""
+    pid, _ = pid_on_port_checked(port)
+    return pid
+
+
+def is_xr_ai_server_process(pid: int, label: str) -> bool:
+    """Return whether *pid* has the expected xr-ai server command line."""
+    try:
+        command = Path(f"/proc/{pid}/cmdline").read_text(errors="replace")
+    except OSError:
+        return False
+    if label == "stt":
+        return "stt_server" in command
+    return "vllm" in command

--- a/utils/xr-ai-vllm/xr_ai_vllm/_pip.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/_pip.py
@@ -51,7 +51,11 @@ def run(
     # own process group so the launcher's killpg() on the wrapper does not
     # reach it. Non-persistent wrappers stay in the wrapper's group so SIGTERM
     # propagates and vLLM exits with the wrapper.
-    proc = subprocess.Popen(vllm_argv, start_new_session=persistent)
+    env = os.environ | {
+        "XR_AI_VLLM_MANAGED": "1",
+        "XR_AI_VLLM_PORT": str(port),
+    }
+    proc = subprocess.Popen(vllm_argv, env=env, start_new_session=persistent)
 
     _lifecycle.wait_until_healthy(
         health_url,


### PR DESCRIPTION
## Summary

Adds a selectable shared model-server layout:

- Default `--vlm-llm-stack` keeps the Nemotron-3 Nano + Cosmos VLM + STT stack.
- `--omni-stack` starts Nemotron-3 Nano Omni + STT instead, with GPU-specific Omni profiles.
- `model_servers --stop` stops every port used by either stack without needing a stack flag.

Nemotron Omni now persists like the other shared vLLM services, allowing `model_servers` to exit after readiness while retaining loaded weights.

## Validation

- `uv run --project tests pytest tests/test_model_servers.py tests/test_models_config.py tests/test_vllm_docker.py -q`
- `uv run --project tests ruff check tests/test_model_servers.py agent-samples/model-servers/main.py ai-services/llm/nemotron_omni/nemotron_omni_llm_server/__main__.py`

Depends on #337 (base branch: `blongs-nv/remove-quick-llm`).
