### PR TITLE
fix(hub): make LiveKit NAT discovery configurable

### DIFF
--- a/agent-samples/simple-vlm-example/yaml/xr_media_hub.yaml
+++ b/agent-samples/simple-vlm-example/yaml/xr_media_hub.yaml
@@ -14,6 +14,11 @@ lk_port_ws:  7880
 lk_port_tcp: 7881
 lk_port_udp: 7882
 
+# Cloud VMs behind NAT may need STUN-based public-IP discovery. Also skip
+# validation when the NAT does not support LiveKit's public-IP self-ping.
+# lk_use_external_ip: true
+# lk_skip_external_ip_validation: true
+
 # ── Web client server ─────────────────────────────────────────────────────────
 enable_web_server: true
 web_server_port:   8080

--- a/agent-samples/xr-render-demo/yaml/xr_media_hub.yaml
+++ b/agent-samples/xr-render-demo/yaml/xr_media_hub.yaml
@@ -14,6 +14,11 @@ lk_port_ws:  7880
 lk_port_tcp: 7881
 lk_port_udp: 7882
 
+# Cloud VMs behind NAT may need STUN-based public-IP discovery. Also skip
+# validation when the NAT does not support LiveKit's public-IP self-ping.
+# lk_use_external_ip: true
+# lk_skip_external_ip_validation: true
+
 # ── Web client server ─────────────────────────────────────────────────────────
 # The page serves both stacks: LiveKit (agent audio/data over the WSS proxy on
 # this port) AND CloudXR (one-tap Launch XR → WebXR over wss://<host>:48322).

--- a/docs/source/getting_started/networking.md
+++ b/docs/source/getting_started/networking.md
@@ -30,6 +30,30 @@ sudo ufw reload
 mobile clients reach LiveKit through the same-origin `wss://<host>:8080/rtc`
 proxy, not directly.
 
+## Cloud VMs behind NAT
+
+The signaling proxy on port 8080 does not proxy WebRTC media. LiveKit still
+needs to advertise an ICE address that clients can reach on ports 7881 and
+7882. On a cloud VM whose network interface has only a private address, enable
+STUN-based public-IP discovery in the sample's `xr_media_hub.yaml`:
+
+```yaml
+lk_use_external_ip: true
+```
+
+LiveKit validates the discovered address with a self-ping before advertising
+it. If the provider's NAT does not support that hairpin path, also skip the
+validation:
+
+```yaml
+lk_use_external_ip: true
+lk_skip_external_ip_validation: true
+```
+
+Skipping validation does not make a closed port reachable. Ensure the VM's
+cloud firewall and host firewall allow 7881/TCP and 7882/UDP. Keep both options
+disabled for local and private-network deployments.
+
 ## RHEL, Fedora, or CentOS (`firewall-cmd`)
 
 ```bash

--- a/services/xr-media-hub/xr_media_hub.yaml
+++ b/services/xr-media-hub/xr_media_hub.yaml
@@ -20,6 +20,13 @@ lk_port_ws:  7880   # WebSocket signaling
 lk_port_tcp: 7881   # WebRTC TCP fallback
 lk_port_udp: 7882   # WebRTC UDP media
 
+# Cloud VMs commonly have a private interface behind a public NAT. Enable
+# STUN-based public-IP discovery so LiveKit advertises a reachable ICE address.
+lk_use_external_ip: false
+# Enable only when the cloud NAT does not support LiveKit's public-IP self-ping
+# validation. Requires lk_use_external_ip: true.
+lk_skip_external_ip_validation: false
+
 # ── Web client server ─────────────────────────────────────────────────────────
 enable_web_server: true
 web_server_host:   "0.0.0.0"

--- a/services/xr-media-hub/xr_media_hub/transport/livekit/_docker.py
+++ b/services/xr-media-hub/xr_media_hub/transport/livekit/_docker.py
@@ -44,7 +44,8 @@ port: {lk_port_ws}
 rtc:
   tcp_port: {lk_port_tcp}
   udp_port: {lk_port_udp}
-  use_external_ip: false
+  use_external_ip: {lk_use_external_ip}
+  skip_external_ip_validation: {lk_skip_external_ip_validation}
 keys:
   {api_key}: {api_secret}
 logging:
@@ -62,6 +63,20 @@ _BANNER = "━" * 56
 _CONTAINER_NAME = "xr-ai-livekit-server"
 
 
+def _render_livekit_config(cfg: LiveKitConnectorConfig) -> str:
+    return _LIVEKIT_YAML.format(
+        lk_port_ws=cfg.lk_port_ws,
+        lk_port_tcp=cfg.lk_port_tcp,
+        lk_port_udp=cfg.lk_port_udp,
+        lk_use_external_ip=str(cfg.lk_use_external_ip).lower(),
+        lk_skip_external_ip_validation=str(
+            cfg.lk_skip_external_ip_validation
+        ).lower(),
+        api_key=cfg.api_key,
+        api_secret=cfg.api_secret,
+    )
+
+
 class LiveKitDocker:
     def __init__(self, cfg: LiveKitConnectorConfig) -> None:
         self._cfg    = cfg
@@ -74,13 +89,7 @@ class LiveKitDocker:
     async def start(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory(prefix="xr_livekit_")
         cfg_path = Path(self._tmpdir.name) / "livekit.yaml"
-        cfg_path.write_text(_LIVEKIT_YAML.format(
-            lk_port_ws  = self._cfg.lk_port_ws,
-            lk_port_tcp = self._cfg.lk_port_tcp,
-            lk_port_udp = self._cfg.lk_port_udp,
-            api_key     = self._cfg.api_key,
-            api_secret  = self._cfg.api_secret,
-        ))
+        cfg_path.write_text(_render_livekit_config(self._cfg))
 
         # Remove any stale container from a previous crashed run.
         subprocess.run(

--- a/services/xr-media-hub/xr_media_hub/transport/livekit/_docker.py
+++ b/services/xr-media-hub/xr_media_hub/transport/livekit/_docker.py
@@ -77,6 +77,12 @@ def _render_livekit_config(cfg: LiveKitConnectorConfig) -> str:
     )
 
 
+def _write_livekit_config(path: Path, cfg: LiveKitConnectorConfig) -> None:
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as cfg_file:
+        cfg_file.write(_render_livekit_config(cfg))
+
+
 class LiveKitDocker:
     def __init__(self, cfg: LiveKitConnectorConfig) -> None:
         self._cfg    = cfg
@@ -89,7 +95,7 @@ class LiveKitDocker:
     async def start(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory(prefix="xr_livekit_")
         cfg_path = Path(self._tmpdir.name) / "livekit.yaml"
-        cfg_path.write_text(_render_livekit_config(self._cfg))
+        _write_livekit_config(cfg_path, self._cfg)
 
         # Remove any stale container from a previous crashed run.
         subprocess.run(

--- a/services/xr-media-hub/xr_media_hub/transport/livekit/config.py
+++ b/services/xr-media-hub/xr_media_hub/transport/livekit/config.py
@@ -20,6 +20,12 @@ class LiveKitConnectorConfig:
     lk_port_tcp: int = 7881   # WebRTC TCP
     lk_port_udp: int = 7882   # WebRTC UDP
 
+    # Discover and advertise the host's public IP for clients outside a NAT.
+    lk_use_external_ip: bool = False
+    # Some cloud NATs do not support the self-ping LiveKit uses to validate the
+    # discovered IP. This setting has an effect only with external IP enabled.
+    lk_skip_external_ip_validation: bool = False
+
     # ── Internal URL for the Python room client (direct WS, no proxy) ─────────
     lk_internal_url: str = "ws://127.0.0.1:7880"
 

--- a/tests/test_livekit_docker_config.py
+++ b/tests/test_livekit_docker_config.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the generated LiveKit server configuration."""
+from __future__ import annotations
+
+import yaml
+from xr_media_hub.transport.livekit._docker import _render_livekit_config
+from xr_media_hub.transport.livekit.config import LiveKitConnectorConfig
+
+
+def _render_config(cfg: LiveKitConnectorConfig) -> dict:
+    return yaml.safe_load(_render_livekit_config(cfg))
+
+
+def test_livekit_nat_options_are_disabled_by_default() -> None:
+    rtc = _render_config(LiveKitConnectorConfig())["rtc"]
+
+    assert rtc["use_external_ip"] is False
+    assert rtc["skip_external_ip_validation"] is False
+
+
+def test_livekit_nat_options_can_be_enabled() -> None:
+    cfg = LiveKitConnectorConfig(
+        lk_use_external_ip=True,
+        lk_skip_external_ip_validation=True,
+    )
+    rtc = _render_config(cfg)["rtc"]
+
+    assert rtc["use_external_ip"] is True
+    assert rtc["skip_external_ip_validation"] is True

--- a/tests/test_livekit_docker_config.py
+++ b/tests/test_livekit_docker_config.py
@@ -4,8 +4,14 @@
 """Unit tests for the generated LiveKit server configuration."""
 from __future__ import annotations
 
+import stat
+from pathlib import Path
+
 import yaml
-from xr_media_hub.transport.livekit._docker import _render_livekit_config
+from xr_media_hub.transport.livekit._docker import (
+    _render_livekit_config,
+    _write_livekit_config,
+)
 from xr_media_hub.transport.livekit.config import LiveKitConnectorConfig
 
 
@@ -29,3 +35,11 @@ def test_livekit_nat_options_can_be_enabled() -> None:
 
     assert rtc["use_external_ip"] is True
     assert rtc["skip_external_ip_validation"] is True
+
+
+def test_livekit_config_file_is_owner_only(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "livekit.yaml"
+
+    _write_livekit_config(cfg_path, LiveKitConnectorConfig())
+
+    assert stat.S_IMODE(cfg_path.stat().st_mode) == 0o600


### PR DESCRIPTION
## Motivation

XR-Media-Hub hard-codes LiveKit external IP discovery to false. On cloud VMs whose network interface is behind public NAT, LiveKit can therefore advertise an unreachable private ICE candidate even though signaling through the hub succeeds.

Users currently have to patch the generated LiveKit configuration before running an example.

## Changes

- Add lk_use_external_ip to enable STUN-based public-IP discovery.
- Add lk_skip_external_ip_validation for NATs that do not support LiveKit public-IP self-ping.
- Render both options into the generated LiveKit configuration while preserving existing defaults.
- Add provider-neutral configuration guidance to both agent samples and the networking documentation.
- Add unit coverage for default and enabled NAT configurations.

## Validation

- Ruff passes for all changed Python files.
- Targeted pytest coverage passes: 3 passed.
- SPDX header validation passes.
- git diff --check passes.