### PR TITLE
fix(tools): scope image sanitizers per VLM call

### DIFF
--- a/agent-sdk/xr-ai-tools/xr_ai_tools/_vision.py
+++ b/agent-sdk/xr-ai-tools/xr_ai_tools/_vision.py
@@ -7,24 +7,34 @@ from __future__ import annotations
 
 import copy
 import re
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
+from itertools import count
 from typing import Any
 
 import nemo_relay
 
 VLM_CALL_NAME = "xr-ai-vlm"
 _IMAGE_REDACTION = "<redacted:image>"
+_IMAGE_SANITIZER_IDS = count()
 
 
-def register_image_sanitizer() -> None:
-    """Redact image locations from VLM events in the active tool scope."""
+@contextmanager
+def image_sanitizer() -> Iterator[None]:
+    """Redact image locations for one VLM call in the active tool scope."""
 
+    handle = nemo_relay.scope.get_handle()
+    name = f"xr-ai-image-{next(_IMAGE_SANITIZER_IDS)}"
     nemo_relay.scope_local.register_llm_sanitize_request(
-        nemo_relay.scope.get_handle(),
-        "xr-ai-image",
+        handle,
+        name,
         0,
         _sanitize_images,
     )
+    try:
+        yield
+    finally:
+        nemo_relay.scope_local.deregister_llm_sanitize_request(handle, name)
 
 
 def relay_request(

--- a/agent-sdk/xr-ai-tools/xr_ai_tools/vision.py
+++ b/agent-sdk/xr-ai-tools/xr_ai_tools/vision.py
@@ -17,8 +17,8 @@ from xr_ai_models import VLMService
 from ._relay import headers_from_relay
 from ._vision import (
     VLM_CALL_NAME,
+    image_sanitizer,
     openai_response,
-    register_image_sanitizer,
     relay_request,
     response_text,
     stream_text,
@@ -125,19 +125,19 @@ class _ImageInference:
                 available=False,
             )
         try:
-            register_image_sanitizer()
-            response = await nemo_relay.llm.execute(
-                VLM_CALL_NAME,
-                relay_request(
-                    self.system_prompt,
-                    [(image.uri, timestamp_us) for image, timestamp_us in inputs],
-                    query,
-                ),
-                self._ask_vlm,
-                model_name=VLM_CALL_NAME,
-                codec=OpenAIChatCodec(),
-                response_codec=OpenAIChatCodec(),
-            )
+            with image_sanitizer():
+                response = await nemo_relay.llm.execute(
+                    VLM_CALL_NAME,
+                    relay_request(
+                        self.system_prompt,
+                        [(image.uri, timestamp_us) for image, timestamp_us in inputs],
+                        query,
+                    ),
+                    self._ask_vlm,
+                    model_name=VLM_CALL_NAME,
+                    codec=OpenAIChatCodec(),
+                    response_codec=OpenAIChatCodec(),
+                )
             text = visible_text(response_text(response))
             if not text:
                 return ImageQueryResult(
@@ -167,26 +167,26 @@ class _ImageInference:
             yield ImageQueryChunk(text="Image input unavailable — please select it again.")
             return
         try:
-            register_image_sanitizer()
-            stream = await nemo_relay.llm.stream_execute(
-                VLM_CALL_NAME,
-                relay_request(
-                    self.system_prompt,
-                    [(image.uri, timestamp_us) for image, timestamp_us in inputs],
-                    query,
-                ),
-                self._stream_vlm,
-                lambda chunk: fragments.append(stream_text(chunk)),
-                lambda: openai_response("".join(fragments)),
-                model_name=VLM_CALL_NAME,
-                codec=OpenAIChatCodec(),
-                response_codec=OpenAIChatCodec(),
-            )
-            async for chunk in stream:
-                text = stream_text(chunk)
-                if text:
-                    emitted_output = True
-                    yield ImageQueryChunk(text=text)
+            with image_sanitizer():
+                stream = await nemo_relay.llm.stream_execute(
+                    VLM_CALL_NAME,
+                    relay_request(
+                        self.system_prompt,
+                        [(image.uri, timestamp_us) for image, timestamp_us in inputs],
+                        query,
+                    ),
+                    self._stream_vlm,
+                    lambda chunk: fragments.append(stream_text(chunk)),
+                    lambda: openai_response("".join(fragments)),
+                    model_name=VLM_CALL_NAME,
+                    codec=OpenAIChatCodec(),
+                    response_codec=OpenAIChatCodec(),
+                )
+                async for chunk in stream:
+                    text = stream_text(chunk)
+                    if text:
+                        emitted_output = True
+                        yield ImageQueryChunk(text=text)
         except Exception:
             _LOGGER.exception("Image VLM stream failed")
             if not emitted_output:

--- a/tests/test_image_tools.py
+++ b/tests/test_image_tools.py
@@ -3,6 +3,7 @@
 
 """CPU-only contracts for image selection and image-input VLM tools."""
 
+import asyncio
 import base64
 import io
 import time
@@ -260,6 +261,45 @@ async def test_image_query_consumes_selected_bytes_and_redacts_relay_events() ->
     assert llm_events
     assert any("<redacted:image>" in event for event in llm_events)
     assert all("jpeg bytes" not in event for event in llm_events)
+
+
+async def test_image_query_can_repeat_within_one_relay_scope() -> None:
+    images = ImageRegistry()
+    image = images.put(b"jpeg bytes", owner="alice")
+    vlm = _Vlm()
+    tool = ImageQueryTool(
+        images=images,
+        vlm=cast(VLMService, vlm),
+        system_prompt="Answer briefly.",
+    )
+
+    with nemo_relay.scope.scope("repeated-vision", nemo_relay.ScopeType.Agent):
+        first = await tool.execute(ImageQueryRequest(image=image, query="What is shown?"))
+        second = await tool.execute(ImageQueryRequest(image=image, query="What is shown now?"))
+
+    assert first.text == "a blue square"
+    assert second.text == "a blue square"
+    assert len(vlm.calls) == 2
+
+
+async def test_image_query_can_overlap_within_one_relay_scope() -> None:
+    images = ImageRegistry()
+    image = images.put(b"jpeg bytes", owner="alice")
+    vlm = _Vlm()
+    tool = ImageQueryTool(
+        images=images,
+        vlm=cast(VLMService, vlm),
+        system_prompt="Answer briefly.",
+    )
+
+    with nemo_relay.scope.scope("overlapping-vision", nemo_relay.ScopeType.Agent):
+        results = await asyncio.gather(
+            tool.execute(ImageQueryRequest(image=image, query="What is shown?")),
+            tool.execute(ImageQueryRequest(image=image, query="What is shown now?")),
+        )
+
+    assert [result.text for result in results] == ["a blue square", "a blue square"]
+    assert len(vlm.calls) == 2
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- register a unique Relay image sanitizer for each VLM call
- deregister it when finite or streaming inference completes
- cover repeated and overlapping image queries in one Relay scope

This extracts the shared fix previously buried in PR #363. Without it, long-lived background visual loops fail after their first call with `xr-ai-image already exists`.

## Validation
- `uv run --project tests pytest tests/test_image_tools.py -q` (23 passed)
- Ruff
- `git diff --check`