### PR TITLE
docs: generate SDK API reference

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -34,6 +34,8 @@ on:
     paths:
       - "docs/**"
       - "agent-sdk/*/README.md"
+      - "agent-sdk/xr-ai-runtime/**/*.py"
+      - "agent-sdk/xr-ai-voice/**/*.py"
       - ".github/workflows/docs.yaml"
       - ".github/scripts/select_latest_docs_release.py"
       - ".github/scripts/publish_docs.sh"
@@ -44,6 +46,8 @@ on:
     paths:
       - "docs/**"
       - "agent-sdk/*/README.md"
+      - "agent-sdk/xr-ai-runtime/**/*.py"
+      - "agent-sdk/xr-ai-voice/**/*.py"
       - ".github/workflows/docs.yaml"
       - ".github/scripts/select_latest_docs_release.py"
       - ".github/scripts/publish_docs.sh"

--- a/agent-sdk/xr-ai-runtime/xr_ai_runtime/events.py
+++ b/agent-sdk/xr-ai-runtime/xr_ai_runtime/events.py
@@ -19,8 +19,13 @@ class Topic(Generic[MessageT]):
     """A stable publish/subscribe name paired with its payload model."""
 
     name: str
+    """Stable name shared by every publisher and subscriber."""
+
     message_type: type[MessageT]
+    """Pydantic model used to validate each publication."""
+
     telemetry: Literal["full", "none"] = "full"
+    """Whether Relay records publication and subscriber-delivery scopes."""
 
     def __post_init__(self) -> None:
         if not self.name.strip():
@@ -41,11 +46,22 @@ class MessageMetadata:
     """Routing and trace context for one published event."""
 
     message_id: str
+    """Unique identifier for this publication."""
+
     correlation_id: str
+    """Identifier shared by publications in one logical operation."""
+
     participant_id: str | None
+    """Participant routing key, or ``None`` for a global event."""
+
     source: str
+    """Runtime-local name of the publisher."""
+
     parent_message_id: str | None
+    """Identifier of the publication that caused this event, when present."""
+
     timestamp_us: int
+    """Publication time as Unix microseconds."""
 
 
 def subscribe(

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/__init__.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/__init__.py
@@ -4,7 +4,7 @@
 """Public voice runtime for XR agents.
 
 Applications configure and register :class:`VoiceAgent`; media sessions,
-Pipecat, audio framing, and pipeline processors are implementation details.
+audio framing, and pipeline processors are implementation details.
 """
 
 from ._processors import VadConfig

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_processors/vad_stt.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_processors/vad_stt.py
@@ -66,9 +66,16 @@ class VadConfig:
     ends. Set to ``0`` or negative to disable probes.
     """
     silence_duration:   float = 0.8
+    """Seconds of silence that finalize an utterance."""
+
     min_speech:         float = 0.15
+    """Minimum speech duration accepted as an utterance."""
+
     silero_threshold:   float = 0.5
+    """Silero VAD speech-probability threshold."""
+
     stop_probe_after_s: float = 0.25
+    """Cadence for bounded early wake and STOP transcription probes."""
 
 
 class VadSttProcessor(FrameProcessor):

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_runtime.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_runtime.py
@@ -42,7 +42,10 @@ class UserQuery(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     text: str = Field(min_length=1)
+    """Gate-accepted speech or direct typed text."""
+
     timestamp_us: int = Field(ge=0)
+    """Input presentation time as Unix microseconds."""
 
 
 class VoiceTranscript(BaseModel):
@@ -51,7 +54,10 @@ class VoiceTranscript(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     text: str = Field(min_length=1)
+    """Final text returned by STT before voice-gate filtering."""
+
     timestamp_us: int = Field(ge=0)
+    """Speech presentation time as Unix microseconds."""
 
 
 class VoiceParticipantLeft(BaseModel):
@@ -72,10 +78,19 @@ class VoiceOutput(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     text: str = ""
+    """Complete response text or one incremental fragment."""
+
     response_id: str | None = Field(default=None, min_length=1)
+    """Stable identifier shared by chunks of an incremental response."""
+
     final: bool = True
+    """Whether this message completes the response."""
+
     interrupt: bool = False
+    """Whether the first response message supersedes active voice output."""
+
     timestamp_us: int | None = Field(default=None, ge=0)
+    """Optional originating input timestamp propagated to TTS."""
 
     @model_validator(mode="after")
     def validate_boundary(self) -> VoiceOutput:
@@ -91,7 +106,10 @@ class VoiceOutput(BaseModel):
 
 
 VOICE_TRANSCRIPT_TOPIC = Topic("voice.transcript", VoiceTranscript)
+"""All final STT results, published before voice-gate filtering."""
+
 VOICE_OUTPUT_TOPIC = Topic("voice.output", VoiceOutput, telemetry="none")
+"""Finite or incremental responses consumed by :class:`VoiceAgent`."""
 
 
 @dataclass(slots=True)

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_transport.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_transport.py
@@ -394,13 +394,19 @@ class HubVoiceTransport(BaseTransport):
         self._output = XRMediaHubOutputTransport(self._ep, params, name=self._output_name)
 
     def input(self) -> XRMediaHubInputTransport:
+        """Return the Pipecat input transport backed by the media hub."""
+
         return self._input
 
     def output(self) -> XRMediaHubOutputTransport:
+        """Return the Pipecat output transport backed by the media hub."""
+
         return self._output
 
     @property
     def endpoint(self) -> ProcessorEndpoint:
+        """Return the owned hub processor endpoint."""
+
         return self._ep
 
     async def wait_until_started(self) -> None:
@@ -408,19 +414,29 @@ class HubVoiceTransport(BaseTransport):
         await self._input_started.wait()
 
     async def send_return_data(self, msg: DataMessage) -> None:
+        """Send participant-routed data through the hub."""
+
         await self._ep.send_return_data(msg)
 
     @property
     def target_participant(self) -> str:
+        """Return the participant currently selected for output."""
+
         return self._output.target_participant
 
     def set_target_participant(self, pid: str) -> None:
+        """Select the participant that receives subsequent output."""
+
         self._output.set_target_participant(pid)
 
     def cleanup_participant(self, pid: str) -> None:
+        """Clear output routing when the selected participant leaves."""
+
         if self._output.target_participant == pid:
             self._output.set_target_participant("")
 
     def shutdown(self) -> None:
+        """Stop and close the owned hub endpoint."""
+
         self._ep.stop()
         self._ep.close()

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_transport.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_transport.py
@@ -359,7 +359,7 @@ class XRMediaHubOutputTransport(BaseOutputTransport):
 # ── Transport wrapper ─────────────────────────────────────────────────────────
 
 class HubVoiceTransport(BaseTransport):
-    """Owns the ProcessorEndpoint + bidirectional Pipecat transports."""
+    """Own the hub endpoint and bidirectional voice media transport."""
 
     def __init__(
         self,

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -28,12 +28,14 @@ api-check:
 
 html: api-check
 	@$(CURRENTENV) $(SPHINXBUILD) -b html $(SPHINXOPTS) "$(SOURCEDIR)" "$(CURRENTBUILDDIR)"
+	@python3 "$(SOURCEDIR)/_api_reference_check.py" "$(CURRENTBUILDDIR)"
 
 versions:
 	@$(SMVENV) $(SPHINXMULTIVERSION) $(SPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)"
 
 strict: api-check
 	@$(CURRENTENV) $(SPHINXBUILD) -W --keep-going -b html $(SPHINXOPTS) "$(SOURCEDIR)" "$(CURRENTBUILDDIR)"
+	@python3 "$(SOURCEDIR)/_api_reference_check.py" "$(CURRENTBUILDDIR)"
 
 strict-versions: api-check
 	@$(SMVENV) $(SPHINXMULTIVERSION) -W --keep-going $(SPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)"

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -19,20 +19,23 @@ LATEST_RELEASE := $(shell git tag --list 'v*' | python3 ../.github/scripts/selec
 CURRENTENV    = XR_AI_DOCS_GITHUB_REF=$(DOCS_GITHUB_REF)
 SMVENV        = XR_AI_DOCS_LATEST_VERSION=$(or $(LATEST_RELEASE),main)
 
-.PHONY: help html versions strict strict-versions latest-release clean
+.PHONY: help api-check html versions strict strict-versions latest-release clean
 help:
 	@echo "Targets: html, versions, strict, strict-versions, latest-release, clean."
 
-html:
+api-check:
+	@python3 "$(SOURCEDIR)/_api_contract.py"
+
+html: api-check
 	@$(CURRENTENV) $(SPHINXBUILD) -b html $(SPHINXOPTS) "$(SOURCEDIR)" "$(CURRENTBUILDDIR)"
 
 versions:
 	@$(SMVENV) $(SPHINXMULTIVERSION) $(SPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)"
 
-strict:
+strict: api-check
 	@$(CURRENTENV) $(SPHINXBUILD) -W --keep-going -b html $(SPHINXOPTS) "$(SOURCEDIR)" "$(CURRENTBUILDDIR)"
 
-strict-versions:
+strict-versions: api-check
 	@$(SMVENV) $(SPHINXMULTIVERSION) -W --keep-going $(SPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)"
 
 latest-release:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,6 +4,7 @@
 # Pins for building the XR AI Sphinx documentation site.
 # Mirrors the NVIDIA/IsaacTeleop docs toolchain.
 sphinx==8.1.3
+sphinx-autoapi==3.8.0
 nvidia-sphinx-theme==0.0.9.post1
 myst-parser==4.0.0
 sphinx-copybutton==0.5.2

--- a/docs/source/_api_contract.py
+++ b/docs/source/_api_contract.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import ast
+from dataclasses import dataclass
 from pathlib import Path
 
 _REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
@@ -13,6 +14,20 @@ API_PACKAGE_DIRS = (
     _REPOSITORY_ROOT / "agent-sdk" / "xr-ai-runtime" / "xr_ai_runtime",
     _REPOSITORY_ROOT / "agent-sdk" / "xr-ai-voice" / "xr_ai_voice",
 )
+
+
+@dataclass(frozen=True)
+class _Module:
+    path: Path
+    parts: tuple[str, ...]
+    is_package: bool
+    tree: ast.Module
+
+
+@dataclass(frozen=True)
+class _Definition:
+    module: _Module
+    node: ast.AST
 
 
 def _literal_exports(tree: ast.Module, path: Path) -> tuple[str, ...]:
@@ -26,22 +41,20 @@ def _literal_exports(tree: ast.Module, path: Path) -> tuple[str, ...]:
             value = ast.literal_eval(node.value)
         except (TypeError, ValueError) as error:
             raise ValueError(f"{path}: __all__ must be a literal sequence") from error
-        if not isinstance(value, (list, tuple)) or not all(
-            isinstance(name, str) for name in value
-        ):
+        if not isinstance(value, (list, tuple)) or not all(isinstance(name, str) for name in value):
             raise ValueError(f"{path}: __all__ must contain only strings")
         return tuple(value)
     raise ValueError(f"{path}: public package must define __all__")
 
 
-def _assignment_has_docstring(tree: ast.Module, node: ast.AST) -> bool:
+def _following_docstring(body: list[ast.stmt], node: ast.AST) -> bool:
     try:
-        index = tree.body.index(node)
+        index = body.index(node)
     except ValueError:
         return False
-    if index + 1 >= len(tree.body):
+    if index + 1 >= len(body):
         return False
-    following = tree.body[index + 1]
+    following = body[index + 1]
     return (
         isinstance(following, ast.Expr)
         and isinstance(following.value, ast.Constant)
@@ -50,31 +63,159 @@ def _assignment_has_docstring(tree: ast.Module, node: ast.AST) -> bool:
     )
 
 
-def _documented_definitions(
+def _load_module(
     package_dir: Path,
-) -> tuple[dict[str, bool], dict[str, list[str]]]:
-    definitions: dict[str, bool] = {}
-    missing_methods: dict[str, list[str]] = {}
-    for path in package_dir.rglob("*.py"):
-        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-        for node in tree.body:
-            if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
-                definitions[node.name] = bool(ast.get_docstring(node))
-                if isinstance(node, ast.ClassDef):
-                    for member in node.body:
-                        if not isinstance(member, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                            continue
-                        if member.name.startswith("_") or ast.get_docstring(member):
-                            continue
-                        missing_methods.setdefault(node.name, []).append(member.name)
-                continue
-            if not isinstance(node, (ast.Assign, ast.AnnAssign)):
-                continue
-            targets = node.targets if isinstance(node, ast.Assign) else (node.target,)
-            for target in targets:
-                if isinstance(target, ast.Name):
-                    definitions[target.id] = _assignment_has_docstring(tree, node)
-    return definitions, missing_methods
+    parts: tuple[str, ...],
+    modules: dict[tuple[str, ...], _Module],
+) -> _Module | None:
+    if parts in modules:
+        return modules[parts]
+
+    candidate = package_dir.joinpath(*parts)
+    if candidate.is_dir():
+        path = candidate / "__init__.py"
+        is_package = True
+    else:
+        path = candidate.with_suffix(".py")
+        is_package = False
+    if not path.is_file():
+        return None
+
+    module = _Module(
+        path=path,
+        parts=parts,
+        is_package=is_package,
+        tree=ast.parse(path.read_text(encoding="utf-8"), filename=str(path)),
+    )
+    modules[parts] = module
+    return module
+
+
+def _imported_module_parts(
+    package_dir: Path,
+    module: _Module,
+    node: ast.ImportFrom,
+) -> tuple[str, ...] | None:
+    imported = tuple(node.module.split(".")) if node.module else ()
+    if node.level == 0:
+        if not imported or imported[0] != package_dir.name:
+            return None
+        return imported[1:]
+
+    package = module.parts if module.is_package else module.parts[:-1]
+    parent_count = node.level - 1
+    if parent_count > len(package):
+        return None
+    return (*package[: len(package) - parent_count], *imported)
+
+
+def _assignment_value(node: ast.Assign | ast.AnnAssign) -> ast.expr | None:
+    return node.value
+
+
+def _resolve_name(
+    package_dir: Path,
+    module: _Module,
+    name: str,
+    modules: dict[tuple[str, ...], _Module],
+    resolving: frozenset[tuple[tuple[str, ...], str]] = frozenset(),
+) -> _Definition | None:
+    key = (module.parts, name)
+    if key in resolving:
+        return None
+    resolving |= {key}
+
+    binding: ast.AST | tuple[tuple[str, ...], str] | None = None
+    for node in module.tree.body:
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.name == name:
+                binding = node
+            continue
+        if isinstance(node, ast.ImportFrom):
+            imported_parts = _imported_module_parts(package_dir, module, node)
+            for alias in node.names:
+                if alias.name == "*" or (alias.asname or alias.name) != name:
+                    continue
+                binding = (imported_parts, alias.name) if imported_parts is not None else None
+            continue
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else (node.target,)
+        if any(isinstance(target, ast.Name) and target.id == name for target in targets):
+            binding = node
+
+    if isinstance(binding, tuple):
+        imported_module = _load_module(package_dir, binding[0], modules)
+        if imported_module is None:
+            return None
+        return _resolve_name(
+            package_dir,
+            imported_module,
+            binding[1],
+            modules,
+            resolving,
+        )
+    if isinstance(binding, (ast.Assign, ast.AnnAssign)):
+        value = _assignment_value(binding)
+        if isinstance(value, ast.Name) and value.id != name:
+            target = _resolve_name(package_dir, module, value.id, modules, resolving)
+            if target is not None:
+                return target
+    if binding is None:
+        return None
+    return _Definition(module=module, node=binding)
+
+
+def _definition_has_docstring(definition: _Definition) -> bool:
+    node = definition.node
+    if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+        return bool(ast.get_docstring(node))
+    return _following_docstring(definition.module.tree.body, node)
+
+
+def _public_methods_without_docstrings(node: ast.ClassDef) -> list[str]:
+    return [
+        member.name
+        for member in node.body
+        if isinstance(member, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and not member.name.startswith("_")
+        and not ast.get_docstring(member)
+    ]
+
+
+def _name_tail(node: ast.expr) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    if isinstance(node, ast.Call):
+        return _name_tail(node.func)
+    return None
+
+
+def _is_documented_field_container(node: ast.ClassDef) -> bool:
+    return any(_name_tail(decorator) == "dataclass" for decorator in node.decorator_list) or any(
+        _name_tail(base) == "BaseModel" for base in node.bases
+    )
+
+
+def _is_class_var(annotation: ast.expr) -> bool:
+    target = annotation.value if isinstance(annotation, ast.Subscript) else annotation
+    return _name_tail(target) == "ClassVar"
+
+
+def _public_fields_without_docstrings(node: ast.ClassDef) -> list[str]:
+    if not _is_documented_field_container(node):
+        return []
+    return [
+        member.target.id
+        for member in node.body
+        if isinstance(member, ast.AnnAssign)
+        and isinstance(member.target, ast.Name)
+        and not member.target.id.startswith("_")
+        and not _is_class_var(member.annotation)
+        and not _following_docstring(node.body, member)
+    ]
 
 
 def validate_public_api() -> list[str]:
@@ -82,18 +223,28 @@ def validate_public_api() -> list[str]:
 
     failures: list[str] = []
     for package_dir in API_PACKAGE_DIRS:
-        facade = package_dir / "__init__.py"
-        tree = ast.parse(facade.read_text(encoding="utf-8"), filename=str(facade))
-        exports = _literal_exports(tree, facade)
-        definitions, missing_methods = _documented_definitions(package_dir)
+        modules: dict[tuple[str, ...], _Module] = {}
+        facade = _load_module(package_dir, (), modules)
+        if facade is None:
+            failures.append(f"{package_dir.name}: package facade does not resolve")
+            continue
+        exports = _literal_exports(facade.tree, facade.path)
         for name in exports:
-            if name not in definitions:
+            definition = _resolve_name(package_dir, facade, name, modules)
+            if definition is None:
                 failures.append(f"{package_dir.name}: exported {name} does not resolve")
-            elif not definitions[name]:
+                continue
+            if not _definition_has_docstring(definition):
                 failures.append(f"{package_dir.name}: exported {name} has no docstring")
+            if not isinstance(definition.node, ast.ClassDef):
+                continue
             failures.extend(
                 f"{package_dir.name}: public method {name}.{method} has no docstring"
-                for method in missing_methods.get(name, ())
+                for method in _public_methods_without_docstrings(definition.node)
+            )
+            failures.extend(
+                f"{package_dir.name}: public field {name}.{field} has no docstring"
+                for field in _public_fields_without_docstrings(definition.node)
             )
     return failures
 

--- a/docs/source/_api_contract.py
+++ b/docs/source/_api_contract.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Static public-API documentation checks shared by Sphinx and CI."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+API_PACKAGE_DIRS = (
+    _REPOSITORY_ROOT / "agent-sdk" / "xr-ai-runtime" / "xr_ai_runtime",
+    _REPOSITORY_ROOT / "agent-sdk" / "xr-ai-voice" / "xr_ai_voice",
+)
+
+
+def _literal_exports(tree: ast.Module, path: Path) -> tuple[str, ...]:
+    for node in tree.body:
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else (node.target,)
+        if not any(isinstance(target, ast.Name) and target.id == "__all__" for target in targets):
+            continue
+        try:
+            value = ast.literal_eval(node.value)
+        except (TypeError, ValueError) as error:
+            raise ValueError(f"{path}: __all__ must be a literal sequence") from error
+        if not isinstance(value, (list, tuple)) or not all(
+            isinstance(name, str) for name in value
+        ):
+            raise ValueError(f"{path}: __all__ must contain only strings")
+        return tuple(value)
+    raise ValueError(f"{path}: public package must define __all__")
+
+
+def _assignment_has_docstring(tree: ast.Module, node: ast.AST) -> bool:
+    try:
+        index = tree.body.index(node)
+    except ValueError:
+        return False
+    if index + 1 >= len(tree.body):
+        return False
+    following = tree.body[index + 1]
+    return (
+        isinstance(following, ast.Expr)
+        and isinstance(following.value, ast.Constant)
+        and isinstance(following.value.value, str)
+        and bool(following.value.value.strip())
+    )
+
+
+def _documented_definitions(
+    package_dir: Path,
+) -> tuple[dict[str, bool], dict[str, list[str]]]:
+    definitions: dict[str, bool] = {}
+    missing_methods: dict[str, list[str]] = {}
+    for path in package_dir.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in tree.body:
+            if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+                definitions[node.name] = bool(ast.get_docstring(node))
+                if isinstance(node, ast.ClassDef):
+                    for member in node.body:
+                        if not isinstance(member, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                            continue
+                        if member.name.startswith("_") or ast.get_docstring(member):
+                            continue
+                        missing_methods.setdefault(node.name, []).append(member.name)
+                continue
+            if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+                continue
+            targets = node.targets if isinstance(node, ast.Assign) else (node.target,)
+            for target in targets:
+                if isinstance(target, ast.Name):
+                    definitions[target.id] = _assignment_has_docstring(tree, node)
+    return definitions, missing_methods
+
+
+def validate_public_api() -> list[str]:
+    """Return documentation contract violations for the enrolled packages."""
+
+    failures: list[str] = []
+    for package_dir in API_PACKAGE_DIRS:
+        facade = package_dir / "__init__.py"
+        tree = ast.parse(facade.read_text(encoding="utf-8"), filename=str(facade))
+        exports = _literal_exports(tree, facade)
+        definitions, missing_methods = _documented_definitions(package_dir)
+        for name in exports:
+            if name not in definitions:
+                failures.append(f"{package_dir.name}: exported {name} does not resolve")
+            elif not definitions[name]:
+                failures.append(f"{package_dir.name}: exported {name} has no docstring")
+            failures.extend(
+                f"{package_dir.name}: public method {name}.{method} has no docstring"
+                for method in missing_methods.get(name, ())
+            )
+    return failures
+
+
+def main() -> int:
+    """Print public API documentation failures and return a process status."""
+
+    failures = validate_public_api()
+    if failures:
+        print("Public API documentation check failed:")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+    print("Public API documentation check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/source/_api_reference_check.py
+++ b/docs/source/_api_reference_check.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Checks for implementation details in the generated public API reference."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_VOICE_REFERENCE = Path("reference/python/xr_ai_voice/index.html")
+_PRIVATE_VOICE_TERMS = {
+    "pipecat": "Pipecat",
+    "xrmediahubinputtransport": "XRMediaHubInputTransport",
+    "xrmediahuboutputtransport": "XRMediaHubOutputTransport",
+}
+
+
+def validate_generated_api(build_dir: Path) -> list[str]:
+    """Return private implementation details present in generated HTML."""
+
+    reference = build_dir / _VOICE_REFERENCE
+    if not reference.is_file():
+        return [f"generated voice API page is missing: {reference}"]
+
+    html = reference.read_text(encoding="utf-8").casefold()
+    return [
+        f"generated voice API exposes private implementation detail: {label}"
+        for term, label in _PRIVATE_VOICE_TERMS.items()
+        if term in html
+    ]
+
+
+def main() -> int:
+    """Validate a Sphinx HTML build directory."""
+
+    if len(sys.argv) != 2:
+        print(f"usage: {Path(sys.argv[0]).name} BUILD_DIR")
+        return 2
+    failures = validate_generated_api(Path(sys.argv[1]))
+    if failures:
+        print("Generated public API reference check failed:")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+    print("Generated public API reference check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,6 +6,12 @@ from __future__ import annotations
 
 import os
 import re
+from pathlib import Path
+from runpy import run_path
+
+API_PACKAGE_DIRS = run_path(str(Path(__file__).with_name("_api_contract.py")))[
+    "API_PACKAGE_DIRS"
+]
 
 _GITHUB_BLOB_PREFIX = "https://github.com/NVIDIA/xr-ai/blob/"
 _GITHUB_TREE_PREFIX = "https://github.com/NVIDIA/xr-ai/tree/"
@@ -43,6 +49,7 @@ author = "NVIDIA"
 
 # -- General configuration ---------------------------------------------------
 extensions = [
+    "autoapi.extension",
     "myst_parser",
     "sphinx_copybutton",
     "sphinx_design",
@@ -50,6 +57,23 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx_multiversion",
 ]
+
+# Build the public Python reference from source without importing SDK packages.
+# This keeps optional voice, model, and native dependencies out of the docs
+# environment. Package ``__all__`` declarations remain the publication boundary.
+autoapi_type = "python"
+autoapi_dirs = [str(path) for path in API_PACKAGE_DIRS]
+autoapi_root = "reference/python"
+autoapi_add_toctree_entry = True
+autoapi_keep_files = False
+autoapi_options = [
+    "members",
+    "show-inheritance",
+    "show-module-summary",
+    "imported-members",
+]
+autoapi_member_order = "bysource"
+autoapi_python_class_content = "class"
 
 # MyST Markdown is the page format (matches the repo's existing docs/*.md).
 source_suffix = {
@@ -89,6 +113,13 @@ html_css_files = ["css/custom.css"]
 html_sidebars = {"**": ["versioning.html", "sidebar-nav-bs"]}
 
 
+def _skip_api_submodules(_app, what, _name, _obj, _skip, _options):
+    """Hide implementation-module pages while retaining facade reexports."""
+
+    return True if what == "module" else None
+
+
 def setup(app):
     app.connect("source-read", _rewrite_github_links)
+    app.connect("autoapi-skip-member", _skip_api_submodules)
     return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -68,7 +68,6 @@ autoapi_add_toctree_entry = True
 autoapi_keep_files = False
 autoapi_options = [
     "members",
-    "show-inheritance",
     "show-module-summary",
     "imported-members",
 ]
@@ -113,13 +112,21 @@ html_css_files = ["css/custom.css"]
 html_sidebars = {"**": ["versioning.html", "sidebar-nav-bs"]}
 
 
-def _skip_api_submodules(_app, what, _name, _obj, _skip, _options):
-    """Hide implementation-module pages while retaining facade reexports."""
+_PRIVATE_API_MEMBER_SUFFIXES = (
+    ".HubVoiceTransport.input",
+    ".HubVoiceTransport.output",
+)
 
-    return True if what == "module" else None
+
+def _skip_private_api_details(_app, what, name, _obj, _skip, _options):
+    """Hide implementation modules and transport-adapter accessors."""
+
+    if what == "module" or name.endswith(_PRIVATE_API_MEMBER_SUFFIXES):
+        return True
+    return None
 
 
 def setup(app):
     app.connect("source-read", _rewrite_github_links)
-    app.connect("autoapi-skip-member", _skip_api_submodules)
+    app.connect("autoapi-skip-member", _skip_private_api_details)
     return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/docs/source/reference/index.md
+++ b/docs/source/reference/index.md
@@ -5,7 +5,7 @@
 
 # Reference
 
-Detailed reference for the xr-render-demo stack.
+Package, Python API, migration, and sample-stack references.
 
 ```{toctree}
 :glob:

--- a/tests/test_api_documentation.py
+++ b/tests/test_api_documentation.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 from types import ModuleType
 
@@ -13,10 +14,23 @@ import pytest
 
 _ROOT = Path(__file__).resolve().parents[1]
 _CONTRACT = _ROOT / "docs" / "source" / "_api_contract.py"
+_REFERENCE_CHECK = _ROOT / "docs" / "source" / "_api_reference_check.py"
 
 
 def _load_contract() -> ModuleType:
     spec = importlib.util.spec_from_file_location("_api_contract_test", _CONTRACT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        del sys.modules[spec.name]
+    return module
+
+
+def _load_reference_check() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("_api_reference_check_test", _REFERENCE_CHECK)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -82,3 +96,119 @@ __all__ = ["Client", "DEFAULT_CLIENT", "Missing"]
         "example_api: exported DEFAULT_CLIENT has no docstring",
         "example_api: exported Missing does not resolve",
     ]
+
+
+def test_unbound_submodule_definition_does_not_satisfy_export(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    contract = _load_contract()
+    package = _package(tmp_path, '__all__ = ["Client"]\n')
+    (package / "implementation.py").write_text(
+        '''
+class Client:
+    """A class that the facade never imports."""
+''',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(contract, "API_PACKAGE_DIRS", (package,))
+
+    assert contract.validate_public_api() == ["example_api: exported Client does not resolve"]
+
+
+def test_reexport_resolves_exact_definition(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    contract = _load_contract()
+    package = _package(
+        tmp_path,
+        """
+from .public import Client
+
+__all__ = ["Client"]
+""",
+    )
+    (package / "public.py").write_text(
+        '''
+class Client:
+    """The class bound by the facade."""
+''',
+        encoding="utf-8",
+    )
+    (package / "unrelated.py").write_text(
+        """
+class Client:
+    pass
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(contract, "API_PACKAGE_DIRS", (package,))
+
+    assert contract.validate_public_api() == []
+
+
+def test_undocumented_dataclass_and_pydantic_fields_fail(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    contract = _load_contract()
+    package = _package(
+        tmp_path,
+        '''
+from dataclasses import dataclass
+from pydantic import BaseModel
+
+
+@dataclass
+class Item:
+    """A documented dataclass."""
+
+    documented: str
+    """A documented field."""
+
+    missing: int
+
+
+class Request(BaseModel):
+    """A documented Pydantic model."""
+
+    missing: str
+
+
+__all__ = ["Item", "Request"]
+''',
+    )
+    monkeypatch.setattr(contract, "API_PACKAGE_DIRS", (package,))
+
+    assert contract.validate_public_api() == [
+        "example_api: public field Item.missing has no docstring",
+        "example_api: public field Request.missing has no docstring",
+    ]
+
+
+def test_generated_voice_reference_rejects_private_transport_details(
+    tmp_path: Path,
+) -> None:
+    reference_check = _load_reference_check()
+    reference = tmp_path / "reference" / "python" / "xr_ai_voice" / "index.html"
+    reference.parent.mkdir(parents=True)
+    reference.write_text(
+        "Pipecat XRMediaHubInputTransport XRMediaHubOutputTransport",
+        encoding="utf-8",
+    )
+
+    assert reference_check.validate_generated_api(tmp_path) == [
+        "generated voice API exposes private implementation detail: Pipecat",
+        "generated voice API exposes private implementation detail: XRMediaHubInputTransport",
+        "generated voice API exposes private implementation detail: XRMediaHubOutputTransport",
+    ]
+
+
+def test_generated_voice_reference_accepts_public_surface(tmp_path: Path) -> None:
+    reference_check = _load_reference_check()
+    reference = tmp_path / "reference" / "python" / "xr_ai_voice" / "index.html"
+    reference.parent.mkdir(parents=True)
+    reference.write_text("VoiceAgent HubVoiceTransport", encoding="utf-8")
+
+    assert reference_check.validate_generated_api(tmp_path) == []

--- a/tests/test_api_documentation.py
+++ b/tests/test_api_documentation.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the static public API documentation contract."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+_CONTRACT = _ROOT / "docs" / "source" / "_api_contract.py"
+
+
+def _load_contract() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("_api_contract_test", _CONTRACT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _package(tmp_path: Path, source: str) -> Path:
+    package = tmp_path / "example_api"
+    package.mkdir()
+    (package / "__init__.py").write_text(source, encoding="utf-8")
+    return package
+
+
+def test_documented_public_api_passes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    contract = _load_contract()
+    package = _package(
+        tmp_path,
+        '''
+class Client:
+    """A documented client."""
+
+    def run(self) -> None:
+        """Run the client."""
+
+
+DEFAULT_CLIENT = Client()
+"""The default client instance."""
+
+__all__ = ["Client", "DEFAULT_CLIENT"]
+''',
+    )
+    monkeypatch.setattr(contract, "API_PACKAGE_DIRS", (package,))
+
+    assert contract.validate_public_api() == []
+
+
+def test_undocumented_public_members_fail(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    contract = _load_contract()
+    package = _package(
+        tmp_path,
+        '''
+class Client:
+    """A documented client."""
+
+    def run(self) -> None:
+        pass
+
+
+DEFAULT_CLIENT = Client()
+__all__ = ["Client", "DEFAULT_CLIENT", "Missing"]
+''',
+    )
+    monkeypatch.setattr(contract, "API_PACKAGE_DIRS", (package,))
+
+    assert contract.validate_public_api() == [
+        "example_api: public method Client.run has no docstring",
+        "example_api: exported DEFAULT_CLIENT has no docstring",
+        "example_api: exported Missing does not resolve",
+    ]


### PR DESCRIPTION
## Summary

- add static, import-free Sphinx AutoAPI generation for the public `xr_ai_runtime` and `xr_ai_voice` facades
- use package `__all__`, annotations, defaults, and co-located docstrings as the API source of truth
- add a package-scoped contract check for unresolved or undocumented exports and public methods
- rebuild documentation when enrolled SDK Python sources change
- keep generated reference sources ephemeral and suppress private implementation-module pages

## Why

Recent API changes repeatedly copied signatures, defaults, and field descriptions into package READMEs and component pages. This establishes a code-first reference layer without installing or importing Pipecat, Torch, native libraries, or other SDK dependencies during the docs build.

## Stack

- PR 1: this foundation
- PR 2: #378 — complete SDK API rollout and deduplication
- PR 3: #379 — generated sample CLI reference
- PR 4: #380 — generated sample configuration reference

## Validation

- `uv run pytest -q test_api_documentation.py test_agent_runtime.py test_voice_runtime.py` — 43 passed
- `uv run --no-project --with-requirements docs/requirements.txt make -C docs strict`
- `uv run --no-project --with-requirements docs/requirements.txt make -C docs strict-versions`
- Ruff 0.15.16 on changed Python files
- SPDX header check
- `git diff --check`
