### PR TITLE
fix(video-mcp): write ready-file only after uvicorn is listening

### DIFF
--- a/agent-mcp-servers/video-mcp/video_mcp_server/__main__.py
+++ b/agent-mcp-servers/video-mcp/video_mcp_server/__main__.py
@@ -51,6 +51,8 @@ async def _wait_until_bound(server: uvicorn.Server, task: asyncio.Task) -> None:
         try:
             await task
         except asyncio.CancelledError:
+            # Expected: we cancelled the task ourselves; await it only to let
+            # the cancellation unwind cleanly before we return to the caller.
             pass
 
 

--- a/agent-mcp-servers/video-mcp/video_mcp_server/__main__.py
+++ b/agent-mcp-servers/video-mcp/video_mcp_server/__main__.py
@@ -182,9 +182,12 @@ async def _serve(config: dict, ready_file: Path | None) -> None:
             recording_enabled,
             config.get("hub_pub", _DEFAULT_HUB_PUB),
         )
+        serve_task = asyncio.create_task(server.serve())
         if ready_file:
+            while not server.started:
+                await asyncio.sleep(0.05)
             ready_file.touch()
-        await server.serve()
+        await serve_task
     finally:
         endpoint.stop()
         endpoint_task.cancel()

--- a/agent-mcp-servers/video-mcp/video_mcp_server/__main__.py
+++ b/agent-mcp-servers/video-mcp/video_mcp_server/__main__.py
@@ -31,6 +31,28 @@ _DEFAULT_CONFIG = Path(__file__).resolve().parent.parent / "video_mcp_server.yam
 _DEFAULT_HUB_PUB = "ipc:///tmp/xr_hub_pub"
 _DEFAULT_HUB_PUSH = "ipc:///tmp/xr_hub_in"
 
+_STARTUP_TIMEOUT_S = 10.0
+
+
+async def _wait_until_bound(server: uvicorn.Server, task: asyncio.Task) -> None:
+    """Poll until *server* binds or *task* dies trying.
+
+    Mirrors xr_media_hub.transport.livekit._token_server.wait_until_bound.
+    On timeout the task is cancelled and awaited so we don't orphan it.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + _STARTUP_TIMEOUT_S
+    while not server.started and not task.done():
+        if loop.time() >= deadline:
+            break
+        await asyncio.sleep(0.05)
+    if not server.started and not task.done():
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
 
 def _error(error: Exception) -> dict:
     return {"error": str(error)}
@@ -183,9 +205,18 @@ async def _serve(config: dict, ready_file: Path | None) -> None:
             config.get("hub_pub", _DEFAULT_HUB_PUB),
         )
         serve_task = asyncio.create_task(server.serve())
+        await _wait_until_bound(server, serve_task)
+        if not server.started:
+            cause = (
+                serve_task.exception()
+                if serve_task.done() and not serve_task.cancelled()
+                else None
+            )
+            raise RuntimeError(
+                f"video-mcp server failed to bind on port {port} "
+                "— port already in use, startup timed out, or ASGI lifespan failed"
+            ) from cause
         if ready_file:
-            while not server.started:
-                await asyncio.sleep(0.05)
             ready_file.touch()
         await serve_task
     finally:

--- a/tests/test_video_mcp_startup.py
+++ b/tests/test_video_mcp_startup.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministic unit tests for video_mcp_server startup / ready-file logic.
+
+These tests exercise ``_wait_until_bound`` directly — no GPU, no NVENC, no
+real uvicorn server.  They cover the three outcomes that the polling loop must
+handle:
+
+1. Server starts normally   → ``started`` flips True, function returns.
+2. Serve task exits early   → task is done before ``started`` is set,
+                              function returns without hanging.
+3. Startup timeout          → neither condition satisfied within the deadline,
+                              task is cancelled and function returns.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from video_mcp_server.__main__ import _wait_until_bound
+
+pytestmark = pytest.mark.asyncio
+
+
+def _mock_server(*, started: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(started=started)
+
+
+async def test_wait_until_bound_success() -> None:
+    """started becomes True quickly → _wait_until_bound returns, task runs on."""
+    server = _mock_server(started=False)
+
+    async def _flip_then_run() -> None:
+        await asyncio.sleep(0.02)
+        server.started = True
+        await asyncio.sleep(10)  # stays alive after binding
+
+    task = asyncio.create_task(_flip_then_run())
+    await _wait_until_bound(server, task)
+
+    assert server.started
+    assert not task.done()
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+async def test_wait_until_bound_task_exits_early() -> None:
+    """Task finishes (raises) before started is set → loop exits, task is done."""
+    server = _mock_server(started=False)
+
+    async def _fail_fast() -> None:
+        await asyncio.sleep(0.01)
+        raise RuntimeError("bind failed")
+
+    task = asyncio.create_task(_fail_fast())
+    await _wait_until_bound(server, task)
+
+    assert not server.started
+    assert task.done()
+    assert not task.cancelled()
+    assert isinstance(task.exception(), RuntimeError)
+
+
+async def test_wait_until_bound_timeout_cancels_task() -> None:
+    """Neither condition satisfied → task is cancelled before returning."""
+    server = _mock_server(started=False)
+
+    async def _hang() -> None:
+        await asyncio.sleep(9999)
+
+    task = asyncio.create_task(_hang())
+    with patch("video_mcp_server.__main__._STARTUP_TIMEOUT_S", 0.1):
+        await _wait_until_bound(server, task)
+
+    assert not server.started
+    assert task.done()
+    assert task.cancelled()


### PR DESCRIPTION
## Summary

- `ready_file.touch()` was called immediately before `await server.serve()`, so the test's `_wait_ready()` could see the file and attempt an HTTP connection before uvicorn had actually bound the port — resulting in `httpx.ConnectError: All connection attempts failed`
- Fix: `create_task(server.serve())` then spin on `server.started` (uvicorn's built-in bool set once the socket is bound and accepting) before touching the ready-file
- Reproduces as a nightly flake: [run 31239403434 / job 93067107257](https://github.com/NVIDIA/xr-ai/actions/runs/31239403434/job/93067107257)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)