### PR TITLE
fix(tools): recover small markers in full frames

### DIFF
--- a/agent-sdk/xr-ai-tools/README.md
+++ b/agent-sdk/xr-ai-tools/README.md
@@ -192,6 +192,9 @@ QR codes with ZXing-C++ and ArUco markers with OpenCV. Its typed result
 distinguishes an unavailable frame from a valid frame with no marker. Every
 marker has the same `marker_type`, `value`, and four-corner contract: `value`
 is decoded text for QR codes and the decimal marker ID for ArUco markers.
+QR detection scans the complete frame at native resolution and at one bounded
+enlarged resolution so small codes remain readable without discarding context.
+Results from both scans are deduplicated and use source-frame coordinates.
 
 ```python
 from xr_ai_tools.marker_tracking import (

--- a/agent-sdk/xr-ai-tools/README.md
+++ b/agent-sdk/xr-ai-tools/README.md
@@ -192,8 +192,8 @@ QR codes with ZXing-C++ and ArUco markers with OpenCV. Its typed result
 distinguishes an unavailable frame from a valid frame with no marker. Every
 marker has the same `marker_type`, `value`, and four-corner contract: `value`
 is decoded text for QR codes and the decimal marker ID for ArUco markers.
-QR detection scans the complete frame at native resolution and at one bounded
-enlarged resolution so small codes remain readable without discarding context.
+Both detectors scan the complete frame at native resolution and at one bounded
+enlarged resolution so small markers remain readable without discarding context.
 Results from both scans are deduplicated and use source-frame coordinates.
 
 ```python

--- a/agent-sdk/xr-ai-tools/xr_ai_tools/marker_tracking.py
+++ b/agent-sdk/xr-ai-tools/xr_ai_tools/marker_tracking.py
@@ -22,8 +22,8 @@ from .tools import Tool
 from .types import StrictRequest
 
 _LOGGER = logging.getLogger(__name__)
-_QR_SCAN_LONG_EDGE = 3840
-_QR_SCAN_MAX_SCALE = 6
+_MARKER_SCAN_LONG_EDGE = 3840
+_MARKER_SCAN_MAX_SCALE = 6
 
 
 class MarkerType(StrEnum):
@@ -95,15 +95,15 @@ def _corners(points: np.ndarray) -> tuple[MarkerPoint, MarkerPoint, MarkerPoint,
     )
 
 
-def _extract_qr_markers(pixels: np.ndarray) -> list[TrackedMarker]:
+def _full_frame_scans(pixels: np.ndarray) -> list[tuple[np.ndarray, int]]:
     height, width = pixels.shape[:2]
     grayscale = Image.fromarray(pixels).convert("L")
     scans = [(np.asarray(grayscale), 1)]
     scale = min(
-        _QR_SCAN_MAX_SCALE,
+        _MARKER_SCAN_MAX_SCALE,
         max(
             1,
-            (_QR_SCAN_LONG_EDGE + max(width, height) - 1)
+            (_MARKER_SCAN_LONG_EDGE + max(width, height) - 1)
             // max(width, height),
         ),
     )
@@ -113,7 +113,12 @@ def _extract_qr_markers(pixels: np.ndarray) -> list[TrackedMarker]:
             Image.Resampling.LANCZOS,
         )
         scans.append((np.asarray(enlarged), scale))
+    return scans
 
+
+def _extract_qr_markers(
+    scans: Iterable[tuple[np.ndarray, int]],
+) -> list[TrackedMarker]:
     markers: list[TrackedMarker] = []
     for scan, scan_scale in scans:
         barcodes = zxingcpp.read_barcodes(
@@ -169,22 +174,27 @@ def _make_aruco_detector(dictionary_name: str) -> cv2.aruco.ArucoDetector:
 
 
 def _extract_aruco_markers(
-    pixels: np.ndarray,
+    scans: Iterable[tuple[np.ndarray, int]],
     detector: cv2.aruco.ArucoDetector,
 ) -> list[TrackedMarker]:
-    if pixels.ndim == 3:
-        pixels = cv2.cvtColor(pixels, cv2.COLOR_RGB2GRAY)
-    corners, identifiers, _rejected = detector.detectMarkers(pixels)
-    if identifiers is None:
-        return []
-    return [
-        TrackedMarker(
-            marker_type=MarkerType.ARUCO,
-            value=str(int(identifier)),
-            corners=_corners(marker_corners),
-        )
-        for marker_corners, identifier in zip(corners, identifiers.reshape(-1), strict=True)
-    ]
+    markers: list[TrackedMarker] = []
+    for scan, scan_scale in scans:
+        corners, identifiers, _rejected = detector.detectMarkers(scan)
+        if identifiers is None:
+            continue
+        for marker_corners, identifier in zip(
+            corners,
+            identifiers.reshape(-1),
+            strict=True,
+        ):
+            marker = TrackedMarker(
+                marker_type=MarkerType.ARUCO,
+                value=str(int(identifier)),
+                corners=_corners(np.asarray(marker_corners) / scan_scale),
+            )
+            if not any(_same_marker(marker, existing) for existing in markers):
+                markers.append(marker)
+    return markers
 
 
 class MarkerTrackingTool(Tool[MarkerTrackingRequest, MarkerTrackingResult]):
@@ -271,11 +281,12 @@ class MarkerTrackingTool(Tool[MarkerTrackingRequest, MarkerTrackingResult]):
 
     def _extract(self, image: Image.Image) -> list[TrackedMarker]:
         pixels = _image_pixels(image)
+        scans = _full_frame_scans(pixels)
         markers: list[TrackedMarker] = []
         if MarkerType.QR_CODE in self.marker_types:
-            markers.extend(_extract_qr_markers(pixels))
+            markers.extend(_extract_qr_markers(scans))
         if self._aruco_detector is not None:
-            markers.extend(_extract_aruco_markers(pixels, self._aruco_detector))
+            markers.extend(_extract_aruco_markers(scans, self._aruco_detector))
         return markers
 
 

--- a/agent-sdk/xr-ai-tools/xr_ai_tools/marker_tracking.py
+++ b/agent-sdk/xr-ai-tools/xr_ai_tools/marker_tracking.py
@@ -22,6 +22,8 @@ from .tools import Tool
 from .types import StrictRequest
 
 _LOGGER = logging.getLogger(__name__)
+_QR_SCAN_LONG_EDGE = 3840
+_QR_SCAN_MAX_SCALE = 6
 
 
 class MarkerType(StrEnum):
@@ -94,26 +96,68 @@ def _corners(points: np.ndarray) -> tuple[MarkerPoint, MarkerPoint, MarkerPoint,
 
 
 def _extract_qr_markers(pixels: np.ndarray) -> list[TrackedMarker]:
-    barcodes = zxingcpp.read_barcodes(
-        pixels,
-        formats=zxingcpp.BarcodeFormat.QRCode,
+    height, width = pixels.shape[:2]
+    grayscale = Image.fromarray(pixels).convert("L")
+    scans = [(np.asarray(grayscale), 1)]
+    scale = min(
+        _QR_SCAN_MAX_SCALE,
+        max(
+            1,
+            (_QR_SCAN_LONG_EDGE + max(width, height) - 1)
+            // max(width, height),
+        ),
     )
-    return [
-        TrackedMarker(
-            marker_type=MarkerType.QR_CODE,
-            value=barcode.text,
-            corners=tuple(
-                MarkerPoint(x=float(point.x), y=float(point.y))
-                for point in (
-                    barcode.position.top_left,
-                    barcode.position.top_right,
-                    barcode.position.bottom_right,
-                    barcode.position.bottom_left,
-                )
-            ),
+    if scale > 1:
+        enlarged = grayscale.resize(
+            (width * scale, height * scale),
+            Image.Resampling.LANCZOS,
         )
-        for barcode in barcodes
-    ]
+        scans.append((np.asarray(enlarged), scale))
+
+    markers: list[TrackedMarker] = []
+    for scan, scan_scale in scans:
+        barcodes = zxingcpp.read_barcodes(
+            np.ascontiguousarray(scan),
+            formats=zxingcpp.BarcodeFormat.QRCode,
+        )
+        for barcode in barcodes:
+            marker = TrackedMarker(
+                marker_type=MarkerType.QR_CODE,
+                value=barcode.text,
+                corners=tuple(
+                    MarkerPoint(
+                        x=float(point.x / scan_scale),
+                        y=float(point.y / scan_scale),
+                    )
+                    for point in (
+                        barcode.position.top_left,
+                        barcode.position.top_right,
+                        barcode.position.bottom_right,
+                        barcode.position.bottom_left,
+                    )
+                ),
+            )
+            if not any(_same_marker(marker, existing) for existing in markers):
+                markers.append(marker)
+    return markers
+
+
+def _same_marker(first: TrackedMarker, second: TrackedMarker) -> bool:
+    if first.marker_type is not second.marker_type or first.value != second.value:
+        return False
+
+    first_center = (
+        sum(point.x for point in first.corners) / len(first.corners),
+        sum(point.y for point in first.corners) / len(first.corners),
+    )
+    second_center = (
+        sum(point.x for point in second.corners) / len(second.corners),
+        sum(point.y for point in second.corners) / len(second.corners),
+    )
+    return (
+        abs(first_center[0] - second_center[0]) <= 24
+        and abs(first_center[1] - second_center[1]) <= 24
+    )
 
 
 def _make_aruco_detector(dictionary_name: str) -> cv2.aruco.ArucoDetector:

--- a/agent-sdk/xr-ai-tools/xr_ai_tools/marker_tracking.py
+++ b/agent-sdk/xr-ai-tools/xr_ai_tools/marker_tracking.py
@@ -95,74 +95,113 @@ def _corners(points: np.ndarray) -> tuple[MarkerPoint, MarkerPoint, MarkerPoint,
     )
 
 
-def _full_frame_scans(pixels: np.ndarray) -> list[tuple[np.ndarray, int]]:
+def _full_frame_scans(
+    pixels: np.ndarray,
+) -> list[tuple[np.ndarray, float, float]]:
     height, width = pixels.shape[:2]
     grayscale = Image.fromarray(pixels).convert("L")
-    scans = [(np.asarray(grayscale), 1)]
-    scale = min(
-        _MARKER_SCAN_MAX_SCALE,
-        max(
-            1,
-            (_MARKER_SCAN_LONG_EDGE + max(width, height) - 1)
-            // max(width, height),
-        ),
+    scans = [(np.asarray(grayscale), 1.0, 1.0)]
+    long_edge = max(width, height)
+    target_long_edge = min(
+        _MARKER_SCAN_LONG_EDGE,
+        long_edge * _MARKER_SCAN_MAX_SCALE,
     )
-    if scale > 1:
-        enlarged = grayscale.resize(
-            (width * scale, height * scale),
-            Image.Resampling.LANCZOS,
+    if target_long_edge <= long_edge:
+        return scans
+
+    if width >= height:
+        resized_width = target_long_edge
+        resized_height = max(1, round(height * target_long_edge / width))
+    else:
+        resized_width = max(1, round(width * target_long_edge / height))
+        resized_height = target_long_edge
+    enlarged = grayscale.resize(
+        (resized_width, resized_height),
+        Image.Resampling.LANCZOS,
+    )
+    scans.append(
+        (
+            np.asarray(enlarged),
+            resized_width / width,
+            resized_height / height,
         )
-        scans.append((np.asarray(enlarged), scale))
+    )
     return scans
 
 
 def _extract_qr_markers(
-    scans: Iterable[tuple[np.ndarray, int]],
+    scans: Iterable[tuple[np.ndarray, float, float]],
 ) -> list[TrackedMarker]:
-    markers: list[TrackedMarker] = []
-    for scan, scan_scale in scans:
+    scan_markers: list[list[TrackedMarker]] = []
+    for scan, scale_x, scale_y in scans:
         barcodes = zxingcpp.read_barcodes(
             np.ascontiguousarray(scan),
             formats=zxingcpp.BarcodeFormat.QRCode,
         )
-        for barcode in barcodes:
-            marker = TrackedMarker(
-                marker_type=MarkerType.QR_CODE,
-                value=barcode.text,
-                corners=tuple(
-                    MarkerPoint(
-                        x=float(point.x / scan_scale),
-                        y=float(point.y / scan_scale),
-                    )
-                    for point in (
-                        barcode.position.top_left,
-                        barcode.position.top_right,
-                        barcode.position.bottom_right,
-                        barcode.position.bottom_left,
-                    )
-                ),
-            )
-            if not any(_same_marker(marker, existing) for existing in markers):
-                markers.append(marker)
-    return markers
+        scan_markers.append(
+            [
+                TrackedMarker(
+                    marker_type=MarkerType.QR_CODE,
+                    value=barcode.text,
+                    corners=tuple(
+                        MarkerPoint(
+                            x=float(point.x / scale_x),
+                            y=float(point.y / scale_y),
+                        )
+                        for point in (
+                            barcode.position.top_left,
+                            barcode.position.top_right,
+                            barcode.position.bottom_right,
+                            barcode.position.bottom_left,
+                        )
+                    ),
+                )
+                for barcode in barcodes
+            ]
+        )
+    return _merge_marker_scans(scan_markers)
 
 
-def _same_marker(first: TrackedMarker, second: TrackedMarker) -> bool:
-    if first.marker_type is not second.marker_type or first.value != second.value:
-        return False
+def _marker_overlap_area(first: TrackedMarker, second: TrackedMarker) -> float:
+    first_left = min(point.x for point in first.corners)
+    first_top = min(point.y for point in first.corners)
+    first_right = max(point.x for point in first.corners)
+    first_bottom = max(point.y for point in first.corners)
+    second_left = min(point.x for point in second.corners)
+    second_top = min(point.y for point in second.corners)
+    second_right = max(point.x for point in second.corners)
+    second_bottom = max(point.y for point in second.corners)
+    return max(0.0, min(first_right, second_right) - max(first_left, second_left)) * max(
+        0.0,
+        min(first_bottom, second_bottom) - max(first_top, second_top),
+    )
 
-    first_center = (
-        sum(point.x for point in first.corners) / len(first.corners),
-        sum(point.y for point in first.corners) / len(first.corners),
-    )
-    second_center = (
-        sum(point.x for point in second.corners) / len(second.corners),
-        sum(point.y for point in second.corners) / len(second.corners),
-    )
-    return (
-        abs(first_center[0] - second_center[0]) <= 24
-        and abs(first_center[1] - second_center[1]) <= 24
-    )
+
+def _merge_marker_scans(
+    marker_scans: Iterable[list[TrackedMarker]],
+) -> list[TrackedMarker]:
+    merged: list[TrackedMarker] = []
+    for scan_markers in marker_scans:
+        unmatched_previous = set(range(len(merged)))
+        for marker in scan_markers:
+            best_index: int | None = None
+            best_overlap = 0.0
+            for index in unmatched_previous:
+                existing = merged[index]
+                if (
+                    marker.marker_type != existing.marker_type
+                    or marker.value != existing.value
+                ):
+                    continue
+                overlap = _marker_overlap_area(marker, existing)
+                if overlap > best_overlap:
+                    best_index = index
+                    best_overlap = overlap
+            if best_index is None:
+                merged.append(marker)
+            else:
+                unmatched_previous.remove(best_index)
+    return merged
 
 
 def _make_aruco_detector(dictionary_name: str) -> cv2.aruco.ArucoDetector:
@@ -174,27 +213,34 @@ def _make_aruco_detector(dictionary_name: str) -> cv2.aruco.ArucoDetector:
 
 
 def _extract_aruco_markers(
-    scans: Iterable[tuple[np.ndarray, int]],
+    scans: Iterable[tuple[np.ndarray, float, float]],
     detector: cv2.aruco.ArucoDetector,
 ) -> list[TrackedMarker]:
-    markers: list[TrackedMarker] = []
-    for scan, scan_scale in scans:
+    marker_scans: list[list[TrackedMarker]] = []
+    for scan, scale_x, scale_y in scans:
         corners, identifiers, _rejected = detector.detectMarkers(scan)
         if identifiers is None:
+            marker_scans.append([])
             continue
+        scan_markers: list[TrackedMarker] = []
         for marker_corners, identifier in zip(
             corners,
             identifiers.reshape(-1),
             strict=True,
         ):
-            marker = TrackedMarker(
-                marker_type=MarkerType.ARUCO,
-                value=str(int(identifier)),
-                corners=_corners(np.asarray(marker_corners) / scan_scale),
+            source_corners = np.asarray(marker_corners, dtype=np.float32) / np.array(
+                [scale_x, scale_y],
+                dtype=np.float32,
             )
-            if not any(_same_marker(marker, existing) for existing in markers):
-                markers.append(marker)
-    return markers
+            scan_markers.append(
+                TrackedMarker(
+                    marker_type=MarkerType.ARUCO,
+                    value=str(int(identifier)),
+                    corners=_corners(source_corners),
+                )
+            )
+        marker_scans.append(scan_markers)
+    return _merge_marker_scans(marker_scans)
 
 
 class MarkerTrackingTool(Tool[MarkerTrackingRequest, MarkerTrackingResult]):

--- a/docs/source/components/agent-sdk.md
+++ b/docs/source/components/agent-sdk.md
@@ -192,7 +192,7 @@ detectors off the event loop, and returns every marker through one
 `marker_type`, `value`, and four-corner contract. QR values are ZXing-C++
 decoded text; ArUco values are decimal IDs detected with a configured OpenCV
 predefined dictionary. Install `xr-ai-tools[marker-tracking]` to use it.
-QR detection scans the complete frame at native resolution and once at a
+Both detectors scan the complete frame at native resolution and once at a
 bounded enlarged resolution. Duplicate detections are removed, and all returned
 corners remain in source-frame coordinates.
 

--- a/docs/source/components/agent-sdk.md
+++ b/docs/source/components/agent-sdk.md
@@ -192,6 +192,9 @@ detectors off the event loop, and returns every marker through one
 `marker_type`, `value`, and four-corner contract. QR values are ZXing-C++
 decoded text; ArUco values are decimal IDs detected with a configured OpenCV
 predefined dictionary. Install `xr-ai-tools[marker-tracking]` to use it.
+QR detection scans the complete frame at native resolution and once at a
+bounded enlarged resolution. Duplicate detections are removed, and all returned
+corners remain in source-frame coordinates.
 
 QR and ArUco are enabled by default. Initialization may select either family
 and choose the ArUco dictionary without changing the model-visible

--- a/tests/test_marker_tracking_tool.py
+++ b/tests/test_marker_tracking_tool.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import time
+from types import SimpleNamespace
 
 import cv2
 import numpy as np
@@ -13,6 +14,7 @@ import pytest
 from PIL import Image
 from pydantic import ValidationError
 from xr_ai_hub import FrameData, FrameSignal, PixelFormat
+from xr_ai_tools import marker_tracking as marker_tracking_module
 from xr_ai_tools.marker_tracking import (
     MarkerTrackingRequest,
     MarkerTrackingTool,
@@ -176,6 +178,27 @@ class _Endpoint:
         )
 
 
+def test_marker_scan_enlargement_respects_dimension_and_scale_limits() -> None:
+    below_long_edge_limit = np.full((2160, 3839), 255, dtype=np.uint8)
+
+    scans = marker_tracking_module._full_frame_scans(below_long_edge_limit)
+
+    assert [scan.shape for scan, _scale_x, _scale_y in scans] == [
+        (2160, 3839),
+        (2161, 3840),
+    ]
+    assert scans[-1][1] == pytest.approx(3840 / 3839)
+    assert scans[-1][2] == pytest.approx(2161 / 2160)
+
+    at_long_edge_limit = np.full((2, 3840), 255, dtype=np.uint8)
+    assert len(marker_tracking_module._full_frame_scans(at_long_edge_limit)) == 1
+
+    below_scale_limit = np.full((2, 100), 255, dtype=np.uint8)
+    limited_scans = marker_tracking_module._full_frame_scans(below_scale_limit)
+    assert limited_scans[-1][0].shape == (12, 600)
+    assert limited_scans[-1][1:] == (6.0, 6.0)
+
+
 @pytest.mark.asyncio
 async def test_marker_tool_detects_qr_and_aruco_with_uniform_schema() -> None:
     endpoint = _Endpoint(_mixed_image())
@@ -229,6 +252,45 @@ async def test_marker_tool_returns_every_qr_marker_in_frame() -> None:
         (MarkerType.QR_CODE, "second QR payload"),
     }
     assert len(result.markers) == 2
+
+
+def test_marker_tool_preserves_repeated_qr_payloads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def barcode(left: int) -> SimpleNamespace:
+        return SimpleNamespace(
+            text="XR AI QR tool",
+            position=SimpleNamespace(
+                top_left=SimpleNamespace(x=left, y=2),
+                top_right=SimpleNamespace(x=left + 6, y=2),
+                bottom_right=SimpleNamespace(x=left + 6, y=8),
+                bottom_left=SimpleNamespace(x=left, y=8),
+            ),
+        )
+
+    detections = iter(
+        [
+            [barcode(2), barcode(10)],
+            [barcode(4), barcode(20)],
+        ]
+    )
+    monkeypatch.setattr(
+        marker_tracking_module.zxingcpp,
+        "read_barcodes",
+        lambda *_args, **_kwargs: next(detections),
+    )
+
+    markers = marker_tracking_module._extract_qr_markers(
+        [
+            (np.full((12, 20), 255, dtype=np.uint8), 1.0, 1.0),
+            (np.full((24, 40), 255, dtype=np.uint8), 2.0, 2.0),
+        ]
+    )
+
+    assert [marker.value for marker in markers] == [
+        "XR AI QR tool",
+        "XR AI QR tool",
+    ]
 
 
 @pytest.mark.asyncio
@@ -303,6 +365,20 @@ async def test_marker_tool_uses_configured_aruco_dictionary() -> None:
     assert [(marker.marker_type, marker.value) for marker in result.markers] == [
         (MarkerType.ARUCO, "42")
     ]
+
+
+def test_marker_tool_preserves_nearby_repeated_aruco_ids() -> None:
+    dictionary = cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_4X4_50)
+    marker = cv2.aruco.generateImageMarker(dictionary, 23, 6)
+    canvas = np.full((20, 30), 255, dtype=np.uint8)
+    canvas[7:13, 5:11] = marker
+    canvas[7:13, 13:19] = marker
+    markers = marker_tracking_module._extract_aruco_markers(
+        marker_tracking_module._full_frame_scans(canvas),
+        cv2.aruco.ArucoDetector(dictionary),
+    )
+
+    assert [tracked.value for tracked in markers] == ["23", "23"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_marker_tracking_tool.py
+++ b/tests/test_marker_tracking_tool.py
@@ -10,6 +10,7 @@ import time
 import cv2
 import numpy as np
 import pytest
+from PIL import Image
 from pydantic import ValidationError
 from xr_ai_hub import FrameData, FrameSignal, PixelFormat
 from xr_ai_tools.marker_tracking import (
@@ -202,6 +203,7 @@ async def test_marker_tool_returns_every_qr_marker_in_frame() -> None:
     second_x = 60 + first.shape[1]
     canvas[20 : 20 + second.shape[0], second_x : second_x + second.shape[1]] = second
     endpoint = _Endpoint(canvas)
+
     tool = MarkerTrackingTool(
         endpoint=endpoint,
         marker_types=(MarkerType.QR_CODE,),
@@ -215,6 +217,40 @@ async def test_marker_tool_returns_every_qr_marker_in_frame() -> None:
         (MarkerType.QR_CODE, "second QR payload"),
     }
     assert len(result.markers) == 2
+
+
+@pytest.mark.asyncio
+async def test_marker_tool_recovers_multiple_small_qr_codes() -> None:
+    first = _qr_image()
+    second = _qr_image(_SECOND_QR_MODULES)
+    source = np.full((3840, 2880), 220, dtype=np.uint8)
+    source[2100 : 2100 + first.shape[0], 120 : 120 + first.shape[1]] = first
+    source[
+        2200 : 2200 + second.shape[0],
+        2100 : 2100 + second.shape[1],
+    ] = second
+    frame = np.asarray(
+        Image.fromarray(source).resize((480, 640), Image.Resampling.LANCZOS)
+    )
+    endpoint = _Endpoint(frame)
+    tool = MarkerTrackingTool(
+        endpoint=endpoint,
+        marker_types=(MarkerType.QR_CODE,),
+    )
+    await endpoint.seed()
+
+    result = await tool.execute(MarkerTrackingRequest(participant_id="alice"))
+
+    assert {marker.value for marker in result.markers} == {
+        "XR AI QR tool",
+        "second QR payload",
+    }
+    assert len(result.markers) == 2
+    assert all(
+        0 <= point.x < frame.shape[1] and 0 <= point.y < frame.shape[0]
+        for marker in result.markers
+        for point in marker.corners
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_marker_tracking_tool.py
+++ b/tests/test_marker_tracking_tool.py
@@ -120,6 +120,18 @@ def _mixed_image() -> np.ndarray:
     return canvas
 
 
+def _downsampled_aruco_scene() -> np.ndarray:
+    dictionary = cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_4X4_50)
+    source = np.full((3840, 2880), 220, dtype=np.uint8)
+    large = cv2.aruco.generateImageMarker(dictionary, 23, 600)
+    small = cv2.aruco.generateImageMarker(dictionary, 42, 48)
+    source[500:1100, 300:900] = large
+    source[1733:1781, 1279:1327] = small
+    return np.asarray(
+        Image.fromarray(source).resize((480, 640), Image.Resampling.LANCZOS)
+    )
+
+
 class _Endpoint:
     def __init__(self, image: np.ndarray) -> None:
         rgb = np.repeat(image[:, :, None], 3, axis=2)
@@ -291,6 +303,33 @@ async def test_marker_tool_uses_configured_aruco_dictionary() -> None:
     assert [(marker.marker_type, marker.value) for marker in result.markers] == [
         (MarkerType.ARUCO, "42")
     ]
+
+
+@pytest.mark.asyncio
+async def test_marker_tool_recovers_small_aruco_from_downsampled_scene() -> None:
+    frame = _downsampled_aruco_scene()
+    dictionary = cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_4X4_50)
+    native_detector = cv2.aruco.ArucoDetector(dictionary)
+    _corners, native_ids, _rejected = native_detector.detectMarkers(frame)
+    assert native_ids is not None
+    assert native_ids.reshape(-1).tolist() == [23]
+
+    endpoint = _Endpoint(frame)
+    tool = MarkerTrackingTool(
+        endpoint=endpoint,
+        marker_types=(MarkerType.ARUCO,),
+    )
+    await endpoint.seed()
+
+    result = await tool.execute(MarkerTrackingRequest(participant_id="alice"))
+
+    assert [(marker.marker_type, marker.value) for marker in result.markers] == [
+        (MarkerType.ARUCO, "23"),
+        (MarkerType.ARUCO, "42"),
+    ]
+    small = next(marker for marker in result.markers if marker.value == "42")
+    assert all(210 <= point.x <= 225 for point in small.corners)
+    assert all(285 <= point.y <= 300 for point in small.corners)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- scan the complete frame at native resolution and at one bounded enlarged resolution for both QR and ArUco markers
- map enlarged-scan corners back into source-frame coordinates
- deduplicate detections across scan resolutions while preserving distinct QR codes with the same payload
- share grayscale conversion and enlargement between the two detectors
- cover multiple small QR codes and small ArUco markers in downsampled portrait frames

## Why

Small visual markers can become unreadable after a high-resolution camera frame is downsampled for transport. Experiments across six ArUco IDs and apparent marker sizes from 5 to 30 pixels found consistent 7-8 pixel recoveries from the enlarged scan. A few 6-pixel phase cases remained native-only, so the implementation unions native and enlarged results. This keeps the whole frame visible and avoids cropping or tiling.

## Impact

`MarkerTrackingTool` keeps the same request and result API. Both QR and ArUco detection become more reliable for small markers, and all corners remain in source-frame coordinates.

## Validation

- `uvx ruff check agent-sdk/xr-ai-tools/xr_ai_tools/marker_tracking.py tests/test_marker_tracking_tool.py agent-sdk/xr-ai-tools/README.md docs/source/components/agent-sdk.md`
- `tests/.venv/bin/pytest -q tests/test_marker_tracking_tool.py tests/test_generate_marker_utility.py` (11 passed)

## Stack

This PR is based on latest `main`, which includes merged PR #371. Its commit is also cherry-picked into PR #363's temporary test stack.
