### PR TITLE
ci(nightly): drop Brev lifecycle, run pytest on the gpu runner

### DIFF
--- a/.github/workflows/nightly-xr-ai-test.yml
+++ b/.github/workflows/nightly-xr-ai-test.yml
@@ -16,14 +16,9 @@ on:
   schedule:
     - cron: "0 4 * * *"  # 04:00 UTC daily
   workflow_dispatch:
-    inputs:
-      keep_running:
-        description: "Leave the Brev instance running after the tests (skip the stop job)"
-        type: boolean
-        default: false
   # Also fire on PRs that edit this workflow itself, so changes to the
-  # CI definition — including the Brev start/stop wiring — get exercised
-  # end-to-end against the GPU runner before merge.
+  # CI definition get exercised end-to-end against the GPU runner before
+  # merge.
   pull_request:
     paths:
       - .github/workflows/nightly-xr-ai-test.yml
@@ -39,72 +34,9 @@ concurrency:
 permissions:
   contents: read
 
-# Source of truth: repository **secrets** (Settings → Secrets and
-# variables → Actions → Secrets), not repo variables. The guard steps
-# below abort if BREV_INSTANCE_NAME resolves empty.
-env:
-  BREV_INSTANCE_NAME: ${{ secrets.BREV_INSTANCE_NAME }}
-  BREV_ORG: ${{ secrets.BREV_ORG }}
-
 jobs:
-  start:
-    name: start brev instance
-    # Runs on the always-on controller VM, which already has the Brev CLI
-    # installed and is logged in — no install/login/token step needed.
-    runs-on: brev-controller
-    timeout-minutes: 25
-    steps:
-      - name: Select org
-        # The controller is normally already pinned to the right org;
-        # switch only if BREV_ORG is provided.
-        run: |
-          set -euo pipefail
-          if [[ -n "${BREV_ORG:-}" ]]; then
-            brev set "$BREV_ORG"
-          fi
-
-      - name: Start instance
-        run: |
-          set -euo pipefail
-          if [[ -z "${BREV_INSTANCE_NAME:-}" ]]; then
-            echo "::error::BREV_INSTANCE_NAME secret is not set"
-            exit 1
-          fi
-          # `brev start` errors if the instance is already RUNNING, so
-          # make this idempotent — skip when it's already up (e.g. a
-          # previous run left it on, or a manual `keep_running`).
-          if brev ls | grep -iw "$BREV_INSTANCE_NAME" | grep -qi "RUNNING"; then
-            echo "$BREV_INSTANCE_NAME is already RUNNING; skipping start."
-          else
-            echo "Starting Brev instance: $BREV_INSTANCE_NAME"
-            brev start "$BREV_INSTANCE_NAME"
-          fi
-
-      - name: Wait until RUNNING
-        # `brev start` returns before the VM is fully up and the GitHub
-        # Actions runner service has re-registered. Poll `brev ls` until
-        # the instance reports RUNNING so the `pytest` job has a live
-        # `gpu` runner to land on (GitHub queues it until then anyway,
-        # but failing here gives a clearer error than a stuck queue).
-        run: |
-          set -euo pipefail
-          for i in $(seq 1 80); do
-            # grep by name keeps other orgs' instance names out of the
-            # log; report just this instance's status field.
-            status=$(brev ls | grep -iw "$BREV_INSTANCE_NAME" | grep -oiE 'RUNNING|STOPPED|STARTING|STOPPING|FAILED' | head -n1 || true)
-            echo "[$i] $BREV_INSTANCE_NAME status: ${status:-<not found>}"
-            if [[ "$status" == "RUNNING" ]]; then
-              echo "Instance is RUNNING."
-              exit 0
-            fi
-            sleep 15
-          done
-          echo "::error::Timed out waiting for $BREV_INSTANCE_NAME to reach RUNNING"
-          exit 1
-
   pytest:
     name: pytest (gpu)
-    needs: start
     runs-on: gpu
     timeout-minutes: 60
 
@@ -237,78 +169,10 @@ jobs:
             echo "No xr-ai-vllm-* containers to remove."
           fi
 
-  stop:
-    name: stop brev instance
-    needs: [start, pytest]
-    # Pause the instance even when the tests fail or the start job errors
-    # out, so a bad run never leaves the GPU billing. `keep_running` lets
-    # a manual `workflow_dispatch` hold the box up for debugging.
-    if: always() && inputs.keep_running != true
-    runs-on: brev-controller
-    timeout-minutes: 20
-    steps:
-      - name: Select org
-        # The controller is normally already pinned to the right org;
-        # switch only if BREV_ORG is provided.
-        run: |
-          set -euo pipefail
-          if [[ -n "${BREV_ORG:-}" ]]; then
-            brev set "$BREV_ORG"
-          fi
-
-      - name: Stop instance
-        run: |
-          set -euo pipefail
-          if [[ -z "${BREV_INSTANCE_NAME:-}" ]]; then
-            echo "::error::BREV_INSTANCE_NAME secret is not set"
-            exit 1
-          fi
-
-          # Capture `brev ls` outside the grep pipe so a failing CLI aborts
-          # the step instead of reading as "nothing to stop" and silently
-          # leaving the GPU billing. Errors go to stderr — this runs in a
-          # command substitution, so stdout would be captured into $status.
-          get_status() {
-            local ls_out rc=0
-            ls_out=$(brev ls 2>&1) || rc=$?
-            if [[ "$rc" -ne 0 ]]; then
-              echo "::error::\`brev ls\` failed (exit $rc):" >&2
-              echo "$ls_out" >&2
-              exit 1
-            fi
-            printf '%s\n' "$ls_out" | grep -iw "$BREV_INSTANCE_NAME" \
-              | grep -oiE 'RUNNING|STOPPED|STARTING|STOPPING|FAILED' | head -n1 || true
-          }
-
-          status=$(get_status)
-          echo "$BREV_INSTANCE_NAME status: ${status:-<not found>}"
-          # Skip only a confirmed STOPPED box; RUNNING or a transient
-          # STARTING/STOPPING must be stopped or it bills indefinitely.
-          if [[ "${status^^}" == "STOPPED" ]]; then
-            echo "$BREV_INSTANCE_NAME is already STOPPED; nothing to do."
-            exit 0
-          fi
-
-          echo "Stopping Brev instance: $BREV_INSTANCE_NAME (status: ${status:-<not found>})"
-          brev stop "$BREV_INSTANCE_NAME"
-
-          # Re-verify: don't conclude success while it's still STOPPING.
-          for i in $(seq 1 40); do
-            status=$(get_status)
-            echo "[$i] $BREV_INSTANCE_NAME status: ${status:-<not found>}"
-            if [[ "${status^^}" == "STOPPED" ]]; then
-              echo "Instance is STOPPED."
-              exit 0
-            fi
-            sleep 15
-          done
-          echo "::error::Timed out waiting for $BREV_INSTANCE_NAME to reach STOPPED"
-          exit 1
-
   notify:
     name: alert on failure
-    needs: [start, pytest, stop]
-    # Fire whenever any job above failed OR was cancelled so a broken
+    needs: [pytest]
+    # Fire when the pytest job failed OR was cancelled so a broken
     # nightly is visible without anyone polling the Actions tab. A
     # timeout-minutes hit concludes as `cancelled`, not `failure`, so
     # failure() alone would silently skip the alert on the most important

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -88,6 +88,17 @@ Since AGENTS.md asks for a changelog entry alongside most changes, that fired on
 a large share of PRs. `Build (strict)` is not a required status check, so
 skipping it does not gate merges.
 
+### 2026-08-11 — Nightly GPU test runs on an always-on `gpu` runner
+
+The nightly workflow no longer brackets its pytest job with Brev lifecycle
+management. The `start` and `stop` jobs, the `brev-controller` runner, the
+`BREV_INSTANCE_NAME`/`BREV_ORG` secrets, and the `keep_running` dispatch input
+are gone; `pytest` runs directly on `runs-on: gpu` and `notify` depends on it
+alone. This supersedes the 2026-06-11 entry below: the GPU host is no longer a
+per-run billed instance, so the start/stop bracket bought nothing and added two
+failure modes (a start timeout that queued pytest indefinitely, and a stop
+failure that had to be loud to avoid a cost leak).
+
 ### 2026-08-10 — Voice-worker ready files wait for inbound IPC
 
 `VoiceSession` and the direct `run_voice_pipeline` compatibility path release a


### PR DESCRIPTION
## Description

The nightly GPU workflow bracketed its pytest job with Brev instance lifecycle management: a `start` job on the `brev-controller` runner booted and polled the instance to `RUNNING`, and a `stop` job paused it afterward to avoid billing an idle GPU.

The GPU host is always on now, so that bracket buys nothing and adds two failure modes:
- a `start` timeout leaves pytest queued against a runner that was already available;
- the `stop` job has to fail loudly on any non-`STOPPED` state to guard a cost leak that no longer exists.

This removes the Brev dependency entirely. `pytest` runs directly on `runs-on: gpu` (unchanged — it always did), and `notify` now depends on `pytest` alone.

Removed:
- `start` and `stop` jobs, and the `brev-controller` runner
- top-level `BREV_INSTANCE_NAME` / `BREV_ORG` env from repo secrets
- the `keep_running` `workflow_dispatch` input (it only skipped the `stop` job)

Unchanged: the 04:00 UTC cron, the self-PR trigger on this workflow's own path, `concurrency`, the `contents: read` / `issues: write` permission split, and every step inside the pytest job.

The `BREV_INSTANCE_NAME` / `BREV_ORG` repository secrets are now unreferenced and can be deleted from Settings → Secrets and variables → Actions.

## Type of change

- CI / infrastructure

## Testing

- `yaml.safe_load` on the workflow — parses; jobs are `[pytest, notify]`, `pytest` is `runs-on: gpu`, no top-level `env`.
- `grep -riI brev .github/` — no matches remain.
- This PR triggers the nightly workflow itself (it edits `.github/workflows/nightly-xr-ai-test.yml`), so the `gpu` runner path gets exercised end-to-end here before merge.

## Checklist

- [x] DCO sign-off on the commit
- [x] `docs/changelog.md` updated (supersedes the 2026-06-11 Brev entry)
- [x] No `pyproject.toml` changes, so `DEPENDENCIES.md` is unaffected