### PR TITLE
Add getting-started skill bank and landing-page pointers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ services/        Hub, model servers, and typed capability services
 utils/           Launcher, logging, VAD, vLLM, and voice-gate utilities
 tests/           Cross-package and integration tests
 docs/source/     User and contributor documentation
+skills/          Skill bank that sets coding agents up
 ```
 
 ## Architecture boundaries

--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ conversational AI within the CloudXR ecosystem.
 ```text
 Set up xr-ai for me: ask me whether to build against the latest release or
 main, then fetch skills/getting-started/SKILL.md at that ref from
-https://raw.githubusercontent.com/NVIDIA/xr-ai/ (fall back to the main copy
-if the ref predates it), install it as a skill (or just follow it), and walk
-me through the rest of the setup.
+https://raw.githubusercontent.com/NVIDIA/xr-ai/. If the file does not exist
+at that ref, the release predates agent setup: get my OK to use main for
+both the skill and the checkout. Install the skill (or just follow it), and
+walk me through the rest of the setup.
 ```
 
 ## Public Beta Notice

--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ conversational AI within the CloudXR ecosystem.
 **Using a coding agent?** Paste this to it:
 
 ```text
-Set up xr-ai for me: fetch
-https://raw.githubusercontent.com/NVIDIA/xr-ai/main/skills/getting-started/SKILL.md,
-install it as a skill (or just follow it), and walk me through the setup.
+Set up xr-ai for me: ask me whether to build against the latest release or
+main, then fetch skills/getting-started/SKILL.md at that ref from
+https://raw.githubusercontent.com/NVIDIA/xr-ai/ (fall back to the main copy
+if the ref predates it), install it as a skill (or just follow it), and walk
+me through the rest of the setup.
 ```
 
 ## Public Beta Notice
@@ -252,7 +254,7 @@ several minutes).  `HF_TOKEN` is required by default; pass
 
 In both modes the VLM and STT keep running after you exit so the next run
 skips the model reload (see
-[vLLM model persistence](docs/source/components/ai-services.md#vllm-model-persistence)); free
+[model-server persistence](docs/source/components/ai-services.md#model-server-persistence)); free
 the VRAM with `cd agent-samples/model-servers && uv run model_servers --stop`.
 
 #### Step 1 — Start the server
@@ -272,9 +274,9 @@ The hub prints:
 ```
 
 This banner appears as soon as the hub itself is ready, while the model
-services and worker are still starting.  The stack accepts clients once the
-launcher prints its `All processes ready` banner; a client connected before
-that gets a session with no agent responding.
+services and worker are still starting.  Clients can connect as soon as it
+appears, but the agent answers queries only after the launcher prints its
+`All processes ready` banner.
 
 #### Step 2 — Connect a client
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@
 Agentic AI for XR — an open-source foundation for multi-modal, real-time
 conversational AI within the CloudXR ecosystem.
 
+**Using a coding agent?** Paste this to it:
+
+```text
+Set up xr-ai for me: fetch
+https://raw.githubusercontent.com/NVIDIA/xr-ai/main/skills/getting-started/SKILL.md,
+install it as a skill (or just follow it), and walk me through the setup.
+```
+
 ## Public Beta Notice
 
 This project is publicly available in beta and is under active development.
@@ -528,6 +536,7 @@ For engineers and agents working in the repo:
 | [`AGENTS.md`](AGENTS.md) | Working contract — hard rules every change must satisfy |
 | [`DEPENDENCIES.md`](DEPENDENCIES.md) | Authoritative dependency map (update with every `pyproject.toml` change) |
 | [Versioned documentation](https://nvidia.github.io/xr-ai/) | Latest release by default, plus `main` development and release-tag documentation |
+| [`skills/README.md`](skills/README.md) | Skill bank: setup skills for coding agents |
 | [`docs/source/overview/architecture.md`](docs/source/overview/architecture.md) | Hub ↔ transport ↔ agent boundaries; known limitations |
 | [`docs/source/components/launcher-and-process-model.md`](docs/source/components/launcher-and-process-model.md) | `Process` / `run_stack` mechanics; ready-file protocol |
 | [`docs/source/components/ai-services.md`](docs/source/components/ai-services.md) | VLM / STT / TTS / LLM / embedding server reference + worker call examples |

--- a/README.md
+++ b/README.md
@@ -234,8 +234,7 @@ runtime-selection details.
 
 There are two ways to run it:
 
-**Standalone** (~23 GB VRAM) — starts its own VLM and STT, owns them for the
-session, and stops them when you exit:
+**Standalone** (~23 GB VRAM) — starts its own VLM and STT:
 
 ```bash
 cd agent-samples/simple-vlm-example
@@ -250,7 +249,11 @@ several minutes).  `HF_TOKEN` is required by default; pass
 
 **With model-servers pre-running** — start `model_servers` to pre-warm VLM
 (port 8100) and STT (port 8103). The demo detects and reuses them.
-When you exit, those services keep running.
+
+In both modes the VLM and STT keep running after you exit so the next run
+skips the model reload (see
+[vLLM model persistence](docs/source/components/ai-services.md#vllm-model-persistence)); free
+the VRAM with `cd agent-samples/model-servers && uv run model_servers --stop`.
 
 #### Step 1 — Start the server
 
@@ -259,14 +262,19 @@ uv run simple_vlm_example
 ```
 
 The hub, VLM, STT, and TTS start together (or reuse running services).
-When ready the hub prints:
+The hub prints:
 
 ```
-[hub]   LiveKit URL : wss://0.0.0.0:8080
+[hub]   LiveKit URL : wss://localhost:8080
 [hub]   Room        : xr-room
 [hub]   Token       : eyJ…
 [hub]   Web client  : https://localhost:8080
 ```
+
+This banner appears as soon as the hub itself is ready, while the model
+services and worker are still starting.  The stack accepts clients once the
+launcher prints its `All processes ready` banner; a client connected before
+that gets a session with no agent responding.
 
 #### Step 2 — Connect a client
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ conversational AI within the CloudXR ecosystem.
 **Using a coding agent?** Paste this to it:
 
 ```text
-Set up xr-ai for me: ask me whether to build against the latest release or
-main, then fetch skills/getting-started/SKILL.md at that ref from
+Set up xr-ai for me: ask me whether to build against the latest release
+(newest stable tag; a prerelease only if no stable exists) or main, then
+fetch skills/getting-started/SKILL.md at that ref from
 https://raw.githubusercontent.com/NVIDIA/xr-ai/. If the file does not exist
 at that ref, the release predates agent setup: get my OK to use main for
 both the skill and the checkout. Install the skill (or just follow it), and

--- a/agent-samples/simple-vlm-example/README.md
+++ b/agent-samples/simple-vlm-example/README.md
@@ -42,6 +42,12 @@ uv sync
 uv run simple_vlm_example
 ```
 
+`HF_TOKEN` is required by default; pass `--allow-anonymous` to run without one
+(see [`credentials.md`](../../docs/source/getting_started/credentials.md)).
+
+The VLM and STT keep running after you exit so the next run skips the model
+reload; free the VRAM with `cd ../model-servers && uv run model_servers --stop`.
+
 Open the web client shown in the hub banner, connect, and then speak or type a
 question.
 

--- a/client-samples/android/README.md
+++ b/client-samples/android/README.md
@@ -90,9 +90,12 @@ uv sync && uv run echo_agent
 The hub prints:
 
 ```
-[hub]   LiveKit URL : wss://0.0.0.0:8080
+[hub]   LiveKit URL : wss://localhost:8080
 [hub]   Token       : eyJ…   ← paste into the app
 ```
+
+From the phone, replace `localhost` with the server machine's IP (the table
+below uses the same value).
 
 In the app:
 

--- a/docs/source/_snippets/agent-setup-prompt.txt
+++ b/docs/source/_snippets/agent-setup-prompt.txt
@@ -1,0 +1,5 @@
+Set up xr-ai for me: ask me whether to build against the latest release or
+main, then fetch skills/getting-started/SKILL.md at that ref from
+https://raw.githubusercontent.com/NVIDIA/xr-ai/ (fall back to the main copy
+if the ref predates it), install it as a skill (or just follow it), and walk
+me through the rest of the setup.

--- a/docs/source/_snippets/agent-setup-prompt.txt
+++ b/docs/source/_snippets/agent-setup-prompt.txt
@@ -1,5 +1,6 @@
 Set up xr-ai for me: ask me whether to build against the latest release or
 main, then fetch skills/getting-started/SKILL.md at that ref from
-https://raw.githubusercontent.com/NVIDIA/xr-ai/ (fall back to the main copy
-if the ref predates it), install it as a skill (or just follow it), and walk
-me through the rest of the setup.
+https://raw.githubusercontent.com/NVIDIA/xr-ai/. If the file does not exist
+at that ref, the release predates agent setup: get my OK to use main for
+both the skill and the checkout. Install the skill (or just follow it), and
+walk me through the rest of the setup.

--- a/docs/source/_snippets/agent-setup-prompt.txt
+++ b/docs/source/_snippets/agent-setup-prompt.txt
@@ -1,5 +1,6 @@
-Set up xr-ai for me: ask me whether to build against the latest release or
-main, then fetch skills/getting-started/SKILL.md at that ref from
+Set up xr-ai for me: ask me whether to build against the latest release
+(newest stable tag; a prerelease only if no stable exists) or main, then
+fetch skills/getting-started/SKILL.md at that ref from
 https://raw.githubusercontent.com/NVIDIA/xr-ai/. If the file does not exist
 at that ref, the release predates agent setup: get my OK to use main for
 both the skill and the checkout. Install the skill (or just follow it), and

--- a/docs/source/components/ai-services.md
+++ b/docs/source/components/ai-services.md
@@ -348,6 +348,11 @@ In pip mode, vLLM is spawned with `start_new_session=True` so the launcher's
 container while the foreground `docker run` client uses its own session.
 Either way vLLM keeps running after the orchestrator exits.
 
+The STT server follows the same pattern without Docker: `stt_server` spawns
+its persistent process with `start_new_session=True`, reuses a healthy server
+that survived a previous stack run, and is stopped by the same
+`model_servers --stop` cleanup.
+
 Docker containers carry a fingerprint of their image, GPU assignment, model
 cache, environment, bootstrap packages, complete vLLM command, and a versioned
 launcher-controlled Docker contract. This prevents a failed container created

--- a/docs/source/components/ai-services.md
+++ b/docs/source/components/ai-services.md
@@ -357,7 +357,8 @@ with stale memory limits, entrypoint, setup commands, or model arguments.
 **Stopping the persisted servers**, from the repo root:
 
 ```bash
-uv run --project agent-samples/model-servers model_servers --stop
+uv run --project agent-samples/model-servers model_servers --stop    # also simple-vlm-example's VLM and STT
+uv run --project agent-samples/xr-render-demo xr_render_demo --stop
 ```
 
 Cleanup locates labelled Docker containers before inspecting ports, then

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,6 +35,7 @@ _NONCANONICAL_TYPE_REFERENCE = re.compile(
 
 _GITHUB_BLOB_PREFIX = "https://github.com/NVIDIA/xr-ai/blob/"
 _GITHUB_TREE_PREFIX = "https://github.com/NVIDIA/xr-ai/tree/"
+_GITHUB_RAW_PREFIX = "https://raw.githubusercontent.com/NVIDIA/xr-ai/"
 _SEMVER_IDENTIFIER = r"(?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)"
 _SEMVER_TAG = (
     rf"v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)"
@@ -60,6 +61,9 @@ def _rewrite_github_links(_app, _docname: str, source: list[str]) -> None:
     )
     source[0] = source[0].replace(
         f"{_GITHUB_TREE_PREFIX}main/", f"{_GITHUB_TREE_PREFIX}{ref}/"
+    )
+    source[0] = source[0].replace(
+        f"{_GITHUB_RAW_PREFIX}main/", f"{_GITHUB_RAW_PREFIX}{ref}/"
     )
 
 

--- a/docs/source/getting_started/clients.md
+++ b/docs/source/getting_started/clients.md
@@ -35,7 +35,7 @@ When you start a server sample, the hub prints its connection details on
 startup:
 
 ```
-[hub]   LiveKit URL : wss://0.0.0.0:8080
+[hub]   LiveKit URL : wss://localhost:8080
 [hub]   Room        : xr-room
 [hub]   Token       : eyJ…
 [hub]   Web client  : https://localhost:8080

--- a/docs/source/getting_started/index.md
+++ b/docs/source/getting_started/index.md
@@ -5,12 +5,15 @@
 
 # Getting Started
 
-The quickstart paths, requirements, connecting clients, networking, and credentials.
+Using a coding agent? Start at {doc}`skills`. The rest of this section is the
+manual path: quickstarts, requirements, connecting clients, networking, and
+credentials.
 
 ```{toctree}
 :maxdepth: 1
 
 quickstart
+skills
 requirements
 clients
 networking

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -10,10 +10,8 @@
 The fastest path: paste this to your agent and it does the rest, including
 walking you through the choices below. See {doc}`skills` for how it works.
 
-```text
-Set up xr-ai for me: fetch
-https://raw.githubusercontent.com/NVIDIA/xr-ai/main/skills/getting-started/SKILL.md,
-install it as a skill (or just follow it), and walk me through the setup.
+```{literalinclude} /_snippets/agent-setup-prompt.txt
+:language: text
 ```
 
 The rest of this page is the manual path.
@@ -129,9 +127,9 @@ The hub prints:
 ```
 
 This banner appears as soon as the hub itself is ready, while the model
-services and worker are still starting. The stack accepts clients once the
-launcher prints its `All processes ready` banner; a client connected before
-that gets a session with no agent responding.
+services and worker are still starting. Clients can connect as soon as it
+appears, but the agent answers queries only after the launcher prints its
+`All processes ready` banner.
 
 ### Step 2 — Connect a client
 

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -5,6 +5,19 @@
 
 # Quickstart
 
+## Set up with a coding agent
+
+The fastest path: paste this to your agent and it does the rest, including
+walking you through the choices below. See {doc}`skills` for how it works.
+
+```text
+Set up xr-ai for me: fetch
+https://raw.githubusercontent.com/NVIDIA/xr-ai/main/skills/getting-started/SKILL.md,
+install it as a skill (or just follow it), and walk me through the setup.
+```
+
+The rest of this page is the manual path.
+
 Every sample follows the same pattern: **start the server, then connect a
 client.** Once it is ready, any supported client — web browser, Android app,
 iOS/visionOS app, or AR glasses — can join the session using the token printed

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -91,8 +91,7 @@ Uses the text-output Reasoner from `nvidia/Cosmos3-Nano` by default. Refer to
 
 There are two ways to run it:
 
-**Standalone** (~23 GB VRAM) — starts its own VLM and STT, owns them for the
-session, and stops them when you exit:
+**Standalone** (~23 GB VRAM) — starts its own VLM and STT:
 
 ```bash
 cd agent-samples/simple-vlm-example
@@ -107,7 +106,11 @@ to run without one (refer to the
 
 **With model-servers pre-running** — start `model_servers` to pre-warm VLM
 (port 8100) and STT (port 8103). The demo detects and reuses them.
-When you exit, those services keep running.
+
+In both modes the VLM and STT keep running after you exit so the next run skips
+the model reload (see the {doc}`AI services guide </components/ai-services>`);
+free the VRAM with `cd agent-samples/model-servers && uv run model_servers
+--stop`.
 
 ### Step 1 — Start the server
 
@@ -116,14 +119,19 @@ uv run simple_vlm_example
 ```
 
 The XR-Media-Hub, VLM, STT, and TTS start together (or reuse running services).
-When ready the hub prints:
+The hub prints:
 
 ```
-[hub]   LiveKit URL : wss://0.0.0.0:8080
+[hub]   LiveKit URL : wss://localhost:8080
 [hub]   Room        : xr-room
 [hub]   Token       : eyJ…
 [hub]   Web client  : https://localhost:8080
 ```
+
+This banner appears as soon as the hub itself is ready, while the model
+services and worker are still starting. The stack accepts clients once the
+launcher prints its `All processes ready` banner; a client connected before
+that gets a session with no agent responding.
 
 ### Step 2 — Connect a client
 

--- a/docs/source/getting_started/skills.md
+++ b/docs/source/getting_started/skills.md
@@ -1,0 +1,34 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Skills
+
+Skills are how a coding agent sets itself up to work with xr-ai: small
+`SKILL.md` modules under the open [Agent Skills](https://agentskills.io) spec
+that the agent installs and follows. This is the primary way to get started.
+Paste this to your agent:
+
+```text
+Set up xr-ai for me: fetch
+https://raw.githubusercontent.com/NVIDIA/xr-ai/main/skills/getting-started/SKILL.md,
+install it as a skill (or just follow it), and walk me through the setup.
+```
+
+The skill has the agent ask two setup questions (latest release or `main`;
+models on the local GPU or a hosted endpoint), clone the repo, and route
+itself to the working contract, the docs, and the reference sample. An agent
+with no skills mechanism can follow the `SKILL.md` contents directly.
+
+Prefer to do it by hand? Follow {doc}`/getting_started/quickstart`.
+
+## Available skills
+
+| Skill | What it does |
+|---|---|
+| [`getting-started`](https://github.com/NVIDIA/xr-ai/blob/main/skills/getting-started/SKILL.md) | Sets an agent up to build on xr-ai: repo, working contract, docs, reference sample |
+
+The bank lives at
+[`skills/`](https://github.com/NVIDIA/xr-ai/tree/main/skills) in the
+repository; new skills land there with the features they cover.

--- a/docs/source/getting_started/skills.md
+++ b/docs/source/getting_started/skills.md
@@ -10,10 +10,8 @@ Skills are how a coding agent sets itself up to work with xr-ai: small
 that the agent installs and follows. This is the primary way to get started.
 Paste this to your agent:
 
-```text
-Set up xr-ai for me: fetch
-https://raw.githubusercontent.com/NVIDIA/xr-ai/main/skills/getting-started/SKILL.md,
-install it as a skill (or just follow it), and walk me through the setup.
+```{literalinclude} /_snippets/agent-setup-prompt.txt
+:language: text
 ```
 
 The skill has the agent ask two setup questions (latest release or `main`;

--- a/docs/source/guides/spdx-headers.md
+++ b/docs/source/guides/spdx-headers.md
@@ -30,6 +30,11 @@ Insert the header **after** these required first-line directives when present:
 `#!/...` shebangs, `<?xml …?>` declarations, `<!DOCTYPE …>`, and Swift's
 `// swift-tools-version:` directive.
 
+In files that must open with YAML frontmatter (e.g. `SKILL.md`), the header
+goes immediately after the closing `---`. The checker accepts this, but its
+`--fix` mode does not recognize frontmatter and would insert above it, so add
+the header by hand in such files.
+
 ## Files to skip
 
 Skip files that can't carry comments or aren't ours to license: `LICENSE`,

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -11,10 +11,8 @@ in real time.
 :::{tip}
 Using a coding agent? Paste this to it:
 
-```text
-Set up xr-ai for me: fetch
-https://raw.githubusercontent.com/NVIDIA/xr-ai/main/skills/getting-started/SKILL.md,
-install it as a skill (or just follow it), and walk me through the setup.
+```{literalinclude} /_snippets/agent-setup-prompt.txt
+:language: text
 ```
 :::
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -8,6 +8,16 @@
 Build AI agents that see and hear what your users experience in XR, and respond
 in real time.
 
+:::{tip}
+Using a coding agent? Paste this to it:
+
+```text
+Set up xr-ai for me: fetch
+https://raw.githubusercontent.com/NVIDIA/xr-ai/main/skills/getting-started/SKILL.md,
+install it as a skill (or just follow it), and walk me through the setup.
+```
+:::
+
 XR AI is an open-source stack that connects web, iOS/visionOS, AR-glasses, and
 XR-headset clients to GPU-accelerated AI services and tool-using agents. An agent
 can perceive live physical context, call native tools, and reply with audio
@@ -31,6 +41,13 @@ It is especially useful when you need to:
 
 ::::{grid} 1 1 2 2
 :gutter: 3
+
+:::{grid-item-card} 🤖 Set up with your agent
+:link: getting_started/skills
+:link-type: doc
+The primary path: one pasted prompt sets a coding agent up with the xr-ai
+skills, and it does the rest.
+:::
 
 :::{grid-item-card} 🚀 Get started
 :link: getting_started/quickstart

--- a/services/xr-media-hub/xr_media_hub/__main__.py
+++ b/services/xr-media-hub/xr_media_hub/__main__.py
@@ -123,7 +123,7 @@ async def main(ready_file: Path | None = None) -> None:
     else:
         lk_scheme   = "ws"
         lk_url_port = cfg.lk_port_ws
-    logger.info("LiveKit URL : {}://0.0.0.0:{}", lk_scheme, lk_url_port)
+    logger.info("LiveKit URL : {}://localhost:{}", lk_scheme, lk_url_port)
     logger.info("Room        : {}", cfg.room_name)
     logger.info("Token       : {}", token)
     if cfg.enable_web_server:

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,30 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# xr-ai skill bank
+
+Skills that set a coding agent up to work with
+[xr-ai](https://github.com/NVIDIA/xr-ai). Each skill is a `SKILL.md` under the
+open [Agent Skills](https://agentskills.io) spec.
+
+## Available skills
+
+| Skill | What it does |
+|---|---|
+| [`getting-started`](getting-started/SKILL.md) | Sets an agent up to build on xr-ai: repo, working contract, docs, reference sample |
+
+## Setup
+
+Download the skill into your agent's skills directory:
+
+```bash
+: "${SKILLS_DIR:?Set SKILLS_DIR to your agent's skills directory}"
+curl -fsSL --create-dirs -o "$SKILLS_DIR/getting-started/SKILL.md" \
+  https://raw.githubusercontent.com/NVIDIA/xr-ai/main/skills/getting-started/SKILL.md
+```
+
+No skills mechanism? Read
+[`getting-started/SKILL.md`](getting-started/SKILL.md) and follow it directly
+in the current session.

--- a/skills/README.md
+++ b/skills/README.md
@@ -21,8 +21,9 @@ Download the skill into your agent's skills directory:
 
 ```bash
 : "${SKILLS_DIR:?Set SKILLS_DIR to your agent's skills directory}"
+REF=main  # or the release tag you will build against, e.g. v0.3.0
 curl -fsSL --create-dirs -o "$SKILLS_DIR/getting-started/SKILL.md" \
-  https://raw.githubusercontent.com/NVIDIA/xr-ai/main/skills/getting-started/SKILL.md
+  "https://raw.githubusercontent.com/NVIDIA/xr-ai/$REF/skills/getting-started/SKILL.md"
 ```
 
 No skills mechanism? Read

--- a/skills/README.md
+++ b/skills/README.md
@@ -17,7 +17,9 @@ open [Agent Skills](https://agentskills.io) spec.
 
 ## Setup
 
-Download the skill into your agent's skills directory:
+Download the skill into your agent's skills directory. Set `REF` to the ref
+you will build against; releases that predate the bank have no copy, so use
+`REF=main` (and build against `main`):
 
 ```bash
 : "${SKILLS_DIR:?Set SKILLS_DIR to your agent's skills directory}"

--- a/skills/getting-started/SKILL.md
+++ b/skills/getting-started/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: getting-started
+description: Get set up to build on the NVIDIA xr-ai stack (XR AI / XR-Media-Hub). Use when a user asks to install, clone, or do initial setup of xr-ai; not for routine work in an already-set-up clone.
+---
+
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Getting started with xr-ai
+
+Pointers only; the linked docs hold the procedures. Paths are relative to the
+repo root, so clone before following them.
+
+## First: two setup questions
+
+Ask the user, then tailor the pointers below to the answers.
+
+1. **Stable or latest?** Build against the latest release tag (default) or
+   `main`. The answer selects both the git ref to check out and the version of
+   the docs site to read: <https://nvidia.github.io/xr-ai/> serves the released
+   version once one is published, with `main` and per-tag versions available.
+2. **Local or remote GPU?** Models on the local GPU, or a hosted/remote
+   endpoint?
+   - **Local:** the Requirements section of the root `README.md` applies,
+     including the VRAM table.
+   - **Remote/hosted:** the LLM and VLM can run on hosted endpoints, and no
+     local GPU is needed for the agent or hub. STT and TTS stay local. Read
+     `docs/source/components/ai-services.md` (section "Hosting models on
+     NVIDIA NIM") and `docs/source/getting_started/credentials.md`.
+
+## Where everything is
+
+- **Repo:** `git clone https://github.com/NVIDIA/xr-ai.git`, then check out
+  the ref chosen above (latest release tag:
+  `git tag -l 'v*' --sort=-v:refname | head -1`).
+- **Working contract:** read `AGENTS.md` first. Every change must satisfy it,
+  and its canonical-references table routes deeper topics.
+- **Docs:** `docs/source/`; published versioned site at
+  <https://nvidia.github.io/xr-ai/>.
+- **Reference sample:** `agent-samples/simple-vlm-example/`, the one to study
+  and copy.
+- **Scaffolding a new sample:** `docs/source/guides/adding-a-sample.md`, full
+  boilerplate templates.
+- **Quickstart order:** root `README.md` Requirements first. Then
+  `agent-samples/simple-vlm-example` runs directly;
+  `agent-samples/model-servers` is a prerequisite for
+  `agent-samples/xr-render-demo`.

--- a/skills/getting-started/SKILL.md
+++ b/skills/getting-started/SKILL.md
@@ -17,12 +17,14 @@ repo root, so clone before following them.
 
 Ask the user, then tailor the pointers below to the answers.
 
-1. **Stable or latest?** Build against the latest release tag (default) or
+1. **Release or main?** Build against the latest release tag (default) or
    `main`. This should match the ref this skill was fetched from; re-fetch the
-   skill from the chosen ref if it does not. The answer selects both the git
-   ref to check out and the version of the docs site to read:
-   <https://nvidia.github.io/xr-ai/> serves the released version once one is
-   published, with `main` and per-tag versions available.
+   skill from the chosen ref if it does not. Releases that predate the skill
+   bank are not covered: with the user's OK, use `main` for both this skill
+   and the checkout. The answer selects both the git ref to check out and the
+   version of the docs site to read: <https://nvidia.github.io/xr-ai/> serves
+   the released version once one is published, with `main` and per-tag
+   versions available.
 2. **Local or remote GPU?** Models on the local GPU, or a hosted/remote
    endpoint?
    - **Local:** the Requirements section of the root `README.md` applies,
@@ -35,9 +37,10 @@ Ask the user, then tailor the pointers below to the answers.
 ## Where everything is
 
 - **Repo:** `git clone https://github.com/NVIDIA/xr-ai.git`, then check out
-  the ref chosen above (latest release tag: `make -s -C docs latest-release`,
-  run in the clone; it prefers stable releases over prereleases, matching what
-  the docs site serves).
+  the ref chosen above (latest release tag, run in the clone:
+  `git tag --list 'v*' | python3 .github/scripts/select_latest_docs_release.py`;
+  it prefers stable releases over prereleases, matching what the docs site
+  serves).
 - **Working contract:** read `AGENTS.md` first. Every change must satisfy it,
   and its canonical-references table routes deeper topics.
 - **Docs:** `docs/source/`; published versioned site at

--- a/skills/getting-started/SKILL.md
+++ b/skills/getting-started/SKILL.md
@@ -18,9 +18,11 @@ repo root, so clone before following them.
 Ask the user, then tailor the pointers below to the answers.
 
 1. **Stable or latest?** Build against the latest release tag (default) or
-   `main`. The answer selects both the git ref to check out and the version of
-   the docs site to read: <https://nvidia.github.io/xr-ai/> serves the released
-   version once one is published, with `main` and per-tag versions available.
+   `main`. This should match the ref this skill was fetched from; re-fetch the
+   skill from the chosen ref if it does not. The answer selects both the git
+   ref to check out and the version of the docs site to read:
+   <https://nvidia.github.io/xr-ai/> serves the released version once one is
+   published, with `main` and per-tag versions available.
 2. **Local or remote GPU?** Models on the local GPU, or a hosted/remote
    endpoint?
    - **Local:** the Requirements section of the root `README.md` applies,
@@ -33,8 +35,9 @@ Ask the user, then tailor the pointers below to the answers.
 ## Where everything is
 
 - **Repo:** `git clone https://github.com/NVIDIA/xr-ai.git`, then check out
-  the ref chosen above (latest release tag:
-  `git tag -l 'v*' --sort=-v:refname | head -1`).
+  the ref chosen above (latest release tag: `make -s -C docs latest-release`,
+  run in the clone; it prefers stable releases over prereleases, matching what
+  the docs site serves).
 - **Working contract:** read `AGENTS.md` first. Every change must satisfy it,
   and its canonical-references table routes deeper topics.
 - **Docs:** `docs/source/`; published versioned site at

--- a/tests/test_docs_versions.py
+++ b/tests/test_docs_versions.py
@@ -75,3 +75,11 @@ def test_source_links_use_the_current_documentation_ref(monkeypatch) -> None:
             f"https://github.com/NVIDIA/xr-ai/tree/{ref}/docs\n"
             f"https://raw.githubusercontent.com/NVIDIA/xr-ai/{ref}/skills/getting-started/SKILL.md"
         ]
+
+
+def test_readme_agent_prompt_matches_docs_snippet() -> None:
+    snippet = (
+        _ROOT / "docs" / "source" / "_snippets" / "agent-setup-prompt.txt"
+    ).read_text()
+    readme = (_ROOT / "README.md").read_text()
+    assert f"```text\n{snippet}```" in readme

--- a/tests/test_docs_versions.py
+++ b/tests/test_docs_versions.py
@@ -64,12 +64,14 @@ def test_source_links_use_the_current_documentation_ref(monkeypatch) -> None:
             monkeypatch.setenv(environment, ref)
         source = [
             "https://github.com/NVIDIA/xr-ai/blob/main/docs/example.md\n"
-            "https://github.com/NVIDIA/xr-ai/tree/main/docs"
+            "https://github.com/NVIDIA/xr-ai/tree/main/docs\n"
+            "https://raw.githubusercontent.com/NVIDIA/xr-ai/main/skills/getting-started/SKILL.md"
         ]
 
         config["_rewrite_github_links"](None, "example", source)
 
         assert source == [
             f"https://github.com/NVIDIA/xr-ai/blob/{ref}/docs/example.md\n"
-            f"https://github.com/NVIDIA/xr-ai/tree/{ref}/docs"
+            f"https://github.com/NVIDIA/xr-ai/tree/{ref}/docs\n"
+            f"https://raw.githubusercontent.com/NVIDIA/xr-ai/{ref}/skills/getting-started/SKILL.md"
         ]


### PR DESCRIPTION
Adds the getting-started skill bank: the agent-first onboarding path for xr-ai. A developer pastes one prompt to their coding agent; the agent installs the version-aligned getting-started skill (skills/getting-started/SKILL.md, open Agent Skills spec) and walks them through setup. Entry points on the GitHub README, the docs landing page, and the quickstart lead with the prompt, a Skills page joins Getting Started in the docs, and the prompt is single-sourced in the docs via a snippet with a contract test keeping the README copy identical. The skill selects release-vs-main up front, reuses the repo's release-selector policy, and fails closed (explicit user OK, main for both skill and checkout) for releases that predate the bank.

A second commit fixes misleading operational docs found by an agent dry-run of this onboarding journey: the hub banner now prints a connectable localhost URL, README/quickstart document that the VLM and STT persist after exit (with the stop command) and that queries are answered after the launcher's "All processes ready" banner, the STT server's persistence is documented alongside vLLM's, and the sample README gains the HF_TOKEN note.
