### PR TITLE
ci(docs): skip the docs build for changelog-only edits

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -33,6 +33,9 @@ on:
     tags: ["v*"]
     paths:
       - "docs/**"
+      # Not part of the Sphinx source tree (``docs/source/``) — the site only
+      # links out to it, so an edit here cannot change a rendered page.
+      - "!docs/changelog.md"
       - ".github/workflows/docs.yaml"
       - ".github/scripts/select_latest_docs_release.py"
       - ".github/scripts/publish_docs.sh"
@@ -42,6 +45,7 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - "docs/**"
+      - "!docs/changelog.md"
       - ".github/workflows/docs.yaml"
       - ".github/scripts/select_latest_docs_release.py"
       - ".github/scripts/publish_docs.sh"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -78,6 +78,16 @@ proves only that *issued* subscriptions are live, not that one was issued for
 that participant. An endpoint answers for exactly the participants it
 subscribes to, and the hub aggregates only those agents.
 
+### 2026-08-11 — Changelog edits don't trigger a docs preview
+
+`docs/changelog.md` is excluded from the `Docs` workflow's path filters. It sits
+outside the Sphinx source tree (`docs/source/`) — `reference/changelog.md` only
+links out to it on GitHub — so a changelog-only edit rebuilt the whole versioned
+site and published a per-PR preview that was byte-identical to the last one.
+Since AGENTS.md asks for a changelog entry alongside most changes, that fired on
+a large share of PRs. `Build (strict)` is not a required status check, so
+skipping it does not gate merges.
+
 ### 2026-08-10 — Voice-worker ready files wait for inbound IPC
 
 `VoiceSession` and the direct `run_voice_pipeline` compatibility path release a


### PR DESCRIPTION
## Description

The `Docs` workflow triggers on `docs/**`, which includes `docs/changelog.md`. That file is not part of the Sphinx source tree — the site source is `docs/source/`, and `docs/source/reference/changelog.md` only links out to the GitHub copy. An edit to `docs/changelog.md` therefore rebuilds every versioned ref and publishes a per-PR preview whose rendered output is identical to the previous one.

AGENTS.md asks for a changelog entry alongside most non-trivial changes, so this fires on a large share of PRs.

This adds a `!docs/changelog.md` exclusion to the `push` and `pull_request` path filters. Everything else under `docs/**` still triggers the build and preview as before.

Note: this PR still runs the docs build, because it also edits `.github/workflows/docs.yaml` — which is the intended behavior, and exercises the parsed filter.

## Type of change

- CI / infrastructure

## Testing

- `yaml.safe_load` on the workflow — both filter lists resolve to `['docs/**', '!docs/changelog.md', ...]` with the exclusion after the include, which is what GitHub requires for negation to apply.
- Confirmed `docs/changelog.md` is referenced only as an external GitHub link from `docs/source/reference/changelog.md` and `docs/source/guides/contributing-and-conventions.md` — it is not in any toctree and not rendered into the site.
- Confirmed `Build (strict)` is not among the required status checks on `main` (`pytest 3.11/3.12`, `uv lock`, `check SPDX headers`, `Analyze (python)`, `Analyze (javascript-typescript)`), so a skipped docs build does not block merge on a changelog-only PR.

## Checklist

- [x] DCO sign-off on the commit
- [x] `docs/changelog.md` updated
- [x] No `pyproject.toml` changes, so `DEPENDENCIES.md` is unaffected