### PR TITLE
fix(vllm): run setup before server entrypoint

### DIFF
--- a/docs/ai-services.md
+++ b/docs/ai-services.md
@@ -266,6 +266,9 @@ Existing `~/.docker/config.json` entries take priority and are not overwritten.
   the legacy `--gpus` flag so the launch works under both legacy and CDI
   container-toolkit modes; `--ipc host` gives vLLM the shared-memory region
   its workers expect.
+- The launcher overrides the image entrypoint with `/bin/bash`, installs any
+  required wheels, then executes `vllm serve`. Failed stopped containers are
+  recreated because Docker cannot change their recorded entrypoint or command.
 - The host `model_cache` is bind-mounted at the same path inside the
   container and `HF_HOME` is set to it, so weights cached by pip mode are
   reused by docker mode and vice versa.

--- a/docs/ai-services.md
+++ b/docs/ai-services.md
@@ -246,7 +246,7 @@ another tag, an internal mirror, or a custom build.
 
 - **Docker Engine** with the user in the `docker` group (`docker version`
   must succeed without `sudo`).
-- **NVIDIA Container Toolkit** so `--gpus` works:
+- **NVIDIA Container Toolkit** so the `nvidia` runtime can expose GPUs:
   https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
 - **NGC pull access** for `nvcr.io/nvidia/vllm`. The wrapper auto-runs
   `docker login nvcr.io` if `NGC_API_KEY` is in the environment (loaded by

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,14 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-08-05 — Docker vLLM setup owns the image entrypoint
+
+The shared vLLM Docker launcher explicitly selects `/bin/bash` before installing
+model-specific wheels and executing `vllm serve`. NGC vLLM images otherwise
+interpret the setup command through their default `vllm serve` entrypoint.
+Failed stopped containers are recreated rather than restarted because Docker
+cannot update their recorded entrypoint or command.
+
 ### 2026-08-04 — Model servers select one multimodal stack
 
 `model_servers` defaults to the separate Nemotron-3 Nano and Cosmos services,

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,10 +12,11 @@ preserved and not re-litigated.
 ### 2026-08-05 — Docker vLLM setup owns the image entrypoint
 
 The shared vLLM Docker launcher explicitly selects `/bin/bash` before installing
-model-specific wheels and executing `vllm serve`. NGC vLLM images otherwise
-interpret the setup command through their default `vllm serve` entrypoint.
-Failed stopped containers are recreated rather than restarted because Docker
-cannot update their recorded entrypoint or command.
+model-specific wheels and executing `vllm serve`. The Omni profile's
+`vllm/vllm-openai:v0.20.0` image otherwise interprets the setup command through
+its default `vllm serve` entrypoint. Failed stopped containers are recreated
+rather than restarted because Docker cannot update their recorded entrypoint or
+command.
 
 ### 2026-08-04 — Model servers select one multimodal stack
 

--- a/docs/source/components/ai-services.md
+++ b/docs/source/components/ai-services.md
@@ -250,8 +250,11 @@ Existing `~/.docker/config.json` entries take priority and are not overwritten.
 
 ### docker mode — runtime details
 
-- Container is launched with `--network host --ipc host --gpus …` (matches
-  gives vLLM the shared-memory region its workers expect).
+- Container is launched with `--network host --ipc host --runtime nvidia`
+  (forwarding `NVIDIA_VISIBLE_DEVICES`), and `/bin/bash` overrides the image
+  entrypoint so setup installs run before `vllm serve`.
+- Failed stopped containers are recreated because Docker cannot change their
+  recorded entrypoint or command.
 - The host `model_cache` is bind-mounted at the same path inside the
   container and `HF_HOME` is set to it, so weights cached by pip mode are
   reused by docker mode and vice versa.

--- a/docs/source/components/ai-services.md
+++ b/docs/source/components/ai-services.md
@@ -235,7 +235,7 @@ another tag, an internal mirror, or a custom build.
 
 - **Docker Engine** with the user in the `docker` group (`docker version`
   must succeed without `sudo`).
-- **NVIDIA Container Toolkit** so `--gpus` works:
+- **NVIDIA Container Toolkit** so the `nvidia` runtime can expose GPUs:
   https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
 - **NGC pull access** for `nvcr.io/nvidia/vllm`. The wrapper auto-runs
   `docker login nvcr.io` if `NGC_API_KEY` is in the environment (loaded by

--- a/tests/test_vllm_docker.py
+++ b/tests/test_vllm_docker.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from xr_ai_vllm._docker import (
     _already_logged_in,
@@ -15,6 +15,7 @@ from xr_ai_vllm._docker import (
     container_exists,
     container_running,
     pid_on_port,
+    run,
 )
 
 
@@ -153,8 +154,10 @@ class TestBuildRunArgv:
         assert "nvcr.io/nvidia/vllm:26.04-py3" in argv
 
     def test_shell_overrides_image_entrypoint(self, tmp_path):
-        argv = build_run_argv(**self._base_kwargs(tmp_path))
-        image = "nvcr.io/nvidia/vllm:26.04-py3"
+        kwargs = self._base_kwargs(tmp_path)
+        image = "vllm/vllm-openai:v0.20.0"
+        kwargs["image"] = image
+        argv = build_run_argv(**kwargs)
         image_index = argv.index(image)
         assert argv[image_index - 2 : image_index] == ["--entrypoint", "/bin/bash"]
         assert argv[image_index + 1] == "-c"
@@ -202,3 +205,43 @@ class TestContainerHelpers:
             side_effect=FileNotFoundError,
         ):
             assert pid_on_port(8100) is None
+
+
+class TestRun:
+    def test_stopped_container_is_removed_and_relaunched(self, tmp_path):
+        argv = ["docker", "run", "fresh-container"]
+        process = MagicMock()
+        process.poll.return_value = None
+
+        with (
+            patch("xr_ai_vllm._docker._docker_available", return_value=True),
+            patch("xr_ai_vllm._docker._lifecycle.health_ok", return_value=False),
+            patch("xr_ai_vllm._docker.container_exists", return_value=True),
+            patch("xr_ai_vllm._docker.container_running", return_value=False),
+            patch("xr_ai_vllm._docker.remove_container", return_value=True) as remove,
+            patch("xr_ai_vllm._docker._maybe_ngc_login"),
+            patch("xr_ai_vllm._docker.build_run_argv", return_value=argv),
+            patch("xr_ai_vllm._docker.subprocess.Popen", return_value=process) as popen,
+            patch("xr_ai_vllm._docker._start_log_streamer", return_value=(None, None)),
+            patch("xr_ai_vllm._docker._lifecycle.wait_until_healthy"),
+            patch("xr_ai_vllm._docker._lifecycle.idle_until_stopped"),
+            patch("xr_ai_vllm._docker.signal.getsignal", return_value=None),
+            patch("xr_ai_vllm._docker.signal.signal"),
+        ):
+            run(
+                image="vllm/vllm-openai:v0.20.0",
+                container_name="xr-ai-vllm-omni",
+                log_prefix="omni",
+                vllm_argv=["vllm", "serve", "model"],
+                host="0.0.0.0",
+                port=8108,
+                model_cache=tmp_path,
+                hf_token=None,
+                cuda_visible_devices="0",
+                extra_env=None,
+                extra_pip=["mamba-ssm"],
+                ready_file=None,
+            )
+
+        remove.assert_called_once_with("xr-ai-vllm-omni")
+        popen.assert_called_once_with(argv, start_new_session=True)

--- a/tests/test_vllm_docker.py
+++ b/tests/test_vllm_docker.py
@@ -152,9 +152,16 @@ class TestBuildRunArgv:
         argv = build_run_argv(**self._base_kwargs(tmp_path))
         assert "nvcr.io/nvidia/vllm:26.04-py3" in argv
 
+    def test_shell_overrides_image_entrypoint(self, tmp_path):
+        argv = build_run_argv(**self._base_kwargs(tmp_path))
+        image = "nvcr.io/nvidia/vllm:26.04-py3"
+        image_index = argv.index(image)
+        assert argv[image_index - 2 : image_index] == ["--entrypoint", "/bin/bash"]
+        assert argv[image_index + 1] == "-c"
+
     def test_no_extra_pip_runs_only_hf_transfer_install(self, tmp_path):
         argv = build_run_argv(**self._base_kwargs(tmp_path))
-        # bash -c "<install>... && vllm serve ..." — the install is the last
+        # /bin/bash -c "<install>... && vllm serve ..." — the install is the last
         # argv entry; with no extra_pip there must be exactly one pip line.
         bash_cmd = argv[-1]
         assert bash_cmd.count("pip install ") == 1

--- a/utils/xr-ai-vllm/xr_ai_vllm/_config.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/_config.py
@@ -79,7 +79,8 @@ def setup_hf_env(cfg: dict, model_cache: Path) -> str | None:
     cuda_devices = cfg.get("cuda_visible_devices")
     if cuda_devices is not None:
         cuda_devices = str(cuda_devices)
-        # Pip mode reads it from the env; docker mode forwards via --gpus.
+        # Pip mode reads it from the env; docker mode forwards it through the
+        # NVIDIA runtime.
         os.environ["CUDA_VISIBLE_DEVICES"] = cuda_devices
 
     hf_token = cfg.get("hf_token") or os.environ.get("HF_TOKEN", "")

--- a/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
@@ -98,7 +98,9 @@ def build_run_argv(
 
     argv += ["-v", f"{model_cache}:{model_cache}"]
 
-    argv.append(image)
+    # NGC vLLM images default to `vllm serve`; override it because the setup
+    # installs must run in a shell before the server starts.
+    argv += ["--entrypoint", "/bin/bash", image]
     # Install hf_transfer before starting vLLM — the NGC image doesn't ship it
     # but HF_HUB_ENABLE_HF_TRANSFER=1 will error if it's missing.
     install_cmds = ["pip install -q hf_transfer"]
@@ -113,7 +115,7 @@ def build_run_argv(
             f"pip install -q --no-build-isolation {shlex.join(extra_pip)}"
         )
     install_cmds.append(shlex.join(vllm_argv))
-    argv += ["bash", "-c", " && ".join(install_cmds)]
+    argv += ["-c", " && ".join(install_cmds)]
     return argv
 
 
@@ -451,37 +453,35 @@ def run(
         return
 
     if container_exists(container_name) and not container_running(container_name):
-        # Stopped container already has hf_transfer installed — restart it
-        # rather than running a fresh image (avoids reinstalling every time).
+        # A container's command and entrypoint are immutable. Recreate failed
+        # containers so launcher fixes and changed service arguments take effect.
         print(
-            f"[{log_prefix}] Restarting stopped container {container_name}",
+            f"[{log_prefix}] Recreating stopped container {container_name}",
             flush=True,
         )
-        proc = subprocess.Popen(
-            ["docker", "start", "-a", container_name],
-            start_new_session=True,
-        )
-        _state["proc"] = proc
-    else:
-        _maybe_ngc_login(image)
-        argv = build_run_argv(
-            image=image,
-            container_name=container_name,
-            port=port,
-            model_cache=model_cache,
-            hf_token=hf_token,
-            cuda_visible_devices=cuda_visible_devices,
-            extra_env=extra_env,
-            extra_pip=extra_pip,
-            vllm_argv=vllm_argv,
-        )
-        print(
-            f"[{log_prefix}] Launching vLLM (docker)  image={image}  "
-            f"container={container_name}  http://{host}:{port}/v1",
-            flush=True,
-        )
-        proc = subprocess.Popen(argv, start_new_session=True)
-        _state["proc"] = proc
+        if not remove_container(container_name):
+            log.error("Could not remove stopped container %s", container_name)
+            sys.exit(1)
+
+    _maybe_ngc_login(image)
+    argv = build_run_argv(
+        image=image,
+        container_name=container_name,
+        port=port,
+        model_cache=model_cache,
+        hf_token=hf_token,
+        cuda_visible_devices=cuda_visible_devices,
+        extra_env=extra_env,
+        extra_pip=extra_pip,
+        vllm_argv=vllm_argv,
+    )
+    print(
+        f"[{log_prefix}] Launching vLLM (docker)  image={image}  "
+        f"container={container_name}  http://{host}:{port}/v1",
+        flush=True,
+    )
+    proc = subprocess.Popen(argv, start_new_session=True)
+    _state["proc"] = proc
 
     streamer_proc, log_path = _start_log_streamer(container_name)
     _state["streamer"] = streamer_proc

--- a/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
@@ -98,8 +98,8 @@ def build_run_argv(
 
     argv += ["-v", f"{model_cache}:{model_cache}"]
 
-    # NGC vLLM images default to `vllm serve`; override it because the setup
-    # installs must run in a shell before the server starts.
+    # Some vLLM images default to `vllm serve`; override the entrypoint so
+    # setup installs run in a shell before the server starts.
     argv += ["--entrypoint", "/bin/bash", image]
     # Install hf_transfer before starting vLLM — the NGC image doesn't ship it
     # but HF_HUB_ENABLE_HF_TRANSFER=1 will error if it's missing.


### PR DESCRIPTION
## What changed

- Override Docker vLLM image entrypoints with `/bin/bash` so prerequisite wheel installation runs before `vllm serve`.
- Recreate stopped containers instead of restarting an immutable stale entrypoint or command.
- Document the lifecycle behavior and cover both generated Docker arguments and stopped-container relaunch.

## Why

The Omni profile's `vllm/vllm-openai:v0.20.0` image defaults to the `["vllm", "serve"]` entrypoint, which interpreted the shell setup string as a vLLM argument. Nemotron Omni then failed while parsing `--compilation-config` rather than starting the server. Restarting the stopped container preserved that broken command.

## Impact

Model-server convenience stacks can install model-specific prerequisites and reliably recover from a failed container launch.

## Validation

- `PYTHONPATH=utils/xr-ai-vllm uv run --with pytest pytest -q --noconftest tests/test_vllm_docker.py`
- 28 tests passed.
- Focused Ruff and SPDX checks passed.
