### PR TITLE
Add a bounded native tool-calling loop

### DIFF
--- a/agent-sdk/xr-ai-tools/README.md
+++ b/agent-sdk/xr-ai-tools/README.md
@@ -71,7 +71,9 @@ structured tool-call audit. Unknown tools and invalid Pydantic arguments are
 returned to the model for repair. Iteration exhaustion, tool-call budget
 exhaustion, empty or truncated responses, and unsafe mixed `return_direct`
 batches raise typed errors carrying the partial transcript and audit. Blank or
-duplicate tool-call IDs are rejected before executing their batch.
+non-string or duplicate tool-call IDs are rejected before executing their batch.
+Error `messages` contain only a valid, resumable transcript; the rejected model
+turn remains available separately as `rejected_response` for diagnostics.
 
 The application or agent continues to own prompts, conversation history, model
 parameters, retries, participant context, cancellation, and background tasks.

--- a/agent-sdk/xr-ai-tools/README.md
+++ b/agent-sdk/xr-ai-tools/README.md
@@ -19,7 +19,7 @@ The base install supplies finite `Tool` and streaming `AsyncTool` types. Install
 from pydantic import BaseModel
 from xr_ai_models import ChatMessage
 from xr_ai_tools import Tool, ToolSet
-from xr_ai_tools.tool_calling import handle_tool_call, tool_definitions
+from xr_ai_tools.tool_calling import run_tool_loop
 
 
 class LookupRequest(BaseModel):
@@ -44,29 +44,47 @@ lookup_tool = Tool(
 tools = (lookup_tool,)
 tool_set = ToolSet(tools)
 
-response = await llm.chat(messages, tools=tool_definitions(tools))
-messages.append(
-    ChatMessage(
-        role="assistant",
-        content=response.content,
-        tool_calls=response.tool_calls,
+async def call_model(messages, definitions):
+    # The caller owns model parameters, headers, timeouts, and retry policy.
+    return await llm.chat(
+        messages,
+        tools=definitions,
+        max_tokens=1024,
+        temperature=0.0,
     )
+
+
+result = await run_tool_loop(
+    [ChatMessage(role="user", content="look up the current answer")],
+    tool_set,
+    call_model,
+    max_iterations=4,
+    max_tool_calls=8,
 )
-for call in response.tool_calls or ():
-    result = await handle_tool_call(call, tool_set)
-    messages.append(result.message)
-    if result.return_direct:
-        final_answer = result.message.content
-        break
+final_answer = result.content
 ```
 
-`tool_definitions(...)` adapts native tools to `xr-ai-models` `ToolDef` values.
-`handle_tool_call(...)` validates and invokes one model-produced `ToolCall`, then
-returns a tool-role `ChatMessage` plus its `return_direct` hint. The application
-or agent owns prompts, model calls, conversation state, iteration policy, and
-whether calls run sequentially or concurrently. A unary side-effect tool uses
-`result_model=None`, returns `None`, and produces `null` as its model-visible
-result.
+`run_tool_loop(...)` is a stateless bounded turn runner. It passes an immutable
+transcript and the current `ToolSet` definitions to the supplied model callback,
+executes emitted calls sequentially, and returns the complete transcript and a
+structured tool-call audit. Unknown tools and invalid Pydantic arguments are
+returned to the model for repair. Iteration exhaustion, tool-call budget
+exhaustion, empty or truncated responses, and unsafe mixed `return_direct`
+batches raise typed errors carrying the partial transcript and audit. Blank or
+duplicate tool-call IDs are rejected before executing their batch.
+
+The application or agent continues to own prompts, conversation history, model
+parameters, retries, participant context, cancellation, and background tasks.
+The loop never retries an executed tool. A direct-return tool must be the only
+call in its model batch, so the loop can reject an ambiguous batch before any
+side effect occurs.
+
+The lower-level `tool_definitions(...)` and `handle_tool_call(...)` helpers
+remain available for specialized loops. The former adapts native tools to
+`xr-ai-models` `ToolDef` values. The latter validates and invokes one
+model-produced `ToolCall`, then returns a tool-role `ChatMessage` plus its
+`return_direct` hint. A unary side-effect tool uses `result_model=None`, returns
+`None`, and produces `null` as its model-visible result.
 
 Tool catalogs can assign model-visible aliases without wrapping or changing the
 underlying tools:

--- a/agent-sdk/xr-ai-tools/xr_ai_tools/tool_calling.py
+++ b/agent-sdk/xr-ai-tools/xr_ai_tools/tool_calling.py
@@ -53,11 +53,13 @@ class ToolLoopError(RuntimeError):
         messages: Sequence[ChatMessage],
         tool_calls: Sequence[ToolCallRecord],
         iterations: int,
+        rejected_response: ChatResponse | None = None,
     ) -> None:
         super().__init__(message)
         self.messages = tuple(messages)
         self.tool_calls = tuple(tool_calls)
         self.iterations = iterations
+        self.rejected_response = rejected_response
 
 
 class ToolLoopIterationLimitError(ToolLoopError):
@@ -159,12 +161,10 @@ async def run_tool_loop(
     for iteration in range(1, max_iterations + 1):
         response = await call_model(tuple(transcript), definitions)
         calls = tuple(response.tool_calls or ())
-        transcript.append(
-            ChatMessage(
-                role="assistant",
-                content=response.content,
-                tool_calls=list(calls) if response.tool_calls is not None else None,
-            )
+        assistant_message = ChatMessage(
+            role="assistant",
+            content=response.content,
+            tool_calls=list(calls) if response.tool_calls is not None else None,
         )
 
         if response.finish_reason in {"length", "max_tokens"}:
@@ -173,6 +173,7 @@ async def run_tool_loop(
                 messages=transcript,
                 tool_calls=records,
                 iterations=iteration,
+                rejected_response=response,
             )
 
         if response.finish_reason == "tool_calls" and not calls:
@@ -181,15 +182,20 @@ async def run_tool_loop(
                 messages=transcript,
                 tool_calls=records,
                 iterations=iteration,
+                rejected_response=response,
             )
 
         call_ids = tuple(call.id for call in calls)
-        if any(not call_id.strip() for call_id in call_ids):
+        if any(
+            not isinstance(call_id, str) or not call_id.strip()
+            for call_id in call_ids
+        ):
             raise ToolLoopMalformedResponseError(
-                "tool-call IDs must not be blank",
+                "tool-call IDs must be non-empty strings",
                 messages=transcript,
                 tool_calls=records,
                 iterations=iteration,
+                rejected_response=response,
             )
         if len(set(call_ids)) != len(call_ids) or seen_call_ids.intersection(call_ids):
             raise ToolLoopMalformedResponseError(
@@ -197,6 +203,7 @@ async def run_tool_loop(
                 messages=transcript,
                 tool_calls=records,
                 iterations=iteration,
+                rejected_response=response,
             )
 
         direct_calls = tuple(
@@ -210,6 +217,7 @@ async def run_tool_loop(
                 messages=transcript,
                 tool_calls=records,
                 iterations=iteration,
+                rejected_response=response,
             )
 
         if len(records) + len(calls) > max_tool_calls:
@@ -218,9 +226,9 @@ async def run_tool_loop(
                 messages=transcript,
                 tool_calls=records,
                 iterations=iteration,
+                rejected_response=response,
             )
 
-        seen_call_ids.update(call_ids)
         if not calls:
             content = response.content.strip()
             if not content:
@@ -229,7 +237,9 @@ async def run_tool_loop(
                     messages=transcript,
                     tool_calls=records,
                     iterations=iteration,
+                    rejected_response=response,
                 )
+            transcript.append(assistant_message)
             return ToolLoopResult(
                 content=content,
                 messages=tuple(transcript),
@@ -238,6 +248,8 @@ async def run_tool_loop(
                 return_direct=False,
             )
 
+        transcript.append(assistant_message)
+        seen_call_ids.update(call_ids)
         for call in calls:
             result = await handle_tool_call(call, tools)
             transcript.append(result.message)

--- a/agent-sdk/xr-ai-tools/xr_ai_tools/tool_calling.py
+++ b/agent-sdk/xr-ai-tools/xr_ai_tools/tool_calling.py
@@ -6,11 +6,11 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Iterable
+from collections.abc import Awaitable, Callable, Iterable, Sequence
 from dataclasses import dataclass
 from typing import Any
 
-from xr_ai_models import ChatMessage, ToolCall, ToolDef
+from xr_ai_models import ChatMessage, ChatResponse, ToolCall, ToolDef
 
 from .tools import Tool, ToolSet
 
@@ -21,6 +21,73 @@ class ToolCallResult:
 
     message: ChatMessage
     return_direct: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ToolCallRecord:
+    """One model-requested call and the model-visible result it produced."""
+
+    call: ToolCall
+    message: ChatMessage
+    return_direct: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ToolLoopResult:
+    """A completed turn with its full transcript and tool-call audit."""
+
+    content: str
+    messages: tuple[ChatMessage, ...]
+    tool_calls: tuple[ToolCallRecord, ...]
+    iterations: int
+    return_direct: bool
+
+
+class ToolLoopError(RuntimeError):
+    """Base error for a turn that cannot safely produce a final answer."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        messages: Sequence[ChatMessage],
+        tool_calls: Sequence[ToolCallRecord],
+        iterations: int,
+    ) -> None:
+        super().__init__(message)
+        self.messages = tuple(messages)
+        self.tool_calls = tuple(tool_calls)
+        self.iterations = iterations
+
+
+class ToolLoopIterationLimitError(ToolLoopError):
+    """The model used every permitted iteration without a final answer."""
+
+
+class ToolLoopToolCallLimitError(ToolLoopError):
+    """A model batch would exceed the turn's total tool-call budget."""
+
+
+class ToolLoopTruncatedResponseError(ToolLoopError):
+    """The model reported a truncated response that is unsafe to execute."""
+
+
+class ToolLoopEmptyResponseError(ToolLoopError):
+    """The model returned neither a tool call nor a non-empty answer."""
+
+
+class ToolLoopDirectReturnError(ToolLoopError):
+    """A model batch mixed a direct-return tool with other calls."""
+
+
+class ToolLoopMalformedResponseError(ToolLoopError):
+    """The model returned tool calls that cannot form a valid transcript."""
+
+
+ModelCallback = Callable[
+    [tuple[ChatMessage, ...], tuple[ToolDef, ...]],
+    Awaitable[ChatResponse],
+]
 
 
 def tool_definitions(
@@ -64,4 +131,153 @@ async def handle_tool_call(call: ToolCall, tools: ToolSet) -> ToolCallResult:
     )
 
 
-__all__ = ["ToolCallResult", "handle_tool_call", "tool_definitions"]
+async def run_tool_loop(
+    messages: Sequence[ChatMessage],
+    tools: ToolSet,
+    call_model: ModelCallback,
+    *,
+    max_iterations: int = 4,
+    max_tool_calls: int = 16,
+) -> ToolLoopResult:
+    """Run one stateless, bounded model turn over native tools.
+
+    The callback owns all model parameters and retry policy. The loop only
+    supplies the current immutable transcript and the current turn's tool
+    definitions. Calls in a model batch execute sequentially in emitted order.
+    """
+
+    if max_iterations < 1:
+        raise ValueError("max_iterations must be at least 1")
+    if max_tool_calls < 0:
+        raise ValueError("max_tool_calls must not be negative")
+
+    transcript = list(messages)
+    definitions = tool_definitions(tools)
+    records: list[ToolCallRecord] = []
+    seen_call_ids: set[str] = set()
+
+    for iteration in range(1, max_iterations + 1):
+        response = await call_model(tuple(transcript), definitions)
+        calls = tuple(response.tool_calls or ())
+        transcript.append(
+            ChatMessage(
+                role="assistant",
+                content=response.content,
+                tool_calls=list(calls) if response.tool_calls is not None else None,
+            )
+        )
+
+        if response.finish_reason in {"length", "max_tokens"}:
+            raise ToolLoopTruncatedResponseError(
+                "model response was truncated",
+                messages=transcript,
+                tool_calls=records,
+                iterations=iteration,
+            )
+
+        if response.finish_reason == "tool_calls" and not calls:
+            raise ToolLoopMalformedResponseError(
+                "model reported tool calls without returning any calls",
+                messages=transcript,
+                tool_calls=records,
+                iterations=iteration,
+            )
+
+        call_ids = tuple(call.id for call in calls)
+        if any(not call_id.strip() for call_id in call_ids):
+            raise ToolLoopMalformedResponseError(
+                "tool-call IDs must not be blank",
+                messages=transcript,
+                tool_calls=records,
+                iterations=iteration,
+            )
+        if len(set(call_ids)) != len(call_ids) or seen_call_ids.intersection(call_ids):
+            raise ToolLoopMalformedResponseError(
+                "tool-call IDs must be unique within a turn",
+                messages=transcript,
+                tool_calls=records,
+                iterations=iteration,
+            )
+
+        direct_calls = tuple(
+            call
+            for call in calls
+            if (tool := tools.get(call.name)) is not None and tool.return_direct
+        )
+        if direct_calls and len(calls) != 1:
+            raise ToolLoopDirectReturnError(
+                "a direct-return tool must be the only call in its model batch",
+                messages=transcript,
+                tool_calls=records,
+                iterations=iteration,
+            )
+
+        if len(records) + len(calls) > max_tool_calls:
+            raise ToolLoopToolCallLimitError(
+                f"model batch would exceed the {max_tool_calls} tool-call limit",
+                messages=transcript,
+                tool_calls=records,
+                iterations=iteration,
+            )
+
+        seen_call_ids.update(call_ids)
+        if not calls:
+            content = response.content.strip()
+            if not content:
+                raise ToolLoopEmptyResponseError(
+                    "model returned neither tool calls nor a final answer",
+                    messages=transcript,
+                    tool_calls=records,
+                    iterations=iteration,
+                )
+            return ToolLoopResult(
+                content=content,
+                messages=tuple(transcript),
+                tool_calls=tuple(records),
+                iterations=iteration,
+                return_direct=False,
+            )
+
+        for call in calls:
+            result = await handle_tool_call(call, tools)
+            transcript.append(result.message)
+            records.append(
+                ToolCallRecord(
+                    call=call,
+                    message=result.message,
+                    return_direct=result.return_direct,
+                )
+            )
+            if result.return_direct:
+                return ToolLoopResult(
+                    content=str(result.message.content),
+                    messages=tuple(transcript),
+                    tool_calls=tuple(records),
+                    iterations=iteration,
+                    return_direct=True,
+                )
+
+    raise ToolLoopIterationLimitError(
+        f"model did not produce a final answer within {max_iterations} iterations",
+        messages=transcript,
+        tool_calls=records,
+        iterations=max_iterations,
+    )
+
+
+__all__ = [
+    "ModelCallback",
+    "ToolCallRecord",
+    "ToolCallResult",
+    "ToolLoopDirectReturnError",
+    "ToolLoopEmptyResponseError",
+    "ToolLoopError",
+    "ToolLoopIterationLimitError",
+    "ToolLoopMalformedResponseError",
+    "ToolLoopResult",
+    "ToolLoopToolCallLimitError",
+    "ToolLoopTruncatedResponseError",
+    "handle_tool_call",
+    "run_tool_loop",
+    "tool_definitions",
+]

--- a/docs/source/components/agent-sdk.md
+++ b/docs/source/components/agent-sdk.md
@@ -38,7 +38,9 @@ tool catalog, and model callback for each turn. It executes model-emitted calls
 sequentially with explicit iteration and total-call limits. The caller retains
 model configuration, conversation policy, retries, participant context,
 cancellation, and task ownership. Typed failures expose the partial transcript
-and tool-call audit for application-specific recovery.
+and tool-call audit for application-specific recovery. Their `messages` remain
+safe to resume because a rejected model turn is exposed separately as
+`rejected_response` rather than appended to the transcript.
 
 ```python
 from pydantic import BaseModel

--- a/docs/source/components/agent-sdk.md
+++ b/docs/source/components/agent-sdk.md
@@ -26,10 +26,19 @@ The complete package references are versioned with this site:
 
 An `Agent` owns state and exposes ordinary `Tool` or `AsyncTool` instances.
 Direct callers use `execute()` or `stream()`; model loops expose the same
-tools through `ToolSet` and `handle_tool_call()`. `AgentRuntime` registers
-agents and publishes typed messages to participant-scoped subscribers. It does
-not own model loops, planning, memory, raw media, agent resources, or
-agent-created background tasks.
+tools through `ToolSet`. Ordinary bounded turns use `run_tool_loop()`; custom
+loops can compose the lower-level `tool_definitions()` and
+`handle_tool_call()` helpers. `AgentRuntime` registers agents and publishes
+typed messages to participant-scoped subscribers. It does not own model loops,
+planning, memory, raw media, agent resources, or agent-created background
+tasks.
+
+`run_tool_loop()` is stateless: callers provide the initial messages, current
+tool catalog, and model callback for each turn. It executes model-emitted calls
+sequentially with explicit iteration and total-call limits. The caller retains
+model configuration, conversation policy, retries, participant context,
+cancellation, and task ownership. Typed failures expose the partial transcript
+and tool-call audit for application-specific recovery.
 
 ```python
 from pydantic import BaseModel

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -1,0 +1,649 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bounded model-loop contracts for Relay-managed native tools."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+from collections.abc import Sequence
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+from xr_ai_models import ChatMessage, ChatResponse, ToolCall, ToolDef
+from xr_ai_tools import Tool, ToolSet
+from xr_ai_tools.tool_calling import (
+    ToolLoopDirectReturnError,
+    ToolLoopEmptyResponseError,
+    ToolLoopIterationLimitError,
+    ToolLoopMalformedResponseError,
+    ToolLoopToolCallLimitError,
+    ToolLoopTruncatedResponseError,
+    run_tool_loop,
+)
+
+
+class ValueRequest(BaseModel):
+    """One integer tool argument."""
+
+    value: int
+
+
+class ValueResult(BaseModel):
+    """One integer tool result."""
+
+    value: int
+
+
+@pytest.fixture(autouse=True)
+def _run_tool_handlers_without_relay(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep loop tests focused; native-tool tests cover the Relay boundary."""
+
+    async def execute(
+        _name: str,
+        arguments: Any,
+        handler: Any,
+        *_args: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        result = handler(arguments)
+        return await result if inspect.isawaitable(result) else result
+
+    monkeypatch.setattr("xr_ai_tools.tools.typed.tool_execute", execute)
+
+
+def _response(
+    content: str = "",
+    *,
+    tool_calls: list[ToolCall] | None = None,
+    finish_reason: str = "stop",
+) -> ChatResponse:
+    return ChatResponse(
+        content=content,
+        reasoning=None,
+        tool_calls=tool_calls,
+        finish_reason=finish_reason,
+        raw={},
+    )
+
+
+class _Model:
+    def __init__(self, responses: Sequence[ChatResponse]) -> None:
+        self._responses = iter(responses)
+        self.requests: list[tuple[tuple[ChatMessage, ...], tuple[ToolDef, ...]]] = []
+
+    async def __call__(
+        self,
+        messages: tuple[ChatMessage, ...],
+        tools: tuple[ToolDef, ...],
+    ) -> ChatResponse:
+        self.requests.append((messages, tools))
+        return next(self._responses)
+
+
+def _call(call_id: str, name: str, arguments: str) -> ToolCall:
+    return ToolCall(id=call_id, name=name, arguments=arguments)
+
+
+async def test_run_tool_loop_returns_final_answer_and_complete_transcript() -> None:
+    initial = (ChatMessage(role="user", content="hello"),)
+    model = _Model((_response("  Hello.  "),))
+
+    result = await run_tool_loop(initial, ToolSet(()), model)
+
+    assert result.content == "Hello."
+    assert result.messages == (
+        *initial,
+        ChatMessage(role="assistant", content="  Hello.  "),
+    )
+    assert result.tool_calls == ()
+    assert result.iterations == 1
+    assert result.return_direct is False
+    assert model.requests == [(initial, ())]
+
+
+async def test_run_tool_loop_executes_batches_sequentially_in_emitted_order() -> None:
+    invoked: list[int] = []
+
+    async def record(request: ValueRequest) -> ValueResult:
+        invoked.append(request.value)
+        return ValueResult(value=request.value)
+
+    tool = Tool("record", "Record a value.", ValueRequest, ValueResult, record)
+    calls = [
+        _call("first", "record", '{"value":1}'),
+        _call("second", "record", '{"value":2}'),
+    ]
+    model = _Model(
+        (
+            _response(tool_calls=calls, finish_reason="tool_calls"),
+            _response("Recorded both."),
+        )
+    )
+
+    result = await run_tool_loop(
+        (ChatMessage(role="user", content="record two values"),),
+        ToolSet((tool,)),
+        model,
+    )
+
+    assert invoked == [1, 2]
+    assert [record.call.id for record in result.tool_calls] == ["first", "second"]
+    assert [message.role for message in result.messages] == [
+        "user",
+        "assistant",
+        "tool",
+        "tool",
+        "assistant",
+    ]
+    assert model.requests[1][0] == result.messages[:-1]
+
+
+async def test_structured_calls_execute_even_when_finish_reason_is_stop() -> None:
+    invoked: list[int] = []
+
+    async def record(request: ValueRequest) -> ValueResult:
+        invoked.append(request.value)
+        return ValueResult(value=request.value)
+
+    tool = Tool("record", "Record a value.", ValueRequest, ValueResult, record)
+    model = _Model(
+        (
+            _response(
+                "I will record it.",
+                tool_calls=[_call("record", "record", '{"value":4}')],
+                finish_reason="stop",
+            ),
+            _response("Recorded."),
+        )
+    )
+
+    result = await run_tool_loop(
+        (ChatMessage(role="user", content="record four"),),
+        ToolSet((tool,)),
+        model,
+    )
+
+    assert invoked == [4]
+    assert result.content == "Recorded."
+    assert result.messages[1].content == "I will record it."
+
+
+async def test_unknown_and_invalid_calls_are_returned_for_model_repair() -> None:
+    invoked: list[int] = []
+
+    async def record(request: ValueRequest) -> ValueResult:
+        invoked.append(request.value)
+        return ValueResult(value=request.value)
+
+    tool = Tool("record", "Record a value.", ValueRequest, ValueResult, record)
+    model = _Model(
+        (
+            _response(
+                tool_calls=[_call("missing", "not_a_tool", "{}")],
+                finish_reason="tool_calls",
+            ),
+            _response(
+                tool_calls=[_call("invalid", "record", '{"value":"bad"}')],
+                finish_reason="tool_calls",
+            ),
+            _response(
+                tool_calls=[_call("valid", "record", '{"value":3}')],
+                finish_reason="tool_calls",
+            ),
+            _response("Repaired."),
+        )
+    )
+
+    result = await run_tool_loop(
+        (ChatMessage(role="user", content="record"),),
+        ToolSet((tool,)),
+        model,
+    )
+
+    assert invoked == [3]
+    errors = [json.loads(record.message.content) for record in result.tool_calls[:2]]
+    assert [error["error"] for error in errors] == [
+        "unknown_tool",
+        "invalid_tool_arguments",
+    ]
+    assert [record.call.id for record in result.tool_calls] == [
+        "missing",
+        "invalid",
+        "valid",
+    ]
+
+
+async def test_direct_return_finishes_without_another_model_call() -> None:
+    async def direct(request: ValueRequest) -> ValueResult:
+        return ValueResult(value=request.value)
+
+    tool = Tool(
+        "direct",
+        "Return a value directly.",
+        ValueRequest,
+        ValueResult,
+        direct,
+        return_direct=True,
+    )
+    model = _Model(
+        (
+            _response(
+                tool_calls=[_call("direct-call", "direct", '{"value":7}')],
+                finish_reason="tool_calls",
+            ),
+        )
+    )
+
+    result = await run_tool_loop(
+        (ChatMessage(role="user", content="direct"),),
+        ToolSet((tool,)),
+        model,
+    )
+
+    assert result.content == '{"value":7}'
+    assert result.return_direct is True
+    assert result.iterations == 1
+    assert len(model.requests) == 1
+
+
+async def test_invalid_direct_call_can_be_repaired_without_returning() -> None:
+    invoked: list[int] = []
+
+    async def direct(request: ValueRequest) -> ValueResult:
+        invoked.append(request.value)
+        return ValueResult(value=request.value)
+
+    tool = Tool(
+        "direct",
+        "Return a value directly.",
+        ValueRequest,
+        ValueResult,
+        direct,
+        return_direct=True,
+    )
+    model = _Model(
+        (
+            _response(
+                tool_calls=[_call("invalid", "direct", "not-json")],
+                finish_reason="tool_calls",
+            ),
+            _response("Could not run that tool."),
+        )
+    )
+
+    result = await run_tool_loop(
+        (ChatMessage(role="user", content="direct"),),
+        ToolSet((tool,)),
+        model,
+    )
+
+    assert result.content == "Could not run that tool."
+    assert result.return_direct is False
+    assert invoked == []
+    assert result.tool_calls[0].return_direct is False
+
+
+async def test_mixed_direct_return_batch_is_rejected_before_any_effect() -> None:
+    invoked: list[str] = []
+
+    async def regular(request: ValueRequest) -> ValueResult:
+        invoked.append(f"regular:{request.value}")
+        return ValueResult(value=request.value)
+
+    async def direct(request: ValueRequest) -> ValueResult:
+        invoked.append(f"direct:{request.value}")
+        return ValueResult(value=request.value)
+
+    regular_tool = Tool(
+        "regular", "Record normally.", ValueRequest, ValueResult, regular
+    )
+    direct_tool = Tool(
+        "direct",
+        "Return directly.",
+        ValueRequest,
+        ValueResult,
+        direct,
+        return_direct=True,
+    )
+    calls = [
+        _call("regular", "regular", '{"value":1}'),
+        _call("direct", "direct", '{"value":2}'),
+    ]
+
+    with pytest.raises(ToolLoopDirectReturnError) as raised:
+        await run_tool_loop(
+            (ChatMessage(role="user", content="both"),),
+            ToolSet((regular_tool, direct_tool)),
+            _Model((_response(tool_calls=calls, finish_reason="tool_calls"),)),
+        )
+
+    assert invoked == []
+    assert raised.value.tool_calls == ()
+    assert raised.value.messages[-1].tool_calls == calls
+
+
+async def test_multiple_direct_return_calls_are_rejected_before_any_effect() -> None:
+    invoked: list[int] = []
+
+    async def direct(request: ValueRequest) -> ValueResult:
+        invoked.append(request.value)
+        return ValueResult(value=request.value)
+
+    tool = Tool(
+        "direct",
+        "Return directly.",
+        ValueRequest,
+        ValueResult,
+        direct,
+        return_direct=True,
+    )
+    calls = [
+        _call("first", "direct", '{"value":1}'),
+        _call("second", "direct", '{"value":2}'),
+    ]
+
+    with pytest.raises(ToolLoopDirectReturnError):
+        await run_tool_loop(
+            (ChatMessage(role="user", content="both"),),
+            ToolSet((tool,)),
+            _Model((_response(tool_calls=calls, finish_reason="tool_calls"),)),
+        )
+
+    assert invoked == []
+
+
+@pytest.mark.parametrize(
+    "calls",
+    [
+        [_call("", "record", '{"value":1}')],
+        [_call("  ", "record", '{"value":1}')],
+        [
+            _call("duplicate", "record", '{"value":1}'),
+            _call("duplicate", "record", '{"value":2}'),
+        ],
+    ],
+)
+async def test_malformed_tool_call_ids_are_rejected_before_any_effect(
+    calls: list[ToolCall],
+) -> None:
+    invoked: list[int] = []
+
+    async def record(request: ValueRequest) -> ValueResult:
+        invoked.append(request.value)
+        return ValueResult(value=request.value)
+
+    tool = Tool("record", "Record a value.", ValueRequest, ValueResult, record)
+
+    with pytest.raises(ToolLoopMalformedResponseError) as raised:
+        await run_tool_loop(
+            (ChatMessage(role="user", content="record"),),
+            ToolSet((tool,)),
+            _Model((_response(tool_calls=calls, finish_reason="tool_calls"),)),
+        )
+
+    assert invoked == []
+    assert raised.value.tool_calls == ()
+
+
+async def test_reused_tool_call_id_is_rejected_before_repeated_effect() -> None:
+    invoked: list[int] = []
+
+    async def record(request: ValueRequest) -> ValueResult:
+        invoked.append(request.value)
+        return ValueResult(value=request.value)
+
+    tool = Tool("record", "Record a value.", ValueRequest, ValueResult, record)
+    model = _Model(
+        (
+            _response(
+                tool_calls=[_call("reused", "record", '{"value":1}')],
+                finish_reason="tool_calls",
+            ),
+            _response(
+                tool_calls=[_call("reused", "record", '{"value":2}')],
+                finish_reason="tool_calls",
+            ),
+        )
+    )
+
+    with pytest.raises(ToolLoopMalformedResponseError) as raised:
+        await run_tool_loop(
+            (ChatMessage(role="user", content="record"),),
+            ToolSet((tool,)),
+            model,
+        )
+
+    assert invoked == [1]
+    assert len(raised.value.tool_calls) == 1
+
+
+async def test_tool_calls_finish_reason_requires_a_nonempty_call_batch() -> None:
+    with pytest.raises(ToolLoopMalformedResponseError):
+        await run_tool_loop(
+            (ChatMessage(role="user", content="answer"),),
+            ToolSet(()),
+            _Model((_response("", tool_calls=[], finish_reason="tool_calls"),)),
+        )
+
+
+async def test_tool_call_budget_rejects_whole_batch_before_effects() -> None:
+    invoked: list[int] = []
+
+    async def record(request: ValueRequest) -> ValueResult:
+        invoked.append(request.value)
+        return ValueResult(value=request.value)
+
+    tool = Tool("record", "Record a value.", ValueRequest, ValueResult, record)
+    calls = [
+        _call("first", "record", '{"value":1}'),
+        _call("second", "record", '{"value":2}'),
+    ]
+
+    with pytest.raises(ToolLoopToolCallLimitError) as raised:
+        await run_tool_loop(
+            (ChatMessage(role="user", content="record"),),
+            ToolSet((tool,)),
+            _Model((_response(tool_calls=calls, finish_reason="tool_calls"),)),
+            max_tool_calls=1,
+        )
+
+    assert invoked == []
+    assert raised.value.iterations == 1
+    assert raised.value.tool_calls == ()
+
+
+async def test_iteration_limit_keeps_partial_transcript_and_audit() -> None:
+    async def record(request: ValueRequest) -> ValueResult:
+        return ValueResult(value=request.value)
+
+    tool = Tool("record", "Record a value.", ValueRequest, ValueResult, record)
+    model = _Model(
+        (
+            _response(
+                tool_calls=[_call("first", "record", '{"value":1}')],
+                finish_reason="tool_calls",
+            ),
+            _response(
+                tool_calls=[_call("second", "record", '{"value":1}')],
+                finish_reason="tool_calls",
+            ),
+        )
+    )
+
+    with pytest.raises(ToolLoopIterationLimitError) as raised:
+        await run_tool_loop(
+            (ChatMessage(role="user", content="never finish"),),
+            ToolSet((tool,)),
+            model,
+            max_iterations=2,
+        )
+
+    assert raised.value.iterations == 2
+    assert len(raised.value.tool_calls) == 2
+    assert [message.role for message in raised.value.messages] == [
+        "user",
+        "assistant",
+        "tool",
+        "assistant",
+        "tool",
+    ]
+
+
+@pytest.mark.parametrize("finish_reason", ["length", "max_tokens"])
+async def test_truncated_batch_is_rejected_before_tool_execution(
+    finish_reason: str,
+) -> None:
+    invoked: list[int] = []
+
+    async def record(request: ValueRequest) -> ValueResult:
+        invoked.append(request.value)
+        return ValueResult(value=request.value)
+
+    tool = Tool("record", "Record a value.", ValueRequest, ValueResult, record)
+    model = _Model(
+        (
+            _response(
+                "partial",
+                tool_calls=[_call("record", "record", '{"value":1}')],
+                finish_reason=finish_reason,
+            ),
+        )
+    )
+
+    with pytest.raises(ToolLoopTruncatedResponseError) as raised:
+        await run_tool_loop(
+            (ChatMessage(role="user", content="record"),),
+            ToolSet((tool,)),
+            model,
+        )
+
+    assert invoked == []
+    assert raised.value.messages[-1].content == "partial"
+
+
+async def test_empty_model_response_is_not_treated_as_success() -> None:
+    initial = (ChatMessage(role="user", content="answer"),)
+
+    with pytest.raises(ToolLoopEmptyResponseError) as raised:
+        await run_tool_loop(initial, ToolSet(()), _Model((_response("  "),)))
+
+    assert raised.value.messages == (
+        *initial,
+        ChatMessage(role="assistant", content="  "),
+    )
+
+
+async def test_cancellation_propagates_from_tool_execution() -> None:
+    started = asyncio.Event()
+    invoked_later = False
+
+    async def cancelled(_request: ValueRequest) -> ValueResult:
+        started.set()
+        raise asyncio.CancelledError
+
+    async def later(request: ValueRequest) -> ValueResult:
+        nonlocal invoked_later
+        invoked_later = True
+        return ValueResult(value=request.value)
+
+    tool = Tool(
+        "cancelled", "Cancel execution.", ValueRequest, ValueResult, cancelled
+    )
+    later_tool = Tool("later", "Run later.", ValueRequest, ValueResult, later)
+    model = _Model(
+        (
+            _response(
+                tool_calls=[
+                    _call("cancel", "cancelled", '{"value":1}'),
+                    _call("later", "later", '{"value":2}'),
+                ],
+                finish_reason="tool_calls",
+            ),
+        )
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await run_tool_loop(
+            (ChatMessage(role="user", content="cancel"),),
+            ToolSet((tool, later_tool)),
+            model,
+        )
+
+    assert started.is_set()
+    assert invoked_later is False
+
+
+async def test_cancellation_propagates_from_model_call() -> None:
+    async def cancelled_model(
+        _messages: tuple[ChatMessage, ...],
+        _tools: tuple[ToolDef, ...],
+    ) -> ChatResponse:
+        raise asyncio.CancelledError
+
+    with pytest.raises(asyncio.CancelledError):
+        await run_tool_loop(
+            (ChatMessage(role="user", content="cancel"),),
+            ToolSet(()),
+            cancelled_model,
+        )
+
+
+async def test_tool_handler_failure_propagates_without_later_calls() -> None:
+    invoked_later = False
+
+    async def failed(_request: ValueRequest) -> ValueResult:
+        raise RuntimeError("tool failed")
+
+    async def later(request: ValueRequest) -> ValueResult:
+        nonlocal invoked_later
+        invoked_later = True
+        return ValueResult(value=request.value)
+
+    failed_tool = Tool("failed", "Fail.", ValueRequest, ValueResult, failed)
+    later_tool = Tool("later", "Run later.", ValueRequest, ValueResult, later)
+    model = _Model(
+        (
+            _response(
+                tool_calls=[
+                    _call("failed", "failed", '{"value":1}'),
+                    _call("later", "later", '{"value":2}'),
+                ],
+                finish_reason="tool_calls",
+            ),
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="tool failed"):
+        await run_tool_loop(
+            (ChatMessage(role="user", content="run"),),
+            ToolSet((failed_tool, later_tool)),
+            model,
+        )
+
+    assert invoked_later is False
+
+
+@pytest.mark.parametrize(
+    ("max_iterations", "max_tool_calls", "message"),
+    [
+        (0, 1, "max_iterations must be at least 1"),
+        (1, -1, "max_tool_calls must not be negative"),
+    ],
+)
+async def test_run_tool_loop_rejects_invalid_limits(
+    max_iterations: int,
+    max_tool_calls: int,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        await run_tool_loop(
+            (),
+            ToolSet(()),
+            _Model(()),
+            max_iterations=max_iterations,
+            max_tool_calls=max_tool_calls,
+        )

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -84,7 +84,7 @@ class _Model:
         return next(self._responses)
 
 
-def _call(call_id: str, name: str, arguments: str) -> ToolCall:
+def _call(call_id: Any, name: str, arguments: str) -> ToolCall:
     return ToolCall(id=call_id, name=name, arguments=arguments)
 
 
@@ -288,6 +288,7 @@ async def test_invalid_direct_call_can_be_repaired_without_returning() -> None:
 
 
 async def test_mixed_direct_return_batch_is_rejected_before_any_effect() -> None:
+    initial = (ChatMessage(role="user", content="both"),)
     invoked: list[str] = []
 
     async def regular(request: ValueRequest) -> ValueResult:
@@ -316,14 +317,16 @@ async def test_mixed_direct_return_batch_is_rejected_before_any_effect() -> None
 
     with pytest.raises(ToolLoopDirectReturnError) as raised:
         await run_tool_loop(
-            (ChatMessage(role="user", content="both"),),
+            initial,
             ToolSet((regular_tool, direct_tool)),
             _Model((_response(tool_calls=calls, finish_reason="tool_calls"),)),
         )
 
     assert invoked == []
     assert raised.value.tool_calls == ()
-    assert raised.value.messages[-1].tool_calls == calls
+    assert raised.value.messages == initial
+    assert raised.value.rejected_response is not None
+    assert raised.value.rejected_response.tool_calls == calls
 
 
 async def test_multiple_direct_return_calls_are_rejected_before_any_effect() -> None:
@@ -359,6 +362,8 @@ async def test_multiple_direct_return_calls_are_rejected_before_any_effect() -> 
 @pytest.mark.parametrize(
     "calls",
     [
+        [_call(None, "record", '{"value":1}')],
+        [_call(7, "record", '{"value":1}')],
         [_call("", "record", '{"value":1}')],
         [_call("  ", "record", '{"value":1}')],
         [
@@ -387,6 +392,9 @@ async def test_malformed_tool_call_ids_are_rejected_before_any_effect(
 
     assert invoked == []
     assert raised.value.tool_calls == ()
+    assert [message.role for message in raised.value.messages] == ["user"]
+    assert raised.value.rejected_response is not None
+    assert raised.value.rejected_response.tool_calls == calls
 
 
 async def test_reused_tool_call_id_is_rejected_before_repeated_effect() -> None:
@@ -419,6 +427,14 @@ async def test_reused_tool_call_id_is_rejected_before_repeated_effect() -> None:
 
     assert invoked == [1]
     assert len(raised.value.tool_calls) == 1
+    assert [message.role for message in raised.value.messages] == [
+        "user",
+        "assistant",
+        "tool",
+    ]
+    assert raised.value.rejected_response is not None
+    assert raised.value.rejected_response.tool_calls is not None
+    assert raised.value.rejected_response.tool_calls[0].id == "reused"
 
 
 async def test_tool_calls_finish_reason_requires_a_nonempty_call_batch() -> None:
@@ -431,6 +447,7 @@ async def test_tool_calls_finish_reason_requires_a_nonempty_call_batch() -> None
 
 
 async def test_tool_call_budget_rejects_whole_batch_before_effects() -> None:
+    initial = (ChatMessage(role="user", content="record"),)
     invoked: list[int] = []
 
     async def record(request: ValueRequest) -> ValueResult:
@@ -445,7 +462,7 @@ async def test_tool_call_budget_rejects_whole_batch_before_effects() -> None:
 
     with pytest.raises(ToolLoopToolCallLimitError) as raised:
         await run_tool_loop(
-            (ChatMessage(role="user", content="record"),),
+            initial,
             ToolSet((tool,)),
             _Model((_response(tool_calls=calls, finish_reason="tool_calls"),)),
             max_tool_calls=1,
@@ -454,6 +471,9 @@ async def test_tool_call_budget_rejects_whole_batch_before_effects() -> None:
     assert invoked == []
     assert raised.value.iterations == 1
     assert raised.value.tool_calls == ()
+    assert raised.value.messages == initial
+    assert raised.value.rejected_response is not None
+    assert raised.value.rejected_response.tool_calls == calls
 
 
 async def test_iteration_limit_keeps_partial_transcript_and_audit() -> None:
@@ -497,6 +517,7 @@ async def test_iteration_limit_keeps_partial_transcript_and_audit() -> None:
 async def test_truncated_batch_is_rejected_before_tool_execution(
     finish_reason: str,
 ) -> None:
+    initial = (ChatMessage(role="user", content="record"),)
     invoked: list[int] = []
 
     async def record(request: ValueRequest) -> ValueResult:
@@ -516,13 +537,15 @@ async def test_truncated_batch_is_rejected_before_tool_execution(
 
     with pytest.raises(ToolLoopTruncatedResponseError) as raised:
         await run_tool_loop(
-            (ChatMessage(role="user", content="record"),),
+            initial,
             ToolSet((tool,)),
             model,
         )
 
     assert invoked == []
-    assert raised.value.messages[-1].content == "partial"
+    assert raised.value.messages == initial
+    assert raised.value.rejected_response is not None
+    assert raised.value.rejected_response.content == "partial"
 
 
 async def test_empty_model_response_is_not_treated_as_success() -> None:
@@ -531,10 +554,9 @@ async def test_empty_model_response_is_not_treated_as_success() -> None:
     with pytest.raises(ToolLoopEmptyResponseError) as raised:
         await run_tool_loop(initial, ToolSet(()), _Model((_response("  "),)))
 
-    assert raised.value.messages == (
-        *initial,
-        ChatMessage(role="assistant", content="  "),
-    )
+    assert raised.value.messages == initial
+    assert raised.value.rejected_response is not None
+    assert raised.value.rejected_response.content == "  "
 
 
 async def test_cancellation_propagates_from_tool_execution() -> None:


### PR DESCRIPTION
## Summary

- add a common stateless `run_tool_loop(...)` helper beside the existing native one-call helpers
- preserve caller ownership of prompts, model parameters, history, participant context, retries, cancellation, and background tasks
- execute model-selected native tools sequentially through the existing Pydantic and NeMo Relay boundary
- return a complete intra-turn transcript and structured tool-call audit
- enforce model-iteration and total-tool-call budgets
- reject truncated responses, malformed call IDs, and ambiguous mixed `return_direct` batches before side effects
- keep unknown tools and invalid arguments model-repairable within the bounded turn

## Why

PR 355 deliberately removed the former generic Agent/AgentRunner because it owned application policy. Two concrete applications now need the same protocol-mechanical loop: the open lab-instrument monitoring sample in PR 363 and the forthcoming native tea-making sample.

This extraction remains a small turn engine rather than restoring an agent framework. Applications still own lifecycle, state, concurrency, model settings, and user-facing recovery.

## Behavior

The caller supplies initial messages, a per-invocation `ToolSet`, and a model callback. The callback receives immutable transcript and tool-definition tuples and retains control of the underlying `LLMService` call.

Tool batches run serially in model order. Cancellation and unexpected model/tool exceptions propagate. The helper never retries an executed tool. Typed errors carry the partial transcript and audit for application-specific handling.

PR 363 is not included because it remains an open PR and is not present on `main`; it can adopt this helper when restacked.

## Validation

- `tests/.venv/bin/pytest -q tests/test_tool_calling.py` — 25 passed
- existing ToolSet/tool-definition focused tests — 3 passed
- `uvx ruff check agent-sdk/xr-ai-tools/xr_ai_tools/tool_calling.py tests/test_tool_calling.py`
- `git diff --check`
