### PR TITLE
fix(web): preserve camera field of view

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
       - name: Install uv
         uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
         with:

--- a/client-samples/web/App/app.js
+++ b/client-samples/web/App/app.js
@@ -45,16 +45,37 @@ const model = {
 // from the "Received" list.
 const AGENT_REPLY_TOPICS = new Set(['agent.response', 'vlm.response']);
 
-// Local camera preview stream (separate from the LiveKit publish stream).
-let _previewStream = null;
-
-function releasePreviewStream() {
-  if (!_previewStream) return;
-  _previewStream.getTracks().forEach(t => t.stop());
-  _previewStream = null;
+function clearCameraPreview() {
   const videoEl = $('camera-preview');
+  videoEl.onresize = null;
   videoEl.srcObject = null;
   videoEl.style.transform = '';
+  videoEl.closest('.preview-card').style.aspectRatio = '';
+}
+
+function showPublishedCameraPreview() {
+  clearCameraPreview();
+  const track = model.session?.cameraTrack;
+  if (!track) return;
+
+  const videoEl = $('camera-preview');
+  const previewCard = videoEl.closest('.preview-card');
+  videoEl.srcObject = new MediaStream([track]);
+
+  const updateAspectRatio = () => {
+    const settings = track.getSettings();
+    const width = videoEl.videoWidth || settings.width;
+    const height = videoEl.videoHeight || settings.height;
+    if (width && height) {
+      previewCard.style.aspectRatio = `${width} / ${height}`;
+    }
+  };
+  videoEl.onresize = updateAspectRatio;
+  updateAspectRatio();
+
+  const facingMode = track.getSettings().facingMode ?? '';
+  videoEl.style.transform = facingMode === 'user' ? 'scaleX(-1)' : '';
+  console.info('Camera preview uses published track settings', track.getSettings());
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -113,36 +134,14 @@ async function stopCamera() {
   try {
     await _stopCamera(model, render, showError);
   } finally {
-    releasePreviewStream();
+    clearCameraPreview();
   }
 }
 
 async function startCamera() {
   await _startCamera(model, { render, showError, enumerateCameras });
   if (model.isCameraActive) {
-    try {
-      releasePreviewStream();
-      // No facingMode default — let the browser pick the same camera LiveKit
-      // picks (both calls use `{video: true}` when no deviceId is selected,
-      // so they converge on the system default). When the user has explicitly
-      // chosen a camera in the dropdown, both pin to that deviceId.
-      const constraints = model.selectedCameraId
-        ? { video: { deviceId: { exact: model.selectedCameraId } } }
-        : { video: true };
-      _previewStream = await navigator.mediaDevices.getUserMedia(constraints);
-      const videoEl = $('camera-preview');
-      videoEl.srcObject = _previewStream;
-
-      // Default: do NOT mirror — XR / glasses / mobile-back-camera capture
-      // should preserve real-world orientation (left = left, right = right).
-      // Only flip when the camera is explicitly user-facing (front mobile cam,
-      // `facingMode === 'user'`). Desktop selfie webcams typically report no
-      // facingMode and stay unmirrored; users who want the FaceTime-style
-      // mirror UX on a desktop webcam can add a manual toggle later.
-      const track = _previewStream.getVideoTracks()[0];
-      const facingMode = track?.getSettings?.()?.facingMode ?? '';
-      videoEl.style.transform = facingMode === 'user' ? 'scaleX(-1)' : '';
-    } catch { /* preview failure is non-fatal */ }
+    showPublishedCameraPreview();
   }
   render();
 }
@@ -150,11 +149,11 @@ async function startCamera() {
 function startAudio()       { return _startAudio(model, render, showError); }
 function stopAudio()        { return _stopAudio(model, render, showError); }
 async function disconnect() {
-  releasePreviewStream();
+  clearCameraPreview();
   try {
     await _disconnect(model, render);
   } finally {
-    releasePreviewStream();
+    clearCameraPreview();
     render();
   }
 }
@@ -180,7 +179,7 @@ function connect()          {
 
 wireBaseEvents(model, { connect, disconnect, startAudio, stopAudio, startCamera, stopCamera, sendPing, sendCustom });
 window.addEventListener('pagehide', () => {
-  releasePreviewStream();
+  clearCameraPreview();
   const pendingDisconnect = model.session?.disconnect();
   if (pendingDisconnect) pendingDisconnect.catch(() => {});
 });

--- a/client-samples/web/StreamKit/Backends/LiveKit/LiveKitBackend.js
+++ b/client-samples/web/StreamKit/Backends/LiveKit/LiveKitBackend.js
@@ -18,7 +18,6 @@ import {
   Room,
   RoomEvent,
   Track,
-  createLocalVideoTrack,
   createLocalAudioTrack,
 } from 'livekit-client';
 
@@ -123,6 +122,15 @@ export class LiveKitBackend {
    */
   constructor(config) {
     this.#config = config;
+  }
+
+  /**
+   * The browser camera track currently published to LiveKit.
+   *
+   * @returns {MediaStreamTrack | null}
+   */
+  get cameraTrack() {
+    return this.#videoTrack?.mediaStreamTrack ?? null;
   }
 
   // ── Public API ──────────────────────────────────────────────────────────────
@@ -323,15 +331,32 @@ export class LiveKitBackend {
     const facingMode = config?.facing   ?? 'user';
 
     const constraints = deviceId
-      ? { deviceId: { exact: deviceId } }
-      : { facingMode };
+      ? { deviceId: { exact: deviceId }, resizeMode: 'none' }
+      : { facingMode, resizeMode: 'none' };
 
-    const track = await createLocalVideoTrack(constraints);
-    this.#videoTrack = track;
-
-    await this.#room.localParticipant.publishTrack(track, {
-      source: Track.Source.Camera,
+    // LiveKit's convenience capture adds a 16:9 h720 constraint, which can make
+    // mobile browsers crop the sensor before the frame reaches WebRTC.
+    const mediaStream = await navigator.mediaDevices.getUserMedia({
+      audio: false,
+      video: constraints,
     });
+    const mediaTrack = mediaStream.getVideoTracks()[0];
+    if (!mediaTrack) {
+      throw new Error('Camera capture returned no video track');
+    }
+
+    try {
+      const publication = await this.#room.localParticipant.publishTrack(mediaTrack, {
+        source: Track.Source.Camera,
+      });
+      const track = publication.videoTrack;
+      if (!track) throw new Error('LiveKit did not publish the camera track');
+      this.#videoTrack = track;
+      console.info('LiveKitBackend: published camera settings', mediaTrack.getSettings());
+    } catch (error) {
+      mediaTrack.stop();
+      throw error;
+    }
   }
 
   /**

--- a/client-samples/web/StreamKit/Backends/StreamingBackend.js
+++ b/client-samples/web/StreamKit/Backends/StreamingBackend.js
@@ -96,6 +96,13 @@
  */
 
 /**
+ * Browser camera track currently published by this backend, when available.
+ *
+ * @name StreamingBackend#cameraTrack
+ * @type {MediaStreamTrack | null}
+ */
+
+/**
  * Establish a connection using the provided session configuration.
  *
  * Network endpoint details (host, port, token) are supplied at construction

--- a/client-samples/web/StreamKit/Config/CameraConfig.js
+++ b/client-samples/web/StreamKit/Config/CameraConfig.js
@@ -34,9 +34,9 @@ export const CameraFacing = Object.freeze({
 /**
  * Configures camera capture for a {@link StreamSession}.
  *
- * Resolution and frame-rate are intentionally not exposed here: the LiveKit
- * JS SDK and the browser negotiate the best supported format automatically,
- * matching the behaviour of the Swift SDK on iOS and visionOS.
+ * Resolution and frame-rate are intentionally not exposed here: the browser
+ * selects a supported native format without forcing an aspect ratio, matching
+ * the behaviour of the Swift SDK on iOS and visionOS.
  *
  * ## Presets
  * ```js

--- a/client-samples/web/StreamKit/StreamSession.js
+++ b/client-samples/web/StreamKit/StreamSession.js
@@ -125,6 +125,15 @@ export class StreamSession {
     return this.#connectionState;
   }
 
+  /**
+   * The browser track currently published as the local camera source.
+   *
+   * @returns {MediaStreamTrack | null}
+   */
+  get cameraTrack() {
+    return this.#backend.cameraTrack ?? null;
+  }
+
   // ── Public API ──────────────────────────────────────────────────────────────
 
   /**

--- a/client-samples/web/index.html
+++ b/client-samples/web/index.html
@@ -326,7 +326,7 @@
     #camera-preview {
       width: 100%;
       height: 100%;
-      object-fit: cover;
+      object-fit: contain;
       display: none;
       /* Mirroring applied dynamically in app.js based on facingMode */
     }

--- a/docs/source/getting_started/clients.md
+++ b/docs/source/getting_started/clients.md
@@ -88,6 +88,10 @@ To connect:
    directly.
 4. Click **Connect**. You are now live in the XR session.
 
+The camera preview displays the same browser track published to the hub and
+adapts to its captured aspect ratio. The browser console logs the published
+track settings when the camera starts.
+
 ## Web-XR (XR render demo)
 
 The XR render demo client lives in `client-samples/web-xr/`. Unlike the basic

--- a/tests/README.md
+++ b/tests/README.md
@@ -28,6 +28,10 @@ Multi-client / multi-agent coverage for the XR-Media-Hub IPC pipeline.
 The IPC suite runs without Docker or LiveKit — it speaks ZMQ over
 `ipc://` only.
 
+Install Node.js 24 before running the test suite. The browser camera behavior
+tests use Node's built-in test runner, and CI pins this version for reproducible
+results.
+
 ```bash
 cd xr-ai/tests
 uv sync

--- a/tests/javascript/web_camera_capture.test.mjs
+++ b/tests/javascript/web_camera_capture.test.mjs
@@ -1,0 +1,204 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import { register } from 'node:module';
+import test from 'node:test';
+
+register('./web_camera_test_loader.mjs', import.meta.url);
+
+const { LiveKitBackend } = await import(
+  '../../client-samples/web/StreamKit/Backends/LiveKit/LiveKitBackend.js'
+);
+
+function makeMediaTrack(settings = {}) {
+  return {
+    stopCount: 0,
+    getSettings: () => ({ width: 1280, height: 720, facingMode: 'environment', ...settings }),
+    stop() {
+      this.stopCount += 1;
+    },
+  };
+}
+
+function makePublishedTrack(mediaTrack) {
+  return {
+    mediaStreamTrack: mediaTrack,
+    stopCount: 0,
+    stop() {
+      this.stopCount += 1;
+      mediaTrack.stop();
+    },
+  };
+}
+
+function makeRoom(publishTrack) {
+  return {
+    state: 'disconnected',
+    remoteParticipants: new Map(),
+    unpublishedTracks: [],
+    localParticipant: {
+      publishTrack,
+      publishData: async () => {},
+      unpublishTrack: async track => {
+        globalThis.__livekitRoom.unpublishedTracks.push(track);
+      },
+    },
+    on() {
+      return this;
+    },
+    removeAllListeners() {},
+    async connect() {
+      this.state = 'connected';
+    },
+    async disconnect() {
+      this.state = 'disconnected';
+    },
+  };
+}
+
+async function connectedBackend(publishTrack) {
+  const room = makeRoom(publishTrack);
+  globalThis.__livekitRoom = room;
+  const backend = new LiveKitBackend({
+    host: 'localhost',
+    port: 7880,
+    secure: false,
+    token: 'test-token',
+    tokenURL: null,
+    hubIdentity: null,
+  });
+  await backend.connect({ identity: 'browser-test' });
+  return { backend, room };
+}
+
+function installMediaDevices(getUserMedia) {
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: { mediaDevices: { getUserMedia } },
+  });
+}
+
+class FakeClassList {
+  values = new Set();
+
+  add(value) {
+    this.values.add(value);
+  }
+
+  remove(value) {
+    this.values.delete(value);
+  }
+}
+
+function installAppBrowser(model) {
+  const previewCard = { style: {} };
+  const video = {
+    classList: new FakeClassList(),
+    closest: () => previewCard,
+    onresize: null,
+    srcObject: null,
+    style: {},
+    videoHeight: 0,
+    videoWidth: 0,
+  };
+  const element = () => ({
+    classList: new FakeClassList(),
+    style: {},
+    textContent: '',
+  });
+  globalThis.__elements = new Map([
+    ['camera-preview', video],
+    ['preview-placeholder', element()],
+    ['preview-live-badge', element()],
+    ['agent-response-text', element()],
+    ['error-toast', element()],
+  ]);
+  globalThis.__appBaseModel = model;
+  globalThis.window = {
+    addEventListener: () => {},
+  };
+  globalThis.MediaStream = class {
+    constructor(tracks) {
+      this.tracks = tracks;
+    }
+
+    getVideoTracks() {
+      return this.tracks;
+    }
+  };
+  return { previewCard, video };
+}
+
+test('publishes and previews the captured full-frame camera track', async () => {
+  const capturedTracks = [makeMediaTrack(), makeMediaTrack()];
+  let currentTrack = capturedTracks[0];
+  const captureConstraints = [];
+  const publishedTracks = [];
+  const publishedWrappers = [];
+  installMediaDevices(async constraints => {
+    captureConstraints.push(constraints);
+    return { getVideoTracks: () => [currentTrack] };
+  });
+
+  const { backend, room } = await connectedBackend(async mediaTrack => {
+    publishedTracks.push(mediaTrack);
+    const wrapper = makePublishedTrack(mediaTrack);
+    publishedWrappers.push(wrapper);
+    return { videoTrack: wrapper };
+  });
+  const model = {
+    agentResponse: null,
+    isCameraActive: false,
+    selectedCameraId: 'camera-7',
+    session: backend,
+  };
+  const { previewCard, video } = installAppBrowser(model);
+  await import(`../../client-samples/web/App/app.js?test=${Date.now()}`);
+
+  await globalThis.__appActions.startCamera();
+
+  assert.deepEqual(captureConstraints[0], {
+    audio: false,
+    video: { deviceId: { exact: 'camera-7' }, resizeMode: 'none' },
+  });
+  assert.equal(publishedTracks[0], capturedTracks[0]);
+  assert.equal(backend.cameraTrack, capturedTracks[0]);
+  assert.equal(video.srcObject.getVideoTracks()[0], capturedTracks[0]);
+  assert.equal(previewCard.style.aspectRatio, '1280 / 720');
+
+  await globalThis.__appActions.stopCamera();
+
+  assert.equal(capturedTracks[0].stopCount, 1);
+  assert.equal(publishedWrappers[0].stopCount, 1);
+  assert.equal(room.unpublishedTracks[0], publishedWrappers[0]);
+  assert.equal(video.srcObject, null);
+  assert.equal(video.onresize, null);
+  assert.equal(previewCard.style.aspectRatio, '');
+
+  currentTrack = capturedTracks[1];
+  await globalThis.__appActions.startCamera();
+  assert.equal(video.srcObject.getVideoTracks()[0], capturedTracks[1]);
+
+  await globalThis.__appActions.disconnect();
+
+  assert.equal(capturedTracks[1].stopCount, 1);
+  assert.equal(publishedWrappers[1].stopCount, 1);
+  assert.equal(video.srcObject, null);
+  assert.equal(video.onresize, null);
+  assert.equal(previewCard.style.aspectRatio, '');
+});
+
+test('stops the captured camera track when LiveKit publication fails', async () => {
+  const mediaTrack = makeMediaTrack();
+  installMediaDevices(async () => ({ getVideoTracks: () => [mediaTrack] }));
+  const failure = new Error('publication failed');
+  const { backend } = await connectedBackend(async () => {
+    throw failure;
+  });
+
+  await assert.rejects(backend.startCamera({ facing: 'environment' }), failure);
+
+  assert.equal(mediaTrack.stopCount, 1);
+  assert.equal(backend.cameraTrack, null);
+});

--- a/tests/javascript/web_camera_test_loader.mjs
+++ b/tests/javascript/web_camera_test_loader.mjs
@@ -3,6 +3,11 @@
 
 const LIVEKIT_URL = 'mock:livekit-client';
 const APP_CORE_URL = 'mock:app-core';
+const WEB_CLIENT_ROOT = new URL('../../client-samples/web/', import.meta.url).href;
+
+function isWebClientJavaScript(url) {
+  return url.startsWith(WEB_CLIENT_ROOT) && new URL(url).pathname.endsWith('.js');
+}
 
 export async function resolve(specifier, context, nextResolve) {
   if (specifier === 'livekit-client') {
@@ -77,6 +82,10 @@ export async function load(url, context, nextLoad) {
         }
       `,
     };
+  }
+
+  if (isWebClientJavaScript(url)) {
+    return nextLoad(url, { ...context, format: 'module' });
   }
 
   return nextLoad(url, context);

--- a/tests/javascript/web_camera_test_loader.mjs
+++ b/tests/javascript/web_camera_test_loader.mjs
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const LIVEKIT_URL = 'mock:livekit-client';
+const APP_CORE_URL = 'mock:app-core';
+
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier === 'livekit-client') {
+    return { url: LIVEKIT_URL, shortCircuit: true };
+  }
+  if (specifier === '/App/core.js') {
+    return { url: APP_CORE_URL, shortCircuit: true };
+  }
+  return nextResolve(specifier, context);
+}
+
+export async function load(url, context, nextLoad) {
+  if (url === LIVEKIT_URL) {
+    return {
+      format: 'module',
+      shortCircuit: true,
+      source: `
+        export class Room {
+          constructor() {
+            if (!globalThis.__livekitRoom) throw new Error('LiveKit room mock is not installed');
+            return globalThis.__livekitRoom;
+          }
+        }
+        export const RoomEvent = Object.freeze({
+          ConnectionStateChanged: 'connectionStateChanged',
+          DataReceived: 'dataReceived',
+          TrackPublished: 'trackPublished',
+          TrackSubscribed: 'trackSubscribed',
+          TrackUnsubscribed: 'trackUnsubscribed',
+        });
+        export const Track = Object.freeze({
+          Kind: Object.freeze({ Audio: 'audio' }),
+          Source: Object.freeze({ Camera: 'camera', Microphone: 'microphone' }),
+        });
+        export async function createLocalAudioTrack() {
+          throw new Error('audio capture is not expected in camera tests');
+        }
+      `,
+    };
+  }
+
+  if (url === APP_CORE_URL) {
+    return {
+      format: 'module',
+      shortCircuit: true,
+      source: `
+        export const $ = id => globalThis.__elements.get(id);
+        export const createBaseModel = () => globalThis.__appBaseModel;
+        export const renderBase = () => {};
+        export const enumerateCameras = async () => {};
+        export const connect = async () => {};
+        export async function disconnect(model) {
+          await model.session?.disconnect();
+          model.session = null;
+          model.isCameraActive = false;
+        }
+        export const startAudio = async () => {};
+        export const stopAudio = async () => {};
+        export async function startCamera(model) {
+          await model.session?.startCamera({ deviceId: model.selectedCameraId });
+          model.isCameraActive = true;
+        }
+        export async function stopCamera(model) {
+          await model.session?.stopCamera();
+          model.isCameraActive = false;
+        }
+        export const sendPing = async () => {};
+        export const sendCustom = async () => {};
+        export function wireBaseEvents(model, actions) {
+          globalThis.__appModel = model;
+          globalThis.__appActions = actions;
+        }
+      `,
+    };
+  }
+
+  return nextLoad(url, context);
+}

--- a/tests/test_web_camera_capture.py
+++ b/tests/test_web_camera_capture.py
@@ -1,36 +1,20 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Contracts for full-frame camera capture in the basic web client."""
+"""Run the browser camera behavior tests with Node's built-in test runner."""
 
+import subprocess
 from pathlib import Path
 
-_ROOT = Path(__file__).resolve().parents[1]
-_BACKEND = _ROOT / "client-samples/web/StreamKit/Backends/LiveKit/LiveKitBackend.js"
-_SESSION = _ROOT / "client-samples/web/StreamKit/StreamSession.js"
-_APP = _ROOT / "client-samples/web/App/app.js"
-_PAGE = _ROOT / "client-samples/web/index.html"
+_TEST = Path(__file__).parent / "javascript/web_camera_capture.test.mjs"
 
 
-def test_camera_capture_does_not_force_livekit_h720_constraints() -> None:
-    backend = _BACKEND.read_text(encoding="utf-8")
+def test_web_camera_capture_behavior() -> None:
+    result = subprocess.run(
+        ["node", "--experimental-default-type=module", str(_TEST)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
 
-    assert "createLocalVideoTrack" not in backend
-    assert "navigator.mediaDevices.getUserMedia" in backend
-    assert "resizeMode: 'none'" in backend
-    assert "publishTrack(mediaTrack" in backend
-
-
-def test_preview_uses_the_published_track_without_cropping() -> None:
-    backend = _BACKEND.read_text(encoding="utf-8")
-    session = _SESSION.read_text(encoding="utf-8")
-    app = _APP.read_text(encoding="utf-8")
-    page = _PAGE.read_text(encoding="utf-8")
-
-    assert "get cameraTrack()" in backend
-    assert "get cameraTrack()" in session
-    assert "model.session?.cameraTrack" in app
-    assert "new MediaStream([track])" in app
-    assert "navigator.mediaDevices.getUserMedia" not in app
-    assert "object-fit: contain" in page
-    assert "object-fit: cover" not in page
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"

--- a/tests/test_web_camera_capture.py
+++ b/tests/test_web_camera_capture.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contracts for full-frame camera capture in the basic web client."""
+
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+_BACKEND = _ROOT / "client-samples/web/StreamKit/Backends/LiveKit/LiveKitBackend.js"
+_SESSION = _ROOT / "client-samples/web/StreamKit/StreamSession.js"
+_APP = _ROOT / "client-samples/web/App/app.js"
+_PAGE = _ROOT / "client-samples/web/index.html"
+
+
+def test_camera_capture_does_not_force_livekit_h720_constraints() -> None:
+    backend = _BACKEND.read_text(encoding="utf-8")
+
+    assert "createLocalVideoTrack" not in backend
+    assert "navigator.mediaDevices.getUserMedia" in backend
+    assert "resizeMode: 'none'" in backend
+    assert "publishTrack(mediaTrack" in backend
+
+
+def test_preview_uses_the_published_track_without_cropping() -> None:
+    backend = _BACKEND.read_text(encoding="utf-8")
+    session = _SESSION.read_text(encoding="utf-8")
+    app = _APP.read_text(encoding="utf-8")
+    page = _PAGE.read_text(encoding="utf-8")
+
+    assert "get cameraTrack()" in backend
+    assert "get cameraTrack()" in session
+    assert "model.session?.cameraTrack" in app
+    assert "new MediaStream([track])" in app
+    assert "navigator.mediaDevices.getUserMedia" not in app
+    assert "object-fit: contain" in page
+    assert "object-fit: cover" not in page

--- a/tests/test_web_camera_capture.py
+++ b/tests/test_web_camera_capture.py
@@ -11,7 +11,7 @@ _TEST = Path(__file__).parent / "javascript/web_camera_capture.test.mjs"
 
 def test_web_camera_capture_behavior() -> None:
     result = subprocess.run(
-        ["node", "--experimental-default-type=module", str(_TEST)],
+        ["node", str(_TEST)],
         check=False,
         capture_output=True,
         text=True,


### PR DESCRIPTION
## Summary

- capture the browser camera directly without LiveKit's implicit 16:9 h720 constraint
- request `resizeMode: none` so mobile browsers preserve the sensor field of view
- preview the exact published camera track with its captured aspect ratio instead of opening a second stream
- replace source-string assertions with focused JavaScript behavior tests using mocked browser capture and LiveKit publication
- load the web client test modules as ESM without Node's removed experimental flag, pin CI to Node.js 24, and document the local Node prerequisite

## Root cause

LiveKit's browser convenience capture path applied a 16:9 h720 constraint. On portrait mobile cameras this could crop the sensor before frames entered WebRTC. The page then opened a separate preview stream and rendered it with `object-fit: cover`, so the preview could differ from—and further crop—the stream received by the server.

## Impact

Mobile and glasses-style browser clients preserve the camera's native aspect ratio and field of view. The preview now represents the same track published to the XR hub.

## Validation

- focused JavaScript behavior tests verify `resizeMode: 'none'`, track identity through capture/publication/preview, and track cleanup on publication failure, camera stop, and disconnect
- JavaScript behavior tests pass with Node.js 24 and Node.js 25.6.1 without `--experimental-default-type=module`
- `pytest -q tests/test_web_camera_capture.py` — 1 passed (runs 2 Node behavior cases)
- `pytest -q -m "not gpu"` — 822 passed, 10 deselected
- `node --check` on all added JavaScript modules
- repository-wide Ruff, SPDX, and `git diff --check`
