### PR TITLE
feat(tools): add magenta polygon image fill

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -113,13 +113,15 @@ xr-ai-tools  (agent-sdk/xr-ai-tools/)
     └── pydantic >=2.10
     └── [relay] xr-ai-models [editable: ../xr-ai-models]
     ├── [frames] numpy >=1.24, Pillow >=10.0, xr-ai-hub-client [editable: ../xr-ai-hub]
+    ├── [image-editing] Pillow >=10.0
     ├── [vision] xr-ai-models [editable: ../xr-ai-models]
     ├── [qr-code] numpy >=1.24, zxing-cpp >=2.3,<4, Pillow >=10.0, xr-ai-hub-client [editable: ../xr-ai-hub]
     └── [services] msgpack >=1.0, pyzmq >=27.0
     Toolkit-independent native tools: Pydantic request and response models,
     Relay-managed finite and async execution, model tool-call workflow helpers,
-    frame selection, single/multi-image inference, participant-scoped QR-code
-    extraction, typed capability clients, and service RPC.
+    frame selection, lossless polygon image editing, single/multi-image
+    inference, participant-scoped QR-code extraction, typed capability clients,
+    and service RPC.
 
 
 xr-openxr-service  (services/openxr-service/)
@@ -227,7 +229,7 @@ xr-ai-tests  (tests/)
     └── xr-ai-agent-runtime       [editable: ../agent-sdk/xr-ai-runtime]
     └── xr-ai-hub-client             [editable: ../agent-sdk/xr-ai-hub]
     └── xr-ai-models            [editable: ../agent-sdk/xr-ai-models]
-    └── xr-ai-tools[frames,qr-code,services,vision] [editable: ../agent-sdk/xr-ai-tools]
+    └── xr-ai-tools[frames,image-editing,qr-code,services,vision] [editable: ../agent-sdk/xr-ai-tools]
     └── xr-rag-service [editable: ../services/rag-service]
     └── xr-video-memory-service [editable: ../services/video-memory-service]
     └── xr-ai-voice             [editable: ../agent-sdk/xr-ai-voice]

--- a/agent-sdk/xr-ai-tools/README.md
+++ b/agent-sdk/xr-ai-tools/README.md
@@ -231,7 +231,9 @@ and at least three ordered pixel coordinates. It connects the final point to
 the first, validates that the polygon is inside the image and encloses an area,
 and stores a new lossless PNG without changing the source image. The returned
 reference inherits the source owner and can be passed directly to an image
-query tool.
+query tool. Stale image references and invalid polygons return
+`available=False` with a recoverable message instead of raising an internal
+tool error.
 
 ```python
 from pathlib import Path

--- a/agent-sdk/xr-ai-tools/README.md
+++ b/agent-sdk/xr-ai-tools/README.md
@@ -138,6 +138,10 @@ preserving provider input. Timelines supplied to video inference are described
 as estimates because recorded-frame timestamps are interpolated from chunk
 metadata rather than persisted per-frame presentation timestamps.
 
+Derived images use `ImageRegistry.put_derived(...)` to inherit the source
+reference's owner, so participant or workflow cleanup releases the source and
+all derived pixels together.
+
 ```python
 from xr_ai_tools.current_frame import CurrentFrameRequest, CurrentFrameTool
 from xr_ai_tools.image import ImageReference, ImageRegistry
@@ -226,7 +230,8 @@ standard magenta (`#FF00FF`). `ImagePolygonFillTool` accepts an image reference
 and at least three ordered pixel coordinates. It connects the final point to
 the first, validates that the polygon is inside the image and encloses an area,
 and stores a new lossless PNG without changing the source image. The returned
-reference can be passed directly to an image query tool.
+reference inherits the source owner and can be passed directly to an image
+query tool.
 
 ```python
 from pathlib import Path

--- a/agent-sdk/xr-ai-tools/README.md
+++ b/agent-sdk/xr-ai-tools/README.md
@@ -218,3 +218,39 @@ qr_codes = QRCodeTool(
 Call `release(participant_id)` when a participant disconnects. Applications
 that expose the tool to a model should inject the active participant identity
 at their workflow boundary, as they do for other participant-scoped tools.
+
+## Magenta polygon image editing
+
+Install `xr-ai-tools[image-editing]` to fill an image-space polygon with
+standard magenta (`#FF00FF`). `ImagePolygonFillTool` accepts an image reference
+and at least three ordered pixel coordinates. It connects the final point to
+the first, validates that the polygon is inside the image and encloses an area,
+and stores a new lossless PNG without changing the source image. The returned
+reference can be passed directly to an image query tool.
+
+```python
+from pathlib import Path
+
+from xr_ai_tools.image import ImageRegistry
+from xr_ai_tools.image_polygon import (
+    ImagePoint,
+    ImagePolygonFillRequest,
+    ImagePolygonFillTool,
+)
+
+images = ImageRegistry()
+source = images.put(Path("measurement.png"))
+fill_polygon = ImagePolygonFillTool(images=images)
+
+result = await fill_polygon.execute(
+    ImagePolygonFillRequest(
+        image=source,
+        coordinates=[
+            ImagePoint(x=40, y=30),
+            ImagePoint(x=140, y=30),
+            ImagePoint(x=140, y=130),
+            ImagePoint(x=40, y=130),
+        ],
+    )
+)
+```

--- a/agent-sdk/xr-ai-tools/pyproject.toml
+++ b/agent-sdk/xr-ai-tools/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
 [project.optional-dependencies]
 relay = ["xr-ai-models"]
 frames = ["numpy>=1.24", "Pillow>=10.0", "xr-ai-hub-client"]
+image-editing = ["Pillow>=10.0"]
 vision = ["xr-ai-models"]
 qr-code = ["numpy>=1.24", "zxing-cpp>=2.3,<4", "Pillow>=10.0", "xr-ai-hub-client"]
 services = ["msgpack>=1.0", "pyzmq>=27.0"]

--- a/agent-sdk/xr-ai-tools/xr_ai_tools/image.py
+++ b/agent-sdk/xr-ai-tools/xr_ai_tools/image.py
@@ -62,6 +62,24 @@ class ImageRegistry:
             self._images.popitem(last=False)
         return ImageReference(uri=uri)
 
+    def put_derived(
+        self,
+        image: ImageInput,
+        *,
+        source: ImageReference,
+    ) -> ImageReference:
+        """Store derived image input with the source reference's owner."""
+
+        if source.uri.startswith(_IMAGE_SCHEME):
+            try:
+                _source_image, owner = self._images[source.uri]
+            except KeyError as exc:
+                raise LookupError(f"image reference is unavailable: {source.uri}") from exc
+        else:
+            self.resolve(source)
+            owner = None
+        return self.put(image, owner=owner)
+
     def resolve(self, reference: ImageReference) -> ImageInput:
         """Resolve an opaque handle or normalize an external image location."""
 

--- a/agent-sdk/xr-ai-tools/xr_ai_tools/image_polygon.py
+++ b/agent-sdk/xr-ai-tools/xr_ai_tools/image_polygon.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import io
+import logging
 import math
 from collections.abc import Sequence
 from pathlib import Path
@@ -20,6 +21,7 @@ from .tools import Tool
 from .types import StrictRequest
 
 _MAGENTA_RGB = (255, 0, 255)
+_LOGGER = logging.getLogger(__name__)
 
 
 class ImagePoint(BaseModel):
@@ -52,7 +54,18 @@ class ImagePolygonFillRequest(StrictRequest):
 class ImagePolygonFillResult(BaseModel):
     """A lossless PNG copy containing the filled polygon."""
 
-    image: ImageReference = Field(description="Opaque reference to the edited PNG image.")
+    image: ImageReference | None = Field(
+        default=None,
+        description="Opaque reference to the edited PNG image when available.",
+    )
+    available: bool = Field(
+        default=True,
+        description="Whether the supplied image and polygon produced an edited image.",
+    )
+    message: str | None = Field(
+        default=None,
+        description="Recoverable failure detail when no edited image was produced.",
+    )
 
 
 def _open_image(source: ImageInput) -> Image.Image:
@@ -127,15 +140,37 @@ class ImagePolygonFillTool(Tool[ImagePolygonFillRequest, ImagePolygonFillResult]
         )
 
     async def _fill(self, request: ImagePolygonFillRequest) -> ImagePolygonFillResult:
-        source = self.images.resolve(request.image)
-        output = await asyncio.to_thread(
-            fill_polygon_magenta,
-            source,
-            request.coordinates,
-        )
-        return ImagePolygonFillResult(
-            image=self.images.put_derived(output, source=request.image)
-        )
+        try:
+            source = self.images.resolve(request.image)
+        except (LookupError, ValueError) as error:
+            _LOGGER.warning("Image input could not be resolved: %s", error)
+            return ImagePolygonFillResult(
+                available=False,
+                message="Image input unavailable — please select it again.",
+            )
+
+        try:
+            output = await asyncio.to_thread(
+                fill_polygon_magenta,
+                source,
+                request.coordinates,
+            )
+        except (OSError, ValueError) as error:
+            _LOGGER.warning("Image polygon could not be filled: %s", error)
+            return ImagePolygonFillResult(
+                available=False,
+                message=f"Image polygon invalid — {error}",
+            )
+
+        try:
+            image = self.images.put_derived(output, source=request.image)
+        except (LookupError, ValueError) as error:
+            _LOGGER.warning("Source image was released during polygon fill: %s", error)
+            return ImagePolygonFillResult(
+                available=False,
+                message="Image input unavailable — please select it again.",
+            )
+        return ImagePolygonFillResult(image=image)
 
 
 __all__ = [

--- a/agent-sdk/xr-ai-tools/xr_ai_tools/image_polygon.py
+++ b/agent-sdk/xr-ai-tools/xr_ai_tools/image_polygon.py
@@ -133,7 +133,9 @@ class ImagePolygonFillTool(Tool[ImagePolygonFillRequest, ImagePolygonFillResult]
             source,
             request.coordinates,
         )
-        return ImagePolygonFillResult(image=self.images.put(output))
+        return ImagePolygonFillResult(
+            image=self.images.put_derived(output, source=request.image)
+        )
 
 
 __all__ = [

--- a/agent-sdk/xr-ai-tools/xr_ai_tools/image_polygon.py
+++ b/agent-sdk/xr-ai-tools/xr_ai_tools/image_polygon.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fill an image-space polygon with opaque magenta pixels."""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import math
+from collections.abc import Sequence
+from pathlib import Path
+from urllib.parse import urlsplit
+
+from PIL import Image, ImageDraw
+from pydantic import BaseModel, ConfigDict, Field
+
+from .image import ImageInput, ImageReference, ImageRegistry
+from .tools import Tool
+from .types import StrictRequest
+
+_MAGENTA_RGB = (255, 0, 255)
+
+
+class ImagePoint(BaseModel):
+    """One non-negative source-image pixel coordinate."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    x: float = Field(
+        ge=0,
+        allow_inf_nan=False,
+        description="Horizontal pixel coordinate from the left edge.",
+    )
+    y: float = Field(
+        ge=0,
+        allow_inf_nan=False,
+        description="Vertical pixel coordinate from the top edge.",
+    )
+
+
+class ImagePolygonFillRequest(StrictRequest):
+    """Fill the polygon defined by ordered image-space vertices."""
+
+    image: ImageReference = Field(description="Source image returned by an image tool or supplied by the caller.")
+    coordinates: list[ImagePoint] = Field(
+        min_length=3,
+        description="Ordered polygon vertices; the final vertex is connected to the first.",
+    )
+
+
+class ImagePolygonFillResult(BaseModel):
+    """A lossless PNG copy containing the filled polygon."""
+
+    image: ImageReference = Field(description="Opaque reference to the edited PNG image.")
+
+
+def _open_image(source: ImageInput) -> Image.Image:
+    if isinstance(source, bytes):
+        stream = io.BytesIO(source)
+        opened = Image.open(stream)
+    else:
+        if isinstance(source, str):
+            parsed = urlsplit(source)
+            if parsed.scheme:
+                raise ValueError("image polygon fill requires bytes or a local image path")
+        opened = Image.open(Path(source))
+
+    with opened:
+        opened.load()
+        mode = "RGBA" if "A" in opened.getbands() or "transparency" in opened.info else "RGB"
+        return opened.convert(mode)
+
+
+def _validate_polygon(image: Image.Image, coordinates: Sequence[ImagePoint]) -> None:
+    if len(coordinates) < 3:
+        raise ValueError("at least three polygon coordinates are required")
+
+    for point in coordinates:
+        if point.x >= image.width or point.y >= image.height:
+            raise ValueError(
+                f"polygon coordinate ({point.x}, {point.y}) is outside "
+                f"the {image.width}x{image.height} image"
+            )
+
+    area_twice = sum(
+        point.x * following.y - following.x * point.y
+        for point, following in zip(
+            coordinates,
+            (*coordinates[1:], coordinates[0]),
+            strict=True,
+        )
+    )
+    if math.isclose(area_twice, 0.0, abs_tol=1e-9):
+        raise ValueError("polygon coordinates must enclose a non-zero area")
+
+
+def fill_polygon_magenta(
+    source: ImageInput,
+    coordinates: Sequence[ImagePoint],
+) -> bytes:
+    """Return lossless PNG bytes with the supplied polygon filled ``#FF00FF``."""
+
+    image = _open_image(source)
+    _validate_polygon(image, coordinates)
+    fill = (*_MAGENTA_RGB, 255) if image.mode == "RGBA" else _MAGENTA_RGB
+    ImageDraw.Draw(image).polygon(
+        [(point.x, point.y) for point in coordinates],
+        fill=fill,
+    )
+    output = io.BytesIO()
+    image.save(output, format="PNG")
+    return output.getvalue()
+
+
+class ImagePolygonFillTool(Tool[ImagePolygonFillRequest, ImagePolygonFillResult]):
+    """Create a magenta polygon overlay without changing the source image."""
+
+    def __init__(self, *, images: ImageRegistry) -> None:
+        self.images = images
+        super().__init__(
+            "fill_image_polygon",
+            "Fill a polygon of at least three ordered pixel coordinates with magenta and return a new image.",
+            ImagePolygonFillRequest,
+            ImagePolygonFillResult,
+            self._fill,
+        )
+
+    async def _fill(self, request: ImagePolygonFillRequest) -> ImagePolygonFillResult:
+        source = self.images.resolve(request.image)
+        output = await asyncio.to_thread(
+            fill_polygon_magenta,
+            source,
+            request.coordinates,
+        )
+        return ImagePolygonFillResult(image=self.images.put(output))
+
+
+__all__ = [
+    "ImagePoint",
+    "ImagePolygonFillRequest",
+    "ImagePolygonFillResult",
+    "ImagePolygonFillTool",
+    "fill_polygon_magenta",
+]

--- a/docs/source/components/agent-sdk.md
+++ b/docs/source/components/agent-sdk.md
@@ -75,7 +75,8 @@ do not contain raw pixels. Install `xr-ai-tools[image-editing]` to use
 `ImagePolygonFillTool`, which copies an image, fills the area enclosed by at
 least three ordered pixel coordinates with magenta, and returns a new lossless
 PNG reference. The source reference remains unchanged, and the edited reference
-can be passed directly to the single-image or multi-image VLM query tools.
+inherits its owner so lifecycle cleanup releases both images. It can be passed
+directly to the single-image or multi-image VLM query tools.
 
 Relay records publications, subscriber callbacks, tool calls, and model calls
 as nested scopes. `Topic.telemetry` controls event volume without changing

--- a/docs/source/components/agent-sdk.md
+++ b/docs/source/components/agent-sdk.md
@@ -76,7 +76,8 @@ do not contain raw pixels. Install `xr-ai-tools[image-editing]` to use
 least three ordered pixel coordinates with magenta, and returns a new lossless
 PNG reference. The source reference remains unchanged, and the edited reference
 inherits its owner so lifecycle cleanup releases both images. It can be passed
-directly to the single-image or multi-image VLM query tools.
+directly to the single-image or multi-image VLM query tools. Invalid polygons
+and unavailable source references return recoverable unavailable results.
 
 Relay records publications, subscriber callbacks, tool calls, and model calls
 as nested scopes. `Topic.telemetry` controls event volume without changing

--- a/docs/source/components/agent-sdk.md
+++ b/docs/source/components/agent-sdk.md
@@ -70,6 +70,13 @@ Agents protect shared mutable state with their own lock or queue. They also
 create, cancel, and await their own tasks. `publish()` waits for all deliveries
 and then propagates subscriber failures.
 
+Image tools share bounded `ImageRegistry` references so model-visible results
+do not contain raw pixels. Install `xr-ai-tools[image-editing]` to use
+`ImagePolygonFillTool`, which copies an image, fills the area enclosed by at
+least three ordered pixel coordinates with magenta, and returns a new lossless
+PNG reference. The source reference remains unchanged, and the edited reference
+can be passed directly to the single-image or multi-image VLM query tools.
+
 Relay records publications, subscriber callbacks, tool calls, and model calls
 as nested scopes. `Topic.telemetry` controls event volume without changing
 delivery: use `"full"` for semantic events and `"none"` for high-volume

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "xr-ai-agent-runtime",
     "xr-ai-hub-client",
     "xr-ai-models",
-    "xr-ai-tools[frames,qr-code,services,vision]",
+    "xr-ai-tools[frames,image-editing,qr-code,services,vision]",
     "xr-ai-voice",
     "xr-media-hub",
     "xr-ai-launcher",

--- a/tests/test_image_polygon_tool.py
+++ b/tests/test_image_polygon_tool.py
@@ -4,6 +4,7 @@
 """Pixel-accurate coverage for the magenta polygon-fill image tool."""
 
 import io
+import json
 
 import pytest
 from PIL import Image
@@ -131,3 +132,55 @@ async def test_image_polygon_fill_tool_returns_a_new_registry_image() -> None:
         images.resolve(source)
     with pytest.raises(LookupError, match="unavailable"):
         images.resolve(result.image)
+
+
+async def test_image_polygon_fill_invoke_returns_unavailable_for_a_stale_image() -> None:
+    images = ImageRegistry(capacity=1)
+    stale = images.put(_png_bytes())
+    images.put(_png_bytes())
+    tool = ImagePolygonFillTool(images=images)
+
+    invocation = await tool.invoke(
+        json.dumps(
+            {
+                "image": stale.model_dump(),
+                "coordinates": [
+                    {"x": 1, "y": 1},
+                    {"x": 6, "y": 1},
+                    {"x": 3, "y": 6},
+                ],
+            }
+        )
+    )
+
+    assert json.loads(invocation.content) == {
+        "image": None,
+        "available": False,
+        "message": "Image input unavailable — please select it again.",
+    }
+
+
+async def test_image_polygon_fill_invoke_returns_invalid_for_out_of_bounds_polygon() -> None:
+    images = ImageRegistry()
+    source = images.put(_png_bytes())
+    tool = ImagePolygonFillTool(images=images)
+
+    invocation = await tool.invoke(
+        json.dumps(
+            {
+                "image": source.model_dump(),
+                "coordinates": [
+                    {"x": 1, "y": 1},
+                    {"x": 8, "y": 1},
+                    {"x": 3, "y": 6},
+                ],
+            }
+        )
+    )
+
+    result = json.loads(invocation.content)
+    assert result["image"] is None
+    assert result["available"] is False
+    assert result["message"] == (
+        "Image polygon invalid — polygon coordinate (8.0, 1.0) is outside the 8x8 image"
+    )

--- a/tests/test_image_polygon_tool.py
+++ b/tests/test_image_polygon_tool.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pixel-accurate coverage for the magenta polygon-fill image tool."""
+
+import io
+
+import pytest
+from PIL import Image
+from pydantic import ValidationError
+from xr_ai_tools.image import ImageRegistry
+from xr_ai_tools.image_polygon import (
+    ImagePoint,
+    ImagePolygonFillRequest,
+    ImagePolygonFillTool,
+    fill_polygon_magenta,
+)
+
+
+def _png_bytes(*, mode: str = "RGB") -> bytes:
+    color = (10, 20, 30, 120) if mode == "RGBA" else (10, 20, 30)
+    image = Image.new(mode, (8, 8), color)
+    output = io.BytesIO()
+    image.save(output, format="PNG")
+    return output.getvalue()
+
+
+def _read_pixel(image: bytes, coordinate: tuple[int, int]):
+    with Image.open(io.BytesIO(image)) as opened:
+        return opened.getpixel(coordinate)
+
+
+def test_fill_polygon_magenta_preserves_pixels_outside_the_polygon() -> None:
+    source = _png_bytes()
+    output = fill_polygon_magenta(
+        source,
+        [
+            ImagePoint(x=2, y=2),
+            ImagePoint(x=5, y=2),
+            ImagePoint(x=5, y=5),
+            ImagePoint(x=2, y=5),
+        ],
+    )
+
+    assert _read_pixel(output, (3, 3)) == (255, 0, 255)
+    assert _read_pixel(output, (0, 0)) == (10, 20, 30)
+    assert _read_pixel(source, (3, 3)) == (10, 20, 30)
+
+
+def test_fill_polygon_magenta_makes_rgba_fill_opaque() -> None:
+    output = fill_polygon_magenta(
+        _png_bytes(mode="RGBA"),
+        [
+            ImagePoint(x=1, y=1),
+            ImagePoint(x=6, y=1),
+            ImagePoint(x=3, y=6),
+        ],
+    )
+
+    assert _read_pixel(output, (3, 3)) == (255, 0, 255, 255)
+    assert _read_pixel(output, (0, 0)) == (10, 20, 30, 120)
+
+
+def test_fill_polygon_magenta_accepts_fractional_detector_coordinates() -> None:
+    output = fill_polygon_magenta(
+        _png_bytes(),
+        [
+            ImagePoint(x=1.25, y=1.5),
+            ImagePoint(x=6.5, y=1.25),
+            ImagePoint(x=3.75, y=6.5),
+        ],
+    )
+
+    assert _read_pixel(output, (3, 3)) == (255, 0, 255)
+
+
+@pytest.mark.parametrize(
+    "coordinates",
+    [
+        [ImagePoint(x=0, y=0), ImagePoint(x=1, y=1)],
+        [ImagePoint(x=0, y=0), ImagePoint(x=1, y=1), ImagePoint(x=2, y=2)],
+        [ImagePoint(x=0, y=0), ImagePoint(x=7, y=0), ImagePoint(x=8, y=7)],
+    ],
+)
+def test_polygon_validation_rejects_invalid_coordinates(coordinates) -> None:
+    if len(coordinates) < 3:
+        with pytest.raises(ValidationError, match="at least 3"):
+            ImagePolygonFillRequest(
+                image={"uri": "xr-image://source"},
+                coordinates=coordinates,
+            )
+        return
+
+    with pytest.raises(ValueError, match="non-zero area|outside"):
+        fill_polygon_magenta(_png_bytes(), coordinates)
+
+
+def test_image_point_rejects_negative_or_extra_values() -> None:
+    with pytest.raises(ValidationError):
+        ImagePoint(x=-1, y=0)
+    with pytest.raises(ValidationError):
+        ImagePoint(x=1, y=2, z=3)
+
+
+async def test_image_polygon_fill_tool_returns_a_new_registry_image() -> None:
+    images = ImageRegistry()
+    source_bytes = _png_bytes()
+    source = images.put(source_bytes)
+    tool = ImagePolygonFillTool(images=images)
+
+    result = await tool.execute(
+        ImagePolygonFillRequest(
+            image=source,
+            coordinates=[
+                ImagePoint(x=1, y=1),
+                ImagePoint(x=6, y=1),
+                ImagePoint(x=6, y=6),
+                ImagePoint(x=1, y=6),
+            ],
+        )
+    )
+
+    assert result.image != source
+    edited = images.resolve(result.image)
+    assert isinstance(edited, bytes)
+    assert _read_pixel(edited, (4, 4)) == (255, 0, 255)
+    assert images.resolve(source) == source_bytes

--- a/tests/test_image_polygon_tool.py
+++ b/tests/test_image_polygon_tool.py
@@ -105,7 +105,7 @@ def test_image_point_rejects_negative_or_extra_values() -> None:
 async def test_image_polygon_fill_tool_returns_a_new_registry_image() -> None:
     images = ImageRegistry()
     source_bytes = _png_bytes()
-    source = images.put(source_bytes)
+    source = images.put(source_bytes, owner="alice")
     tool = ImagePolygonFillTool(images=images)
 
     result = await tool.execute(
@@ -125,3 +125,9 @@ async def test_image_polygon_fill_tool_returns_a_new_registry_image() -> None:
     assert isinstance(edited, bytes)
     assert _read_pixel(edited, (4, 4)) == (255, 0, 255)
     assert images.resolve(source) == source_bytes
+
+    images.release_owner("alice")
+    with pytest.raises(LookupError, match="unavailable"):
+        images.resolve(source)
+    with pytest.raises(LookupError, match="unavailable"):
+        images.resolve(result.image)


### PR DESCRIPTION
## Summary

- add a Relay-managed `ImagePolygonFillTool` that consumes an `ImageReference` and at least three ordered pixel coordinates
- fill the enclosed polygon with exact magenta (`#FF00FF`) and return a new lossless PNG reference without changing the source
- validate fractional coordinates, image bounds, and non-zero polygon area
- document the `image-editing` optional dependency and add pixel-accurate RGB/RGBA tests

## Testing

- `uv run pytest -q -m "not gpu"` — 795 passed, 10 deselected
- `uv run --with ruff ruff check .` — passed
- `git diff --check` — passed
