### PR TITLE
docs: generate complete SDK reference

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -34,8 +34,7 @@ on:
     paths:
       - "docs/**"
       - "agent-sdk/*/README.md"
-      - "agent-sdk/xr-ai-runtime/**/*.py"
-      - "agent-sdk/xr-ai-voice/**/*.py"
+      - "agent-sdk/**/*.py"
       - ".github/workflows/docs.yaml"
       - ".github/scripts/select_latest_docs_release.py"
       - ".github/scripts/publish_docs.sh"
@@ -46,8 +45,7 @@ on:
     paths:
       - "docs/**"
       - "agent-sdk/*/README.md"
-      - "agent-sdk/xr-ai-runtime/**/*.py"
-      - "agent-sdk/xr-ai-voice/**/*.py"
+      - "agent-sdk/**/*.py"
       - ".github/workflows/docs.yaml"
       - ".github/scripts/select_latest_docs_release.py"
       - ".github/scripts/publish_docs.sh"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,8 +91,11 @@ See [Adding a sample](docs/source/guides/adding-a-sample.md) and the
 
 ## Change contract
 
-- Update the relevant README and `docs/source/` page in the same change as an
-  API, command, configuration, package, or quickstart change.
+- Public Python API names, signatures, types, defaults, and field behavior live
+  in `__all__`, declarations, and co-located docstrings; Sphinx generates their
+  reference pages. Update narrative README or `docs/source/` content only when
+  concepts, workflows, operations, or architecture change. Breaking changes
+  also require a migration entry.
 - Any `pyproject.toml` change must update `DEPENDENCIES.md`; regenerate the
   affected project's gitignored `uv.lock` locally to verify resolution.
 - Never put API keys or tokens in source files. Use environment variables or

--- a/agent-sdk/xr-ai-hub/xr_ai_hub/__init__.py
+++ b/agent-sdk/xr-ai-hub/xr_ai_hub/__init__.py
@@ -7,8 +7,8 @@ xr_ai_hub — lightweight agent-side SDK for XR-Media-Hub.
 Agents only need this package (pyzmq + msgpack). The hub implementation and
 its LiveKit, FastAPI, and uvicorn dependencies are not included.
 
-Typical usage
--------------
+Typical usage::
+
     from xr_ai_hub import ProcessorEndpoint, DataMessage, FrameSignal
 
     ep = ProcessorEndpoint(sub_addr="ipc:///tmp/xr_hub_pub",

--- a/agent-sdk/xr-ai-hub/xr_ai_hub/_codec.py
+++ b/agent-sdk/xr-ai-hub/xr_ai_hub/_codec.py
@@ -28,21 +28,51 @@ _decoders: dict[int, Callable[[list], Any]] = {}
 
 
 def register_encoder(type_id: int, fn: Callable[[Any], list]) -> None:
-    """Register a serializer for type_id. fn must return a msgpack-serialisable list."""
+    """Register the payload serializer for a wire message type.
+
+    Parameters
+    ----------
+    type_id :
+        Numeric wire identifier, normally a :class:`~xr_ai_hub.MsgType` value.
+    fn :
+        Callable that converts a message object to a msgpack-serializable list.
+    """
     _encoders[type_id] = fn
 
 
 def register_decoder(type_id: int, fn: Callable[[list], Any]) -> None:
-    """Register a deserializer for type_id. fn receives the decoded list."""
+    """Register the payload deserializer for a wire message type.
+
+    Parameters
+    ----------
+    type_id :
+        Numeric wire identifier, normally a :class:`~xr_ai_hub.MsgType` value.
+    fn :
+        Callable that converts a decoded msgpack list to a message object.
+    """
     _decoders[type_id] = fn
 
 
 def encode(type_id: int, msg: Any) -> bytes:
+    """Encode a registered message as a type byte followed by msgpack payload.
+
+    Raises
+    ------
+    KeyError
+        If no encoder is registered for ``type_id``.
+    """
     payload = msgpack.packb(_encoders[type_id](msg), use_bin_type=True)
     return _TYPE_HDR.pack(type_id) + cast(bytes, payload)
 
 
 def decode(raw: bytes) -> tuple[int, Any]:
+    """Decode a wire message into its numeric type identifier and payload object.
+
+    Raises
+    ------
+    KeyError
+        If no decoder is registered for the encoded type identifier.
+    """
     (type_id,) = _TYPE_HDR.unpack_from(raw, 0)
     payload = msgpack.unpackb(raw[1:], raw=False)
     return type_id, _decoders[type_id](payload)

--- a/agent-sdk/xr-ai-hub/xr_ai_hub/_live_frames.py
+++ b/agent-sdk/xr-ai-hub/xr_ai_hub/_live_frames.py
@@ -20,6 +20,15 @@ class LiveFrameSource:
 
     The source stops at raw ``FrameData`` so consumers own image conversion and
     model work without adding dependencies to the hub client.
+
+    Parameters
+    ----------
+    endpoint :
+        Running processor endpoint used to observe signals and request pixels.
+    max_age_s :
+        Maximum accepted frame age in seconds.
+    timeout_s :
+        Maximum time :meth:`get` waits for a fresh frame signal.
     """
 
     def __init__(
@@ -58,7 +67,7 @@ class LiveFrameSource:
         return time.time_ns() // 1_000 - signal.pts_us < self._max_age_us
 
     def participants(self) -> list[str]:
-        """Return participant IDs with a frame inside the configured freshness window."""
+        """Return participant IDs with a frame inside the freshness window."""
         return sorted(
             {
                 participant_id
@@ -68,7 +77,14 @@ class LiveFrameSource:
         )
 
     async def get(self, participant_id: str) -> FrameData:
-        """Return fresh pixels for ``participant_id`` or raise ``FrameUnavailable``."""
+        """Return fresh pixels for a participant.
+
+        Raises
+        ------
+        FrameUnavailable
+            If no fresh signal arrives before the configured timeout or the
+            hub cannot supply pixels for the selected frame.
+        """
         signal = self._freshest(participant_id)
         if signal is None or not self._is_fresh(signal):
             event = asyncio.Event()
@@ -104,7 +120,7 @@ class LiveFrameSource:
         return frame
 
     def release(self, participant_id: str) -> None:
-        """Drop cached signals and wake pending requests for a disconnected participant."""
+        """Drop a participant's signals and wake its pending frame requests."""
         self._latest = {
             key: signal
             for key, signal in self._latest.items()

--- a/agent-sdk/xr-ai-hub/xr_ai_hub/_processor.py
+++ b/agent-sdk/xr-ai-hub/xr_ai_hub/_processor.py
@@ -78,6 +78,7 @@ CallbackUnsubscribe = Callable[[], None]
 
 # Reserved topic for internal SDK status messages — not forwarded to app callbacks.
 AGENT_STATUS_TOPIC = "_agent.status"
+"""Reserved return-data topic used for aggregated agent readiness status."""
 
 _FRAME_REQUEST_TIMEOUT = 1.0  # seconds before request_frame() gives up
 
@@ -113,9 +114,16 @@ class Subscribe(Flag):
         ep.subscribe("alice", filter=Subscribe.DATA)
     """
     DATA  = auto()  # `data.{pid}.*`
+    """Application data messages for a participant."""
+
     AUDIO = auto()  # `audio.{pid}.*`
+    """PCM audio chunks for a participant."""
+
     VIDEO = auto()  # `video.{pid}.*` AND `video_data.{pid}.*` (signal + pixels)
+    """Video frame signals and requested pixel data for a participant."""
+
     ALL   = DATA | AUDIO | VIDEO
+    """All participant-scoped message categories."""
 
 
 # Topic-prefix categories used by the subscription machinery. Each Subscribe
@@ -165,6 +173,23 @@ class ProcessorEndpoint:
 
         ep = ProcessorEndpoint(..., auto_subscribe=False)
         ep.subscribe("alice")  # may be called before alice has joined
+
+    Parameters
+    ----------
+    sub_addr :
+        ZMQ address of the hub publisher that supplies inbound messages.
+    push_addr :
+        ZMQ address of the hub receiver for outbound messages.
+    auto_subscribe :
+        Whether participant join and leave events automatically manage
+        subscriptions. Defaults to ``True``.
+    filter :
+        Default message categories selected for each subscription.
+    agent_id :
+        Stable identity used for agent presence and readiness. When omitted,
+        ``XR_AI_AGENT_ID`` or a process-local generated identity is used.
+    announces_readiness :
+        Whether this endpoint participates in the hub's readiness aggregation.
     """
 
     def __init__(
@@ -356,11 +381,20 @@ class ProcessorEndpoint:
 
     # ── callback registration ─────────────────────────────────────────────────
 
-    def on_frame(self,       cb: FrameSignalCallback) -> None: self._frame_cbs.append(cb)
-    def on_frame_data(self,  cb: FrameDataCallback)   -> None: self._frame_data_cbs.append(cb)
-    def on_audio(self,       cb: AudioCallback)       -> None: self._audio_cbs.append(cb)
+    def on_frame(self, cb: FrameSignalCallback) -> None:
+        """Register an async callback for video frame metadata."""
+        self._frame_cbs.append(cb)
+
+    def on_frame_data(self, cb: FrameDataCallback) -> None:
+        """Register an async callback for requested frame pixel data."""
+        self._frame_data_cbs.append(cb)
+
+    def on_audio(self, cb: AudioCallback) -> None:
+        """Register an async callback for inbound PCM audio chunks."""
+        self._audio_cbs.append(cb)
+
     def on_data(self, cb: DataCallback) -> CallbackUnsubscribe:
-        """Register a data callback and return an idempotent unsubscriber."""
+        """Register an async data callback and return an idempotent unsubscriber."""
 
         self._data_cbs.append(cb)
 
@@ -369,14 +403,19 @@ class ProcessorEndpoint:
                 self._data_cbs.remove(cb)
 
         return unsubscribe
-    def on_participant(self, cb: ParticipantCallback) -> None: self._participant_cbs.append(cb)
+
+    def on_participant(self, cb: ParticipantCallback) -> None:
+        """Register an async callback for participant join and leave events."""
+        self._participant_cbs.append(cb)
 
     # ── return path ───────────────────────────────────────────────────────────
 
     async def send_return_data(self, msg: DataMessage) -> None:
+        """Send an application data message to its target participant."""
         await self._push.send(encode(MsgType.RETURN_DATA, msg))
 
     async def send_return_audio(self, chunk: AudioChunk) -> None:
+        """Queue a PCM audio chunk for playback by its target participant."""
         await self._push.send(encode(MsgType.RETURN_AUDIO, chunk))
 
     async def flush_return_audio(self, participant_id: str) -> None:
@@ -542,7 +581,11 @@ class ProcessorEndpoint:
     _ROSTER_HANDSHAKE_WAIT = 0.1
 
     async def run(self) -> None:
-        """Receive and dispatch messages until stop() is called."""
+        """Receive and dispatch messages until :meth:`stop` is called.
+
+        Registered callbacks run in independent tasks. An unhandled callback
+        exception is fatal to the processor process.
+        """
         self._running_event.clear()
         self._running = True
         self._running_event.set()
@@ -706,6 +749,7 @@ class ProcessorEndpoint:
         await self._running_event.wait()
 
     def stop(self) -> None:
+        """Request receive-loop shutdown and detach this agent's presence."""
         # Detach here rather than only when run() unwinds: run() blocks in
         # recv() until the next message, so a stopped agent would otherwise
         # keep the room at "loading" indefinitely.
@@ -714,5 +758,6 @@ class ProcessorEndpoint:
         self._running_event.clear()
 
     def close(self) -> None:
+        """Close the endpoint's ZMQ sockets without waiting for queued messages."""
         self._sub.close(linger=0)
         self._push.close(linger=0)

--- a/agent-sdk/xr-ai-hub/xr_ai_hub/_shm.py
+++ b/agent-sdk/xr-ai-hub/xr_ai_hub/_shm.py
@@ -60,7 +60,10 @@ _STATE_OFFSET = 4
 class SlotView(NamedTuple):
     """Zero-copy view into one ring-buffer slot's pixel data."""
     data:   memoryview
+    """Pixel bytes backed directly by the shared-memory segment."""
+
     signal: FrameSignal
+    """Metadata identifying and describing the occupied slot."""
 
 
 class ShmRingBuffer:
@@ -72,6 +75,18 @@ class ShmRingBuffer:
 
     The caller that uses read_slot() MUST call release_slot() before the next
     write_frame() for that slot can succeed. Both operations are O(1).
+
+    Parameters
+    ----------
+    name :
+        Operating-system name of the shared-memory segment.
+    num_slots :
+        Number of fixed-capacity slots to allocate when ``create`` is true.
+    max_frame_bytes :
+        Maximum pixel payload per slot when ``create`` is true.
+    create :
+        Create and initialize the segment instead of attaching to an existing
+        one. The creator is responsible for eventually calling :meth:`unlink`.
     """
 
     def __init__(
@@ -114,9 +129,13 @@ class ShmRingBuffer:
         pts_us:  int,
         seq:     int,
     ) -> int:
-        """
-        Write frame into the next free slot. Returns slot index.
-        Raises RuntimeError if all slots are occupied (back-pressure signal).
+        """Write a frame into the next free slot and return its index.
+
+        Raises
+        ------
+        RuntimeError
+            If every slot is occupied. This is the producer's back-pressure
+            signal; consumers release occupied slots with :meth:`release_slot`.
         """
         slot    = self._claim_slot()
         hdr_off = _GH_SIZE + slot * self._slot_stride
@@ -134,9 +153,15 @@ class ShmRingBuffer:
     # ── consumer ──────────────────────────────────────────────────────────────
 
     def read_slot(self, signal: FrameSignal) -> SlotView:
-        """
-        Return a zero-copy memoryview of a ready slot's pixel data.
-        The view is valid until release_slot() is called — do not hold it longer.
+        """Return a zero-copy view of a ready slot's pixel data.
+
+        The view remains valid until :meth:`release_slot` is called for the
+        slot and must not be retained afterward.
+
+        Raises
+        ------
+        RuntimeError
+            If the indicated slot is not ready for consumption.
         """
         hdr_off = _GH_SIZE + signal.slot * self._slot_stride
         hdr     = _SH.unpack_from(self._buf, hdr_off)
@@ -149,7 +174,7 @@ class ShmRingBuffer:
         )
 
     def release_slot(self, slot: int) -> None:
-        """Mark slot FREE so the producer can reuse it."""
+        """Mark a consumed slot as free so the producer can reuse it."""
         hdr_off = _GH_SIZE + slot * self._slot_stride
         hdr     = _SH.unpack_from(self._buf, hdr_off)
         _SH.pack_into(self._buf, hdr_off, _MAGIC_SLOT, _STATE_FREE, hdr[2], 0, hdr[4], hdr[5], hdr[6], hdr[7], 0)
@@ -170,6 +195,7 @@ class ShmRingBuffer:
     # ── lifecycle ─────────────────────────────────────────────────────────────
 
     def close(self) -> None:
+        """Release this process's view and close its shared-memory handle."""
         self._buf.release()
         try:
             self._shm.close()
@@ -179,8 +205,13 @@ class ShmRingBuffer:
             pass
 
     def unlink(self) -> None:
-        """Remove the underlying shared memory segment. Call once from the owner (Hub)."""
+        """Remove the shared-memory segment; call once from its creating owner."""
         self._shm.unlink()
 
-    def __enter__(self):    return self
-    def __exit__(self, *_): self.close()
+    def __enter__(self):
+        """Return this ring buffer from a context manager."""
+        return self
+
+    def __exit__(self, *_):
+        """Close this process's handle when leaving a context manager."""
+        self.close()

--- a/agent-sdk/xr-ai-hub/xr_ai_hub/_types.py
+++ b/agent-sdk/xr-ai-hub/xr_ai_hub/_types.py
@@ -10,39 +10,80 @@ from typing import Any
 
 
 class PixelFormat(IntEnum):
+    """Pixel layouts supported by shared-memory video frames."""
+
     I420  = 0
+    """Planar YUV 4:2:0 with Y, U, and V planes."""
+
     NV12  = 1
+    """YUV 4:2:0 with a Y plane followed by interleaved UV samples."""
+
     RGB24 = 2
+    """Packed 24-bit RGB pixels."""
+
     RGBA  = 3
+    """Packed 32-bit RGB pixels with an alpha channel."""
+
     BGRA  = 4
+    """Packed 32-bit BGR pixels with an alpha channel."""
 
 
 class MsgType(IntEnum):
+    """Wire-level message identifiers used by the hub IPC protocol."""
+
     # Inbound  (connector → hub)
     FRAME_SIGNAL  = 1
+    """Metadata indicating that a video frame is ready in shared memory."""
+
     AUDIO_CHUNK   = 2
+    """Inbound PCM audio from a connector."""
+
     CONTROL       = 3
+    """Hub-internal control data."""
+
     DATA_MESSAGE  = 4
+    """Inbound application data from a connector."""
+
     # Outbound (hub → connector)
     RETURN_AUDIO     = 5   # agent/TTS audio destined for a specific client
+    """PCM audio returned to a client."""
+
     RETURN_DATA      = 6   # agent text/binary destined for a specific client
+    """Application data returned to a client."""
+
     # Bidirectional lifecycle events
     PARTICIPANT_EVENT   = 7  # participant joined or left the LiveKit room
+    """Participant join or leave notification."""
+
     CONNECTOR_REGISTER  = 8  # connector announces itself + its shm name to the hub
+    """Connector registration and shared-memory discovery."""
+
     # Frame pixel request/response (processor → hub → processor)
     FRAME_REQUEST = 9   # processor requests pixel data for a specific frame by seq
+    """Request for the latest pixels from a participant track."""
+
     FRAME_DATA    = 10  # hub delivers pixel data to requesting processor
+    """Pixel data returned in response to a frame request."""
+
     # Return-audio control (processor → hub → connector)
     RETURN_AUDIO_FLUSH = 11  # drop any audio queued for a participant's return track
+    """Request to discard queued return audio for a participant."""
+
     # Roster (processor → hub → processor): used by an endpoint started
     # mid-session to learn about participants who joined before it did.
     ROSTER_REQUEST = 12
+    """Request to replay join events for the current participant roster."""
+
     # Subscription barrier (processor → hub → processor): round-trip that
     # proves the processor's pending SUBSCRIBEs have been applied by the hub.
     SUBSCRIPTION_PROBE = 13
+    """Subscription-barrier token echoed by the hub."""
+
     # Agent presence (processor → hub): tells the hub an agent exists so it
     # can be counted as not-yet-available when aggregating agent status.
     AGENT_PRESENCE = 14
+    """Readiness-participating agent attachment or detachment."""
+
     # Add new types here; existing code is unaffected.
 
 
@@ -50,26 +91,56 @@ class MsgType(IntEnum):
 class FrameSignal:
     """Signals that a decoded frame has been written into the shared-memory ring buffer."""
     slot:           int
+    """Index of the shared-memory slot containing the frame."""
+
     seq:            int          # per-(participant, track) monotonically increasing sequence
+    """Sequence number that increases for each participant and track pair."""
+
     pts_us:         int          # presentation timestamp, microseconds (signed)
+    """Presentation timestamp in microseconds."""
+
     width:          int
+    """Frame width in pixels."""
+
     height:         int
+    """Frame height in pixels."""
+
     fmt:            PixelFormat
+    """Pixel layout used by the frame data."""
+
     data_sz:        int          # bytes actually written into the slot
+    """Number of frame-data bytes written into the slot."""
+
     participant_id: str = "default"  # LiveKit participant identity
+    """Identity of the participant that produced the frame."""
+
     track_id:       str = "default"  # LiveKit track SID
+    """Identity of the participant's video track."""
 
 
 @dataclass(slots=True)
 class AudioChunk:
     """Raw PCM audio chunk from the connector."""
     pts_us:         int
+    """Presentation timestamp in microseconds."""
+
     sample_rate:    int
+    """Sample rate in hertz."""
+
     channels:       int
+    """Number of interleaved audio channels."""
+
     samples:        int    # frames per channel
+    """Number of sample frames per channel."""
+
     data:           bytes  # float32 LE, interleaved
+    """Little-endian, interleaved float32 PCM samples."""
+
     participant_id: str = "default"  # LiveKit participant identity
+    """Identity of the participant that produced the audio."""
+
     track_id:       str = "default"  # LiveKit track SID
+    """Identity of the participant's audio track."""
 
 
 @dataclass(slots=True)
@@ -81,32 +152,52 @@ class DataMessage:
     there is no track SID for data.
     """
     participant_id: str
+    """Identity of the participant that sent or should receive the payload."""
+
     topic:          str    # LiveKit data channel topic
+    """Application-defined data-channel topic."""
+
     pts_us:         int
+    """Presentation timestamp in microseconds."""
+
     data:           bytes
+    """Opaque message payload."""
 
 
 @dataclass(slots=True)
 class ParticipantEvent:
     """A LiveKit participant has joined or left the room."""
     participant_id: str
+    """Identity of the participant whose state changed."""
+
     joined:         bool   # True = joined, False = left
+    """Whether the participant joined; ``False`` indicates departure."""
+
     pts_us:         int
+    """Timestamp of the event in microseconds."""
+
     connector_id:   str = ""  # which connector this participant arrived on
+    """Identity of the connector that reported the participant."""
 
 
 @dataclass(slots=True)
 class ConnectorRegistration:
     """Sent by a connector on startup so the hub can open its ring buffer."""
     connector_id: str
+    """Identity assigned to the connector."""
+
     shm_name:     str
+    """Name of the connector's shared-memory ring buffer."""
 
 
 @dataclass(slots=True)
 class FrameRequest:
     """Sent by a processor to request a copy of the current latest frame."""
     participant_id: str
+    """Identity of the participant whose frame is requested."""
+
     track_id: str
+    """Identity of the video track whose frame is requested."""
 
 
 @dataclass(slots=True)
@@ -120,26 +211,45 @@ class FrameData:
     sampling rate. The hub only copies pixels when a request arrives.
     """
     seq:            int
+    """Sequence number of the copied frame."""
+
     pts_us:         int
+    """Presentation timestamp in microseconds."""
+
     width:          int
+    """Frame width in pixels."""
+
     height:         int
+    """Frame height in pixels."""
+
     fmt:            PixelFormat
+    """Pixel layout used by :attr:`data`."""
+
     data:           bytes          # raw pixels in the format specified by fmt
+    """Raw pixel bytes encoded in :attr:`fmt`."""
+
     participant_id: str = "default"
+    """Identity of the participant that produced the frame."""
+
     track_id:       str = "default"
+    """Identity of the participant's video track."""
 
 
 @dataclass(slots=True)
 class ControlMessage:
     """Extensible key/value control message (hub-internal, no track concept)."""
     topic:   str
+    """Control-message topic."""
+
     payload: dict[str, Any] = field(default_factory=dict)
+    """Topic-specific control values."""
 
 
 @dataclass(slots=True)
 class ReturnAudioFlush:
     """Drop any audio queued for *participant_id*'s return track."""
     participant_id: str
+    """Identity of the participant whose queued return audio is discarded."""
 
 
 @dataclass(slots=True)
@@ -163,6 +273,7 @@ class SubscriptionProbe:
     proves every subscription issued before the probe is live on the hub.
     """
     token: str
+    """Opaque correlation token echoed by the hub."""
 
 
 @dataclass(slots=True)
@@ -178,5 +289,10 @@ class AgentPresence:
     agents whose scope covers it.
     """
     agent_id: str
+    """Identity of the agent endpoint."""
+
     attached: bool
+    """Whether the endpoint is attaching to or detaching from the hub."""
+
     scope:    list[str] | None = None
+    """Participant IDs served by the agent, or ``None`` for every participant."""

--- a/agent-sdk/xr-ai-models/README.md
+++ b/agent-sdk/xr-ai-models/README.md
@@ -130,50 +130,9 @@ The simple VLM sample provides complete local and hosted profiles.
 
 ## Protocols
 
-```python
-class LLMService(Protocol):
-    capabilities: Capabilities
-    async def chat(self, messages, *, tools=None, max_tokens=None,
-                   temperature=None, enable_thinking=False,
-                   thinking_budget=None, timeout=None,
-                   headers=None) -> ChatResponse: ...
-    def stream(self, messages, *, ...) -> AsyncIterator[str]: ...
-    async def health(self) -> bool: ...
-    async def close(self) -> None: ...
-
-class VLMService(Protocol):
-    capabilities: Capabilities
-    async def ask_image(self, image, question, *, system_prompt="",
-                        max_tokens=None, temperature=None,
-                        timeout=None, headers=None) -> ChatResponse: ...
-    async def ask_images(self, images, question, *, system_prompt="",
-                         max_tokens=None, temperature=None,
-                         timeout=None, headers=None) -> ChatResponse: ...
-    async def ask_video(self, video, question, *, system_prompt="",
-                        max_tokens=None, temperature=None,
-                        timeout=None, headers=None) -> ChatResponse: ...
-    def stream(self, image, question, *, system_prompt="",
-               max_tokens=None, temperature=None,
-               timeout=None, headers=None) -> AsyncIterator[str]: ...
-    def stream_images(self, images, question, *, system_prompt="",
-                      max_tokens=None, temperature=None,
-                      timeout=None, headers=None) -> AsyncIterator[str]: ...
-    async def health(self) -> bool: ...
-
-class STTService(Protocol):
-    async def transcribe(self, audio: bytes, *, sample_rate=None,
-                         channels=1, timeout=None) -> str: ...
-    async def health(self) -> bool: ...
-
-class TTSService(Protocol):
-    async def synthesize(self, text: str, *, response_format="wav",
-                         timeout=None) -> bytes: ...
-    async def health(self) -> bool: ...
-
-class EmbeddingService(Protocol):
-    async def embed(self, texts, *, timeout=None) -> list[list[float]]: ...
-    async def health(self) -> bool: ...
-```
+The versioned documentation site generates exact protocol methods, parameters,
+types, and defaults from the public Python declarations. This README keeps only
+the behavioral rules that span multiple calls or implementations.
 
 `ChatResponse.reasoning` is the canonical reasoning field — the
 `reasoning_field` knob normalizes `reasoning_content` (nemotron_v3 parser)

--- a/agent-sdk/xr-ai-models/xr_ai_models/_config.py
+++ b/agent-sdk/xr-ai-models/xr_ai_models/_config.py
@@ -16,11 +16,16 @@ from ._utils import merge_dicts
 
 
 Category = Literal["llm", "vlm", "stt", "tts", "embedding"]
+"""A model role supported by :class:`ModelsConfig`."""
+
 ModelKind = Literal["openai_compat"]
+"""A supported model-service adapter implementation."""
+
 Readiness = Literal["health", "none"]
 Ownership = Literal["managed", "reused", "external"]
 
 KIND_OPENAI_COMPAT: ModelKind = "openai_compat"
+"""The adapter kind for OpenAI-compatible HTTP endpoints."""
 
 
 @dataclass(frozen=True)
@@ -28,10 +33,19 @@ class AdapterSpec:
     """API dialect and model-specific request/response behavior."""
 
     kind: ModelKind = KIND_OPENAI_COMPAT
+    """The concrete client implementation used for this role."""
+
     model_name: str = ""
+    """The model identifier sent to endpoints that require one."""
+
     reasoning_field: str | None = None
+    """The response field containing reasoning, or ``None`` for auto-detection."""
+
     capabilities: dict[str, Any] = field(default_factory=dict)
+    """Overrides used to construct the service's capability flags."""
+
     default_extras: dict[str, Any] = field(default_factory=dict)
+    """Model-specific fields merged into every request payload."""
 
 
 @dataclass(frozen=True)
@@ -39,12 +53,21 @@ class EndpointSpec:
     """Connectivity, authentication, timeout, and readiness for an adapter."""
 
     base_url: str = ""
+    """The endpoint root URL, without a model-specific route."""
+
     api_key_env: str | None = None
+    """Environment variable containing the bearer token, when required."""
+
     timeout: float = 60.0
+    """Default request timeout in seconds."""
+
     readiness: Readiness = "health"
+    """How the client determines whether the endpoint is ready."""
 
     @property
     def health_check(self) -> bool:
+        """Whether readiness requires a successful endpoint health check."""
+
         return self.readiness == "health"
 
 
@@ -53,7 +76,10 @@ class DeploymentSpec:
     """Process ownership for the endpoint that serves a model role."""
 
     ownership: Ownership = "external"
+    """Whether the launcher starts, reuses, or does not manage the service."""
+
     service: str | None = None
+    """The launcher service name for managed or reused deployments."""
 
 
 class _RoleSpec:
@@ -64,38 +90,56 @@ class _RoleSpec:
 
     @property
     def kind(self) -> ModelKind:
+        """The adapter implementation used for this role."""
+
         return self.adapter.kind
 
     @property
     def model_name(self) -> str:
+        """The endpoint's configured model identifier."""
+
         return self.adapter.model_name
 
     @property
     def reasoning_field(self) -> str | None:
+        """The response field containing reasoning, when explicitly configured."""
+
         return self.adapter.reasoning_field
 
     @property
     def capabilities(self) -> dict[str, Any]:
+        """Capability overrides declared for this model role."""
+
         return self.adapter.capabilities
 
     @property
     def default_extras(self) -> dict[str, Any]:
+        """Model-specific fields included in every request payload."""
+
         return self.adapter.default_extras
 
     @property
     def base_url(self) -> str:
+        """The endpoint root URL."""
+
         return self.endpoint.base_url
 
     @property
     def api_key_env(self) -> str | None:
+        """The environment variable containing the endpoint bearer token."""
+
         return self.endpoint.api_key_env
 
     @property
     def timeout(self) -> float:
+        """The default request timeout in seconds."""
+
         return self.endpoint.timeout
 
     @property
     def health_check(self) -> bool:
+        """Whether readiness requires a successful endpoint health check."""
+
         return self.endpoint.health_check
 
     def _set_specs(
@@ -136,9 +180,16 @@ def _reject_mixed_construction(**legacy_nondefault: bool) -> None:
 
 @dataclass(frozen=True, init=False)
 class LLMSpec(_RoleSpec):
+    """Configuration for a text chat-completion model role."""
+
     adapter: AdapterSpec = field(default_factory=AdapterSpec)
+    """Model-specific request and response behavior."""
+
     endpoint: EndpointSpec = field(default_factory=EndpointSpec)
+    """Endpoint connectivity, authentication, and readiness settings."""
+
     deployment: DeploymentSpec = field(default_factory=DeploymentSpec)
+    """Launcher ownership metadata for the serving process."""
 
     def __init__(
         self,
@@ -196,9 +247,16 @@ class LLMSpec(_RoleSpec):
 
 @dataclass(frozen=True, init=False)
 class VLMSpec(_RoleSpec):
+    """Configuration for an image- or video-language model role."""
+
     adapter: AdapterSpec = field(default_factory=AdapterSpec)
+    """Model-specific request and response behavior."""
+
     endpoint: EndpointSpec = field(default_factory=EndpointSpec)
+    """Endpoint connectivity, authentication, and readiness settings."""
+
     deployment: DeploymentSpec = field(default_factory=DeploymentSpec)
+    """Launcher ownership metadata for the serving process."""
 
     def __init__(
         self,
@@ -253,11 +311,18 @@ class VLMSpec(_RoleSpec):
 
 @dataclass(frozen=True, init=False)
 class STTSpec(_RoleSpec):
+    """Configuration for a speech-to-text model role."""
+
     adapter: AdapterSpec = field(default_factory=AdapterSpec)
+    """Model-specific request and response behavior."""
+
     endpoint: EndpointSpec = field(
         default_factory=lambda: EndpointSpec(timeout=30.0)
     )
+    """Endpoint connectivity, authentication, and readiness settings."""
+
     deployment: DeploymentSpec = field(default_factory=DeploymentSpec)
+    """Launcher ownership metadata for the serving process."""
 
     def __init__(
         self,
@@ -297,13 +362,22 @@ class STTSpec(_RoleSpec):
             ),
             deployment or DeploymentSpec(),
         )
+
+
 @dataclass(frozen=True, init=False)
 class TTSSpec(_RoleSpec):
+    """Configuration for a text-to-speech model role."""
+
     adapter: AdapterSpec = field(default_factory=AdapterSpec)
+    """Model-specific request and response behavior."""
+
     endpoint: EndpointSpec = field(
         default_factory=lambda: EndpointSpec(timeout=30.0)
     )
+    """Endpoint connectivity, authentication, and readiness settings."""
+
     deployment: DeploymentSpec = field(default_factory=DeploymentSpec)
+    """Launcher ownership metadata for the serving process."""
 
     def __init__(
         self,
@@ -347,9 +421,16 @@ class TTSSpec(_RoleSpec):
 
 @dataclass(frozen=True, init=False)
 class EmbeddingSpec(_RoleSpec):
+    """Configuration for a text-embedding model role."""
+
     adapter: AdapterSpec = field(default_factory=AdapterSpec)
+    """Model-specific request and response behavior."""
+
     endpoint: EndpointSpec = field(default_factory=EndpointSpec)
+    """Endpoint connectivity, authentication, and readiness settings."""
+
     deployment: DeploymentSpec = field(default_factory=DeploymentSpec)
+    """Launcher ownership metadata for the serving process."""
 
     def __init__(
         self,
@@ -394,6 +475,8 @@ class EmbeddingSpec(_RoleSpec):
 
 
 Spec = LLMSpec | VLMSpec | STTSpec | TTSSpec | EmbeddingSpec
+"""Any typed model-role specification stored in :class:`ModelsConfig`."""
+
 T = TypeVar("T", LLMSpec, VLMSpec, STTSpec, TTSSpec, EmbeddingSpec)
 
 
@@ -402,24 +485,37 @@ class ModelsConfig:
     """Logical-name to typed model-role specifications."""
 
     entries: dict[str, Spec]
+    """Model-role specifications keyed by application-defined logical name."""
 
     def llm(self, name: str) -> LLMSpec:
+        """Return the LLM specification named *name*."""
+
         return _typed(self.entries, name, LLMSpec)
 
     def vlm(self, name: str) -> VLMSpec:
+        """Return the VLM specification named *name*."""
+
         return _typed(self.entries, name, VLMSpec)
 
     def stt(self, name: str) -> STTSpec:
+        """Return the speech-to-text specification named *name*."""
+
         return _typed(self.entries, name, STTSpec)
 
     def tts(self, name: str) -> TTSSpec:
+        """Return the text-to-speech specification named *name*."""
+
         return _typed(self.entries, name, TTSSpec)
 
     def embedding(self, name: str) -> EmbeddingSpec:
+        """Return the embedding specification named *name*."""
+
         return _typed(self.entries, name, EmbeddingSpec)
 
     @property
     def required_credentials(self) -> tuple[str, ...]:
+        """Return the sorted environment-variable names required by all roles."""
+
         return tuple(sorted({
             spec.endpoint.api_key_env
             for spec in self.entries.values()
@@ -440,7 +536,12 @@ def _typed(entries: dict[str, Spec], name: str, cls: type[T]) -> T:
 
 
 def load_models_config(path: Path | str) -> ModelsConfig:
-    """Load a JSON or YAML model profile and resolve adapter presets."""
+    """Load a YAML or JSON model profile and resolve its adapter presets.
+
+    The file may contain model entries directly or nested below a ``models``
+    key. Invalid entries raise :class:`ValueError` with the file path and role
+    name included in the message.
+    """
 
     raw = yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
     if not isinstance(raw, dict):
@@ -451,7 +552,11 @@ def load_models_config(path: Path | str) -> ModelsConfig:
 def load_models_config_from_dict(
     raw: dict[str, Any], *, source: str = "<dict>"
 ) -> ModelsConfig:
-    """Build a model configuration from a parsed direct or ``models`` mapping."""
+    """Build a model configuration from a parsed direct or ``models`` mapping.
+
+    ``source`` labels validation errors and is useful when the mapping did not
+    originate from a file.
+    """
 
     if not isinstance(raw, dict):
         raise ValueError(f"{source}: top-level must be a mapping")

--- a/agent-sdk/xr-ai-models/xr_ai_models/_factory.py
+++ b/agent-sdk/xr-ai-models/xr_ai_models/_factory.py
@@ -16,6 +16,13 @@ from ._protocols import Capabilities, EmbeddingService, LLMService, STTService, 
 
 
 def make_embedding(config: ModelsConfig, name: str) -> EmbeddingService:
+    """Construct the embedding service for the named configuration entry.
+
+    Raises :class:`KeyError` when *name* is absent, :class:`TypeError` when it
+    names a different model role, and :class:`ValueError` for an unsupported
+    adapter kind.
+    """
+
     spec = config.embedding(name)
     if spec.kind == KIND_OPENAI_COMPAT:
         return OpenAICompatEmbedding(
@@ -29,6 +36,13 @@ def make_embedding(config: ModelsConfig, name: str) -> EmbeddingService:
 
 
 def make_llm(config: ModelsConfig, name: str) -> LLMService:
+    """Construct the text chat service for the named configuration entry.
+
+    Raises :class:`KeyError` when *name* is absent, :class:`TypeError` when it
+    names a different model role, and :class:`ValueError` for an unsupported
+    adapter kind.
+    """
+
     spec = config.llm(name)
     adapter = spec.adapter
     endpoint = spec.endpoint
@@ -47,6 +61,13 @@ def make_llm(config: ModelsConfig, name: str) -> LLMService:
 
 
 def make_vlm(config: ModelsConfig, name: str) -> VLMService:
+    """Construct the visual chat service for the named configuration entry.
+
+    Raises :class:`KeyError` when *name* is absent, :class:`TypeError` when it
+    names a different model role, and :class:`ValueError` for an unsupported
+    adapter kind.
+    """
+
     spec = config.vlm(name)
     adapter = spec.adapter
     endpoint = spec.endpoint
@@ -64,6 +85,13 @@ def make_vlm(config: ModelsConfig, name: str) -> VLMService:
 
 
 def make_stt(config: ModelsConfig, name: str) -> STTService:
+    """Construct the speech-to-text service for the named configuration entry.
+
+    Raises :class:`KeyError` when *name* is absent, :class:`TypeError` when it
+    names a different model role, and :class:`ValueError` for an unsupported
+    adapter kind.
+    """
+
     spec = config.stt(name)
     adapter = spec.adapter
     endpoint = spec.endpoint
@@ -78,6 +106,13 @@ def make_stt(config: ModelsConfig, name: str) -> STTService:
 
 
 def make_tts(config: ModelsConfig, name: str) -> TTSService:
+    """Construct the text-to-speech service for the named configuration entry.
+
+    Raises :class:`KeyError` when *name* is absent, :class:`TypeError` when it
+    names a different model role, and :class:`ValueError` for an unsupported
+    adapter kind.
+    """
+
     spec = config.tts(name)
     adapter = spec.adapter
     endpoint = spec.endpoint

--- a/agent-sdk/xr-ai-models/xr_ai_models/_openai_compat.py
+++ b/agent-sdk/xr-ai-models/xr_ai_models/_openai_compat.py
@@ -260,10 +260,12 @@ def _pcm_to_wav(pcm: bytes, sample_rate: int, channels: int) -> bytes:
 
 
 class OpenAICompatLLM:
-    """OpenAI-compatible /v1/chat/completions client.
+    """OpenAI-compatible ``/v1/chat/completions`` client.
 
     Used directly for plain LLMs (Llama-Nemotron, Nemotron3-Nano,
     Nemotron-Omni) and indirectly via :class:`OpenAICompatVLM` for VLMs.
+    The API key is read once from ``api_key_env`` during construction. An
+    injected HTTP client remains owned by the caller and is not closed here.
     """
 
     def __init__(
@@ -282,8 +284,12 @@ class OpenAICompatLLM:
         base = base_url.rstrip("/")
         self._chat_url   = base + "/v1/chat/completions"
         self.health_url  = base + "/health"
+        """The URL used to check endpoint readiness."""
+
         self._model      = model_name
         self.capabilities = capabilities or Capabilities()
+        """Features declared for this model endpoint."""
+
         self._reasoning_field = reasoning_field
         self._default_extras  = default_extras or {}
         self._api_key = os.environ.get(api_key_env) if api_key_env else None
@@ -340,6 +346,13 @@ class OpenAICompatLLM:
         timeout: float | None = None,
         headers: Mapping[str, str] | None = None,
     ) -> ChatResponse:
+        """Generate and return one normalized chat response.
+
+        Per-call generation values override endpoint defaults. ``headers`` may
+        supply request context but cannot override the configured authorization
+        header.
+        """
+
         payload = self._build_payload(
             messages,
             tools=tools, max_tokens=max_tokens, temperature=temperature,
@@ -367,6 +380,12 @@ class OpenAICompatLLM:
         timeout: float | None = None,
         headers: Mapping[str, str] | None = None,
     ) -> AsyncIterator[str]:
+        """Stream user-visible text deltas from a chat completion.
+
+        Malformed server-sent event lines and deltas without content are
+        skipped. Tool-call and reasoning deltas are not yielded.
+        """
+
         payload = self._build_payload(
             messages,
             tools=tools, max_tokens=max_tokens, temperature=temperature,
@@ -397,9 +416,17 @@ class OpenAICompatLLM:
                     yield content
 
     async def health(self) -> bool:
+        """Return whether the endpoint health check succeeds.
+
+        Returns ``True`` without an HTTP request when health checks were
+        disabled at construction time.
+        """
+
         return await _http_health(self._client, self.health_url, self._health_check)
 
     async def close(self) -> None:
+        """Close the internally created HTTP client, if one is owned."""
+
         if self._owns_client:
             await self._client.aclose()
 
@@ -414,7 +441,12 @@ class OpenAICompatLLM:
 
 
 class OpenAICompatVLM:
-    """Vision LLM client — image-bearing chat completions, fronted as ``ask_image``."""
+    """OpenAI-compatible client for image- and video-bearing chat requests.
+
+    Image and video paths or bytes are converted to ``data:`` URLs before
+    submission. An injected HTTP client remains owned by the caller and is not
+    closed here.
+    """
 
     def __init__(
         self,
@@ -441,10 +473,14 @@ class OpenAICompatVLM:
 
     @property
     def capabilities(self) -> Capabilities:
+        """Return the features declared for the underlying chat endpoint."""
+
         return self._llm.capabilities
 
     @property
     def health_url(self) -> str:
+        """Return the URL used to check endpoint readiness."""
+
         return self._llm.health_url
 
     def _build_image_messages(
@@ -480,6 +516,8 @@ class OpenAICompatVLM:
         timeout: float | None = None,
         headers: Mapping[str, str] | None = None,
     ) -> ChatResponse:
+        """Generate one response to *question* about *image*."""
+
         return await self.ask_images(
             [image],
             question,
@@ -501,6 +539,11 @@ class OpenAICompatVLM:
         timeout: float | None = None,
         headers: Mapping[str, str] | None = None,
     ) -> ChatResponse:
+        """Generate one response to *question* about an ordered image sequence.
+
+        Raises :class:`ValueError` when *images* is empty.
+        """
+
         return await self._llm.chat(
             self._build_image_messages(images, question, system_prompt),
             max_tokens=max_tokens, temperature=temperature, timeout=timeout,
@@ -533,6 +576,12 @@ class OpenAICompatVLM:
         timeout: float | None = None,
         headers: Mapping[str, str] | None = None,
     ) -> ChatResponse:
+        """Generate one response to *question* about *video*.
+
+        Raises :class:`ValueError` unless video support was declared in the
+        configured capabilities.
+        """
+
         if not self.capabilities.video:
             raise ValueError(
                 "this VLM was constructed with capabilities.video=False; "
@@ -556,6 +605,8 @@ class OpenAICompatVLM:
         timeout: float | None = None,
         headers: Mapping[str, str] | None = None,
     ) -> AsyncIterator[str]:
+        """Stream response text for *question* about *image*."""
+
         async for chunk in self.stream_images(
             [image],
             question,
@@ -578,6 +629,11 @@ class OpenAICompatVLM:
         timeout: float | None = None,
         headers: Mapping[str, str] | None = None,
     ) -> AsyncIterator[str]:
+        """Stream response text for a question about an ordered image sequence.
+
+        Raises :class:`ValueError` when *images* is empty.
+        """
+
         async for chunk in self._llm.stream(
             self._build_image_messages(images, question, system_prompt),
             max_tokens=max_tokens, temperature=temperature, timeout=timeout,
@@ -586,9 +642,13 @@ class OpenAICompatVLM:
             yield chunk
 
     async def health(self) -> bool:
+        """Return whether the underlying chat endpoint is ready."""
+
         return await self._llm.health()
 
     async def close(self) -> None:
+        """Release resources owned by the underlying chat client."""
+
         await self._llm.close()
 
     async def __aenter__(self) -> "OpenAICompatVLM":
@@ -602,7 +662,11 @@ class OpenAICompatVLM:
 
 
 class OpenAICompatSTT:
-    """STT client — multipart POST to /v1/audio/transcriptions."""
+    """OpenAI-compatible ``/v1/audio/transcriptions`` client.
+
+    The API key is read once from ``api_key_env`` during construction. An
+    injected HTTP client remains owned by the caller and is not closed here.
+    """
 
     def __init__(
         self,
@@ -616,6 +680,8 @@ class OpenAICompatSTT:
         base = base_url.rstrip("/")
         self._url       = base + "/v1/audio/transcriptions"
         self.health_url = base + "/health"
+        """The URL used to check endpoint readiness."""
+
         self._api_key   = os.environ.get(api_key_env) if api_key_env else None
         _warn_if_cleartext_key(base_url, self._api_key)
         self._health_check = health_check
@@ -630,6 +696,13 @@ class OpenAICompatSTT:
         channels: int = 1,
         timeout: float | None = None,
     ) -> str:
+        """Transcribe WAV data or 16-bit PCM audio into text.
+
+        When ``sample_rate`` is provided, *audio* is interpreted as raw signed
+        16-bit PCM with the given channel count and wrapped in a WAV container.
+        Otherwise, *audio* must already contain a server-supported audio file.
+        """
+
         wav_bytes = _pcm_to_wav(audio, sample_rate, channels) if sample_rate is not None else audio
         kwargs: dict[str, Any] = {
             "files":   {"file": ("audio.wav", wav_bytes, "audio/wav")},
@@ -645,9 +718,17 @@ class OpenAICompatSTT:
         return resp.json().get("text", "")
 
     async def health(self) -> bool:
+        """Return whether the endpoint health check succeeds.
+
+        Returns ``True`` without an HTTP request when health checks were
+        disabled at construction time.
+        """
+
         return await _http_health(self._client, self.health_url, self._health_check)
 
     async def close(self) -> None:
+        """Close the internally created HTTP client, if one is owned."""
+
         if self._owns_client:
             await self._client.aclose()
 
@@ -662,7 +743,11 @@ class OpenAICompatSTT:
 
 
 class OpenAICompatTTS:
-    """TTS client — JSON POST to /v1/audio/speech, returns raw audio bytes."""
+    """OpenAI-compatible ``/v1/audio/speech`` client.
+
+    The API key is read once from ``api_key_env`` during construction. An
+    injected HTTP client remains owned by the caller and is not closed here.
+    """
 
     def __init__(
         self,
@@ -676,6 +761,8 @@ class OpenAICompatTTS:
         base = base_url.rstrip("/")
         self._url       = base + "/v1/audio/speech"
         self.health_url = base + "/health"
+        """The URL used to check endpoint readiness."""
+
         self._api_key   = os.environ.get(api_key_env) if api_key_env else None
         _warn_if_cleartext_key(base_url, self._api_key)
         self._health_check = health_check
@@ -689,6 +776,8 @@ class OpenAICompatTTS:
         response_format: str = "wav",
         timeout: float | None = None,
     ) -> bytes:
+        """Synthesize *text* and return audio bytes in *response_format*."""
+
         kwargs: dict[str, Any] = {
             "json":    {"input": text, "response_format": response_format},
             "headers": _auth_headers(self._api_key),
@@ -702,9 +791,17 @@ class OpenAICompatTTS:
         return resp.content
 
     async def health(self) -> bool:
+        """Return whether the endpoint health check succeeds.
+
+        Returns ``True`` without an HTTP request when health checks were
+        disabled at construction time.
+        """
+
         return await _http_health(self._client, self.health_url, self._health_check)
 
     async def close(self) -> None:
+        """Close the internally created HTTP client, if one is owned."""
+
         if self._owns_client:
             await self._client.aclose()
 
@@ -719,7 +816,11 @@ class OpenAICompatTTS:
 
 
 class OpenAICompatEmbedding:
-    """OpenAI-compatible ``/v1/embeddings`` client."""
+    """OpenAI-compatible ``/v1/embeddings`` client.
+
+    The API key is read once from ``api_key_env`` during construction. An
+    injected HTTP client remains owned by the caller and is not closed here.
+    """
 
     def __init__(
         self,
@@ -734,6 +835,8 @@ class OpenAICompatEmbedding:
         base = base_url.rstrip("/")
         self._url = base + "/v1/embeddings"
         self.health_url = base + "/health"
+        """The URL used to check endpoint readiness."""
+
         self._model = model_name
         self._api_key = os.environ.get(api_key_env) if api_key_env else None
         _warn_if_cleartext_key(base_url, self._api_key)
@@ -747,6 +850,12 @@ class OpenAICompatEmbedding:
         *,
         timeout: float | None = None,
     ) -> list[list[float]]:
+        """Embed *texts* and return one vector per input in input order.
+
+        An empty input is handled locally. A response containing a different
+        number of vectors raises :class:`ValueError`.
+        """
+
         if not texts:
             return []
         kwargs: dict[str, Any] = {
@@ -765,9 +874,17 @@ class OpenAICompatEmbedding:
         return [[float(value) for value in row["embedding"]] for row in rows]
 
     async def health(self) -> bool:
+        """Return whether the endpoint health check succeeds.
+
+        Returns ``True`` without an HTTP request when health checks were
+        disabled at construction time.
+        """
+
         return await _http_health(self._client, self.health_url, self._health_check)
 
     async def close(self) -> None:
+        """Close the internally created HTTP client, if one is owned."""
+
         if self._owns_client:
             await self._client.aclose()
 

--- a/agent-sdk/xr-ai-models/xr_ai_models/_protocols.py
+++ b/agent-sdk/xr-ai-models/xr_ai_models/_protocols.py
@@ -17,48 +17,79 @@ from typing import Any, AsyncIterator, Literal, Mapping, Protocol, Sequence, run
 
 
 ImageInput = bytes | Path | str
-"""bytes, filesystem path, ``data:`` URL, or ``http(s)://`` URL."""
+"""Image bytes, a filesystem path, a ``data:`` URL, or an HTTP(S) URL."""
 
 VideoInput = bytes | Path | str
-"""bytes, filesystem path, ``data:`` URL, or ``http(s)://`` URL."""
+"""Video bytes, a filesystem path, a ``data:`` URL, or an HTTP(S) URL."""
 
 
 @dataclass(frozen=True)
 class TextPart:
+    """Text content in a multimodal chat message."""
+
     text: str
+    """The text presented to the model."""
+
     type: Literal["text"] = "text"
+    """The OpenAI-compatible discriminator for this content part."""
 
 
 @dataclass(frozen=True)
 class ImagePart:
+    """An image reference in a multimodal chat message."""
+
     url: str
+    """An HTTP(S) or ``data:`` URL containing the image."""
+
     type: Literal["image_url"] = "image_url"
+    """The OpenAI-compatible discriminator for this content part."""
 
 
 @dataclass(frozen=True)
 class VideoPart:
+    """A video reference in a multimodal chat message."""
+
     url: str
+    """An HTTP(S) or ``data:`` URL containing the video."""
+
     type: Literal["video_url"] = "video_url"
+    """The OpenAI-compatible discriminator for this content part."""
 
 
 ContentPart = TextPart | ImagePart | VideoPart
+"""A supported text, image, or video part in a chat message."""
 
 
 @dataclass(frozen=True)
 class ToolCall:
+    """A function-tool invocation requested by a model."""
+
     id: str
+    """The provider-assigned identifier used to submit the tool result."""
+
     name: str
+    """The function name requested by the model."""
+
     arguments: str
     """JSON-encoded arguments string, per the OpenAI tool-call contract."""
 
 
 @dataclass(frozen=True)
 class ToolDef:
+    """A function tool definition exposed to a chat model."""
+
     name: str
+    """The function name the model uses in a :class:`ToolCall`."""
+
     description: str
+    """A natural-language description of what the function does."""
+
     parameters: dict[str, Any]
+    """The function parameters as a JSON Schema object."""
 
     def to_openai(self) -> dict[str, Any]:
+        """Return this definition in OpenAI's function-tool wire format."""
+
         return {
             "type": "function",
             "function": {
@@ -71,33 +102,67 @@ class ToolDef:
 
 @dataclass(frozen=True)
 class ChatMessage:
+    """One input turn in an LLM or VLM conversation."""
+
     role: Literal["system", "user", "assistant", "tool"]
+    """The participant role associated with the message."""
+
     content: str | list[ContentPart]
+    """Plain text or ordered multimodal content supplied by the participant."""
+
     tool_calls: list[ToolCall] | None = None
+    """Tool calls emitted by an assistant turn, when present."""
+
     tool_call_id: str | None = None
+    """The call identifier answered by a tool-result message, when applicable."""
 
 
 @dataclass(frozen=True)
 class ChatResponse:
+    """A normalized non-streaming response from a chat model."""
+
     content: str
+    """The assistant's user-visible response text."""
+
     reasoning: str | None
+    """Normalized model reasoning, when the endpoint returns it."""
+
     tool_calls: list[ToolCall] | None
+    """Function-tool invocations requested by the model, when present."""
+
     finish_reason: str | None
+    """The provider's reason for ending generation, when supplied."""
+
     raw: dict[str, Any]
+    """The unmodified provider response object."""
 
 
 @dataclass(frozen=True)
 class Capabilities:
+    """Features supported by a configured model endpoint."""
+
     streaming: bool = True
+    """Whether the endpoint supports token streaming."""
+
     tool_calls: bool = False
+    """Whether the endpoint supports function-tool calls."""
+
     vision: bool = False
+    """Whether the endpoint accepts image inputs."""
+
     video: bool = False
+    """Whether the endpoint accepts video inputs."""
+
     reasoning: bool = False
+    """Whether the endpoint can return model reasoning."""
 
 
 @runtime_checkable
 class LLMService(Protocol):
+    """Structural interface for text chat-completion services."""
+
     capabilities: Capabilities
+    """Features supported by this service."""
 
     async def chat(
         self,
@@ -110,7 +175,10 @@ class LLMService(Protocol):
         thinking_budget: int | None = None,
         timeout: float | None = None,
         headers: Mapping[str, str] | None = None,
-    ) -> ChatResponse: pass
+    ) -> ChatResponse:
+        """Generate one complete response for a sequence of chat messages."""
+
+        pass
 
     def stream(
         self,
@@ -123,16 +191,28 @@ class LLMService(Protocol):
         thinking_budget: int | None = None,
         timeout: float | None = None,
         headers: Mapping[str, str] | None = None,
-    ) -> AsyncIterator[str]: pass
+    ) -> AsyncIterator[str]:
+        """Stream user-visible response text for a sequence of chat messages."""
 
-    async def health(self) -> bool: pass
+        pass
 
-    async def close(self) -> None: pass
+    async def health(self) -> bool:
+        """Return whether the configured endpoint is ready for requests."""
+
+        pass
+
+    async def close(self) -> None:
+        """Release resources owned by the service."""
+
+        pass
 
 
 @runtime_checkable
 class VLMService(Protocol):
+    """Structural interface for visual chat-completion services."""
+
     capabilities: Capabilities
+    """Features supported by this service."""
 
     async def ask_image(
         self,
@@ -144,7 +224,10 @@ class VLMService(Protocol):
         temperature: float | None = None,
         timeout: float | None = None,
         headers: Mapping[str, str] | None = None,
-    ) -> ChatResponse: pass
+    ) -> ChatResponse:
+        """Generate one response to a question about an image."""
+
+        pass
 
     async def ask_images(
         self,
@@ -156,7 +239,10 @@ class VLMService(Protocol):
         temperature: float | None = None,
         timeout: float | None = None,
         headers: Mapping[str, str] | None = None,
-    ) -> ChatResponse: pass
+    ) -> ChatResponse:
+        """Generate one response to a question about multiple images."""
+
+        pass
 
     async def ask_video(
         self,
@@ -168,7 +254,10 @@ class VLMService(Protocol):
         temperature: float | None = None,
         timeout: float | None = None,
         headers: Mapping[str, str] | None = None,
-    ) -> ChatResponse: pass
+    ) -> ChatResponse:
+        """Generate one response to a question about a video."""
+
+        pass
 
     def stream(
         self,
@@ -180,7 +269,10 @@ class VLMService(Protocol):
         temperature: float | None = None,
         timeout: float | None = None,
         headers: Mapping[str, str] | None = None,
-    ) -> AsyncIterator[str]: pass
+    ) -> AsyncIterator[str]:
+        """Stream response text for a question about an image."""
+
+        pass
 
     def stream_images(
         self,
@@ -192,15 +284,26 @@ class VLMService(Protocol):
         temperature: float | None = None,
         timeout: float | None = None,
         headers: Mapping[str, str] | None = None,
-    ) -> AsyncIterator[str]: pass
+    ) -> AsyncIterator[str]:
+        """Stream response text for a question about multiple images."""
 
-    async def health(self) -> bool: pass
+        pass
 
-    async def close(self) -> None: pass
+    async def health(self) -> bool:
+        """Return whether the configured endpoint is ready for requests."""
+
+        pass
+
+    async def close(self) -> None:
+        """Release resources owned by the service."""
+
+        pass
 
 
 @runtime_checkable
 class STTService(Protocol):
+    """Structural interface for speech-to-text services."""
+
     async def transcribe(
         self,
         audio: bytes,
@@ -208,37 +311,68 @@ class STTService(Protocol):
         sample_rate: int | None = None,
         channels: int = 1,
         timeout: float | None = None,
-    ) -> str: pass
+    ) -> str:
+        """Transcribe WAV data or 16-bit PCM audio into text."""
 
-    async def health(self) -> bool: pass
+        pass
 
-    async def close(self) -> None: pass
+    async def health(self) -> bool:
+        """Return whether the configured endpoint is ready for requests."""
+
+        pass
+
+    async def close(self) -> None:
+        """Release resources owned by the service."""
+
+        pass
 
 
 @runtime_checkable
 class TTSService(Protocol):
+    """Structural interface for text-to-speech services."""
+
     async def synthesize(
         self,
         text: str,
         *,
         response_format: str = "wav",
         timeout: float | None = None,
-    ) -> bytes: pass
+    ) -> bytes:
+        """Synthesize text and return audio in the requested format."""
 
-    async def health(self) -> bool: pass
+        pass
 
-    async def close(self) -> None: pass
+    async def health(self) -> bool:
+        """Return whether the configured endpoint is ready for requests."""
+
+        pass
+
+    async def close(self) -> None:
+        """Release resources owned by the service."""
+
+        pass
 
 
 @runtime_checkable
 class EmbeddingService(Protocol):
+    """Structural interface for text-embedding services."""
+
     async def embed(
         self,
         texts: Sequence[str],
         *,
         timeout: float | None = None,
-    ) -> list[list[float]]: pass
+    ) -> list[list[float]]:
+        """Embed text strings, returning one vector for each input in order."""
 
-    async def health(self) -> bool: pass
+        pass
 
-    async def close(self) -> None: pass
+    async def health(self) -> bool:
+        """Return whether the configured endpoint is ready for requests."""
+
+        pass
+
+    async def close(self) -> None:
+        """Release resources owned by the service."""
+
+        pass

--- a/agent-sdk/xr-ai-models/xr_ai_models/presets/__init__.py
+++ b/agent-sdk/xr-ai-models/xr_ai_models/presets/__init__.py
@@ -38,6 +38,14 @@ _PRESETS: dict[str, dict[str, Any]] = {
 
 
 def get_preset(name: str) -> dict[str, Any]:
+    """Return an independent copy of a built-in model preset.
+
+    Raises
+    ------
+    KeyError
+        If ``name`` does not identify a built-in preset.
+    """
+
     try:
         return deepcopy(_PRESETS[name])
     except KeyError as exc:
@@ -47,6 +55,8 @@ def get_preset(name: str) -> dict[str, Any]:
 
 
 def available_presets() -> list[str]:
+    """Return the sorted names of all built-in model presets."""
+
     return sorted(_PRESETS)
 
 

--- a/agent-sdk/xr-ai-tools/xr_ai_tools/current_frame.py
+++ b/agent-sdk/xr-ai-tools/xr_ai_tools/current_frame.py
@@ -20,17 +20,29 @@ class ImageFrame(TimedImage):
     """One selected camera frame and its source metadata."""
 
     width: int = Field(gt=0)
+    """Frame width in pixels."""
+
     height: int = Field(gt=0)
+    """Frame height in pixels."""
+
     sequence: int = Field(ge=0)
+    """Source track sequence number."""
+
     participant_id: str = Field(min_length=1)
+    """Participant that published the frame."""
+
     track_id: str = ""
+    """Source video track identifier, when available."""
 
 
 class CurrentFrameRequest(StrictRequest):
+    """Select the latest camera frame for one participant."""
+
     participant_id: str = Field(
         min_length=1,
         description="Participant whose latest camera frame should be returned.",
     )
+    """Participant whose latest camera frame should be returned."""
 
 
 class CurrentFrameTool(Tool[CurrentFrameRequest, ImageFrame]):

--- a/agent-sdk/xr-ai-tools/xr_ai_tools/image.py
+++ b/agent-sdk/xr-ai-tools/xr_ai_tools/image.py
@@ -25,10 +25,13 @@ class ImageReference(BaseModel):
         min_length=1,
         description=("Opaque xr-image URI returned by an image tool, local image path, file URI, or HTTP(S) URL."),
     )
+    """Opaque image URI, local path, file URI, or HTTP(S) URL."""
 
     @field_validator("uri")
     @classmethod
     def reject_inline_data(cls, value: str) -> str:
+        """Reject data URIs so image bytes remain outside request payloads."""
+
         if value.startswith("data:"):
             raise ValueError("register inline image data with ImageRegistry.put()")
         return value
@@ -40,7 +43,10 @@ class TimedImage(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     image: ImageReference
+    """Reference to the image content."""
+
     timestamp_us: int = Field(ge=0)
+    """Position on the image sequence's microsecond timeline."""
 
 
 class ImageRegistry:
@@ -112,6 +118,8 @@ class ImageRegistry:
                 del self._images[uri]
 
     def clear(self) -> None:
+        """Remove all registered opaque images."""
+
         self._images.clear()
 
     def __len__(self) -> int:

--- a/agent-sdk/xr-ai-tools/xr_ai_tools/image_polygon.py
+++ b/agent-sdk/xr-ai-tools/xr_ai_tools/image_polygon.py
@@ -34,21 +34,27 @@ class ImagePoint(BaseModel):
         allow_inf_nan=False,
         description="Horizontal pixel coordinate from the left edge.",
     )
+    """Horizontal pixel coordinate from the left edge."""
+
     y: float = Field(
         ge=0,
         allow_inf_nan=False,
         description="Vertical pixel coordinate from the top edge.",
     )
+    """Vertical pixel coordinate from the top edge."""
 
 
 class ImagePolygonFillRequest(StrictRequest):
     """Fill the polygon defined by ordered image-space vertices."""
 
     image: ImageReference = Field(description="Source image returned by an image tool or supplied by the caller.")
+    """Source image returned by an image tool or supplied by the caller."""
+
     coordinates: list[ImagePoint] = Field(
         min_length=3,
         description="Ordered polygon vertices; the final vertex is connected to the first.",
     )
+    """Ordered vertices, with the final vertex connected to the first."""
 
 
 class ImagePolygonFillResult(BaseModel):
@@ -58,14 +64,19 @@ class ImagePolygonFillResult(BaseModel):
         default=None,
         description="Opaque reference to the edited PNG image when available.",
     )
+    """Opaque reference to the edited PNG image when available."""
+
     available: bool = Field(
         default=True,
         description="Whether the supplied image and polygon produced an edited image.",
     )
+    """Whether the supplied image and polygon produced an edited image."""
+
     message: str | None = Field(
         default=None,
         description="Recoverable failure detail when no edited image was produced.",
     )
+    """Recoverable failure detail when no edited image was produced."""
 
 
 def _open_image(source: ImageInput) -> Image.Image:

--- a/agent-sdk/xr-ai-tools/xr_ai_tools/marker_tracking.py
+++ b/agent-sdk/xr-ai-tools/xr_ai_tools/marker_tracking.py
@@ -30,7 +30,10 @@ class MarkerType(StrEnum):
     """Marker families supported by :class:`MarkerTrackingTool`."""
 
     QR_CODE = "qr_code"
+    """QR codes containing arbitrary text."""
+
     ARUCO = "aruco"
+    """ArUco fiducial markers containing numeric identifiers."""
 
 
 class MarkerTrackingRequest(StrictRequest):
@@ -40,25 +43,34 @@ class MarkerTrackingRequest(StrictRequest):
         min_length=1,
         description="Participant whose current camera frame should be scanned.",
     )
+    """Participant whose current camera frame should be scanned."""
 
 
 class MarkerPoint(BaseModel):
     """One image-space corner of a tracked marker."""
 
     x: float = Field(description="Horizontal pixel coordinate.")
+    """Horizontal pixel coordinate."""
+
     y: float = Field(description="Vertical pixel coordinate.")
+    """Vertical pixel coordinate."""
 
 
 class TrackedMarker(BaseModel):
     """One detected marker and its quadrilateral in the source frame."""
 
     marker_type: MarkerType = Field(description="Detected marker family.")
+    """Detected marker family."""
+
     value: str = Field(
         description="Decoded QR text or decimal ArUco marker identifier."
     )
+    """Decoded QR text or decimal ArUco marker identifier."""
+
     corners: tuple[MarkerPoint, MarkerPoint, MarkerPoint, MarkerPoint] = Field(
         description="Four clockwise image-space corners."
     )
+    """Four clockwise image-space corners."""
 
 
 class MarkerTrackingResult(BaseModel):
@@ -68,14 +80,19 @@ class MarkerTrackingResult(BaseModel):
         default_factory=list,
         description="Detected markers in detector-provided order.",
     )
+    """Detected markers in detector-provided order."""
+
     available: bool = Field(
         default=True,
         description="Whether a current frame was available and could be scanned.",
     )
+    """Whether a current frame was available and could be scanned."""
+
     message: str | None = Field(
         default=None,
         description="Human-readable detail when no marker was returned.",
     )
+    """Human-readable detail when no marker was returned."""
 
 
 def _image_pixels(image: Image.Image | np.ndarray) -> np.ndarray:

--- a/agent-sdk/xr-ai-tools/xr_ai_tools/rag.py
+++ b/agent-sdk/xr-ai-tools/xr_ai_tools/rag.py
@@ -13,47 +13,74 @@ from .types import EmptyRequest, StrictRequest
 
 
 class RetrieveRequest(StrictRequest):
+    """Search parameters for retrieving relevant document passages."""
+
     query: str = Field(
         min_length=1,
         description="Question or search phrase to retrieve context for.",
     )
+    """Question or search phrase to retrieve context for."""
+
     top_k: int = Field(
         default=4,
         ge=1,
         le=20,
         description="Maximum matching chunks to return.",
     )
+    """Maximum number of matching passages to return."""
 
     @field_validator("query")
     @classmethod
     def query_must_not_be_blank(cls, value: str) -> str:
+        """Require visible text in the retrieval query."""
+
         if not value.strip():
             raise ValueError("query must not be blank")
         return value
 
 
 class RetrievedChunk(BaseModel):
+    """A document passage returned by similarity search."""
+
     text: str = Field(description="Retrieved document passage.")
+    """Retrieved document passage."""
+
     source: str = Field(
         description="Source path relative to the configured document directory."
     )
+    """Source path relative to the configured document directory."""
+
     score: float = Field(
         description="Cosine similarity between the query and passage."
     )
+    """Cosine similarity between the query and passage."""
 
 
 class RetrieveResult(BaseModel):
+    """Ranked document passages returned for a retrieval request."""
+
     results: list[RetrievedChunk]
+    """Matching passages in service-defined relevance order."""
 
 
 class ListDocumentsResult(BaseModel):
+    """Documents currently indexed by the retrieval service."""
+
     documents: list[str]
+    """Source paths relative to the configured document directory."""
 
 
 class RAGHealthResult(BaseModel):
+    """Readiness and index statistics reported by the RAG service."""
+
     ready: bool
+    """Whether the service is ready to answer retrieval requests."""
+
     document_count: int
+    """Number of indexed documents."""
+
     chunk_count: int
+    """Number of indexed document passages."""
 
 
 class RAGTools:
@@ -91,17 +118,23 @@ class RAGTools:
         )
 
     async def get_health(self) -> RAGHealthResult:
+        """Return detailed readiness and index statistics."""
+
         return RAGHealthResult.model_validate(
             await self._rpc.call("get_health", {}, timeout_s=2.0)
         )
 
     async def health(self) -> bool:
+        """Return whether the RAG service is reachable and ready."""
+
         try:
             return (await self.get_health()).ready
         except Exception:
             return False
 
     async def close(self) -> None:
+        """Close the underlying service connection."""
+
         await self._rpc.close()
 
 

--- a/agent-sdk/xr-ai-tools/xr_ai_tools/rpc.py
+++ b/agent-sdk/xr-ai-tools/xr_ai_tools/rpc.py
@@ -79,6 +79,17 @@ class RPCClient:
         *,
         timeout_s: float | None = None,
     ) -> dict[str, Any]:
+        """Call a remote operation and return its decoded result map.
+
+        Args:
+            operation: Remote dispatch name.
+            arguments: Msgpack-compatible operation arguments.
+            timeout_s: Per-call timeout, overriding the client default.
+
+        Raises:
+            RPCError: If transport, protocol, timeout, or remote execution fails.
+        """
+
         self._ensure_started()
         socket = self._socket
         assert socket is not None
@@ -144,6 +155,8 @@ class RPCClient:
                 socket.close(linger=0)
 
     async def close(self) -> None:
+        """Cancel pending calls and close the transport."""
+
         receiver, self._receiver = self._receiver, None
         if receiver is not None:
             receiver.cancel()
@@ -168,6 +181,12 @@ class RPCServer:
         self._send_lock = asyncio.Lock()
 
     async def serve(self, *, ready: Callable[[], None] | None = None) -> None:
+        """Bind the endpoint and dispatch requests until cancelled.
+
+        Args:
+            ready: Optional callback invoked after the endpoint is bound.
+        """
+
         if self._socket is not None:
             raise RuntimeError("RPC server is already running")
         socket = zmq.asyncio.Context.instance().socket(zmq.ROUTER)
@@ -235,6 +254,8 @@ class RPCServer:
                 await self._socket.send_multipart([identity, _pack(response)])
 
     async def close(self) -> None:
+        """Cancel active request handlers and close the bound socket."""
+
         tasks = tuple(self._tasks)
         for task in tasks:
             task.cancel()

--- a/agent-sdk/xr-ai-tools/xr_ai_tools/spatial.py
+++ b/agent-sdk/xr-ai-tools/xr_ai_tools/spatial.py
@@ -38,6 +38,12 @@ def offset_user_frame(
     right: float = 0.0,
     up: float = 0.0,
 ) -> Vector3:
+    """Offset a point along the user's horizontal axes and world-space up.
+
+    The user's forward and right axes are projected onto the horizontal plane.
+    Returned coordinates are rounded to millimeter precision.
+    """
+
     (forward_x, forward_z), (right_x, right_z) = _horizontal_axes(frame)
     return _position(
         start.x + forward_x * forward + right_x * right,
@@ -47,6 +53,8 @@ def offset_user_frame(
 
 
 def gaze_target(frame: SpatialFrame, distance: float = 1.5) -> Vector3:
+    """Return a point along the user's three-dimensional gaze direction."""
+
     if distance < 0:
         raise ValueError("distance must be non-negative")
     return _position(
@@ -61,6 +69,8 @@ def user_relative(
     direction: Literal["front", "back", "left", "right", "above", "below"],
     distance: float,
 ) -> Vector3:
+    """Return a point in a named direction from the user's frame origin."""
+
     if distance < 0:
         raise ValueError("distance must be non-negative; flip the direction instead")
     offsets = {
@@ -88,6 +98,8 @@ def anchor_relative(
     ],
     distance: float,
 ) -> Vector3:
+    """Return a point in a named user-relative direction from an anchor."""
+
     if distance < 0:
         raise ValueError("distance must be non-negative; flip the direction instead")
     offsets = {
@@ -107,6 +119,8 @@ def toward(
     target: Vector3,
     distance: float,
 ) -> Vector3:
+    """Move a point by a signed distance along the line toward a target."""
+
     delta_x = target.x - start.x
     delta_y = target.y - start.y
     delta_z = target.z - start.z
@@ -122,6 +136,8 @@ def toward(
 
 
 def midpoint(first: Vector3, second: Vector3) -> Vector3:
+    """Return the midpoint between two positions."""
+
     return _position(
         (first.x + second.x) / 2,
         (first.y + second.y) / 2,

--- a/agent-sdk/xr-ai-tools/xr_ai_tools/text_memory.py
+++ b/agent-sdk/xr-ai-tools/xr_ai_tools/text_memory.py
@@ -22,70 +22,131 @@ _MAX_TIMESTAMP_US = 9_223_372_036_854_775_807
 
 
 class AddTranscriptRequest(StrictRequest):
+    """One timestamped transcript segment to persist."""
+
     source_id: str = Field(description="Participant or internal source identifier.")
+    """Participant or internal source identifier."""
+
     timestamp_us: int = Field(description="Unix timestamp in microseconds.")
+    """Unix timestamp in microseconds."""
+
     text: str = Field(min_length=1, description="Text segment to persist.")
+    """Text segment to persist."""
 
     @field_validator("text")
     @classmethod
     def text_must_not_be_blank(cls, value: str) -> str:
+        """Require visible text in a persisted segment."""
+
         if not value.strip():
             raise ValueError("text must not be blank")
         return value
 
 
 class AddTranscriptResult(BaseModel):
+    """Confirmation that a transcript segment was persisted."""
+
     ok: bool = True
+    """Whether the append operation succeeded."""
 
 
 class TranscriptSegment(BaseModel):
+    """Persisted transcript text at a point in time."""
+
     timestamp_us: int
+    """Unix timestamp in microseconds."""
+
     text: str
+    """Persisted transcript text."""
 
 
 class QueryTranscriptsRequest(StrictRequest):
+    """Source and inclusive time window for a transcript query."""
+
     source_id: str = Field(description="Participant or internal source identifier.")
+    """Participant or internal source identifier."""
+
     start_us: int = Field(description="Inclusive window start in Unix microseconds.")
+    """Inclusive window start in Unix microseconds."""
+
     end_us: int = Field(description="Inclusive window end in Unix microseconds.")
+    """Inclusive window end in Unix microseconds."""
 
 
 class QueryTranscriptsResult(BaseModel):
+    """Transcript segments selected from one source and time window."""
+
     segments: list[TranscriptSegment]
+    """Matching segments ordered by timestamp."""
 
 
 class ListTranscriptSourcesResult(BaseModel):
+    """Persistent source identifiers known to text memory."""
+
     sources: list[str]
+    """Source identifiers in lexical order."""
 
 
 class TranscriptStatsRequest(StrictRequest):
+    """Select one transcript source for statistics."""
+
     source_id: str = Field(description="Participant or internal source identifier.")
+    """Participant or internal source identifier."""
 
 
 class TranscriptStatsResult(BaseModel):
+    """Aggregate storage and time-range statistics for one source."""
+
     source_id: str
+    """Participant or internal source identifier."""
+
     count: int
+    """Number of stored transcript segments."""
+
     total_chars: int
+    """Total number of characters across stored segments."""
+
     earliest_us: int | None
+    """Earliest stored Unix timestamp in microseconds, if present."""
+
     latest_us: int | None
+    """Latest stored Unix timestamp in microseconds, if present."""
 
 
 class RecallConversationRequest(StrictRequest):
+    """Participant and inclusive time window for conversation recall."""
+
     participant_id: str = Field(description="Participant whose conversation to recall.")
+    """Participant whose conversation to recall."""
+
     start_us: int = Field(default=0, description="Inclusive window start in Unix microseconds.")
+    """Inclusive window start in Unix microseconds."""
+
     end_us: int = Field(
         default=_MAX_TIMESTAMP_US,
         description="Inclusive window end in Unix microseconds.",
     )
+    """Inclusive window end in Unix microseconds."""
 
 
 class ConversationEntry(BaseModel):
+    """One timestamped user or agent turn in a recalled conversation."""
+
     timestamp_us: int
+    """Unix timestamp in microseconds."""
+
     role: Literal["user", "agent"]
+    """Speaker responsible for the text."""
+
     text: str
+    """Conversation text."""
 
 
 class RecallConversationResult(BaseModel):
+    """Chronological user and agent turns recalled for a participant."""
+
     entries: list[ConversationEntry]
+    """Conversation turns ordered by timestamp."""
 
 
 class _TranscriptStore:

--- a/agent-sdk/xr-ai-tools/xr_ai_tools/tool_calling.py
+++ b/agent-sdk/xr-ai-tools/xr_ai_tools/tool_calling.py
@@ -20,7 +20,10 @@ class ToolCallResult:
     """One model-ready tool response and its control-flow hint."""
 
     message: ChatMessage
+    """Tool-role message to append to the model conversation."""
+
     return_direct: bool
+    """Whether the agent should return the tool result immediately."""
 
 
 @dataclass(frozen=True, slots=True)

--- a/agent-sdk/xr-ai-tools/xr_ai_tools/tool_calling.py
+++ b/agent-sdk/xr-ai-tools/xr_ai_tools/tool_calling.py
@@ -31,8 +31,13 @@ class ToolCallRecord:
     """One model-requested call and the model-visible result it produced."""
 
     call: ToolCall
+    """Model-emitted tool call that was executed."""
+
     message: ChatMessage
+    """Tool-role message produced for the model transcript."""
+
     return_direct: bool
+    """Whether this call ended the loop without another model turn."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -40,10 +45,19 @@ class ToolLoopResult:
     """A completed turn with its full transcript and tool-call audit."""
 
     content: str
+    """Final answer or direct-return tool content."""
+
     messages: tuple[ChatMessage, ...]
+    """Complete resumable transcript for the turn."""
+
     tool_calls: tuple[ToolCallRecord, ...]
+    """Executed tool calls in model-emitted order."""
+
     iterations: int
+    """Number of model iterations consumed by the turn."""
+
     return_direct: bool
+    """Whether the result came directly from a tool."""
 
 
 class ToolLoopError(RuntimeError):
@@ -93,6 +107,7 @@ ModelCallback = Callable[
     [tuple[ChatMessage, ...], tuple[ToolDef, ...]],
     Awaitable[ChatResponse],
 ]
+"""Async model invocation supplied with the transcript and tool definitions."""
 
 
 def tool_definitions(

--- a/agent-sdk/xr-ai-tools/xr_ai_tools/tools.py
+++ b/agent-sdk/xr-ai-tools/xr_ai_tools/tools.py
@@ -23,7 +23,10 @@ class ToolInvocationResult:
     """A model-visible result from one local tool invocation."""
 
     content: str
+    """Model-visible serialized result or validation error."""
+
     return_direct: bool
+    """Whether the agent should return the content without another model turn."""
 
 
 class Tool(Generic[RequestT, ResultT]):

--- a/agent-sdk/xr-ai-tools/xr_ai_tools/tracking.py
+++ b/agent-sdk/xr-ai-tools/xr_ai_tools/tracking.py
@@ -11,22 +11,50 @@ from .types import EmptyRequest, SpatialFrame, Vector3
 
 
 class HeadPose(BaseModel):
+    """Head pose and orientation reported by the OpenXR service."""
+
     is_valid: bool
+    """Whether the remaining pose fields describe a valid tracked pose."""
+
     position: Vector3
+    """World-space head position."""
+
     forward: Vector3
+    """World-space forward direction."""
+
     right: Vector3
+    """World-space right direction."""
+
     up: Vector3
+    """World-space up direction."""
+
     yaw_deg: float
+    """Head yaw in degrees."""
+
     pitch_deg: float
+    """Head pitch in degrees."""
+
     ts: int
+    """Service-provided pose timestamp."""
+
     error: str | None = None
+    """Tracking failure detail when the pose is invalid."""
 
 
 class OpenXRHealth(BaseModel):
+    """OpenXR service health and session state."""
+
     status: str = "ok"
+    """Service health status label."""
+
     session_open: bool
+    """Whether an OpenXR session is currently open."""
+
     open_attempts: int
+    """Number of attempts made to open an OpenXR session."""
+
     last_open_error: str | None = None
+    """Most recent session-open failure, if any."""
 
 
 class TrackingTools:
@@ -56,17 +84,23 @@ class TrackingTools:
         )
 
     async def get_health(self) -> OpenXRHealth:
+        """Return detailed OpenXR service and session health."""
+
         return OpenXRHealth.model_validate(
             await self._rpc.call("get_health", {}, timeout_s=2.0)
         )
 
     async def health(self) -> bool:
+        """Return whether the service is reachable with an open XR session."""
+
         try:
             return (await self.get_health()).session_open
         except Exception:
             return False
 
     async def close(self) -> None:
+        """Close the underlying service connection."""
+
         await self._rpc.close()
 
 

--- a/agent-sdk/xr-ai-tools/xr_ai_tools/types.py
+++ b/agent-sdk/xr-ai-tools/xr_ai_tools/types.py
@@ -7,24 +7,44 @@ from pydantic import BaseModel, ConfigDict
 
 
 class StrictRequest(BaseModel):
+    """Base model for tool requests that rejects undeclared arguments."""
+
     model_config = ConfigDict(extra="forbid")
 
 
 class EmptyRequest(StrictRequest):
+    """Request model for a tool that accepts no arguments."""
+
     pass
 
 
 class Vector3(BaseModel):
+    """A three-dimensional Cartesian vector or position."""
+
     x: float
+    """Component on the x-axis."""
+
     y: float
+    """Component on the y-axis."""
+
     z: float
+    """Component on the z-axis."""
 
 
 class SpatialFrame(BaseModel):
+    """An origin and orthogonal orientation axes in world space."""
+
     origin: Vector3
+    """World-space origin of the frame."""
+
     forward: Vector3
+    """Forward direction of the frame."""
+
     right: Vector3
+    """Right direction of the frame."""
+
     up: Vector3
+    """Up direction of the frame."""
 
 
 __all__ = ["EmptyRequest", "SpatialFrame", "StrictRequest", "Vector3"]

--- a/agent-sdk/xr-ai-tools/xr_ai_tools/video_memory.py
+++ b/agent-sdk/xr-ai-tools/xr_ai_tools/video_memory.py
@@ -14,24 +14,44 @@ from .types import EmptyRequest, StrictRequest
 
 
 class ListRecordedParticipantsResult(BaseModel):
+    """Participants with camera recordings available in video memory."""
+
     participants: list[str]
+    """Exact recorded participant identifiers."""
 
 
 class VideoStatsRequest(StrictRequest):
+    """Select one participant's recording statistics."""
+
     participant_id: str = Field(min_length=1)
+    """Participant whose camera recording should be inspected."""
 
 
 class VideoStatsResult(BaseModel):
+    """Storage and time-range statistics for one participant's recording."""
+
     participant_id: str
+    """Participant whose recording was inspected."""
+
     num_chunks: int
+    """Number of persisted video chunks."""
+
     total_bytes: int
+    """Total encoded size of all chunks in bytes."""
+
     avg_chunk_bytes: int
+    """Average encoded chunk size in bytes."""
+
     earliest_us: int
+    """Earliest recorded Unix timestamp in microseconds."""
+
     latest_us: int
+    """Latest recorded Unix timestamp in microseconds."""
 
 
 class _ParticipantRequest(StrictRequest):
     participant_id: str = Field(min_length=1)
+    """Participant whose camera recording should be queried."""
 
 
 class _DurationRequest(_ParticipantRequest):
@@ -40,6 +60,7 @@ class _DurationRequest(_ParticipantRequest):
         le=300,
         description="Whole seconds of recorded history in the requested window.",
     )
+    """Whole seconds of recorded history in the requested window."""
 
 
 class LatestVideoRequest(_DurationRequest):
@@ -53,13 +74,23 @@ class HistoricalVideoRequest(_DurationRequest):
         gt=0,
         description="Unix-epoch timestamp in microseconds at the start of the window.",
     )
+    """Unix timestamp in microseconds at the start of the window."""
 
 
 class RecordedVideoResult(BaseModel):
+    """A recorded H.264 file and its covered time range."""
+
     path: str
+    """Local path to the exported H.264 file."""
+
     size: int
+    """Encoded file size in bytes."""
+
     start_us: int
+    """Beginning of the returned window in Unix microseconds."""
+
     end_us: int
+    """End of the returned window in Unix microseconds."""
 
 
 class _FrameSamplingRequest(_DurationRequest):
@@ -68,16 +99,21 @@ class _FrameSamplingRequest(_DurationRequest):
         le=256,
         description="Maximum total number of evenly distributed frames to return.",
     )
+    """Maximum total number of evenly distributed frames to return."""
+
     max_width: int | None = Field(
         default=None,
         gt=0,
         description="Optional maximum exported width; requires max_height.",
     )
+    """Optional maximum exported width; requires ``max_height``."""
+
     max_height: int | None = Field(
         default=None,
         gt=0,
         description="Optional maximum exported height; requires max_width.",
     )
+    """Optional maximum exported height; requires ``max_width``."""
 
     @model_validator(mode="after")
     def validate_resolution(self) -> _FrameSamplingRequest:
@@ -97,46 +133,82 @@ class HistoricalFramesRequest(_FrameSamplingRequest):
         gt=0,
         description="Unix-epoch timestamp in microseconds at the start of the window.",
     )
+    """Unix timestamp in microseconds at the start of the window."""
 
 
 class SampledVideoFrame(TimedImage):
+    """One image sampled from a recorded video window."""
+
     timestamp_us: int = Field(
         ge=0,
         description="Estimated Unix-epoch timestamp interpolated from recording chunk metadata.",
     )
+    """Estimated Unix timestamp interpolated from recording chunk metadata."""
     width: int
+    """Frame width in pixels."""
+
     height: int
+    """Frame height in pixels."""
 
 
 class SampleFramesResult(BaseModel):
+    """Bounded image samples and metadata for a recorded video window."""
+
     frames: list[SampledVideoFrame]
+    """Sampled frames in chronological order."""
+
     start_us: int
+    """Beginning of the sampled window in Unix microseconds."""
+
     end_us: int
+    """End of the sampled window in Unix microseconds."""
+
     duration_seconds: int
+    """Requested duration of the sampled window in whole seconds."""
+
     frame_budget: int
+    """Requested maximum number of returned frames."""
+
     max_width: int | None
+    """Requested maximum frame width, if resizing was enabled."""
+
     max_height: int | None
+    """Requested maximum frame height, if resizing was enabled."""
 
 
 class HistoricalFrameRequest(_ParticipantRequest):
+    """Select the recorded frame nearest an absolute timestamp."""
+
     start_us: int = Field(
         gt=0,
         description="Unix-epoch timestamp in microseconds of the requested frame.",
     )
+    """Unix timestamp in microseconds of the requested frame."""
 
 
 class HistoricalFrameResult(TimedImage):
+    """The recorded image nearest a requested absolute timestamp."""
+
     timestamp_us: int = Field(
         ge=0,
         description="Estimated Unix-epoch timestamp interpolated from recording chunk metadata.",
     )
+    """Estimated Unix timestamp interpolated from recording chunk metadata."""
     width: int
+    """Frame width in pixels."""
+
     height: int
+    """Frame height in pixels."""
 
 
 class VideoHealthResult(BaseModel):
+    """Readiness and recording state reported by video memory."""
+
     ready: bool = True
+    """Whether the service is ready for queries."""
+
     recording_enabled: bool
+    """Whether the service is currently persisting camera video."""
 
 
 class VideoMemoryTools:
@@ -263,17 +335,23 @@ class VideoMemoryTools:
         )
 
     async def get_health(self) -> VideoHealthResult:
+        """Return detailed video-memory readiness and recording state."""
+
         return VideoHealthResult.model_validate(
             await self._rpc.call("get_health", {}, timeout_s=2.0)
         )
 
     async def health(self) -> bool:
+        """Return whether the video-memory service is reachable and ready."""
+
         try:
             return (await self.get_health()).ready
         except Exception:
             return False
 
     async def close(self) -> None:
+        """Close the underlying service connection."""
+
         await self._rpc.close()
 
 

--- a/agent-sdk/xr-ai-tools/xr_ai_tools/vision.py
+++ b/agent-sdk/xr-ai-tools/xr_ai_tools/vision.py
@@ -36,29 +36,46 @@ _MAX_IMAGES = 4
 
 
 class ImageQueryRequest(StrictRequest):
+    """An image reference and the question to answer from it."""
+
     image: ImageReference = Field(description="Image selected by another tool or caller.")
+    """Image selected by another tool or caller."""
+
     query: str = Field(min_length=1, description="Question to answer from the image.")
+    """Question to answer from the image."""
 
 
 class MultiImageQueryRequest(StrictRequest):
+    """An ordered image collection and one question spanning the images."""
+
     images: list[ImageReference] = Field(
         min_length=1,
         max_length=_MAX_IMAGES,
         description="Ordered images selected by other tools or the caller.",
     )
+    """Ordered images selected by other tools or the caller."""
+
     query: str = Field(min_length=1, description="Question to answer from the images.")
+    """Question to answer from the images."""
 
 
 class VideoQueryRequest(StrictRequest):
+    """Chronological image frames and a temporal question about them."""
+
     frames: list[TimedImage] = Field(
         min_length=1,
         max_length=_MAX_IMAGES,
         description="Chronologically ordered image frames with Unix timestamps.",
     )
+    """Chronologically ordered image frames with Unix timestamps."""
+
     query: str = Field(min_length=1, description="Question to answer from the timed frames.")
+    """Question to answer from the timed frames."""
 
     @model_validator(mode="after")
     def validate_timeline(self) -> VideoQueryRequest:
+        """Require frames to be supplied in chronological order."""
+
         timestamps = [frame.timestamp_us for frame in self.frames]
         if timestamps != sorted(timestamps):
             raise ValueError("frames must be in chronological timestamp order")
@@ -66,15 +83,23 @@ class VideoQueryRequest(StrictRequest):
 
 
 class ImageQueryResult(BaseModel):
+    """A complete VLM answer and visual-input availability state."""
+
     text: str = Field(description="Complete answer text.")
+    """Complete answer text."""
+
     available: bool = Field(
         default=True,
         description="Whether the supplied visual input produced a usable answer.",
     )
+    """Whether the supplied visual input produced a usable answer."""
 
 
 class ImageQueryChunk(BaseModel):
+    """One incremental text fragment from a streaming VLM answer."""
+
     text: str = Field(description="A partial fragment of the streamed answer text.")
+    """Partial fragment of the streamed answer text."""
 
 
 class _ImageInference:

--- a/agent-sdk/xr-ai-voice/README.md
+++ b/agent-sdk/xr-ai-voice/README.md
@@ -48,13 +48,8 @@ async with runtime:
 ## Voice tuning and data echo
 
 `VadConfig` controls utterance boundaries and bounded early transcription:
-
-| Field | Default | Meaning |
-|---|---:|---|
-| `silence_duration` | `0.8` | Seconds of silence that finalize an utterance. |
-| `min_speech` | `0.15` | Minimum speech duration accepted as an utterance. |
-| `silero_threshold` | `0.5` | Silero VAD speech-probability threshold. |
-| `stop_probe_after_s` | `0.25` | Cadence for up to three early wake/STOP transcription probes; set to `0` or less to disable probes. |
+the generated Python reference lists every field, type, default, and description.
+Set `stop_probe_after_s` to `0` or less to disable early probes.
 
 `VoiceAgent.text_topic` controls the completed-response echo sent through the
 hub data channel. Its default is `"agent.response"`; set it to `""` when the

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_runtime.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_runtime.py
@@ -22,7 +22,6 @@ from xr_ai_runtime import Agent, AgentRuntime, RuntimeContext, Topic, subscribe
 from xr_ai_voicegate import VoiceGateConfig
 
 from ._processors import VadConfig
-from ._readiness import ProbeFn
 from ._session import _VoiceSession
 from ._transport import HubVoiceTransport
 from ._types import VoiceQuery
@@ -201,7 +200,7 @@ class VoiceAgent(Agent):
         tts: TTSService,
         vad: VadConfig,
         voice_gate: VoiceGateConfig,
-        probes: Mapping[str, ProbeFn] | None = None,
+        probes: Mapping[str, Callable[[], Awaitable[bool]]] | None = None,
         ready_file: Path | None = None,
         closeables: Iterable[Any] = (),
         text_topic: str = "agent.response",

--- a/docs/source/_api_contract.py
+++ b/docs/source/_api_contract.py
@@ -35,6 +35,21 @@ PUBLIC_API_MODULES = (
     "xr_ai_tools.video_memory",
     "xr_ai_tools.vision",
 )
+PUBLIC_API_EXCLUSIONS = (
+    "xr_ai_models.presets.cosmos3_nano_reasoner",
+    "xr_ai_models.presets.cosmos_vlm",
+    "xr_ai_models.presets.llama_nemotron",
+    "xr_ai_models.presets.magpie_tts",
+    "xr_ai_models.presets.nemotron3_nano",
+    "xr_ai_models.presets.nemotron_embedding",
+    "xr_ai_models.presets.nemotron_omni",
+    "xr_ai_models.presets.parakeet_stt",
+    "xr_ai_models.presets.piper_tts",
+    "xr_ai_runtime.agent",
+    "xr_ai_runtime.events",
+    "xr_ai_runtime.runtime",
+    "xr_ai_tools.utilities.generate_marker",
+)
 
 
 @dataclass(frozen=True)
@@ -260,11 +275,46 @@ def _validate_module(
     return failures
 
 
+def _importable_module_name(package_dir: Path, path: Path) -> str | None:
+    relative = path.relative_to(package_dir)
+    parts = relative.parts[:-1]
+    if path.name != "__init__.py":
+        parts = (*parts, path.stem)
+    if any(part.startswith("_") for part in parts):
+        return None
+    return ".".join((package_dir.name, *parts))
+
+
+def _importable_modules(package_dir: Path) -> set[str]:
+    return {
+        module_name
+        for path in package_dir.rglob("*.py")
+        if (module_name := _importable_module_name(package_dir, path)) is not None
+    }
+
+
 def validate_public_api() -> list[str]:
     """Return documentation contract violations for the enrolled packages."""
 
     failures: list[str] = []
     package_dirs = {path.name: path for path in API_PACKAGE_DIRS}
+    discovered_modules = set().union(
+        *(_importable_modules(package_dir) for package_dir in API_PACKAGE_DIRS)
+    )
+    classified_modules = {
+        *package_dirs,
+        *PUBLIC_API_MODULES,
+        *PUBLIC_API_EXCLUSIONS,
+    }
+    failures.extend(
+        f"{module_name}: importable module is neither enrolled nor excluded"
+        for module_name in sorted(discovered_modules - classified_modules)
+    )
+    failures.extend(
+        f"{module_name}: excluded module does not resolve"
+        for module_name in sorted(set(PUBLIC_API_EXCLUSIONS) - discovered_modules)
+    )
+
     for package_dir in API_PACKAGE_DIRS:
         failures.extend(_validate_module(package_dir, (), package_dir.name))
 

--- a/docs/source/_api_contract.py
+++ b/docs/source/_api_contract.py
@@ -11,8 +11,29 @@ from pathlib import Path
 
 _REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 API_PACKAGE_DIRS = (
+    _REPOSITORY_ROOT / "agent-sdk" / "xr-ai-hub" / "xr_ai_hub",
+    _REPOSITORY_ROOT / "agent-sdk" / "xr-ai-models" / "xr_ai_models",
     _REPOSITORY_ROOT / "agent-sdk" / "xr-ai-runtime" / "xr_ai_runtime",
+    _REPOSITORY_ROOT / "agent-sdk" / "xr-ai-tools" / "xr_ai_tools",
     _REPOSITORY_ROOT / "agent-sdk" / "xr-ai-voice" / "xr_ai_voice",
+)
+PUBLIC_API_MODULES = (
+    "xr_ai_models.presets",
+    "xr_ai_tools.async_tools",
+    "xr_ai_tools.current_frame",
+    "xr_ai_tools.image",
+    "xr_ai_tools.image_polygon",
+    "xr_ai_tools.marker_tracking",
+    "xr_ai_tools.rag",
+    "xr_ai_tools.rpc",
+    "xr_ai_tools.spatial",
+    "xr_ai_tools.text_memory",
+    "xr_ai_tools.tool_calling",
+    "xr_ai_tools.tools",
+    "xr_ai_tools.tracking",
+    "xr_ai_tools.types",
+    "xr_ai_tools.video_memory",
+    "xr_ai_tools.vision",
 )
 
 
@@ -109,10 +130,6 @@ def _imported_module_parts(
     return (*package[: len(package) - parent_count], *imported)
 
 
-def _assignment_value(node: ast.Assign | ast.AnnAssign) -> ast.expr | None:
-    return node.value
-
-
 def _resolve_name(
     package_dir: Path,
     module: _Module,
@@ -148,15 +165,9 @@ def _resolve_name(
         imported_module = _load_module(package_dir, binding[0], modules)
         if imported_module is None:
             return None
-        return _resolve_name(
-            package_dir,
-            imported_module,
-            binding[1],
-            modules,
-            resolving,
-        )
+        return _resolve_name(package_dir, imported_module, binding[1], modules, resolving)
     if isinstance(binding, (ast.Assign, ast.AnnAssign)):
-        value = _assignment_value(binding)
+        value = binding.value
         if isinstance(value, ast.Name) and value.id != name:
             target = _resolve_name(package_dir, module, value.id, modules, resolving)
             if target is not None:
@@ -218,34 +229,50 @@ def _public_fields_without_docstrings(node: ast.ClassDef) -> list[str]:
     ]
 
 
+def _validate_module(
+    package_dir: Path,
+    parts: tuple[str, ...],
+    label: str,
+) -> list[str]:
+    modules: dict[tuple[str, ...], _Module] = {}
+    module = _load_module(package_dir, parts, modules)
+    if module is None:
+        return [f"{label}: public module does not resolve"]
+
+    failures: list[str] = []
+    for name in _literal_exports(module.tree, module.path):
+        definition = _resolve_name(package_dir, module, name, modules)
+        if definition is None:
+            failures.append(f"{label}: exported {name} does not resolve")
+            continue
+        if not _definition_has_docstring(definition):
+            failures.append(f"{label}: exported {name} has no docstring")
+        if not isinstance(definition.node, ast.ClassDef):
+            continue
+        failures.extend(
+            f"{label}: public method {name}.{method} has no docstring"
+            for method in _public_methods_without_docstrings(definition.node)
+        )
+        failures.extend(
+            f"{label}: public field {name}.{field} has no docstring"
+            for field in _public_fields_without_docstrings(definition.node)
+        )
+    return failures
+
+
 def validate_public_api() -> list[str]:
     """Return documentation contract violations for the enrolled packages."""
 
     failures: list[str] = []
+    package_dirs = {path.name: path for path in API_PACKAGE_DIRS}
     for package_dir in API_PACKAGE_DIRS:
-        modules: dict[tuple[str, ...], _Module] = {}
-        facade = _load_module(package_dir, (), modules)
-        if facade is None:
-            failures.append(f"{package_dir.name}: package facade does not resolve")
-            continue
-        exports = _literal_exports(facade.tree, facade.path)
-        for name in exports:
-            definition = _resolve_name(package_dir, facade, name, modules)
-            if definition is None:
-                failures.append(f"{package_dir.name}: exported {name} does not resolve")
-                continue
-            if not _definition_has_docstring(definition):
-                failures.append(f"{package_dir.name}: exported {name} has no docstring")
-            if not isinstance(definition.node, ast.ClassDef):
-                continue
-            failures.extend(
-                f"{package_dir.name}: public method {name}.{method} has no docstring"
-                for method in _public_methods_without_docstrings(definition.node)
-            )
-            failures.extend(
-                f"{package_dir.name}: public field {name}.{field} has no docstring"
-                for field in _public_fields_without_docstrings(definition.node)
-            )
+        failures.extend(_validate_module(package_dir, (), package_dir.name))
+
+    for module_name in PUBLIC_API_MODULES:
+        package_name, *parts = module_name.split(".")
+        failures.extend(
+            _validate_module(package_dirs[package_name], tuple(parts), module_name)
+        )
     return failures
 
 

--- a/docs/source/_api_reference_check.py
+++ b/docs/source/_api_reference_check.py
@@ -5,11 +5,16 @@
 
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
-_VOICE_REFERENCE = Path("reference/python/xr_ai_voice/index.html")
-_PRIVATE_VOICE_TERMS = {
+_API_REFERENCE = Path("reference/python")
+_PRIVATE_MODULE_REFERENCE = re.compile(
+    r"\bxr_ai_[a-z0-9_]+\._[a-z0-9_.]+",
+    flags=re.IGNORECASE,
+)
+_PRIVATE_TERMS = {
     "pipecat": "Pipecat",
     "xrmediahubinputtransport": "XRMediaHubInputTransport",
     "xrmediahuboutputtransport": "XRMediaHubOutputTransport",
@@ -19,15 +24,28 @@ _PRIVATE_VOICE_TERMS = {
 def validate_generated_api(build_dir: Path) -> list[str]:
     """Return private implementation details present in generated HTML."""
 
-    reference = build_dir / _VOICE_REFERENCE
-    if not reference.is_file():
-        return [f"generated voice API page is missing: {reference}"]
+    reference = build_dir / _API_REFERENCE
+    pages = sorted(reference.rglob("*.html")) if reference.is_dir() else []
+    if not pages:
+        return [f"generated API reference is missing: {reference}"]
 
-    html = reference.read_text(encoding="utf-8").casefold()
+    private_references: set[str] = set()
+    private_terms: set[str] = set()
+    for page in pages:
+        html = page.read_text(encoding="utf-8")
+        private_references.update(
+            match.group(0) for match in _PRIVATE_MODULE_REFERENCE.finditer(html)
+        )
+        folded = html.casefold()
+        private_terms.update(
+            label for term, label in _PRIVATE_TERMS.items() if term in folded
+        )
     return [
-        f"generated voice API exposes private implementation detail: {label}"
-        for term, label in _PRIVATE_VOICE_TERMS.items()
-        if term in html
+        *(f"generated API exposes private module path: {name}" for name in sorted(private_references)),
+        *(
+            f"generated API exposes private implementation detail: {label}"
+            for label in sorted(private_terms)
+        ),
     ]
 
 

--- a/docs/source/components/agent-sdk.md
+++ b/docs/source/components/agent-sdk.md
@@ -17,202 +17,48 @@ installation.
 | `xr-ai-tools` | `xr_ai_tools` | Relay-managed tools and model tool-call helpers |
 | `xr-ai-voice` | `xr_ai_voice` | Voice agent, transport, and private media pipeline |
 
-The complete package references are versioned with this site:
+Package guides are versioned with this site:
 {doc}`/reference/agent-sdk-hub`, {doc}`/reference/agent-sdk-models`,
 {doc}`/reference/agent-sdk-runtime`, {doc}`/reference/agent-sdk-tools`, and
-{doc}`/reference/agent-sdk-voice`.
+{doc}`/reference/agent-sdk-voice`. The generated {doc}`/reference/python/index`
+is the source of truth for public names, signatures, types, defaults, fields,
+and method-level behavior.
 
-## Runtime and tools
+## Ownership boundaries
 
-An `Agent` owns state and exposes ordinary `Tool` or `AsyncTool` instances.
-Direct callers use `execute()` or `stream()`; model loops expose the same
-tools through `ToolSet`. Ordinary bounded turns use `run_tool_loop()`; custom
-loops can compose the lower-level `tool_definitions()` and
-`handle_tool_call()` helpers. `AgentRuntime` registers agents and publishes
-typed messages to participant-scoped subscribers. It does not own model loops,
-planning, memory, raw media, agent resources, or agent-created background
-tasks.
+An `Agent` owns its state, resources, background tasks, lifecycle, and
+concurrency policy. It exposes ordinary `Tool` or `AsyncTool` instances for
+direct execution and model tool-call loops. Bounded turns use `ToolSet` and
+`run_tool_loop()`; callers retain model configuration, conversation policy,
+retries, participant context, cancellation, and task ownership. `AgentRuntime`
+owns only typed publication and delivery tasks; it does not own model loops,
+planning, memory, media, or agent-created work. A publication waits for its
+subscribers, so a subscriber that performs lengthy work should hand it to its
+own bounded queue.
 
-`run_tool_loop()` is stateless: callers provide the initial messages, current
-tool catalog, and model callback for each turn. It executes model-emitted calls
-sequentially with explicit iteration and total-call limits. The caller retains
-model configuration, conversation policy, retries, participant context,
-cancellation, and task ownership. Typed failures expose the partial transcript
-and tool-call audit for application-specific recovery. Their `messages` remain
-safe to resume because a rejected model turn is exposed separately as
-`rejected_response` rather than appended to the transcript.
+Workers construct model clients with the factories in `xr_ai_models` and depend
+on the corresponding typed service protocols. Adapter behavior, endpoint
+connectivity, deployment ownership, credentials, and model-specific wire
+details remain inside that package. See {doc}`ai-services` for deployment and
+operational guidance.
 
-```python
-from pydantic import BaseModel
-from xr_ai_runtime import Agent, AgentRuntime, Topic
-from xr_ai_tools import Tool
+`VoiceAgent` owns readiness, hub transport, voice gating, its private media
+pipeline, signal handling, and cleanup. It publishes final pre-gate transcripts
+separately from gate-accepted user queries and consumes typed voice output.
+Application agents subscribe to the events they own and clean up their own
+participant state. Pipecat and the media session remain implementation details.
 
+`ProcessorEndpoint` is the minimal agent-side hub boundary. It receives data,
+audio, frame signals, and participant events and sends participant-routed return
+traffic. Video tools acquire frames on demand; raw pixels and media stay on the
+hub path rather than entering agent APIs.
 
-class EchoRequest(BaseModel):
-    text: str
+## Documentation boundary
 
-
-class EchoResponse(BaseModel):
-    text: str
-
-
-class EchoAgent(Agent):
-    def __init__(self) -> None:
-        self.echo = Tool(
-            "echo",
-            "Echo text.",
-            EchoRequest,
-            EchoResponse,
-            self._echo,
-        )
-        super().__init__((self.echo,))
-
-    async def _echo(self, request: EchoRequest) -> EchoResponse:
-        return EchoResponse(text=request.text)
-
-
-runtime = AgentRuntime()
-agent = runtime.register("echo", EchoAgent())
-async with runtime:
-    result = await agent.echo.execute(EchoRequest(text="hello"))
-```
-
-Agents protect shared mutable state with their own lock or queue. They also
-create, cancel, and await their own tasks. `publish()` waits for all deliveries
-and then propagates subscriber failures.
-
-Image tools share bounded `ImageRegistry` references so model-visible results
-do not contain raw pixels. Install `xr-ai-tools[image-editing]` to use
-`ImagePolygonFillTool`, which copies an image, fills the area enclosed by at
-least three ordered pixel coordinates with magenta, and returns a new lossless
-PNG reference. The source reference remains unchanged, and the edited reference
-inherits its owner so lifecycle cleanup releases both images. It can be passed
-directly to the single-image or multi-image VLM query tools. Invalid polygons
-and unavailable source references return recoverable unavailable results.
-
-Relay records publications, subscriber callbacks, tool calls, and model calls
-as nested scopes. `Topic.telemetry` controls event volume without changing
-delivery: use `"full"` for semantic events and `"none"` for high-volume
-fragments that a consumer summarizes into one operation. Voice uses this model
-to record one response per completed output, separate STT scopes, and
-sentence-level TTS scopes without storing audio payloads.
-
-## Models
-
-Workers construct clients from a model profile with `make_llm`, `make_vlm`,
-`make_stt`, `make_tts`, or `make_embedding`. Callers depend on the
-corresponding service protocol, so endpoint and model-specific behavior stays
-inside `xr_ai_models`.
-
-```python
-from xr_ai_models import ChatMessage, load_models_config, make_llm
-
-config = load_models_config("yaml/models.local.json")
-async with make_llm(config, "agent_llm") as llm:
-    response = await llm.chat([ChatMessage(role="user", content="hello")])
-```
-
-A structured profile separates adapter behavior, endpoint connectivity, and
-deployment ownership. See {doc}`ai-services` for supported services, presets,
-and deployment configuration.
-
-## Voice
-
-Every non-empty final STT result is published before wake-phrase filtering
-on `VOICE_TRANSCRIPT_TOPIC` as `VoiceTranscript`. This includes speech that the
-gate rejects because it contains no wake phrase. Early wake/STOP probes remain
-private and are not published as final transcripts. Accepted speech is
-published separately as `UserQuery` after the gate removes the wake phrase and
-any preceding background speech.
-
-`VoiceAgent` publishes transcripts through a private bounded FIFO so slow
-runtime subscribers cannot delay STT, voice gating, or accepted queries. The
-queue preserves order, drops the oldest pending transcript when full, and is
-cancelled with pending entries discarded during shutdown. Subscribers should
-hand off lengthy work to their own bounded queues and return promptly.
-
-Accepted speech and typed text are published as `UserQuery` events, participant
-and interruption lifecycle events use application-named topics, and voice
-consumes `voice.output`. `VoiceAgent` privately owns model readiness, hub
-transport, voice gating, the media pipeline, signal handling, and cleanup.
-Pipecat and the media session remain implementation details.
-Voice consumes only untopiced client data when `text_input=True`; named
-application and control messages are not user queries. The hub preserves the
-original data-channel topic for all processors.
-
-```python
-voice = VoiceAgent(
-    query_topic=queries,
-    stt=stt,
-    tts=tts,
-    vad=VadConfig(),
-    voice_gate=voice_gate_config,
-    probes={"vlm": vlm.health},
-    ready_file=ready_file,
-    closeables=(vlm,),
-    participant_left_topic=participant_left,
-)
-runtime.register("voice", voice)
-
-async with runtime:
-    await voice.run(runtime)
-```
-
-The private session opens its hub transport only after readiness probes succeed
-and touches the ready file after its receive loop starts. Applications that
-already need the public `HubVoiceTransport` for frames or status publication
-construct it explicitly and pass it to `VoiceAgent`; the agent does not expose
-its private session or transport. The agent preserves participant routing,
-cancels superseded or interrupted output, and closes transports and model
-clients. Application agents subscribe to lifecycle events and clean up their
-own participant state.
-
-## Hub IPC
-
-`ProcessorEndpoint` receives data, audio, frame signals, and participant
-events through hub PUB IPC and sends participant-routed return data and audio
-through PUSH IPC. The `xr-ai-hub-client` distribution depends only on
-`pyzmq` and `msgpack`; server, model, and voice dependencies stay out.
-
-```python
-from xr_ai_hub import DataMessage, ProcessorEndpoint, Subscribe
-
-endpoint = ProcessorEndpoint(
-    sub_addr="ipc:///tmp/xr_hub_pub",
-    push_addr="ipc:///tmp/xr_hub_in",
-    filter=Subscribe.DATA | Subscribe.VIDEO,
-)
-
-async def on_data(message: DataMessage) -> None:
-    print(message.participant_id, message.topic)
-
-endpoint.on_data(on_data)
-await endpoint.run()
-```
-
-Video pixels are pulled on demand with `request_frame()` or
-`LiveFrameSource`; frame signals do not copy pixels. Readiness participation
-is opt-in and scoped to subscribed participants. The hub aggregates each
-responsible agent's status and gates readiness on confirmed subscriptions.
-
-## Marker tracking
-
-`xr_ai_tools.marker_tracking.MarkerTrackingTool` is an optional finite tool for
-QR and ArUco detection. It acquires a participant's current frame, runs enabled
-detectors off the event loop, and returns every marker through one
-`marker_type`, `value`, and four-corner contract. QR values are ZXing-C++
-decoded text; ArUco values are decimal IDs detected with a configured OpenCV
-predefined dictionary. Install `xr-ai-tools[marker-tracking]` to use it.
-Both detectors scan the complete frame at native resolution and once at a
-bounded enlarged resolution. Duplicate detections are removed, and all returned
-corners remain in source-frame coordinates.
-
-QR and ArUco are enabled by default. Initialization may select either family
-and choose the ArUco dictionary without changing the model-visible
-`track_markers` request or result schema.
-
-The `xr-ai-tools` package also includes
-`xr_ai_tools/utilities/generate_marker.py`, a standalone `uv run` utility for
-generating QR and ArUco PNGs for testing. The script declares its own inline
-dependencies, supports OpenCV predefined ArUco dictionaries, and does not add
-an agent-facing API.
+Public API membership comes from literal `__all__` declarations. Sphinx parses
+the source without importing SDK packages, then renders co-located docstrings,
+annotations, and defaults. Package READMEs retain installation, quickstarts,
+and cross-call behavioral guidance; this component page records only shared
+architecture and ownership. Guides, troubleshooting, and migrations remain
+handwritten because they describe workflows and decisions rather than API
+shape.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,9 +9,9 @@ import re
 from pathlib import Path
 from runpy import run_path
 
-API_PACKAGE_DIRS = run_path(str(Path(__file__).with_name("_api_contract.py")))[
-    "API_PACKAGE_DIRS"
-]
+_API_CONTRACT = run_path(str(Path(__file__).with_name("_api_contract.py")))
+API_PACKAGE_DIRS = _API_CONTRACT["API_PACKAGE_DIRS"]
+PUBLIC_API_MODULES = _API_CONTRACT["PUBLIC_API_MODULES"]
 
 _GITHUB_BLOB_PREFIX = "https://github.com/NVIDIA/xr-ai/blob/"
 _GITHUB_TREE_PREFIX = "https://github.com/NVIDIA/xr-ai/tree/"
@@ -119,9 +119,11 @@ _PRIVATE_API_MEMBER_SUFFIXES = (
 
 
 def _skip_private_api_details(_app, what, name, _obj, _skip, _options):
-    """Hide implementation modules and transport-adapter accessors."""
+    """Hide private modules and transport-adapter accessors."""
 
-    if what == "module" or name.endswith(_PRIVATE_API_MEMBER_SUFFIXES):
+    if what == "module" and name not in PUBLIC_API_MODULES:
+        return True
+    if name.endswith(_PRIVATE_API_MEMBER_SUFFIXES):
         return True
     return None
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,6 +4,7 @@
 """Sphinx configuration for the XR AI versioned documentation site."""
 from __future__ import annotations
 
+import ast
 import os
 import re
 from pathlib import Path
@@ -12,6 +13,22 @@ from runpy import run_path
 _API_CONTRACT = run_path(str(Path(__file__).with_name("_api_contract.py")))
 API_PACKAGE_DIRS = _API_CONTRACT["API_PACKAGE_DIRS"]
 PUBLIC_API_MODULES = _API_CONTRACT["PUBLIC_API_MODULES"]
+_PUBLIC_PACKAGE_EXPORTS = {
+    package_dir.name: frozenset(
+        _API_CONTRACT["_literal_exports"](
+            ast.parse(
+                (package_dir / "__init__.py").read_text(encoding="utf-8"),
+                filename=str(package_dir / "__init__.py"),
+            ),
+            package_dir / "__init__.py",
+        )
+    )
+    for package_dir in API_PACKAGE_DIRS
+}
+_PRIVATE_TYPE_REFERENCE = re.compile(
+    rf"\b(?P<package>{'|'.join(map(re.escape, _PUBLIC_PACKAGE_EXPORTS))})"
+    r"\._[A-Za-z0-9_.]*\.(?P<name>[A-Za-z][A-Za-z0-9_]*)"
+)
 
 _GITHUB_BLOB_PREFIX = "https://github.com/NVIDIA/xr-ai/blob/"
 _GITHUB_TREE_PREFIX = "https://github.com/NVIDIA/xr-ai/tree/"
@@ -41,6 +58,42 @@ def _rewrite_github_links(_app, _docname: str, source: list[str]) -> None:
     source[0] = source[0].replace(
         f"{_GITHUB_TREE_PREFIX}main/", f"{_GITHUB_TREE_PREFIX}{ref}/"
     )
+
+
+def _canonicalize_public_type_references(value):
+    if not isinstance(value, str):
+        return value
+
+    def replace(match: re.Match[str]) -> str:
+        package = match.group("package")
+        name = match.group("name")
+        if name in _PUBLIC_PACKAGE_EXPORTS[package]:
+            return f"{package}.{name}"
+        return match.group(0)
+
+    return _PRIVATE_TYPE_REFERENCE.sub(replace, value)
+
+
+def _prepare_api_templates(environment) -> None:
+    environment.finalize = _canonicalize_public_type_references
+
+
+def _canonicalize_api_annotations(_app, env, _docnames) -> None:
+    for module_annotations in getattr(env, "autoapi_annotations", {}).values():
+        for name, value in module_annotations.items():
+            module_annotations[name] = _canonicalize_public_type_references(value)
+    for api_object in getattr(env, "autoapi_all_objects", {}).values():
+        for attribute in ("annotation", "args", "return_annotation"):
+            value = getattr(api_object, attribute, None)
+            if isinstance(value, str):
+                try:
+                    setattr(
+                        api_object,
+                        attribute,
+                        _canonicalize_public_type_references(value),
+                    )
+                except AttributeError:
+                    pass
 
 # -- Project information -----------------------------------------------------
 project = "XR AI"
@@ -73,6 +126,7 @@ autoapi_options = [
 ]
 autoapi_member_order = "bysource"
 autoapi_python_class_content = "class"
+autoapi_prepare_jinja_env = _prepare_api_templates
 
 # MyST Markdown is the page format (matches the repo's existing docs/*.md).
 source_suffix = {
@@ -129,6 +183,7 @@ def _skip_private_api_details(_app, what, name, _obj, _skip, _options):
 
 
 def setup(app):
+    app.connect("env-before-read-docs", _canonicalize_api_annotations)
     app.connect("source-read", _rewrite_github_links)
     app.connect("autoapi-skip-member", _skip_private_api_details)
     return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/docs/source/guides/contributing-and-conventions.md
+++ b/docs/source/guides/contributing-and-conventions.md
@@ -21,8 +21,13 @@ uv run pytest
 uv tool run ruff check <changed-python-files>
 ```
 
-Update the relevant README and this documentation with user-visible changes.
+Public Python references are generated from each enrolled module's literal
+`__all__`, declarations, annotations, defaults, and docstrings. An API-only
+change therefore updates the code, its co-located documentation, and tests; the
+strict documentation build rejects unresolved or undocumented exports. Update
+a README or narrative page when concepts, workflows, operations, or
+architecture change, and add a migration entry for a breaking change.
+
 A `pyproject.toml` change also requires a `DEPENDENCIES.md` update; regenerate
-the affected project's gitignored `uv.lock` locally. New source files require an
-SPDX header; see
-[SPDX headers](spdx-headers.md).
+the affected project's gitignored `uv.lock` locally. New source files require
+an SPDX header; see [SPDX headers](spdx-headers.md).

--- a/tests/test_api_documentation.py
+++ b/tests/test_api_documentation.py
@@ -44,6 +44,16 @@ def _package(tmp_path: Path, source: str) -> Path:
     return package
 
 
+def _enroll(
+    monkeypatch: pytest.MonkeyPatch,
+    contract: ModuleType,
+    package: Path,
+    public_modules: tuple[str, ...] = (),
+) -> None:
+    monkeypatch.setattr(contract, "API_PACKAGE_DIRS", (package,))
+    monkeypatch.setattr(contract, "PUBLIC_API_MODULES", public_modules)
+
+
 def test_documented_public_api_passes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -65,7 +75,7 @@ DEFAULT_CLIENT = Client()
 __all__ = ["Client", "DEFAULT_CLIENT"]
 ''',
     )
-    monkeypatch.setattr(contract, "API_PACKAGE_DIRS", (package,))
+    _enroll(monkeypatch, contract, package)
 
     assert contract.validate_public_api() == []
 
@@ -89,7 +99,7 @@ DEFAULT_CLIENT = Client()
 __all__ = ["Client", "DEFAULT_CLIENT", "Missing"]
 ''',
     )
-    monkeypatch.setattr(contract, "API_PACKAGE_DIRS", (package,))
+    _enroll(monkeypatch, contract, package)
 
     assert contract.validate_public_api() == [
         "example_api: public method Client.run has no docstring",
@@ -111,7 +121,7 @@ class Client:
 ''',
         encoding="utf-8",
     )
-    monkeypatch.setattr(contract, "API_PACKAGE_DIRS", (package,))
+    _enroll(monkeypatch, contract, package)
 
     assert contract.validate_public_api() == ["example_api: exported Client does not resolve"]
 
@@ -123,11 +133,11 @@ def test_reexport_resolves_exact_definition(
     contract = _load_contract()
     package = _package(
         tmp_path,
-        """
+        '''
 from .public import Client
 
 __all__ = ["Client"]
-""",
+''',
     )
     (package / "public.py").write_text(
         '''
@@ -143,7 +153,7 @@ class Client:
 """,
         encoding="utf-8",
     )
-    monkeypatch.setattr(contract, "API_PACKAGE_DIRS", (package,))
+    _enroll(monkeypatch, contract, package)
 
     assert contract.validate_public_api() == []
 
@@ -179,12 +189,91 @@ class Request(BaseModel):
 __all__ = ["Item", "Request"]
 ''',
     )
-    monkeypatch.setattr(contract, "API_PACKAGE_DIRS", (package,))
+    _enroll(monkeypatch, contract, package)
 
     assert contract.validate_public_api() == [
         "example_api: public field Item.missing has no docstring",
         "example_api: public field Request.missing has no docstring",
     ]
+
+
+def test_public_module_checks_its_local_definition(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    contract = _load_contract()
+    package = _package(tmp_path, "__all__ = []\n")
+    (package / "public.py").write_text(
+        '''
+class Client:
+    pass
+
+
+__all__ = ["Client"]
+''',
+        encoding="utf-8",
+    )
+    (package / "other.py").write_text(
+        '''
+class Client:
+    """An unrelated documented class with the same name."""
+''',
+        encoding="utf-8",
+    )
+    _enroll(monkeypatch, contract, package, ("example_api.public",))
+
+    assert contract.validate_public_api() == [
+        "example_api.public: exported Client has no docstring"
+    ]
+
+
+def test_public_module_resolves_documented_import(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    contract = _load_contract()
+    package = _package(tmp_path, "__all__ = []\n")
+    (package / "public.py").write_text(
+        '''
+from .implementation import Client
+
+__all__ = ["Client"]
+''',
+        encoding="utf-8",
+    )
+    (package / "implementation.py").write_text(
+        '''
+class Client:
+    """A documented client."""
+''',
+        encoding="utf-8",
+    )
+    _enroll(monkeypatch, contract, package, ("example_api.public",))
+
+    assert contract.validate_public_api() == []
+
+
+def test_public_subpackage_is_supported(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    contract = _load_contract()
+    package = _package(tmp_path, "__all__ = []\n")
+    subpackage = package / "extras"
+    subpackage.mkdir()
+    subpackage.joinpath("__init__.py").write_text(
+        '''
+class Client:
+    """A documented client in a public subpackage."""
+
+
+__all__ = ["Client"]
+''',
+        encoding="utf-8",
+    )
+    _enroll(monkeypatch, contract, package, ("example_api.extras",))
+
+    assert contract.validate_public_api() == []
 
 
 def test_generated_voice_reference_rejects_private_transport_details(

--- a/tests/test_api_documentation.py
+++ b/tests/test_api_documentation.py
@@ -49,9 +49,11 @@ def _enroll(
     contract: ModuleType,
     package: Path,
     public_modules: tuple[str, ...] = (),
+    exclusions: tuple[str, ...] = (),
 ) -> None:
     monkeypatch.setattr(contract, "API_PACKAGE_DIRS", (package,))
     monkeypatch.setattr(contract, "PUBLIC_API_MODULES", public_modules)
+    monkeypatch.setattr(contract, "PUBLIC_API_EXCLUSIONS", exclusions)
 
 
 def test_documented_public_api_passes(
@@ -121,7 +123,12 @@ class Client:
 ''',
         encoding="utf-8",
     )
-    _enroll(monkeypatch, contract, package)
+    _enroll(
+        monkeypatch,
+        contract,
+        package,
+        exclusions=("example_api.implementation",),
+    )
 
     assert contract.validate_public_api() == ["example_api: exported Client does not resolve"]
 
@@ -153,9 +160,45 @@ class Client:
 """,
         encoding="utf-8",
     )
-    _enroll(monkeypatch, contract, package)
+    _enroll(
+        monkeypatch,
+        contract,
+        package,
+        exclusions=("example_api.public", "example_api.unrelated"),
+    )
 
     assert contract.validate_public_api() == []
+
+
+def test_import_source_must_bind_exported_name(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    contract = _load_contract()
+    package = _package(
+        tmp_path,
+        '''
+from .source import Client
+
+__all__ = ["Client"]
+''',
+    )
+    (package / "source.py").write_text("VALUE = 1\n", encoding="utf-8")
+    (package / "unrelated.py").write_text(
+        '''
+class Client:
+    """An unrelated documented class."""
+''',
+        encoding="utf-8",
+    )
+    _enroll(
+        monkeypatch,
+        contract,
+        package,
+        exclusions=("example_api.source", "example_api.unrelated"),
+    )
+
+    assert contract.validate_public_api() == ["example_api: exported Client does not resolve"]
 
 
 def test_undocumented_dataclass_and_pydantic_fields_fail(
@@ -220,7 +263,13 @@ class Client:
 ''',
         encoding="utf-8",
     )
-    _enroll(monkeypatch, contract, package, ("example_api.public",))
+    _enroll(
+        monkeypatch,
+        contract,
+        package,
+        ("example_api.public",),
+        ("example_api.other",),
+    )
 
     assert contract.validate_public_api() == [
         "example_api.public: exported Client has no docstring"
@@ -248,7 +297,13 @@ class Client:
 ''',
         encoding="utf-8",
     )
-    _enroll(monkeypatch, contract, package, ("example_api.public",))
+    _enroll(
+        monkeypatch,
+        contract,
+        package,
+        ("example_api.public",),
+        ("example_api.implementation",),
+    )
 
     assert contract.validate_public_api() == []
 
@@ -276,25 +331,46 @@ __all__ = ["Client"]
     assert contract.validate_public_api() == []
 
 
-def test_generated_voice_reference_rejects_private_transport_details(
+def test_importable_module_must_be_enrolled_or_explicitly_excluded(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    contract = _load_contract()
+    package = _package(tmp_path, "__all__ = []\n")
+    (package / "extra.py").write_text("VALUE = 1\n", encoding="utf-8")
+    _enroll(monkeypatch, contract, package)
+
+    assert contract.validate_public_api() == [
+        "example_api.extra: importable module is neither enrolled nor excluded"
+    ]
+
+    monkeypatch.setattr(contract, "PUBLIC_API_EXCLUSIONS", ("example_api.extra",))
+    assert contract.validate_public_api() == []
+
+
+def test_generated_reference_rejects_private_implementation_details(
     tmp_path: Path,
 ) -> None:
     reference_check = _load_reference_check()
-    reference = tmp_path / "reference" / "python" / "xr_ai_voice" / "index.html"
-    reference.parent.mkdir(parents=True)
-    reference.write_text(
+    models = tmp_path / "reference" / "python" / "xr_ai_models" / "index.html"
+    models.parent.mkdir(parents=True)
+    models.write_text("xr_ai_models._protocols.LLMService", encoding="utf-8")
+    voice = tmp_path / "reference" / "python" / "xr_ai_voice" / "index.html"
+    voice.parent.mkdir(parents=True)
+    voice.write_text(
         "Pipecat XRMediaHubInputTransport XRMediaHubOutputTransport",
         encoding="utf-8",
     )
 
     assert reference_check.validate_generated_api(tmp_path) == [
-        "generated voice API exposes private implementation detail: Pipecat",
-        "generated voice API exposes private implementation detail: XRMediaHubInputTransport",
-        "generated voice API exposes private implementation detail: XRMediaHubOutputTransport",
+        "generated API exposes private module path: xr_ai_models._protocols.LLMService",
+        "generated API exposes private implementation detail: Pipecat",
+        "generated API exposes private implementation detail: XRMediaHubInputTransport",
+        "generated API exposes private implementation detail: XRMediaHubOutputTransport",
     ]
 
 
-def test_generated_voice_reference_accepts_public_surface(tmp_path: Path) -> None:
+def test_generated_reference_accepts_public_surface(tmp_path: Path) -> None:
     reference_check = _load_reference_check()
     reference = tmp_path / "reference" / "python" / "xr_ai_voice" / "index.html"
     reference.parent.mkdir(parents=True)


### PR DESCRIPTION
## Summary

- roll static API generation out to all five SDK packages and intentionally public tools/model modules
- document the existing public surface in co-located docstrings without changing signatures, exports, or behavior
- enforce resolvable, documented literal `__all__` contracts and simplify duplicated API prose

## Stack

- Depends on #377
- This is PR 2 of 4 in the documentation-maintenance stack
- Followed by #379 and #380

## Validation

- `python3 docs/source/_api_contract.py`
- `uv run --with pytest==8.3.5 pytest -q --noconftest tests/test_api_documentation.py` (5 passed)
- model configuration/OpenAI compatibility/API documentation tests (92 passed)
- `uv run --no-project --with-requirements docs/requirements.txt make -C docs strict`
- `uv run --no-project --with-requirements docs/requirements.txt make -C docs strict-versions`
- Ruff 0.15.16 on all touched Python areas
- `python3 .github/scripts/check_spdx_headers.py`
- AST comparison confirms SDK Python changes are documentation-only
