### PR TITLE
fix(simple-vlm): defer voice endpoint access

### DIFF
--- a/agent-samples/simple-vlm-example/worker/simple_vlm_example_worker/app.py
+++ b/agent-samples/simple-vlm-example/worker/simple_vlm_example_worker/app.py
@@ -110,7 +110,10 @@ async def run_app(
                     system_prompt=config.system_prompt,
                 ),
             ),
-            session.endpoint.set_status,
+            lambda status, participant_id: session.endpoint.set_status(
+                status,
+                participant_id,
+            ),
         ),
     )
 

--- a/tests/test_simple_vlm_example_worker.py
+++ b/tests/test_simple_vlm_example_worker.py
@@ -21,6 +21,7 @@ from xr_ai_hub import FrameData, FrameSignal, FrameUnavailable, PixelFormat, Pro
 from xr_ai_models import ChatResponse, VLMService
 from xr_ai_runtime import AgentRuntime
 from xr_ai_voice import UserQuery, VoiceAgent, VoiceInterrupted, VoiceOutput, VoiceSession
+from xr_ai_voice import _session as session_module
 from xr_ai_voicegate import VoiceGateConfig
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -506,9 +507,10 @@ async def test_app_wires_text_voice_cleanup_readiness_and_shutdown(
     monkeypatch.setattr(app, "make_tts", lambda _models, _name: tts)
     monkeypatch.setattr(app, "CurrentFrameTool", _CurrentFrameTool)
     monkeypatch.setattr(app, "StreamingImageQueryTool", _StreamingImageQueryTool)
+    monkeypatch.setattr(session_module, "HubVoiceTransport", lambda: transport)
 
     def make_session(**kwargs):
-        session = VoiceSession(transport=transport, **kwargs)  # type: ignore[arg-type]
+        session = VoiceSession(**kwargs)  # type: ignore[arg-type]
         sessions.append(session)
 
         async def run(handler, **options) -> None:


### PR DESCRIPTION
## Summary

- defer status endpoint resolution until the voice session initializes its transport
- update the simple VLM wiring test to exercise the production lazy-transport lifecycle

## Testing

- .venv/bin/pytest -v test_simple_vlm_example_worker.py (19 passed)
- uvx ruff check agent-samples/simple-vlm-example/worker/simple_vlm_example_worker/app.py tests/test_simple_vlm_example_worker.py