### PR TITLE
Pin LiveKit server Docker image to a deterministic version

### DIFF
--- a/server-runtime/xr_media_hub/transport/livekit/_docker.py
+++ b/server-runtime/xr_media_hub/transport/livekit/_docker.py
@@ -61,6 +61,10 @@ _BANNER = "━" * 56
 
 _CONTAINER_NAME = "xr-ai-livekit-server"
 
+# Pinned LiveKit server image so builds are reproducible instead of tracking
+# the floating ":latest" tag. Bump deliberately after validating a release.
+_LIVEKIT_IMAGE = "livekit/livekit-server:v1.13.5"
+
 
 class LiveKitDocker:
     def __init__(self, cfg: LiveKitConnectorConfig) -> None:
@@ -95,7 +99,7 @@ class LiveKitDocker:
                 "--name", _CONTAINER_NAME,
                 "--network", "host",
                 "-v", f"{cfg_path}:/etc/livekit.yaml:ro",
-                "livekit/livekit-server:latest",
+                _LIVEKIT_IMAGE,
                 "--config", "/etc/livekit.yaml",
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,

--- a/tests/test_integration_livekit.py
+++ b/tests/test_integration_livekit.py
@@ -37,7 +37,7 @@ from xr_media_hub.transport.livekit.config       import LiveKitConnectorConfig
 pytestmark = [pytest.mark.asyncio, pytest.mark.gpu]
 
 
-_LIVEKIT_IMAGE   = "livekit/livekit-server:latest"
+_LIVEKIT_IMAGE   = _docker_mod._LIVEKIT_IMAGE
 _PORT_OPEN_WAIT  = 30.0   # matches _docker._READY_TIMEOUT
 _PORT_CLOSE_WAIT = 10.0
 


### PR DESCRIPTION
Fixes #27

`_docker.py` hard-coded `livekit/livekit-server:latest`, which makes container boots non-reproducible. Pinned to a specific release (`v1.13.5`) behind a module constant so it can be bumped deliberately. The integration test now reuses that constant instead of its own `:latest` literal (single source of truth).