### PR TITLE
Allow wake phrases after sentence boundaries

### DIFF
--- a/agent-samples/simple-vlm-example/README.md
+++ b/agent-samples/simple-vlm-example/README.md
@@ -78,8 +78,8 @@ tail -F /tmp/log_simple-vlm-example_*/relay-events.jsonl
 ```
 
 Voice-gate behavior remains in `yaml/voice_gate.yaml`. Wake phrases match at
-the start of the transcript or after sentence-final `.`, `?`, or `!`; preceding
-text is discarded before dispatch. Worker timing, frame freshness, the default
-`ping` question, and optional prompt overrides are in
-`yaml/simple_vlm_example_worker.yaml`; the default prompt ships inside the
-worker package.
+the start of the transcript or after sentence-final `.`, `?`, or `!` followed
+by whitespace or a closing quote; preceding text is discarded before dispatch.
+Worker timing, frame freshness, the default `ping` question, and optional prompt
+overrides are in `yaml/simple_vlm_example_worker.yaml`; the default prompt ships
+inside the worker package.

--- a/agent-samples/simple-vlm-example/README.md
+++ b/agent-samples/simple-vlm-example/README.md
@@ -77,7 +77,9 @@ sensitive data.
 tail -F /tmp/log_simple-vlm-example_*/relay-events.jsonl
 ```
 
-Voice-gate behavior remains in `yaml/voice_gate.yaml`. Worker timing, frame
-freshness, the default `ping` question, and optional prompt overrides are in
+Voice-gate behavior remains in `yaml/voice_gate.yaml`. Wake phrases match at
+the start of the transcript or after sentence-final `.`, `?`, or `!`; preceding
+text is discarded before dispatch. Worker timing, frame freshness, the default
+`ping` question, and optional prompt overrides are in
 `yaml/simple_vlm_example_worker.yaml`; the default prompt ships inside the
 worker package.

--- a/agent-samples/simple-vlm-example/yaml/voice_gate.yaml
+++ b/agent-samples/simple-vlm-example/yaml/voice_gate.yaml
@@ -5,9 +5,10 @@
 # Consumed by xr_ai_voicegate.VoiceGate inside the unified pipecat pipeline.
 #
 # Magic phrases are sentence-boundary opt-ins: an STT transcript must begin
-# with one of these or contain one after '.', '?', or '!'. Matching is
-# case-insensitive. Text through the matched phrase is stripped before the
-# agent sees the query; commas and other mid-sentence mentions do not match.
+# with one of these or contain one after '.', '?', or '!' followed by
+# whitespace or a closing quote. Matching is case-insensitive. Text through
+# the matched phrase is stripped before the agent sees the query; commas and
+# other mid-sentence mentions do not match.
 magic_phrases:
   - "agent"
   - "hey agent"

--- a/agent-samples/simple-vlm-example/yaml/voice_gate.yaml
+++ b/agent-samples/simple-vlm-example/yaml/voice_gate.yaml
@@ -4,10 +4,10 @@
 # Voice-gate (speech-input opt-in) configuration for simple-vlm-example.
 # Consumed by xr_ai_voicegate.VoiceGate inside the unified pipecat pipeline.
 #
-# Magic phrases are strict-prefix opt-ins: an STT transcript must begin
-# with one of these (case-insensitive, no leading filler words) or it is
-# dropped, so ambient conversation never triggers the agent. The matched
-# phrase is stripped before the brain sees the query.
+# Magic phrases are sentence-boundary opt-ins: an STT transcript must begin
+# with one of these or contain one after '.', '?', or '!'. Matching is
+# case-insensitive. Text through the matched phrase is stripped before the
+# agent sees the query; commas and other mid-sentence mentions do not match.
 magic_phrases:
   - "agent"
   - "hey agent"

--- a/agent-sdk/xr-ai-voice/README.md
+++ b/agent-sdk/xr-ai-voice/README.md
@@ -105,3 +105,8 @@ When wake phrases and the listening chime are enabled, the VAD/STT stage probes
 the opening audio while the user is still speaking. A recognized phrase emits
 the chime immediately, while only the final transcript enters the voice gate as
 a query. STOP commands use the same early-probe path for immediate interruption.
+
+The final transcript accepts a wake phrase at its beginning or immediately
+after sentence-final `.`, `?`, or `!` punctuation. Text before that boundary and
+the matched phrase are discarded. A phrase after a comma, semicolon, or within
+ordinary prose does not activate the gate.

--- a/agent-sdk/xr-ai-voice/README.md
+++ b/agent-sdk/xr-ai-voice/README.md
@@ -106,7 +106,7 @@ the opening audio while the user is still speaking. A recognized phrase emits
 the chime immediately, while only the final transcript enters the voice gate as
 a query. STOP commands use the same early-probe path for immediate interruption.
 
-The final transcript accepts a wake phrase at its beginning or immediately
-after sentence-final `.`, `?`, or `!` punctuation. Text before that boundary and
-the matched phrase are discarded. A phrase after a comma, semicolon, or within
-ordinary prose does not activate the gate.
+The final transcript accepts a wake phrase at its beginning or after
+sentence-final `.`, `?`, or `!` punctuation followed by whitespace or a closing
+quote. Text before that boundary and the matched phrase are discarded. A phrase
+after a comma, semicolon, or within ordinary prose does not activate the gate.

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_processors/vad_stt.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_processors/vad_stt.py
@@ -45,9 +45,8 @@ from xr_ai_voicegate._phrases import STOP_RE
 from .._frames import ParticipantLeftFrame
 
 
-# True acknowledges, False requests another bounded probe, and None rejects
-# the prefix so ordinary ambient speech does not consume all probe attempts.
-PartialTranscriptHandler = Callable[[str, str], Awaitable[bool | None]]
+# True acknowledges and False requests another bounded probe.
+PartialTranscriptHandler = Callable[[str, str], Awaitable[bool]]
 _MAX_PARTIAL_PROBES = 3
 
 
@@ -342,8 +341,6 @@ class VadSttProcessor(FrameProcessor):
                     return
                 if decision is True:
                     logger.info("early wake phrase acknowledged pid={!r}", pid)
-                    return
-                if decision is None:
                     return
 
     async def _transcribe(

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_processors/voice_gate.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_processors/voice_gate.py
@@ -91,18 +91,17 @@ class VoiceGateProcessor(FrameProcessor):
         """Whether partial STT should probe for an early wake acknowledgement."""
         return self._gate.wake_ack_enabled
 
-    async def handle_partial_transcript(self, pid: str, text: str) -> bool | None:
-        """Classify a partial prefix and acknowledge a complete wake phrase.
+    async def handle_partial_transcript(self, pid: str, text: str) -> bool:
+        """Handle a partial transcript and acknowledge a complete wake phrase.
 
-        True means acknowledged, False means the prefix needs more audio, and
-        None means the current sentence cannot become a configured match.
+        True means acknowledged and False means the probe needs more audio.
+        A later sentence can introduce a wake phrase even when the current
+        partial transcript is not a phrase prefix.
         """
         if self._gate.matches_magic_phrase(text):
             await self._emit_chime(pid, early=True)
             return True
-        if self._gate.could_match_magic_phrase(text):
-            return False
-        return None
+        return False
 
     # ── AudioSink ─────────────────────────────────────────────────────────────
 

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_processors/voice_gate.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_processors/voice_gate.py
@@ -95,7 +95,7 @@ class VoiceGateProcessor(FrameProcessor):
         """Classify a partial prefix and acknowledge a complete wake phrase.
 
         True means acknowledged, False means the prefix needs more audio, and
-        None means it cannot become a configured strict-prefix match.
+        None means the current sentence cannot become a configured match.
         """
         if self._gate.matches_magic_phrase(text):
             await self._emit_chime(pid, early=True)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,10 +12,11 @@ preserved and not re-litigated.
 ### 2026-08-13 — Wake phrases may follow a sentence boundary
 
 The shared voice gate accepts a configured wake phrase at transcript start or
-after sentence-final `.`, `?`, or `!` punctuation. It discards preceding text
-and the phrase before dispatch, allowing a valid command to survive noisy STT
-preambles without sending background speech to the agent. Commas, semicolons,
-and ordinary mid-sentence mentions remain non-matches to limit false wakes.
+after sentence-final `.`, `?`, or `!` punctuation followed by whitespace or a
+closing quote. It discards preceding text and the phrase before dispatch,
+allowing a valid command to survive noisy STT preambles without sending
+background speech to the agent. Commas, semicolons, URLs, and ordinary
+mid-sentence mentions remain non-matches to limit false wakes.
 
 ### 2026-08-12 — NeMo Agent Toolkit compatibility is retired
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,14 @@ Significant decisions, in reverse-chronological order. Update this whenever a
 non-trivial architectural or design decision is made so the rationale is
 preserved and not re-litigated.
 
+### 2026-08-13 — Wake phrases may follow a sentence boundary
+
+The shared voice gate accepts a configured wake phrase at transcript start or
+after sentence-final `.`, `?`, or `!` punctuation. It discards preceding text
+and the phrase before dispatch, allowing a valid command to survive noisy STT
+preambles without sending background speech to the agent. Commas, semicolons,
+and ordinary mid-sentence mentions remain non-matches to limit false wakes.
+
 ### 2026-08-12 — NeMo Agent Toolkit compatibility is retired
 
 All surviving capabilities now use native `xr-ai-tools` contracts. OpenXR,

--- a/tests/test_voice_pipeline.py
+++ b/tests/test_voice_pipeline.py
@@ -539,32 +539,6 @@ async def test_vad_stt_retries_partial_probe_after_background_sentence(monkeypat
 
 
 @pytest.mark.asyncio
-async def test_vad_stt_stops_partial_probes_after_rejected_prefix(monkeypatch):
-    _StagedVad.instances.clear()
-    stt = _StagedStt(texts=["ordinary room conversation"])
-
-    async def reject_partial(_pid: str, _text: str) -> bool | None:
-        return None
-
-    monkeypatch.setattr("xr_ai_voice._processors.vad_stt.VadDetector", _StagedVad)
-    proc = VadSttProcessor(
-        stt=stt,
-        vad_cfg=VadConfig(stop_probe_after_s=0.05),
-        on_partial_transcript=reject_partial,
-    )
-    frame = InputAudioRawFrame(
-        audio=b"\x00\x00" * 320,
-        sample_rate=16000,
-        num_channels=1,
-    )
-    frame.transport_source = "web-client"
-
-    await _run_chain(proc, sends=[frame], settle_s=0.25)
-
-    assert len(stt.calls) == 1
-
-
-@pytest.mark.asyncio
 async def test_vad_stt_stop_probe_emits_interruption_on_stop_match(monkeypatch):
     """When the probe's partial transcript matches ``STOP_RE`` the
     processor pushes ``InterruptionFrame`` + the matched

--- a/tests/test_voice_pipeline.py
+++ b/tests/test_voice_pipeline.py
@@ -509,6 +509,36 @@ async def test_vad_stt_retries_partial_probe_until_wake_phrase_is_recognized(mon
 
 
 @pytest.mark.asyncio
+async def test_vad_stt_retries_partial_probe_after_background_sentence(monkeypatch):
+    _StagedVad.instances.clear()
+    stt = _StagedStt(texts=[
+        "background.",
+        "background. hey agent place a cube",
+    ])
+    gate = VoiceGateProcessor(
+        cfg=VoiceGateConfig(magic_phrases=("hey agent",)),
+        tts=_FakeTts(),
+    )
+
+    monkeypatch.setattr("xr_ai_voice._processors.vad_stt.VadDetector", _StagedVad)
+    proc = VadSttProcessor(
+        stt=stt,
+        vad_cfg=VadConfig(stop_probe_after_s=0.05),
+        on_partial_transcript=gate.handle_partial_transcript,
+    )
+    frame = InputAudioRawFrame(
+        audio=b"\x00\x00" * 320,
+        sample_rate=16000,
+        num_channels=1,
+    )
+    frame.transport_source = "web-client"
+
+    await _run_chain(proc, sends=[frame], settle_s=0.25)
+
+    assert len(stt.calls) == 2
+
+
+@pytest.mark.asyncio
 async def test_vad_stt_stops_partial_probes_after_rejected_prefix(monkeypatch):
     _StagedVad.instances.clear()
     stt = _StagedStt(texts=["ordinary room conversation"])
@@ -1036,7 +1066,7 @@ async def test_voice_gate_processor_chimes_on_partial_wake_without_dispatching_e
 
 
 @pytest.mark.asyncio
-async def test_voice_gate_processor_classifies_partial_wake_prefixes():
+async def test_voice_gate_processor_keeps_partial_wake_probes_open():
     cfg = VoiceGateConfig(
         magic_phrases=("agent", "hey agent"),
         listening_chime=True,
@@ -1044,7 +1074,8 @@ async def test_voice_gate_processor_classifies_partial_wake_prefixes():
     proc = VoiceGateProcessor(cfg=cfg, tts=_FakeTts())
 
     assert await proc.handle_partial_transcript("pid-1", "hey") is False
-    assert await proc.handle_partial_transcript("pid-1", "room conversation") is None
+    assert await proc.handle_partial_transcript("pid-1", "room conversation") is False
+    assert await proc.handle_partial_transcript("pid-1", "background.") is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_xr_ai_voicegate.py
+++ b/tests/test_xr_ai_voicegate.py
@@ -177,6 +177,12 @@ def test_phrase_after_boundary_tolerates_closing_quote():
     assert strip_magic(pat, 'Someone said "noise." Agent, help') == "help"
 
 
+@pytest.mark.parametrize("text", ["visit www.agent.com now", "background.agent, help"])
+def test_phrase_after_dot_without_separator_does_not_match(text: str):
+    pat = build_magic_pattern(["agent"])
+    assert strip_magic(pat, text) is None
+
+
 @pytest.mark.parametrize("separator", [",", ";", ":", "-"])
 def test_phrase_after_mid_sentence_punctuation_does_not_match(separator: str):
     """Only sentence-final punctuation may introduce a later wake phrase."""

--- a/tests/test_xr_ai_voicegate.py
+++ b/tests/test_xr_ai_voicegate.py
@@ -120,7 +120,7 @@ def _recording_handlers(gate: VoiceGate) -> list[tuple]:
 # ════════════════════════════════════════════════════════════════════════════
 
 
-def test_phrase_strict_prefix_strip_returns_query_tail():
+def test_phrase_at_transcript_start_strips_query_tail():
     """Case 1: 'agent, what am I looking at?' strips to the query tail."""
     pat = build_magic_pattern(["agent"])
     assert strip_magic(pat, "agent, what am I looking at?") == "what am I looking at?"
@@ -151,16 +151,42 @@ def test_phrase_tolerates_internal_and_trailing_punctuation():
 
 
 def test_phrase_mid_sentence_does_not_match():
-    """Case 5: strict-prefix only — 'the agent told me ...' must not strip."""
+    """Case 5: an ordinary mid-sentence mention must not strip."""
     pat = build_magic_pattern(["agent"])
     assert strip_magic(pat, "the agent told me to wait") is None
 
 
 def test_phrase_no_filler_allowance_before_phrase():
     """Case 6: even one filler word before the phrase ('hello agent') is
-    rejected. Strict prefix means literally first token after whitespace."""
+    rejected because no sentence boundary separates it from the phrase."""
     pat = build_magic_pattern(["agent"])
     assert strip_magic(pat, "hello agent") is None
+
+
+@pytest.mark.parametrize("boundary", [".", "?", "!"])
+def test_phrase_after_sentence_boundary_strips_preamble(boundary: str):
+    """A boundary wake discards noisy preamble and returns only the query."""
+    pat = build_magic_pattern(["hey agent"])
+    text = f"Background speech{boundary} Hey agent, what am I looking at?"
+    assert strip_magic(pat, text) == "what am I looking at?"
+
+
+def test_phrase_after_boundary_tolerates_closing_quote():
+    """Closing quote punctuation between a sentence and wake is ignored."""
+    pat = build_magic_pattern(["agent"])
+    assert strip_magic(pat, 'Someone said "noise." Agent, help') == "help"
+
+
+@pytest.mark.parametrize("separator", [",", ";", ":", "-"])
+def test_phrase_after_mid_sentence_punctuation_does_not_match(separator: str):
+    """Only sentence-final punctuation may introduce a later wake phrase."""
+    pat = build_magic_pattern(["agent"])
+    assert strip_magic(pat, f"background{separator} agent, help") is None
+
+
+def test_partial_phrase_after_sentence_boundary_can_continue_matching():
+    gate, _, _ = _gate(phrases=("hey agent",))
+    assert gate.could_match_magic_phrase("background. hey ag") is True
 
 
 def test_phrase_empty_list_yields_none_pattern_and_passthrough_strip():
@@ -351,6 +377,16 @@ async def test_feed_magic_phrase_with_query_fires_on_query_with_fresh_match_true
     await gate.feed("p1", "agent, what is this?")
 
     assert events == [("query", "p1", "what is this?", True)]
+
+
+@pytest.mark.asyncio
+async def test_feed_boundary_phrase_discards_background_and_dispatches_query():
+    gate, _, _ = _gate(phrases=("agent",))
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "Which I can find. Agent, what am I looking at?")
+
+    assert events == [("query", "p1", "what am I looking at?", True)]
 
 
 @pytest.mark.asyncio

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/_phrases.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/_phrases.py
@@ -20,14 +20,16 @@ STOP_RE: re.Pattern = re.compile(
 
 
 def build_magic_pattern(phrases: Sequence[str]) -> re.Pattern | None:
-    """Compile one strict-prefix regex covering every configured phrase.
+    """Compile one sentence-boundary regex covering every configured phrase.
 
     Longest-first ordering picks the most specific match when one phrase
     is a prefix of another (e.g. "agent" vs "agent buddy"). Inside each
     phrase, the literal space between words is treated as "whitespace OR
     punctuation" so STT transcripts like "Hey, agent." still match the
-    configured "hey agent". Returns ``None`` when ``phrases`` is empty
-    so the gate degrades to always-on.
+    configured "hey agent". A phrase may begin the transcript or follow
+    sentence-final punctuation; commas and other mid-sentence punctuation do
+    not open the gate. Returns ``None`` when ``phrases`` is empty so the gate
+    degrades to always-on.
     """
     cleaned = tuple(p.strip().lower() for p in phrases if p and p.strip())
     if not cleaned:
@@ -37,14 +39,20 @@ def build_magic_pattern(phrases: Sequence[str]) -> re.Pattern | None:
         sep.join(re.escape(w) for w in p.split())
         for p in sorted(cleaned, key=len, reverse=True)
     )
-    return re.compile(rf'^\s*(?:{alts})\b[\s,.:;!?-]*', re.IGNORECASE)
+    return re.compile(
+        rf'(?:^|[.!?])[\s"\'\u2019\u201d)\]]*(?:{alts})\b[\s,.:;!?-]*',
+        re.IGNORECASE,
+    )
 
 
 def strip_magic(pattern: re.Pattern | None, text: str) -> str | None:
-    """Return the transcript with the matched phrase stripped, or ``None``
-    when no phrase is the strict prefix. With ``pattern is None`` the gate
-    is disabled and ``text`` is returned unchanged."""
+    """Return text after a sentence-boundary phrase, or ``None`` if absent.
+
+    Text before a boundary match is discarded with the phrase so background
+    speech never becomes part of the agent query. With ``pattern is None`` the
+    gate is disabled and ``text`` is returned unchanged.
+    """
     if pattern is None:
         return text
-    m = pattern.match(text)
+    m = pattern.search(text)
     return None if m is None else text[m.end():]

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/_phrases.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/_phrases.py
@@ -27,9 +27,9 @@ def build_magic_pattern(phrases: Sequence[str]) -> re.Pattern | None:
     phrase, the literal space between words is treated as "whitespace OR
     punctuation" so STT transcripts like "Hey, agent." still match the
     configured "hey agent". A phrase may begin the transcript or follow
-    sentence-final punctuation; commas and other mid-sentence punctuation do
-    not open the gate. Returns ``None`` when ``phrases`` is empty so the gate
-    degrades to always-on.
+    sentence-final punctuation separated by whitespace or a closing delimiter;
+    commas and other mid-sentence punctuation do not open the gate. Returns
+    ``None`` when ``phrases`` is empty so the gate degrades to always-on.
     """
     cleaned = tuple(p.strip().lower() for p in phrases if p and p.strip())
     if not cleaned:
@@ -40,7 +40,9 @@ def build_magic_pattern(phrases: Sequence[str]) -> re.Pattern | None:
         for p in sorted(cleaned, key=len, reverse=True)
     )
     return re.compile(
-        rf'(?:^|[.!?])[\s"\'\u2019\u201d)\]]*(?:{alts})\b[\s,.:;!?-]*',
+        rf'(?:^[\s"\'\u2019\u201d)\]]*|'
+        rf'[.!?][\s"\'\u2019\u201d)\]]+)'
+        rf'(?:{alts})\b[\s,.:;!?-]*',
         re.IGNORECASE,
     )
 

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/config.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/config.py
@@ -16,8 +16,9 @@ import yaml
 class VoiceGateConfig:
     """Voice-gate behaviour knobs.
 
-    ``magic_phrases``    — strict-prefix opt-in words; empty tuple disables
-                           the gate so every STT transcript is dispatched.
+    ``magic_phrases``    — sentence-boundary opt-in phrases; a match is valid
+                           at transcript start or after ``.``, ``?``, or ``!``.
+                           An empty tuple dispatches every STT transcript.
     ``followup_grace_s`` — seconds after a phrase match during which the
                            next utterance from the same participant must
                            begin to bypass the gate. It may finish later.

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/gate.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/gate.py
@@ -157,12 +157,12 @@ class VoiceGate:
         return self._chime_enabled
 
     def matches_magic_phrase(self, text: str) -> bool:
-        """Return whether *text* begins with a configured magic phrase."""
+        """Return whether *text* has a phrase at a sentence boundary."""
         return self._magic_re is not None and strip_magic(self._magic_re, text) is not None
 
     def could_match_magic_phrase(self, text: str) -> bool:
-        """Return whether a growing partial transcript can become a match."""
-        candidate = _normalize_phrase(text)
+        """Return whether the current partial sentence can become a match."""
+        candidate = _normalize_phrase(_current_sentence(text))
         return bool(candidate) and any(
             phrase.startswith(candidate) for phrase in self._magic_prefixes
         )
@@ -370,3 +370,8 @@ class VoiceGate:
 
 def _normalize_phrase(text: str) -> str:
     return " ".join(re.findall(r"\w+", text.casefold()))
+
+
+def _current_sentence(text: str) -> str:
+    boundary = max(text.rfind(mark) for mark in ".!?")
+    return text[boundary + 1:] if boundary >= 0 else text


### PR DESCRIPTION
## Summary

- accept configured wake phrases at transcript start or after `.`, `?`, or `!`
- discard preceding background transcript text and the matched phrase before dispatch
- keep commas, semicolons, and ordinary mid-sentence mentions as non-matches
- apply the same sentence-boundary rule to partial-transcript wake probing

## Tests

- `uv run --project tests pytest -q tests/test_xr_ai_voicegate.py` (66 passed)
- `uv run --project tests pytest -q tests/test_voice_pipeline.py` (84 passed)