### PR TITLE
feat(tools): add swappable QR code extraction

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -113,11 +113,12 @@ xr-ai-tools  (agent-sdk/xr-ai-tools/)
     └── [relay] xr-ai-models [editable: ../xr-ai-models]
     ├── [frames] numpy >=1.24, Pillow >=10.0, xr-ai-hub-client [editable: ../xr-ai-hub]
     ├── [vision] xr-ai-models [editable: ../xr-ai-models]
+    ├── [qr-code] numpy >=1.24, zxing-cpp >=2.3,<4, Pillow >=10.0, xr-ai-hub-client [editable: ../xr-ai-hub]
     └── [services] msgpack >=1.0, pyzmq >=27.0
     Toolkit-independent native tools: Pydantic request and response models,
     Relay-managed finite and async execution, model tool-call workflow helpers,
-    frame selection, single/multi-image inference, typed capability clients,
-    and service RPC.
+    frame selection, single/multi-image inference, participant-scoped QR-code
+    extraction, typed capability clients, and service RPC.
 
 
 xr-openxr-service  (services/openxr-service/)
@@ -225,7 +226,7 @@ xr-ai-tests  (tests/)
     └── xr-ai-agent-runtime       [editable: ../agent-sdk/xr-ai-runtime]
     └── xr-ai-hub-client             [editable: ../agent-sdk/xr-ai-hub]
     └── xr-ai-models            [editable: ../agent-sdk/xr-ai-models]
-    └── xr-ai-tools[frames,services,vision] [editable: ../agent-sdk/xr-ai-tools]
+    └── xr-ai-tools[frames,qr-code,services,vision] [editable: ../agent-sdk/xr-ai-tools]
     └── xr-rag-service [editable: ../services/rag-service]
     └── xr-video-memory-service [editable: ../services/video-memory-service]
     └── xr-ai-voice             [editable: ../agent-sdk/xr-ai-voice]
@@ -245,8 +246,9 @@ xr-ai-tests  (tests/)
     The unmarked suite is multi-client / multi-agent integration tests over
     the IPC layer, driven via ZMQ `ipc://` only — no Docker / LiveKit /
     NVENC required. Also covers unit tests for the leaf util packages
-    (launcher, logging, vllm), native spatial-math, text-memory, vision, and typed service-tool
-    tests, plus the sample-local scene native tools (LOVR is stubbed). Root pytest adds
+    (launcher, logging, vllm), native spatial-math, text-memory, vision, QR-code,
+    and typed service-tool tests, plus the sample-local scene native tools (LOVR
+    is stubbed). Root pytest adds
     services/stt-server to its Python path (not a dependency) so the
     endpoint tests can import its FastAPI app with a mocked backend,
     avoiding a test-time NeMo installation.

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ frames are dropped if it is closed.
 | Agent runtime | `agent-sdk/xr-ai-runtime/` | Agent registration and typed pub/sub routing |
 | Models | `agent-sdk/xr-ai-models/` | Typed model protocols and OpenAI-compatible clients |
 | Voice | `agent-sdk/xr-ai-voice/` | Voice agent, session, transport, and pipeline |
-| Agent tools | `agent-sdk/xr-ai-tools/` | Toolkit-independent Relay-managed native tools |
+| Agent tools | `agent-sdk/xr-ai-tools/` | Toolkit-independent Relay-managed native tools, including QR-code extraction |
 | Reusable services | `services/` | Model-serving and typed capability processes |
 | Agent demos | `agent-samples/` | End-to-end agent pipelines |
 | Tests | `tests/` | Multi-client / multi-agent integration tests |

--- a/agent-sdk/xr-ai-tools/README.md
+++ b/agent-sdk/xr-ai-tools/README.md
@@ -179,3 +179,42 @@ change = await video.execute(
     VideoQueryRequest(frames=sample.frames, query="What changed over time?")
 )
 ```
+
+## QR-code reading and extraction
+
+Install `xr-ai-tools[qr-code]` to use `QRCodeTool`. The finite
+`read_qr_codes` tool acquires a participant's current camera frame and uses
+ZXing-C++ by default. Its typed result distinguishes an unavailable frame from
+a valid frame with no readable code, and returns every decoded UTF-8 payload
+with optional source-image corner coordinates. When one frame contains
+multiple QR codes, `result.codes` contains one entry for each code.
+
+```python
+from xr_ai_tools.qr_code import QRCodeRequest, QRCodeTool
+
+qr_codes = QRCodeTool(endpoint=processor_endpoint)
+result = await qr_codes.execute(QRCodeRequest(participant_id="participant-1"))
+for code in result.codes:
+    print(code.data, code.corners)
+```
+
+Frame acquisition and extraction are separate. Pass any sync or async callable
+as `extractor=` to replace ZXing-C++ without changing the tool or its callers.
+The callable receives one RGB `PIL.Image.Image` and returns an iterable of
+`DecodedQRCode` values or equivalent dictionaries; `corners` may be omitted by
+backends that decode without localization.
+
+```python
+async def model_extractor(image):
+    return await custom_qr_model.extract(image)
+
+
+qr_codes = QRCodeTool(
+    endpoint=processor_endpoint,
+    extractor=model_extractor,
+)
+```
+
+Call `release(participant_id)` when a participant disconnects. Applications
+that expose the tool to a model should inject the active participant identity
+at their workflow boundary, as they do for other participant-scoped tools.

--- a/agent-sdk/xr-ai-tools/pyproject.toml
+++ b/agent-sdk/xr-ai-tools/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
 relay = ["xr-ai-models"]
 frames = ["numpy>=1.24", "Pillow>=10.0", "xr-ai-hub-client"]
 vision = ["xr-ai-models"]
+qr-code = ["numpy>=1.24", "zxing-cpp>=2.3,<4", "Pillow>=10.0", "xr-ai-hub-client"]
 services = ["msgpack>=1.0", "pyzmq>=27.0"]
 
 [tool.uv.sources]

--- a/agent-sdk/xr-ai-tools/xr_ai_tools/qr_code.py
+++ b/agent-sdk/xr-ai-tools/xr_ai_tools/qr_code.py
@@ -1,0 +1,210 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenCV-backed QR-code extraction from live participant frames."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable, Iterable, Mapping
+from inspect import isawaitable, iscoroutinefunction
+from typing import Any, TypeAlias
+
+import cv2
+import numpy as np
+from PIL import Image
+from pydantic import BaseModel, Field
+from xr_ai_hub import FrameUnavailable, LiveFrameSource, ProcessorEndpoint
+
+from ._pixels import frame_to_pil
+from .tools import Tool
+from .types import StrictRequest
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class QRCodeRequest(StrictRequest):
+    """Read QR codes from one participant's current live camera frame."""
+
+    participant_id: str = Field(
+        min_length=1,
+        description="Participant whose current camera frame should be scanned.",
+    )
+
+
+class QRCodePoint(BaseModel):
+    """One image-space corner of a decoded QR code."""
+
+    x: float = Field(description="Horizontal pixel coordinate.")
+    y: float = Field(description="Vertical pixel coordinate.")
+
+
+class DecodedQRCode(BaseModel):
+    """A decoded QR payload and its quadrilateral in the source frame."""
+
+    data: str = Field(description="UTF-8 text extracted from the QR code.")
+    corners: tuple[QRCodePoint, QRCodePoint, QRCodePoint, QRCodePoint] | None = Field(
+        default=None,
+        description="Four image-space corners, or null if the extractor does not localize.",
+    )
+
+
+class QRCodeResult(BaseModel):
+    """All readable QR codes found in one current camera frame."""
+
+    codes: list[DecodedQRCode] = Field(
+        default_factory=list,
+        description="Decoded QR codes in extractor-provided order.",
+    )
+    available: bool = Field(
+        default=True,
+        description="Whether a current frame was available and could be scanned.",
+    )
+    message: str | None = Field(
+        default=None,
+        description="Human-readable detail when no QR payload was returned.",
+    )
+
+
+QRCodeExtraction: TypeAlias = DecodedQRCode | Mapping[str, Any]
+QRCodeExtractor: TypeAlias = Callable[
+    [Image.Image],
+    Iterable[QRCodeExtraction] | Awaitable[Iterable[QRCodeExtraction]],
+]
+
+
+def decode_qr_codes(image: np.ndarray) -> list[DecodedQRCode]:
+    """Decode every readable QR code in a grayscale or BGR image."""
+
+    pixels = np.asarray(image)
+    if pixels.dtype != np.uint8:
+        raise TypeError("QR-code image must use uint8 pixels")
+    if pixels.ndim not in (2, 3):
+        raise ValueError("QR-code image must be grayscale or color")
+
+    decoded, points = _detect_multi(pixels)
+    codes: list[DecodedQRCode] = []
+    if points is None:
+        return codes
+    for data, quadrilateral in zip(decoded, points, strict=False):
+        if not data:
+            continue
+        vertices = np.asarray(quadrilateral, dtype=np.float64).reshape(-1, 2)
+        if vertices.shape != (4, 2):
+            continue
+        corners = tuple(
+            QRCodePoint(x=float(vertex[0]), y=float(vertex[1]))
+            for vertex in vertices
+        )
+        codes.append(DecodedQRCode(data=data, corners=corners))
+    return codes
+
+
+def extract_qr_codes_opencv(image: Image.Image) -> list[DecodedQRCode]:
+    """Default extractor that adapts a PIL frame to OpenCV's QR detector."""
+
+    return decode_qr_codes(np.asarray(image.convert("L")))
+
+
+def _detect_multi(image: np.ndarray) -> tuple[tuple[str, ...], np.ndarray | None]:
+    detector = cv2.QRCodeDetector()
+    detected, decoded, points, _straight_codes = detector.detectAndDecodeMulti(image)
+    if detected and decoded and points is not None:
+        return tuple(decoded), points
+
+    data, single_points, _straight_code = detector.detectAndDecode(image)
+    if data and single_points is not None:
+        return (data,), np.asarray(single_points).reshape(1, 4, 2)
+    return (), None
+
+
+class QRCodeTool(Tool[QRCodeRequest, QRCodeResult]):
+    """A finite tool that reads QR payloads from a current camera frame."""
+
+    def __init__(
+        self,
+        *,
+        endpoint: ProcessorEndpoint,
+        frame_max_age_s: float = 2.0,
+        frame_timeout_s: float = 5.0,
+        manage_status: bool = True,
+        extractor: QRCodeExtractor | None = None,
+    ) -> None:
+        if frame_max_age_s <= 0.0:
+            raise ValueError("frame_max_age_s must be positive")
+        if frame_timeout_s <= 0.0:
+            raise ValueError("frame_timeout_s must be positive")
+        self.endpoint = endpoint
+        self.manage_status = manage_status
+        self.extractor = (
+            extractor if extractor is not None else extract_qr_codes_opencv
+        )
+        self.frames = LiveFrameSource(
+            endpoint,
+            max_age_s=frame_max_age_s,
+            timeout_s=frame_timeout_s,
+        )
+        super().__init__(
+            "read_qr_codes",
+            "Read all QR codes in a participant's current live camera frame "
+            "and return their decoded text and available corner coordinates.",
+            QRCodeRequest,
+            QRCodeResult,
+            self._read_current,
+        )
+
+    def release(self, participant_id: str) -> None:
+        """Forget cached frame state after a participant disconnects."""
+
+        self.frames.release(participant_id)
+
+    async def _read_current(self, request: QRCodeRequest) -> QRCodeResult:
+        try:
+            frame = await self.frames.get(request.participant_id)
+        except FrameUnavailable as exc:
+            return QRCodeResult(available=False, message=str(exc))
+
+        if self.manage_status:
+            await self.endpoint.set_status("processing", request.participant_id)
+        try:
+            image = await asyncio.to_thread(frame_to_pil, frame)
+            codes = await self._extract(image)
+        except Exception:
+            _LOGGER.exception("QR-code extraction failed")
+            return QRCodeResult(
+                available=False,
+                message="QR-code extraction failed — please retry.",
+            )
+        finally:
+            if self.manage_status:
+                await self.endpoint.set_status("idle", request.participant_id)
+
+        if not codes:
+            return QRCodeResult(
+                message="No readable QR code was found in the current camera frame.",
+            )
+        return QRCodeResult(codes=codes)
+
+    async def _extract(self, image: Image.Image) -> list[DecodedQRCode]:
+        call = self.extractor
+        if iscoroutinefunction(call) or iscoroutinefunction(getattr(call, "__call__", None)):
+            extracted = call(image)
+        else:
+            extracted = await asyncio.to_thread(call, image)
+        if isawaitable(extracted):
+            extracted = await extracted
+        return [DecodedQRCode.model_validate(code) for code in extracted]
+
+
+__all__ = [
+    "DecodedQRCode",
+    "QRCodeExtraction",
+    "QRCodeExtractor",
+    "QRCodePoint",
+    "QRCodeRequest",
+    "QRCodeResult",
+    "QRCodeTool",
+    "decode_qr_codes",
+    "extract_qr_codes_opencv",
+]

--- a/agent-sdk/xr-ai-tools/xr_ai_tools/qr_code.py
+++ b/agent-sdk/xr-ai-tools/xr_ai_tools/qr_code.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""OpenCV-backed QR-code extraction from live participant frames."""
+"""ZXing-C++-backed QR-code extraction from live participant frames."""
 
 from __future__ import annotations
 
@@ -11,8 +11,8 @@ from collections.abc import Awaitable, Callable, Iterable, Mapping
 from inspect import isawaitable, iscoroutinefunction
 from typing import Any, TypeAlias
 
-import cv2
 import numpy as np
+import zxingcpp
 from PIL import Image
 from pydantic import BaseModel, Field
 from xr_ai_hub import FrameUnavailable, LiveFrameSource, ProcessorEndpoint
@@ -74,8 +74,10 @@ QRCodeExtractor: TypeAlias = Callable[
 ]
 
 
-def decode_qr_codes(image: np.ndarray) -> list[DecodedQRCode]:
-    """Decode every readable QR code in a grayscale or BGR image."""
+def extract_qr_codes_zxing(
+    image: Image.Image | np.ndarray,
+) -> list[DecodedQRCode]:
+    """Decode every readable QR code with the ZXing-C++ Python bindings."""
 
     pixels = np.asarray(image)
     if pixels.dtype != np.uint8:
@@ -83,40 +85,25 @@ def decode_qr_codes(image: np.ndarray) -> list[DecodedQRCode]:
     if pixels.ndim not in (2, 3):
         raise ValueError("QR-code image must be grayscale or color")
 
-    decoded, points = _detect_multi(pixels)
-    codes: list[DecodedQRCode] = []
-    if points is None:
-        return codes
-    for data, quadrilateral in zip(decoded, points, strict=False):
-        if not data:
-            continue
-        vertices = np.asarray(quadrilateral, dtype=np.float64).reshape(-1, 2)
-        if vertices.shape != (4, 2):
-            continue
-        corners = tuple(
-            QRCodePoint(x=float(vertex[0]), y=float(vertex[1]))
-            for vertex in vertices
+    barcodes = zxingcpp.read_barcodes(
+        pixels,
+        formats=zxingcpp.BarcodeFormat.QRCode,
+    )
+    return [
+        DecodedQRCode(
+            data=barcode.text,
+            corners=tuple(
+                QRCodePoint(x=float(point.x), y=float(point.y))
+                for point in (
+                    barcode.position.top_left,
+                    barcode.position.top_right,
+                    barcode.position.bottom_right,
+                    barcode.position.bottom_left,
+                )
+            ),
         )
-        codes.append(DecodedQRCode(data=data, corners=corners))
-    return codes
-
-
-def extract_qr_codes_opencv(image: Image.Image) -> list[DecodedQRCode]:
-    """Default extractor that adapts a PIL frame to OpenCV's QR detector."""
-
-    return decode_qr_codes(np.asarray(image.convert("L")))
-
-
-def _detect_multi(image: np.ndarray) -> tuple[tuple[str, ...], np.ndarray | None]:
-    detector = cv2.QRCodeDetector()
-    detected, decoded, points, _straight_codes = detector.detectAndDecodeMulti(image)
-    if detected and decoded and points is not None:
-        return tuple(decoded), points
-
-    data, single_points, _straight_code = detector.detectAndDecode(image)
-    if data and single_points is not None:
-        return (data,), np.asarray(single_points).reshape(1, 4, 2)
-    return (), None
+        for barcode in barcodes
+    ]
 
 
 class QRCodeTool(Tool[QRCodeRequest, QRCodeResult]):
@@ -138,7 +125,7 @@ class QRCodeTool(Tool[QRCodeRequest, QRCodeResult]):
         self.endpoint = endpoint
         self.manage_status = manage_status
         self.extractor = (
-            extractor if extractor is not None else extract_qr_codes_opencv
+            extractor if extractor is not None else extract_qr_codes_zxing
         )
         self.frames = LiveFrameSource(
             endpoint,
@@ -205,6 +192,5 @@ __all__ = [
     "QRCodeRequest",
     "QRCodeResult",
     "QRCodeTool",
-    "decode_qr_codes",
-    "extract_qr_codes_opencv",
+    "extract_qr_codes_zxing",
 ]

--- a/docs/source/components/agent-sdk.md
+++ b/docs/source/components/agent-sdk.md
@@ -157,3 +157,15 @@ Video pixels are pulled on demand with `request_frame()` or
 `LiveFrameSource`; frame signals do not copy pixels. Readiness participation
 is opt-in and scoped to subscribed participants. The hub aggregates each
 responsible agent's status and gates readiness on confirmed subscriptions.
+
+## QR-code extraction
+
+`xr_ai_tools.qr_code.QRCodeTool` is an optional ZXing-C++-backed finite tool.
+It acquires a participant's current frame, decodes all readable QR payloads off
+the event loop, and returns every QR code in the frame as a separate payload
+with its four image-space corners. Install `xr-ai-tools[qr-code]` to use it.
+
+ZXing-C++ is the default extractor. Applications can inject any sync or async
+callable that accepts an RGB PIL image and returns the same typed payload
+contract, including a model-backed implementation that does not provide corner
+coordinates.

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "xr-ai-agent-runtime",
     "xr-ai-hub-client",
     "xr-ai-models",
-    "xr-ai-tools[frames,services,vision]",
+    "xr-ai-tools[frames,qr-code,services,vision]",
     "xr-ai-voice",
     "xr-media-hub",
     "xr-ai-launcher",

--- a/tests/test_qr_code_tool.py
+++ b/tests/test_qr_code_tool.py
@@ -1,0 +1,184 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU-only tests for OpenCV-backed live QR-code extraction."""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+import pytest
+from pydantic import ValidationError
+from xr_ai_hub import FrameData, FrameSignal, PixelFormat
+from xr_ai_tools.qr_code import QRCodeRequest, QRCodeTool, decode_qr_codes
+
+_QR_MODULES = (
+    "0000000000000000000000000",
+    "0000000000000000000000000",
+    "0011111110010110111111100",
+    "0010000010110100100000100",
+    "0010111010110010101110100",
+    "0010111010010100101110100",
+    "0010111010100010101110100",
+    "0010000010100110100000100",
+    "0011111110101010111111100",
+    "0000000000111110000000000",
+    "0011010011011000111011000",
+    "0010110100000101000100000",
+    "0001111110000011010000100",
+    "0000111101110001100001100",
+    "0001100010001100001000000",
+    "0000000000110110001101000",
+    "0011111110111010011111000",
+    "0010000010011010010000000",
+    "0010111010011100000010000",
+    "0010111010111010111001100",
+    "0010111010010110101110100",
+    "0010000010110011001000000",
+    "0011111110100000100111000",
+    "0000000000000000000000000",
+    "0000000000000000000000000",
+)
+
+
+def _qr_image(scale: int = 6) -> np.ndarray:
+    modules = np.array(
+        [[0 if value == "1" else 255 for value in row] for row in _QR_MODULES],
+        dtype=np.uint8,
+    )
+    return modules.repeat(scale, axis=0).repeat(scale, axis=1)
+
+
+class _Endpoint:
+    def __init__(self, image: np.ndarray) -> None:
+        rgb = np.repeat(image[:, :, None], 3, axis=2)
+        self.frame = FrameData(
+            seq=1,
+            pts_us=time.time_ns() // 1_000,
+            width=rgb.shape[1],
+            height=rgb.shape[0],
+            fmt=PixelFormat.RGB24,
+            data=rgb.tobytes(),
+            participant_id="alice",
+            track_id="camera",
+        )
+        self.frame_callback = None
+        self.statuses: list[tuple[str, str]] = []
+
+    def on_frame(self, callback) -> None:
+        self.frame_callback = callback
+
+    def on_participant(self, _callback) -> None:
+        pass
+
+    async def request_frame(self, _signal: FrameSignal) -> FrameData:
+        return self.frame
+
+    async def set_status(self, status: str, participant_id: str) -> None:
+        self.statuses.append((status, participant_id))
+
+    async def seed(self) -> None:
+        await self.frame_callback(
+            FrameSignal(
+                slot=0,
+                seq=self.frame.seq,
+                pts_us=self.frame.pts_us,
+                width=self.frame.width,
+                height=self.frame.height,
+                fmt=self.frame.fmt,
+                data_sz=len(self.frame.data),
+                participant_id=self.frame.participant_id,
+                track_id=self.frame.track_id,
+            )
+        )
+
+
+def test_decode_qr_codes_extracts_every_payload_and_quadrilateral() -> None:
+    qr = _qr_image()
+    canvas = np.full((qr.shape[0] + 40, qr.shape[1] * 2 + 80), 255, dtype=np.uint8)
+    canvas[20 : 20 + qr.shape[0], 20 : 20 + qr.shape[1]] = qr
+    second_x = 60 + qr.shape[1]
+    canvas[20 : 20 + qr.shape[0], second_x : second_x + qr.shape[1]] = qr
+
+    codes = decode_qr_codes(canvas)
+
+    assert [code.data for code in codes] == ["XR AI QR tool", "XR AI QR tool"]
+    assert all(code.corners is not None and len(code.corners) == 4 for code in codes)
+    assert all(
+        point.x >= 0 and point.y >= 0
+        for code in codes
+        for point in code.corners or ()
+    )
+
+
+@pytest.mark.asyncio
+async def test_qr_code_tool_reads_the_current_participant_frame() -> None:
+    endpoint = _Endpoint(_qr_image())
+    tool = QRCodeTool(endpoint=endpoint)
+    await endpoint.seed()
+
+    result = await tool.execute(QRCodeRequest(participant_id="alice"))
+
+    assert result.available is True
+    assert result.message is None
+    assert [code.data for code in result.codes] == ["XR AI QR tool"]
+    assert endpoint.statuses == [("processing", "alice"), ("idle", "alice")]
+    assert tool.frames.participants() == ["alice"]
+    tool.release("alice")
+    assert tool.frames.participants() == []
+
+
+@pytest.mark.asyncio
+async def test_qr_code_tool_accepts_sync_and_async_custom_extractors() -> None:
+    calls: list[tuple[str, tuple[int, int]]] = []
+
+    def sync_extractor(image):
+        calls.append(("sync", image.size))
+        return [{"data": "sync backend"}]
+
+    async def async_extractor(image):
+        calls.append(("async", image.size))
+        return [{"data": "model backend", "corners": None}]
+
+    results = []
+    for extractor in (sync_extractor, async_extractor):
+        endpoint = _Endpoint(np.full((32, 48), 255, dtype=np.uint8))
+        tool = QRCodeTool(endpoint=endpoint, extractor=extractor)
+        await endpoint.seed()
+        results.append(
+            await tool.execute(QRCodeRequest(participant_id="alice"))
+        )
+
+    assert calls == [("sync", (48, 32)), ("async", (48, 32))]
+    assert [result.codes[0].data for result in results] == [
+        "sync backend",
+        "model backend",
+    ]
+    assert all(result.codes[0].corners is None for result in results)
+
+
+@pytest.mark.asyncio
+async def test_qr_code_tool_distinguishes_no_code_from_no_frame() -> None:
+    endpoint = _Endpoint(np.full((100, 100), 255, dtype=np.uint8))
+    tool = QRCodeTool(endpoint=endpoint, frame_timeout_s=0.01)
+    await endpoint.seed()
+
+    no_code = await tool.execute(QRCodeRequest(participant_id="alice"))
+    no_frame = await tool.execute(QRCodeRequest(participant_id="missing"))
+
+    assert no_code.available is True
+    assert no_code.codes == []
+    assert no_code.message is not None and "No readable QR code" in no_code.message
+    assert no_frame.available is False
+    assert no_frame.codes == []
+    assert no_frame.message is not None and "No camera frame" in no_frame.message
+
+
+def test_qr_code_request_is_strict_and_decoder_validates_pixels() -> None:
+    with pytest.raises(ValidationError):
+        QRCodeRequest(participant_id="alice", unsupported=True)
+    with pytest.raises(TypeError, match="uint8"):
+        decode_qr_codes(np.zeros((10, 10), dtype=np.float32))
+    with pytest.raises(ValueError, match="grayscale or color"):
+        decode_qr_codes(np.zeros((10,), dtype=np.uint8))

--- a/tests/test_qr_code_tool.py
+++ b/tests/test_qr_code_tool.py
@@ -45,13 +45,48 @@ _QR_MODULES = (
     "0000000000000000000000000",
 )
 
+_SECOND_QR_MODULES = (
+    "00000000000000000000000000000",
+    "00000000000000000000000000000",
+    "00000000000000000000000000000",
+    "00000000000000000000000000000",
+    "00001111111001000011111110000",
+    "00001000001010011010000010000",
+    "00001011101000010010111010000",
+    "00001011101011110010111010000",
+    "00001011101000000010111010000",
+    "00001000001011011010000010000",
+    "00001111111010101011111110000",
+    "00000000000001001000000000000",
+    "00001111101111010101010100000",
+    "00000011000000100000011010000",
+    "00000010011101011100011100000",
+    "00001110000110011101011110000",
+    "00000000111100100101000000000",
+    "00000000000011010001101110000",
+    "00001111111010111011010100000",
+    "00001000001001011001011100000",
+    "00001011101011001010000000000",
+    "00001011101010100001110100000",
+    "00001011101011011000010000000",
+    "00001000001011001101111000000",
+    "00001111111011101110100100000",
+    "00000000000000000000000000000",
+    "00000000000000000000000000000",
+    "00000000000000000000000000000",
+    "00000000000000000000000000000",
+)
 
-def _qr_image(scale: int = 6) -> np.ndarray:
-    modules = np.array(
-        [[0 if value == "1" else 255 for value in row] for row in _QR_MODULES],
+
+def _qr_image(
+    modules: tuple[str, ...] = _QR_MODULES,
+    scale: int = 6,
+) -> np.ndarray:
+    pixels = np.array(
+        [[0 if value == "1" else 255 for value in row] for row in modules],
         dtype=np.uint8,
     )
-    return modules.repeat(scale, axis=0).repeat(scale, axis=1)
+    return pixels.repeat(scale, axis=0).repeat(scale, axis=1)
 
 
 class _Endpoint:
@@ -99,15 +134,21 @@ class _Endpoint:
 
 
 def test_zxing_extracts_every_qr_payload_and_quadrilateral() -> None:
-    qr = _qr_image()
-    canvas = np.full((qr.shape[0] + 40, qr.shape[1] * 2 + 80), 255, dtype=np.uint8)
-    canvas[20 : 20 + qr.shape[0], 20 : 20 + qr.shape[1]] = qr
-    second_x = 60 + qr.shape[1]
-    canvas[20 : 20 + qr.shape[0], second_x : second_x + qr.shape[1]] = qr
+    first = _qr_image()
+    second = _qr_image(_SECOND_QR_MODULES)
+    canvas = np.full(
+        (max(first.shape[0], second.shape[0]) + 40, first.shape[1] + second.shape[1] + 80),
+        255,
+        dtype=np.uint8,
+    )
+    canvas[20 : 20 + first.shape[0], 20 : 20 + first.shape[1]] = first
+    second_x = 60 + first.shape[1]
+    canvas[20 : 20 + second.shape[0], second_x : second_x + second.shape[1]] = second
 
     codes = extract_qr_codes_zxing(canvas)
 
-    assert [code.data for code in codes] == ["XR AI QR tool", "XR AI QR tool"]
+    assert {code.data for code in codes} == {"XR AI QR tool", "second QR payload"}
+    assert len(codes) == 2
     assert all(code.corners is not None and len(code.corners) == 4 for code in codes)
     assert all(
         point.x >= 0 and point.y >= 0

--- a/tests/test_qr_code_tool.py
+++ b/tests/test_qr_code_tool.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""CPU-only tests for OpenCV-backed live QR-code extraction."""
+"""CPU-only tests for ZXing-C++-backed live QR-code extraction."""
 
 from __future__ import annotations
 
@@ -11,7 +11,11 @@ import numpy as np
 import pytest
 from pydantic import ValidationError
 from xr_ai_hub import FrameData, FrameSignal, PixelFormat
-from xr_ai_tools.qr_code import QRCodeRequest, QRCodeTool, decode_qr_codes
+from xr_ai_tools.qr_code import (
+    QRCodeRequest,
+    QRCodeTool,
+    extract_qr_codes_zxing,
+)
 
 _QR_MODULES = (
     "0000000000000000000000000",
@@ -94,14 +98,14 @@ class _Endpoint:
         )
 
 
-def test_decode_qr_codes_extracts_every_payload_and_quadrilateral() -> None:
+def test_zxing_extracts_every_qr_payload_and_quadrilateral() -> None:
     qr = _qr_image()
     canvas = np.full((qr.shape[0] + 40, qr.shape[1] * 2 + 80), 255, dtype=np.uint8)
     canvas[20 : 20 + qr.shape[0], 20 : 20 + qr.shape[1]] = qr
     second_x = 60 + qr.shape[1]
     canvas[20 : 20 + qr.shape[0], second_x : second_x + qr.shape[1]] = qr
 
-    codes = decode_qr_codes(canvas)
+    codes = extract_qr_codes_zxing(canvas)
 
     assert [code.data for code in codes] == ["XR AI QR tool", "XR AI QR tool"]
     assert all(code.corners is not None and len(code.corners) == 4 for code in codes)
@@ -179,6 +183,6 @@ def test_qr_code_request_is_strict_and_decoder_validates_pixels() -> None:
     with pytest.raises(ValidationError):
         QRCodeRequest(participant_id="alice", unsupported=True)
     with pytest.raises(TypeError, match="uint8"):
-        decode_qr_codes(np.zeros((10, 10), dtype=np.float32))
+        extract_qr_codes_zxing(np.zeros((10, 10), dtype=np.float32))
     with pytest.raises(ValueError, match="grayscale or color"):
-        decode_qr_codes(np.zeros((10,), dtype=np.uint8))
+        extract_qr_codes_zxing(np.zeros((10,), dtype=np.uint8))


### PR DESCRIPTION
## Summary

- add a participant-scoped read_qr_codes native tool using ZXing-C++ multi-code detection
- return every QR code from the same image as a separate decoded payload with optional image-space corners
- distinguish no-frame from valid-frame/no-code results
- make extraction swappable through a sync or async callable for alternative libraries or model-backed implementations
- isolate zxing-cpp in the qr-code optional dependency and document the typed integration contract

## Testing

- multi-code regression image with two distinct QR payloads and quadrilaterals
- uv run pytest test_native_tools.py test_vision_functions.py test_qr_code_tool.py -q (35 passed)
- non-GPU repository suite with GPU files and one unrelated flaky voice test deselected (856 passed, 3 deselected)
- Ruff on the new tool and tests
- SPDX header check on all changed files
- verified OpenCV is absent from source and the resolved test environment