### PR TITLE
Add participant-scoped voice output aggregation

### DIFF
--- a/agent-sdk/xr-ai-voice/README.md
+++ b/agent-sdk/xr-ai-voice/README.md
@@ -104,25 +104,37 @@ pacing rather than a client playback acknowledgement. An estimate that is too
 short moves queuing downstream into TTS; one that is too long creates silence.
 Tune all three playback settings for the selected TTS voice.
 
-Rewrites have the explicit `rewrite_timeout_s` deadline. If a rewrite fails or
-times out, the original text is joined so updates are not lost. The earliest
-input timestamp is preserved. An `interrupt=True` contribution bypasses an LLM
-rewrite, cancels a rewrite already in progress, and replaces active speech
-without model latency. `queue_capacity` bounds all pending contributions for one
-participant, including chunks waiting behind another stream. When the bound is
-reached, the oldest non-urgent pending contribution is dropped with a warning
-so new output cannot grow stale in an unbounded buffer. Batches also have a
-bounded size; retained contributions remain ordered for following batches.
+Rewrites have an aggregator-enforced `rewrite_timeout_s` deadline, which is also
+passed to the model service. If a rewrite fails or times out, the original text
+is joined so updates are not lost. The earliest input timestamp is preserved.
+An `interrupt=True` contribution bypasses the coalescing delay and LLM rewrite,
+cancels a rewrite already in progress, and replaces active speech without model
+latency. Routine updates already collected in its batch remain ordered for the
+next batch. `queue_capacity` bounds all pending contributions for one
+participant, including chunks waiting behind another stream. At capacity,
+routine input replaces the oldest routine contribution but never an urgent one.
+Urgent input replaces the oldest routine contribution when possible, otherwise
+the oldest urgent contribution, so the freshest alert wins. Every drop is
+logged, and dropping a stream fragment quarantines that stream ID. Batches also
+have a bounded size; retained contributions remain ordered for following
+batches.
 
 A lone incremental contribution starts streaming immediately with a new
 aggregator-owned response ID. Other contributions wait behind that stream;
 finite updates that accumulated while it ran are coalesced when it finishes.
 An urgent contribution interrupts the active stream. A stream that stops
 producing chunks is closed after `stream_idle_timeout_s`, allowing pending
-updates to proceed. Call `stop()` before shutting down the runtime so the agent
-can cancel its participant-owned tasks. Contributions published after shutdown
-starts are logged and dropped; shutdown logs the number of accepted pending
-contributions it discards.
+updates to proceed. An interrupted or dropped stream ID remains quarantined
+until its terminator arrives. Each ignored fragment refreshes the quarantine;
+after a full `stream_idle_timeout_s` without another fragment, the ID may begin
+a new stream. This expiry bounds stale stream state independently from pending
+queue capacity.
+
+Call `stop()` before shutting down the runtime so the agent can cancel its
+participant-owned tasks. Contributions published after shutdown starts are
+logged and dropped. Shutdown and participant release log accepted contributions
+that are still pending or in pre-publication processing. Output already handed
+to the voice pipeline during the playback hold is not counted as discarded.
 
 ## Voice tuning and data echo
 

--- a/agent-sdk/xr-ai-voice/README.md
+++ b/agent-sdk/xr-ai-voice/README.md
@@ -87,6 +87,12 @@ async with runtime:
         await aggregation.stop()
 ```
 
+Applications should call `await aggregation.release(participant_id)` from
+their participant-left subscriber so buffered speech and stream state are
+discarded as soon as that participant departs. The application owns its
+lifecycle topic; the shared aggregator therefore exposes cleanup directly
+rather than subscribing to one hard-coded topic name.
+
 Aggregation is participant-scoped. A lone finite contribution passes through
 without an LLM call after the short coalescing window. Two or more finite
 contributions in one batch are rewritten into a single concise utterance. The

--- a/agent-sdk/xr-ai-voice/README.md
+++ b/agent-sdk/xr-ai-voice/README.md
@@ -11,6 +11,9 @@ applications work with XR concepts rather than Pipecat modules:
 - `VoiceAgent` publishes every final pre-gate STT result on `voice.transcript`
   and accepted speech, text, participant lifecycle, and interruption on typed
   topics; it subscribes to `voice.output`.
+- `VoiceAggregationAgent` optionally serializes candidate speech per
+  participant and rewrites simultaneous finite updates into one concise
+  response before publishing to `voice.output`.
 - `VoiceAgent` privately owns readiness, hub transport, pipeline assembly,
   signals, execution, and cleanup.
 - `HubVoiceTransport` is available when an application needs to share one transport explicitly.
@@ -44,6 +47,62 @@ runtime.register("voice", voice)
 async with runtime:
     await voice.run(runtime)
 ```
+
+## Multiple voice producers
+
+Applications with foreground responses, background monitors, timers, and
+alerts can register one `VoiceAggregationAgent`. Producers publish the same
+`VoiceOutput` payload to `VOICE_CONTRIBUTION_TOPIC`; only the aggregator
+publishes the final response to `VOICE_OUTPUT_TOPIC`:
+
+```python
+from xr_ai_voice import (
+    VOICE_CONTRIBUTION_TOPIC,
+    VoiceAggregationAgent,
+    VoiceOutput,
+)
+
+aggregation = runtime.register(
+    "voice-aggregation",
+    VoiceAggregationAgent(llm=llm),
+)
+```
+
+A producer uses its runtime context while handling an application event:
+
+```python
+await ctx.publish(
+    VOICE_CONTRIBUTION_TOPIC,
+    VoiceOutput(text="The timer is done."),
+)
+```
+
+The application stops participant-owned aggregation tasks before the runtime:
+
+```python
+async with runtime:
+    try:
+        await voice.run(runtime)
+    finally:
+        await aggregation.stop()
+```
+
+Aggregation is participant-scoped. A lone finite contribution passes through
+without an LLM call after the short coalescing window. Two or more finite
+contributions in one batch are rewritten into a single concise utterance; if
+the rewrite fails, their original text is joined so updates are not lost. The
+earliest input timestamp is preserved, and an interrupt on any contribution
+makes the combined response interrupt active speech. Queue capacity provides
+bounded ingress, and batches have a bounded size; additional contributions
+remain ordered for following batches.
+
+A lone incremental contribution starts streaming immediately with a new
+aggregator-owned response ID. Other contributions wait behind that stream;
+finite updates that accumulated while it ran are coalesced when it finishes.
+An urgent contribution interrupts the active stream. A stream that stops
+producing chunks is closed after `stream_idle_timeout_s`, allowing pending
+updates to proceed. Call `stop()` before shutting down the runtime so the agent
+can cancel its participant-owned tasks.
 
 ## Voice tuning and data echo
 
@@ -95,14 +154,15 @@ await runtime.publish(
 ```
 
 Incremental producers reuse a `response_id`, set `final=False` while more
-chunks remain, and end with `final=True`. Aggregation is private to voice/TTS,
-and producer identity is part of the response key so independent agents cannot
-merge output accidentally. Output is serialized per participant; urgent output
-sets `interrupt=True` to replace active and queued speech. Producers may copy
-the originating query's `timestamp_us` into `VoiceOutput` so the TTS response
-preserves the input timestamp. `VoiceStreamClosedError` identifies an empty final
-chunk for a stream that voice already closed, including when wrapped in the
-runtime publication exception group.
+chunks remain, and end with `final=True`. Without the optional aggregation
+agent, producer identity is part of the response key so independent agents
+cannot merge output accidentally. `VoiceAgent` serializes output per
+participant; urgent output sets `interrupt=True` to replace active and queued
+speech. Producers may copy the originating query's `timestamp_us` into
+`VoiceOutput` so the TTS response preserves the input timestamp.
+`VoiceStreamClosedError` identifies an empty final chunk for a stream that
+voice already closed, including when wrapped in the runtime publication
+exception group.
 
 Lifecycle publication runs on `VoiceAgent`-owned tasks, so participant cleanup
 cannot block the shared media processor. Join and leave publications are

--- a/agent-sdk/xr-ai-voice/README.md
+++ b/agent-sdk/xr-ai-voice/README.md
@@ -89,8 +89,13 @@ async with runtime:
 
 Aggregation is participant-scoped. A lone finite contribution passes through
 without an LLM call after the short coalescing window. Two or more finite
-contributions in one batch are rewritten into a single concise utterance; if
-the rewrite fails, their original text is joined so updates are not lost. The
+contributions in one batch are rewritten into a single concise utterance. The
+aggregator keeps each output open for an estimated spoken duration, based on
+`speech_rate_wpm`, so updates produced while that output is playing form the
+next batch instead of becoming separate queued utterances. This is pacing
+rather than a client playback acknowledgement, so applications can tune the
+speech-rate estimate for their selected TTS voice. If the rewrite fails, their
+original text is joined so updates are not lost. The
 earliest input timestamp is preserved, and an interrupt on any contribution
 makes the combined response interrupt active speech. Queue capacity provides
 bounded ingress, and batches have a bounded size; additional contributions

--- a/agent-sdk/xr-ai-voice/README.md
+++ b/agent-sdk/xr-ai-voice/README.md
@@ -97,15 +97,22 @@ Aggregation is participant-scoped. A lone finite contribution passes through
 without an LLM call after the short coalescing window. Two or more finite
 contributions in one batch are rewritten into a single concise utterance. The
 aggregator keeps each output open for an estimated spoken duration, based on
-`speech_rate_wpm`, so updates produced while that output is playing form the
-next batch instead of becoming separate queued utterances. This is pacing
-rather than a client playback acknowledgement, so applications can tune the
-speech-rate estimate for their selected TTS voice. If the rewrite fails, their
-original text is joined so updates are not lost. The
-earliest input timestamp is preserved, and an interrupt on any contribution
-makes the combined response interrupt active speech. Queue capacity provides
-bounded ingress, and batches have a bounded size; additional contributions
-remain ordered for following batches.
+`speech_rate_wpm` and clamped between `minimum_playback_s` and
+`maximum_playback_s`, so updates produced while that output is playing form the
+next batch instead of becoming separate queued utterances. This is open-loop
+pacing rather than a client playback acknowledgement. An estimate that is too
+short moves queuing downstream into TTS; one that is too long creates silence.
+Tune all three playback settings for the selected TTS voice.
+
+Rewrites have the explicit `rewrite_timeout_s` deadline. If a rewrite fails or
+times out, the original text is joined so updates are not lost. The earliest
+input timestamp is preserved. An `interrupt=True` contribution bypasses an LLM
+rewrite, cancels a rewrite already in progress, and replaces active speech
+without model latency. `queue_capacity` bounds all pending contributions for one
+participant, including chunks waiting behind another stream. When the bound is
+reached, the oldest non-urgent pending contribution is dropped with a warning
+so new output cannot grow stale in an unbounded buffer. Batches also have a
+bounded size; retained contributions remain ordered for following batches.
 
 A lone incremental contribution starts streaming immediately with a new
 aggregator-owned response ID. Other contributions wait behind that stream;
@@ -113,7 +120,9 @@ finite updates that accumulated while it ran are coalesced when it finishes.
 An urgent contribution interrupts the active stream. A stream that stops
 producing chunks is closed after `stream_idle_timeout_s`, allowing pending
 updates to proceed. Call `stop()` before shutting down the runtime so the agent
-can cancel its participant-owned tasks.
+can cancel its participant-owned tasks. Contributions published after shutdown
+starts are logged and dropped; shutdown logs the number of accepted pending
+contributions it discards.
 
 ## Voice tuning and data echo
 

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/__init__.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/__init__.py
@@ -3,10 +3,12 @@
 
 """Public voice runtime for XR agents.
 
-Applications configure and register :class:`VoiceAgent`; media sessions,
+Applications configure and register :class:`VoiceAgent` and may route
+concurrent producers through :class:`VoiceAggregationAgent`; media sessions,
 audio framing, and pipeline processors are implementation details.
 """
 
+from ._aggregation import VOICE_CONTRIBUTION_TOPIC, VoiceAggregationAgent
 from ._processors import VadConfig
 from ._runtime import (
     VOICE_OUTPUT_TOPIC,
@@ -25,9 +27,11 @@ from ._transport import HubVoiceTransport
 __all__ = [
     "HubVoiceTransport",
     "VadConfig",
+    "VOICE_CONTRIBUTION_TOPIC",
     "VOICE_OUTPUT_TOPIC",
     "VOICE_TRANSCRIPT_TOPIC",
     "UserQuery",
+    "VoiceAggregationAgent",
     "VoiceAgent",
     "VoiceInterrupted",
     "VoiceOutput",

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_aggregation.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_aggregation.py
@@ -163,6 +163,15 @@ class VoiceAggregationAgent(Agent):
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
 
+    async def release(self, participant_id: str) -> None:
+        """Cancel and release one departed participant's aggregation state."""
+
+        state = self._states.pop(participant_id, None)
+        if state is None or state.task is None:
+            return
+        state.task.cancel()
+        await asyncio.gather(state.task, return_exceptions=True)
+
     async def _run_participant(
         self,
         participant_id: str,

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_aggregation.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_aggregation.py
@@ -57,11 +57,12 @@ class VoiceAggregationAgent(Agent):
     """Serialize and coalesce candidate speech independently per participant.
 
     A lone finite contribution passes through without a model call after the
-    short coalescing window. Multiple finite contributions in that window are
-    rewritten into one response. A lone incremental response streams through
-    immediately; other contributions wait until that stream ends. An urgent
-    contribution interrupts the active stream and is combined with pending
-    finite updates.
+    short coalescing window. The aggregator keeps that response open for its
+    estimated spoken duration, so updates arriving while it is being spoken
+    wait and coalesce instead of building a speech queue. Multiple pending
+    finite contributions are rewritten into one response. A lone incremental
+    response streams through immediately and uses the same playback estimate
+    after its final chunk. An urgent contribution interrupts the active output.
     """
 
     def __init__(
@@ -75,6 +76,8 @@ class VoiceAggregationAgent(Agent):
         max_tokens: int = 192,
         stream_idle_timeout_s: float = 15.0,
         participant_idle_timeout_s: float = 60.0,
+        speech_rate_wpm: float = 150.0,
+        minimum_playback_s: float = 0.4,
     ) -> None:
         if not prompt.strip():
             raise ValueError("voice aggregation prompt must not be empty")
@@ -90,6 +93,10 @@ class VoiceAggregationAgent(Agent):
             raise ValueError("voice stream idle timeout must be positive")
         if participant_idle_timeout_s <= 0:
             raise ValueError("voice participant idle timeout must be positive")
+        if speech_rate_wpm <= 0:
+            raise ValueError("voice aggregation speech rate must be positive")
+        if minimum_playback_s < 0:
+            raise ValueError("voice aggregation minimum playback must not be negative")
         super().__init__()
         self._llm = llm
         self._prompt = prompt.strip()
@@ -99,6 +106,8 @@ class VoiceAggregationAgent(Agent):
         self._max_tokens = max_tokens
         self._stream_idle_timeout_s = stream_idle_timeout_s
         self._participant_idle_timeout_s = participant_idle_timeout_s
+        self._speech_rate_wpm = speech_rate_wpm
+        self._minimum_playback_s = minimum_playback_s
         self._states: dict[str, _ParticipantState] = {}
         self._stopping = False
 
@@ -176,7 +185,7 @@ class VoiceAggregationAgent(Agent):
                 await self._forward_stream(participant_id, state, contribution)
                 continue
             batch = await self._finite_batch(state, contribution)
-            await self._speak_batch(participant_id, batch)
+            await self._speak_batch(participant_id, state, batch)
 
     async def _next(self, state: _ParticipantState) -> _Contribution:
         if state.backlog:
@@ -224,6 +233,8 @@ class VoiceAggregationAgent(Agent):
         input_key = first.stream_key
         assert input_key is not None
         output_id = uuid.uuid4().hex
+        started_at = asyncio.get_running_loop().time()
+        spoken_text = first.output.text
         await self._publish_stream(first, output_id, interrupt=first.output.interrupt)
 
         while True:
@@ -252,8 +263,20 @@ class VoiceAggregationAgent(Agent):
                         input_key[0],
                         input_key[1],
                     )
-                await self._publish_stream(contribution, output_id, interrupt=False)
+                spoken_text += contribution.output.text
+                await self._publish_stream(
+                    contribution,
+                    output_id,
+                    interrupt=False,
+                    final=False,
+                )
                 if contribution.output.final:
+                    elapsed = asyncio.get_running_loop().time() - started_at
+                    remaining = max(0.0, self._playback_duration(spoken_text) - elapsed)
+                    if await self._hold_output(state, remaining):
+                        state.discarded_streams.add(input_key)
+                        return
+                    await self._publish_stream_end(first, output_id)
                     return
                 continue
 
@@ -269,6 +292,7 @@ class VoiceAggregationAgent(Agent):
         response_id: str,
         *,
         interrupt: bool,
+        final: bool | None = None,
     ) -> None:
         try:
             await contribution.ctx.publish(
@@ -276,7 +300,7 @@ class VoiceAggregationAgent(Agent):
                 VoiceOutput(
                     text=contribution.output.text,
                     response_id=response_id,
-                    final=contribution.output.final,
+                    final=contribution.output.final if final is None else final,
                     interrupt=interrupt,
                     timestamp_us=contribution.output.timestamp_us,
                 ),
@@ -303,6 +327,7 @@ class VoiceAggregationAgent(Agent):
     async def _speak_batch(
         self,
         participant_id: str,
+        state: _ParticipantState,
         batch: list[_Contribution],
     ) -> None:
         text = (
@@ -320,20 +345,59 @@ class VoiceAggregationAgent(Agent):
             ),
             default=None,
         )
-        try:
-            await batch[0].ctx.publish(
-                VOICE_OUTPUT_TOPIC,
-                VoiceOutput(
-                    text=text,
-                    interrupt=any(
-                        contribution.output.interrupt
-                        for contribution in batch
-                    ),
-                    timestamp_us=timestamp_us,
+        output_id = uuid.uuid4().hex
+        output = _Contribution(
+            output=VoiceOutput(
+                text=text,
+                response_id=output_id,
+                final=False,
+                interrupt=any(
+                    contribution.output.interrupt
+                    for contribution in batch
                 ),
-            )
-        except RuntimeClosedError:
+                timestamp_us=timestamp_us,
+            ),
+            ctx=batch[0].ctx,
+            participant_id=batch[0].participant_id,
+            source=batch[0].source,
+        )
+        await self._publish_stream(
+            output,
+            output_id,
+            interrupt=output.output.interrupt,
+        )
+        if await self._hold_output(state, self._playback_duration(text)):
             return
+        await self._publish_stream_end(output, output_id)
+
+    async def _hold_output(
+        self,
+        state: _ParticipantState,
+        duration_s: float,
+    ) -> bool:
+        """Buffer new updates while the current response is expected to play."""
+
+        deadline = asyncio.get_running_loop().time() + duration_s
+        while True:
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                return False
+            try:
+                contribution = await asyncio.wait_for(
+                    state.queue.get(),
+                    timeout=remaining,
+                )
+            except TimeoutError:
+                return False
+            if contribution.output.interrupt:
+                state.backlog.appendleft(contribution)
+                return True
+            state.backlog.append(contribution)
+
+    def _playback_duration(self, text: str) -> float:
+        words = len(text.split())
+        estimated_s = words * 60.0 / self._speech_rate_wpm
+        return min(30.0, max(self._minimum_playback_s, estimated_s))
 
     async def _rewrite(
         self,

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_aggregation.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_aggregation.py
@@ -215,6 +215,10 @@ class VoiceAggregationAgent(Agent):
         state: _ParticipantState,
         contribution: _Contribution,
     ) -> None:
+        self._prune_expired_streams(
+            state,
+            asyncio.get_running_loop().time(),
+        )
         state.in_flight_count = 1
         key = contribution.stream_key
         try:
@@ -272,6 +276,22 @@ class VoiceAggregationAgent(Agent):
             contribution.output.interrupt,
             self._queue_capacity,
         )
+
+    def _restore_batch(
+        self,
+        state: _ParticipantState,
+        batch: list[_Contribution],
+    ) -> None:
+        state.pending.extendleft(reversed(batch))
+        while len(state.pending) > self._queue_capacity:
+            victim_index = next(
+                (index for index, pending in enumerate(state.pending) if not pending.output.interrupt),
+                0,
+            )
+            victim = state.pending[victim_index]
+            del state.pending[victim_index]
+            self._drop_contribution(state, victim, incoming=False)
+        state.changed.set()
 
     def _discard_stream(
         self,
@@ -555,6 +575,7 @@ class VoiceAggregationAgent(Agent):
                     )
                     rewrite.cancel()
                     await asyncio.gather(rewrite, return_exceptions=True)
+                    self._restore_batch(state, batch)
                     state.in_flight_count = 1
                     await self._dispatch_urgent(
                         participant_id,

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_aggregation.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_aggregation.py
@@ -1,0 +1,403 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Participant-scoped aggregation for concurrent voice producers."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from collections import deque
+from dataclasses import dataclass, field
+
+import nemo_relay
+from loguru import logger
+from xr_ai_models import ChatMessage, LLMService
+from xr_ai_runtime import Agent, RuntimeClosedError, RuntimeContext, Topic, subscribe
+
+from ._runtime import VOICE_OUTPUT_TOPIC, VoiceOutput
+
+VOICE_CONTRIBUTION_TOPIC = Topic(
+    "voice.contribution",
+    VoiceOutput,
+    telemetry="none",
+)
+"""Candidate spoken output consumed by :class:`VoiceAggregationAgent`."""
+
+_DEFAULT_PROMPT = """Combine simultaneous spoken updates into one concise, natural response.
+Preserve every actionable fact, proper name, value, unit, and warning. Remove repetition.
+Do not invent information or mention agents, queues, sources, or aggregation.
+Use plain spoken prose with at most two sentences."""
+
+
+@dataclass(frozen=True, slots=True)
+class _Contribution:
+    output: VoiceOutput
+    ctx: RuntimeContext
+    participant_id: str
+    source: str
+
+    @property
+    def stream_key(self) -> tuple[str, str] | None:
+        if self.output.response_id is None:
+            return None
+        return (self.source, self.output.response_id)
+
+
+@dataclass(slots=True)
+class _ParticipantState:
+    queue: asyncio.Queue[_Contribution]
+    backlog: deque[_Contribution] = field(default_factory=deque)
+    discarded_streams: set[tuple[str, str]] = field(default_factory=set)
+    task: asyncio.Task[None] | None = None
+
+
+class VoiceAggregationAgent(Agent):
+    """Serialize and coalesce candidate speech independently per participant.
+
+    A lone finite contribution passes through without a model call after the
+    short coalescing window. Multiple finite contributions in that window are
+    rewritten into one response. A lone incremental response streams through
+    immediately; other contributions wait until that stream ends. An urgent
+    contribution interrupts the active stream and is combined with pending
+    finite updates.
+    """
+
+    def __init__(
+        self,
+        *,
+        llm: LLMService,
+        prompt: str = _DEFAULT_PROMPT,
+        coalesce_window_s: float = 0.15,
+        queue_capacity: int = 64,
+        max_batch_size: int = 8,
+        max_tokens: int = 192,
+        stream_idle_timeout_s: float = 15.0,
+        participant_idle_timeout_s: float = 60.0,
+    ) -> None:
+        if not prompt.strip():
+            raise ValueError("voice aggregation prompt must not be empty")
+        if coalesce_window_s < 0:
+            raise ValueError("voice aggregation window must not be negative")
+        if queue_capacity <= 0:
+            raise ValueError("voice aggregation queue capacity must be positive")
+        if max_batch_size < 2:
+            raise ValueError("voice aggregation batch size must be at least two")
+        if max_tokens <= 0:
+            raise ValueError("voice aggregation token limit must be positive")
+        if stream_idle_timeout_s <= 0:
+            raise ValueError("voice stream idle timeout must be positive")
+        if participant_idle_timeout_s <= 0:
+            raise ValueError("voice participant idle timeout must be positive")
+        super().__init__()
+        self._llm = llm
+        self._prompt = prompt.strip()
+        self._coalesce_window_s = coalesce_window_s
+        self._queue_capacity = queue_capacity
+        self._max_batch_size = max_batch_size
+        self._max_tokens = max_tokens
+        self._stream_idle_timeout_s = stream_idle_timeout_s
+        self._participant_idle_timeout_s = participant_idle_timeout_s
+        self._states: dict[str, _ParticipantState] = {}
+        self._stopping = False
+
+    @subscribe(VOICE_CONTRIBUTION_TOPIC)
+    async def contribute(self, output: VoiceOutput, ctx: RuntimeContext) -> None:
+        """Enqueue one finite response or incremental response fragment."""
+
+        participant_id = ctx.metadata.participant_id
+        if participant_id is None:
+            raise ValueError("voice contribution requires a participant")
+        if self._stopping:
+            raise RuntimeError("voice aggregation agent is stopping")
+        state = self._states.get(participant_id)
+        if state is None or state.task is None or state.task.done():
+            state = _ParticipantState(
+                queue=asyncio.Queue(maxsize=self._queue_capacity),
+            )
+            task = asyncio.create_task(
+                self._run_participant(participant_id, state),
+                name=f"voice-aggregation:{participant_id}",
+                context=nemo_relay.fork_asyncio_context(),
+            )
+            state.task = task
+            self._states[participant_id] = state
+            task.add_done_callback(
+                lambda completed, pid=participant_id, owned=state: self._discard(
+                    pid,
+                    owned,
+                    completed,
+                )
+            )
+        await state.queue.put(
+            _Contribution(
+                output=output,
+                ctx=ctx,
+                participant_id=participant_id,
+                source=ctx.metadata.source,
+            )
+        )
+
+    async def stop(self) -> None:
+        """Cancel and await all participant aggregation tasks."""
+
+        self._stopping = True
+        tasks = tuple(
+            state.task
+            for state in self._states.values()
+            if state.task is not None
+        )
+        self._states.clear()
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def _run_participant(
+        self,
+        participant_id: str,
+        state: _ParticipantState,
+    ) -> None:
+        while True:
+            try:
+                contribution = await asyncio.wait_for(
+                    self._next(state),
+                    timeout=self._participant_idle_timeout_s,
+                )
+            except TimeoutError:
+                return
+            key = contribution.stream_key
+            if key is not None and key in state.discarded_streams:
+                if contribution.output.final:
+                    state.discarded_streams.discard(key)
+                continue
+            if key is not None and not contribution.output.final:
+                await self._forward_stream(participant_id, state, contribution)
+                continue
+            batch = await self._finite_batch(state, contribution)
+            await self._speak_batch(participant_id, batch)
+
+    async def _next(self, state: _ParticipantState) -> _Contribution:
+        if state.backlog:
+            return state.backlog.popleft()
+        return await state.queue.get()
+
+    async def _finite_batch(
+        self,
+        state: _ParticipantState,
+        first: _Contribution,
+    ) -> list[_Contribution]:
+        if self._coalesce_window_s:
+            await asyncio.sleep(self._coalesce_window_s)
+        batch = [first]
+        while len(batch) < self._max_batch_size:
+            contribution = self._next_nowait(state)
+            if contribution is None:
+                break
+            key = contribution.stream_key
+            if key is not None and key in state.discarded_streams:
+                if contribution.output.final:
+                    state.discarded_streams.discard(key)
+                continue
+            if key is not None and not contribution.output.final:
+                state.backlog.appendleft(contribution)
+                break
+            batch.append(contribution)
+        return batch
+
+    @staticmethod
+    def _next_nowait(state: _ParticipantState) -> _Contribution | None:
+        if state.backlog:
+            return state.backlog.popleft()
+        try:
+            return state.queue.get_nowait()
+        except asyncio.QueueEmpty:
+            return None
+
+    async def _forward_stream(
+        self,
+        participant_id: str,
+        state: _ParticipantState,
+        first: _Contribution,
+    ) -> None:
+        input_key = first.stream_key
+        assert input_key is not None
+        output_id = uuid.uuid4().hex
+        await self._publish_stream(first, output_id, interrupt=first.output.interrupt)
+
+        while True:
+            try:
+                contribution = await asyncio.wait_for(
+                    state.queue.get(),
+                    timeout=self._stream_idle_timeout_s,
+                )
+            except TimeoutError:
+                logger.warning(
+                    "voice contribution stream timed out pid={!r} source={!r} response_id={!r}",
+                    participant_id,
+                    input_key[0],
+                    input_key[1],
+                )
+                state.discarded_streams.add(input_key)
+                await self._publish_stream_end(first, output_id)
+                return
+
+            if contribution.stream_key == input_key:
+                if contribution.output.interrupt:
+                    logger.warning(
+                        "ignored interrupt on non-initial voice contribution chunk "
+                        "pid={!r} source={!r} response_id={!r}",
+                        participant_id,
+                        input_key[0],
+                        input_key[1],
+                    )
+                await self._publish_stream(contribution, output_id, interrupt=False)
+                if contribution.output.final:
+                    return
+                continue
+
+            if contribution.output.interrupt:
+                state.discarded_streams.add(input_key)
+                state.backlog.appendleft(contribution)
+                return
+            state.backlog.append(contribution)
+
+    async def _publish_stream(
+        self,
+        contribution: _Contribution,
+        response_id: str,
+        *,
+        interrupt: bool,
+    ) -> None:
+        try:
+            await contribution.ctx.publish(
+                VOICE_OUTPUT_TOPIC,
+                VoiceOutput(
+                    text=contribution.output.text,
+                    response_id=response_id,
+                    final=contribution.output.final,
+                    interrupt=interrupt,
+                    timestamp_us=contribution.output.timestamp_us,
+                ),
+            )
+        except RuntimeClosedError:
+            return
+
+    async def _publish_stream_end(
+        self,
+        contribution: _Contribution,
+        response_id: str,
+    ) -> None:
+        try:
+            await contribution.ctx.publish(
+                VOICE_OUTPUT_TOPIC,
+                VoiceOutput(
+                    response_id=response_id,
+                    timestamp_us=contribution.output.timestamp_us,
+                ),
+            )
+        except RuntimeClosedError:
+            return
+
+    async def _speak_batch(
+        self,
+        participant_id: str,
+        batch: list[_Contribution],
+    ) -> None:
+        text = (
+            batch[0].output.text.strip()
+            if len(batch) == 1
+            else await self._rewrite(participant_id, batch)
+        )
+        if not text:
+            return
+        timestamp_us = min(
+            (
+                contribution.output.timestamp_us
+                for contribution in batch
+                if contribution.output.timestamp_us is not None
+            ),
+            default=None,
+        )
+        try:
+            await batch[0].ctx.publish(
+                VOICE_OUTPUT_TOPIC,
+                VoiceOutput(
+                    text=text,
+                    interrupt=any(
+                        contribution.output.interrupt
+                        for contribution in batch
+                    ),
+                    timestamp_us=timestamp_us,
+                ),
+            )
+        except RuntimeClosedError:
+            return
+
+    async def _rewrite(
+        self,
+        participant_id: str,
+        batch: list[_Contribution],
+    ) -> str:
+        updates = [
+            {
+                "source": contribution.source,
+                "text": contribution.output.text.strip(),
+            }
+            for contribution in batch
+            if contribution.output.text.strip()
+        ]
+        fallback = " ".join(update["text"] for update in updates)
+        if len(updates) < 2:
+            return fallback
+        try:
+            response = await self._llm.chat(
+                (
+                    ChatMessage(role="system", content=self._prompt),
+                    ChatMessage(
+                        role="user",
+                        content="Pending spoken updates:\n"
+                        + json.dumps(updates, ensure_ascii=False),
+                    ),
+                ),
+                max_tokens=self._max_tokens,
+                temperature=0.0,
+                enable_thinking=False,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.opt(exception=True).error(
+                "voice contribution rewrite failed pid={!r}",
+                participant_id,
+            )
+            return fallback
+        text = response.content.strip()
+        if not text or response.tool_calls:
+            logger.warning(
+                "voice contribution rewrite returned no usable text pid={!r}",
+                participant_id,
+            )
+            return fallback
+        return text
+
+    def _discard(
+        self,
+        participant_id: str,
+        state: _ParticipantState,
+        task: asyncio.Task[None],
+    ) -> None:
+        if self._states.get(participant_id) is state:
+            self._states.pop(participant_id, None)
+        if task.cancelled():
+            return
+        if error := task.exception():
+            logger.error(
+                "voice aggregation stopped pid={!r}: {!r}",
+                participant_id,
+                error,
+            )
+
+
+__all__ = ["VOICE_CONTRIBUTION_TOPIC", "VoiceAggregationAgent"]

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_aggregation.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_aggregation.py
@@ -49,8 +49,8 @@ class _Contribution:
 class _ParticipantState:
     pending: deque[_Contribution] = field(default_factory=deque)
     changed: asyncio.Event = field(default_factory=asyncio.Event)
-    discarded_streams: set[tuple[str, str]] = field(default_factory=set)
-    active_stream: tuple[str, str] | None = None
+    discarded_streams: dict[tuple[str, str], float] = field(default_factory=dict)
+    in_flight_count: int = 0
     task: asyncio.Task[None] | None = None
 
 
@@ -103,9 +103,7 @@ class VoiceAggregationAgent(Agent):
         if maximum_playback_s <= 0:
             raise ValueError("voice aggregation maximum playback must be positive")
         if minimum_playback_s > maximum_playback_s:
-            raise ValueError(
-                "voice aggregation minimum playback must not exceed maximum playback"
-            )
+            raise ValueError("voice aggregation minimum playback must not exceed maximum playback")
         if rewrite_timeout_s <= 0:
             raise ValueError("voice aggregation rewrite timeout must be positive")
         super().__init__()
@@ -217,16 +215,22 @@ class VoiceAggregationAgent(Agent):
         state: _ParticipantState,
         contribution: _Contribution,
     ) -> None:
+        state.in_flight_count = 1
         key = contribution.stream_key
-        if key is not None and key in state.discarded_streams:
-            if contribution.output.final:
-                state.discarded_streams.discard(key)
-            return
-        if key is not None and not contribution.output.final:
-            await self._forward_stream(participant_id, state, contribution)
-            return
-        batch = await self._finite_batch(state, contribution)
-        await self._speak_batch(participant_id, state, batch)
+        try:
+            if key is not None and self._discarded_stream_fragment(
+                state,
+                key,
+                final=contribution.output.final,
+            ):
+                return
+            if key is not None and not contribution.output.final:
+                await self._forward_stream(participant_id, state, contribution)
+                return
+            batch = await self._finite_batch(state, contribution)
+            await self._speak_batch(participant_id, state, batch)
+        finally:
+            state.in_flight_count = 0
 
     def _enqueue(
         self,
@@ -235,44 +239,91 @@ class VoiceAggregationAgent(Agent):
     ) -> None:
         if len(state.pending) >= self._queue_capacity:
             victim_index = next(
-                (
-                    index
-                    for index, pending in enumerate(state.pending)
-                    if not pending.output.interrupt
-                    and pending.stream_key != state.active_stream
-                ),
-                0,
+                (index for index, pending in enumerate(state.pending) if not pending.output.interrupt),
+                None,
             )
+            if victim_index is None and not contribution.output.interrupt:
+                self._drop_contribution(state, contribution, incoming=True)
+                return
+            if victim_index is None:
+                victim_index = 0
             victim = state.pending[victim_index]
             del state.pending[victim_index]
-            victim_key = victim.stream_key
-            if victim_key is not None and (
-                not victim.output.final or victim_key == state.active_stream
-            ):
-                self._discard_stream(state, victim_key)
-            logger.warning(
-                "dropped oldest pending voice contribution pid={!r} source={!r} "
-                "response_id={!r} capacity={}",
-                victim.participant_id,
-                victim.source,
-                victim.output.response_id,
-                self._queue_capacity,
-            )
+            self._drop_contribution(state, victim, incoming=False)
         state.pending.append(contribution)
         state.changed.set()
+
+    def _drop_contribution(
+        self,
+        state: _ParticipantState,
+        contribution: _Contribution,
+        *,
+        incoming: bool,
+    ) -> None:
+        key = contribution.stream_key
+        if key is not None:
+            self._discard_stream(state, key)
+        logger.warning(
+            "dropped {} voice contribution pid={!r} source={!r} response_id={!r} interrupt={} capacity={}",
+            "incoming" if incoming else "oldest pending",
+            contribution.participant_id,
+            contribution.source,
+            contribution.output.response_id,
+            contribution.output.interrupt,
+            self._queue_capacity,
+        )
 
     def _discard_stream(
         self,
         state: _ParticipantState,
         stream_key: tuple[str, str],
     ) -> None:
-        if (
-            stream_key not in state.discarded_streams
-            and len(state.discarded_streams) >= self._queue_capacity
-        ):
-            state.discarded_streams.pop()
-        state.discarded_streams.add(stream_key)
+        now = asyncio.get_running_loop().time()
+        self._prune_expired_streams(state, now)
+        state.discarded_streams[stream_key] = now + self._stream_idle_timeout_s
         state.changed.set()
+
+    @staticmethod
+    def _prune_expired_streams(
+        state: _ParticipantState,
+        now: float,
+    ) -> None:
+        for key, expires_at in tuple(state.discarded_streams.items()):
+            if expires_at <= now:
+                state.discarded_streams.pop(key, None)
+
+    def _discarded_stream_fragment(
+        self,
+        state: _ParticipantState,
+        stream_key: tuple[str, str],
+        *,
+        final: bool,
+    ) -> bool:
+        now = asyncio.get_running_loop().time()
+        expires_at = state.discarded_streams.get(stream_key)
+        if expires_at is None:
+            return False
+        if expires_at <= now:
+            state.discarded_streams.pop(stream_key, None)
+            return False
+        if final:
+            state.discarded_streams.pop(stream_key, None)
+        else:
+            state.discarded_streams[stream_key] = now + self._stream_idle_timeout_s
+        return True
+
+    def _stream_is_discarded(
+        self,
+        state: _ParticipantState,
+        stream_key: tuple[str, str],
+    ) -> bool:
+        expires_at = state.discarded_streams.get(stream_key)
+        if expires_at is None:
+            return False
+        if expires_at <= asyncio.get_running_loop().time():
+            state.discarded_streams.pop(stream_key, None)
+            return False
+        return True
 
     @staticmethod
     def _pop_next(state: _ParticipantState) -> _Contribution | None:
@@ -296,6 +347,8 @@ class VoiceAggregationAgent(Agent):
         state: _ParticipantState,
         first: _Contribution,
     ) -> list[_Contribution]:
+        if first.output.interrupt:
+            return [first]
         if self._coalesce_window_s:
             await asyncio.sleep(self._coalesce_window_s)
         batch = [first]
@@ -304,14 +357,20 @@ class VoiceAggregationAgent(Agent):
             if contribution is None:
                 break
             key = contribution.stream_key
-            if key is not None and key in state.discarded_streams:
-                if contribution.output.final:
-                    state.discarded_streams.discard(key)
+            if key is not None and self._discarded_stream_fragment(
+                state,
+                key,
+                final=contribution.output.final,
+            ):
                 continue
             if key is not None and not contribution.output.final:
                 state.pending.appendleft(contribution)
                 state.changed.set()
                 break
+            if contribution.output.interrupt:
+                state.pending.extendleft(reversed(batch))
+                state.changed.set()
+                return [contribution]
             batch.append(contribution)
         return batch
 
@@ -326,9 +385,9 @@ class VoiceAggregationAgent(Agent):
         output_id = uuid.uuid4().hex
         started_at = asyncio.get_running_loop().time()
         spoken_text = first.output.text
-        state.active_stream = input_key
         try:
             await self._publish_stream(first, output_id, interrupt=first.output.interrupt)
+            state.in_flight_count = 0
 
             while True:
                 try:
@@ -338,8 +397,7 @@ class VoiceAggregationAgent(Agent):
                     )
                 except TimeoutError:
                     logger.warning(
-                        "voice contribution stream timed out pid={!r} source={!r} "
-                        "response_id={!r}",
+                        "voice contribution stream timed out pid={!r} source={!r} response_id={!r}",
                         participant_id,
                         input_key[0],
                         input_key[1],
@@ -361,12 +419,14 @@ class VoiceAggregationAgent(Agent):
                             input_key[1],
                         )
                     spoken_text += contribution.output.text
+                    state.in_flight_count = 1
                     await self._publish_stream(
                         contribution,
                         output_id,
                         interrupt=False,
                         final=False,
                     )
+                    state.in_flight_count = 0
                     if contribution.output.final:
                         elapsed = asyncio.get_running_loop().time() - started_at
                         remaining = max(
@@ -386,11 +446,11 @@ class VoiceAggregationAgent(Agent):
                     continue
 
                 self._discard_stream(state, input_key)
+                state.in_flight_count = 1
                 await self._dispatch_urgent(participant_id, state, contribution)
                 return
         finally:
-            if state.active_stream == input_key:
-                state.active_stream = None
+            state.in_flight_count = 0
 
     async def _wait_for_stream_contribution(
         self,
@@ -398,13 +458,13 @@ class VoiceAggregationAgent(Agent):
         input_key: tuple[str, str],
     ) -> _Contribution | None:
         while True:
-            if input_key in state.discarded_streams:
+            if self._stream_is_discarded(state, input_key):
                 return None
             contribution = self._pop_stream_contribution(state, input_key)
             if contribution is not None:
                 return contribution
             state.changed.clear()
-            if input_key in state.discarded_streams:
+            if self._stream_is_discarded(state, input_key):
                 return None
             contribution = self._pop_stream_contribution(state, input_key)
             if contribution is not None:
@@ -466,6 +526,7 @@ class VoiceAggregationAgent(Agent):
         state: _ParticipantState,
         batch: list[_Contribution],
     ) -> None:
+        state.in_flight_count = len(batch)
         interrupts = any(contribution.output.interrupt for contribution in batch)
         if len(batch) == 1:
             text = batch[0].output.text.strip()
@@ -487,12 +548,14 @@ class VoiceAggregationAgent(Agent):
                     return_when=asyncio.FIRST_COMPLETED,
                 )
                 if urgent in done:
+                    state.in_flight_count += 1
                     logger.debug(
                         "urgent voice contribution preempted rewrite pid={!r}",
                         participant_id,
                     )
                     rewrite.cancel()
                     await asyncio.gather(rewrite, return_exceptions=True)
+                    state.in_flight_count = 1
                     await self._dispatch_urgent(
                         participant_id,
                         state,
@@ -506,6 +569,7 @@ class VoiceAggregationAgent(Agent):
                         task.cancel()
                 await asyncio.gather(rewrite, urgent, return_exceptions=True)
         if not text:
+            state.in_flight_count = 0
             return
         timestamp_us = min(
             (
@@ -533,6 +597,7 @@ class VoiceAggregationAgent(Agent):
             output_id,
             interrupt=output.output.interrupt,
         )
+        state.in_flight_count = 0
         urgent_contribution = await self._hold_output(
             state,
             self._playback_duration(text),
@@ -591,6 +656,7 @@ class VoiceAggregationAgent(Agent):
         state: _ParticipantState,
         contribution: _Contribution,
     ) -> None:
+        state.in_flight_count = 1
         key = contribution.stream_key
         if key is not None and not contribution.output.final:
             await self._forward_stream(participant_id, state, contribution)
@@ -607,11 +673,7 @@ class VoiceAggregationAgent(Agent):
 
     @staticmethod
     def _fallback_text(batch: list[_Contribution]) -> str:
-        return " ".join(
-            contribution.output.text.strip()
-            for contribution in batch
-            if contribution.output.text.strip()
-        )
+        return " ".join(contribution.output.text.strip() for contribution in batch if contribution.output.text.strip())
 
     async def _rewrite(
         self,
@@ -630,20 +692,20 @@ class VoiceAggregationAgent(Agent):
         if len(updates) < 2:
             return fallback
         try:
-            response = await self._llm.chat(
-                (
-                    ChatMessage(role="system", content=self._prompt),
-                    ChatMessage(
-                        role="user",
-                        content="Pending spoken updates:\n"
-                        + json.dumps(updates, ensure_ascii=False),
+            async with asyncio.timeout(self._rewrite_timeout_s):
+                response = await self._llm.chat(
+                    (
+                        ChatMessage(role="system", content=self._prompt),
+                        ChatMessage(
+                            role="user",
+                            content="Pending spoken updates:\n" + json.dumps(updates, ensure_ascii=False),
+                        ),
                     ),
-                ),
-                max_tokens=self._max_tokens,
-                temperature=0.0,
-                enable_thinking=False,
-                timeout=self._rewrite_timeout_s,
-            )
+                    max_tokens=self._max_tokens,
+                    temperature=0.0,
+                    enable_thinking=False,
+                    timeout=self._rewrite_timeout_s,
+                )
         except asyncio.CancelledError:
             raise
         except Exception:
@@ -668,10 +730,10 @@ class VoiceAggregationAgent(Agent):
         *,
         reason: str,
     ) -> None:
-        count = len(state.pending)
+        count = len(state.pending) + state.in_flight_count
         if count:
             logger.warning(
-                "discarded pending voice contributions pid={!r} count={} reason={}",
+                "discarded accepted voice contributions pid={!r} count={} reason={}",
                 participant_id,
                 count,
                 reason,

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_aggregation.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_aggregation.py
@@ -385,6 +385,10 @@ class VoiceAggregationAgent(Agent):
                 continue
             if key is not None and not contribution.output.final:
                 state.pending.appendleft(contribution)
+                urgent = self._pop_finite_interrupt(state)
+                if urgent is not None:
+                    self._restore_batch(state, batch)
+                    return [urgent]
                 state.changed.set()
                 break
             if contribution.output.interrupt:
@@ -667,6 +671,14 @@ class VoiceAggregationAgent(Agent):
     def _pop_interrupt(state: _ParticipantState) -> _Contribution | None:
         for index, contribution in enumerate(state.pending):
             if contribution.output.interrupt:
+                del state.pending[index]
+                return contribution
+        return None
+
+    @staticmethod
+    def _pop_finite_interrupt(state: _ParticipantState) -> _Contribution | None:
+        for index, contribution in enumerate(state.pending):
+            if contribution.output.interrupt and (contribution.stream_key is None or contribution.output.final):
                 del state.pending[index]
                 return contribution
         return None

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_aggregation.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_aggregation.py
@@ -47,9 +47,10 @@ class _Contribution:
 
 @dataclass(slots=True)
 class _ParticipantState:
-    queue: asyncio.Queue[_Contribution]
-    backlog: deque[_Contribution] = field(default_factory=deque)
+    pending: deque[_Contribution] = field(default_factory=deque)
+    changed: asyncio.Event = field(default_factory=asyncio.Event)
     discarded_streams: set[tuple[str, str]] = field(default_factory=set)
+    active_stream: tuple[str, str] | None = None
     task: asyncio.Task[None] | None = None
 
 
@@ -78,6 +79,8 @@ class VoiceAggregationAgent(Agent):
         participant_idle_timeout_s: float = 60.0,
         speech_rate_wpm: float = 150.0,
         minimum_playback_s: float = 0.4,
+        maximum_playback_s: float = 30.0,
+        rewrite_timeout_s: float = 5.0,
     ) -> None:
         if not prompt.strip():
             raise ValueError("voice aggregation prompt must not be empty")
@@ -97,6 +100,14 @@ class VoiceAggregationAgent(Agent):
             raise ValueError("voice aggregation speech rate must be positive")
         if minimum_playback_s < 0:
             raise ValueError("voice aggregation minimum playback must not be negative")
+        if maximum_playback_s <= 0:
+            raise ValueError("voice aggregation maximum playback must be positive")
+        if minimum_playback_s > maximum_playback_s:
+            raise ValueError(
+                "voice aggregation minimum playback must not exceed maximum playback"
+            )
+        if rewrite_timeout_s <= 0:
+            raise ValueError("voice aggregation rewrite timeout must be positive")
         super().__init__()
         self._llm = llm
         self._prompt = prompt.strip()
@@ -108,6 +119,8 @@ class VoiceAggregationAgent(Agent):
         self._participant_idle_timeout_s = participant_idle_timeout_s
         self._speech_rate_wpm = speech_rate_wpm
         self._minimum_playback_s = minimum_playback_s
+        self._maximum_playback_s = maximum_playback_s
+        self._rewrite_timeout_s = rewrite_timeout_s
         self._states: dict[str, _ParticipantState] = {}
         self._stopping = False
 
@@ -119,12 +132,15 @@ class VoiceAggregationAgent(Agent):
         if participant_id is None:
             raise ValueError("voice contribution requires a participant")
         if self._stopping:
-            raise RuntimeError("voice aggregation agent is stopping")
+            logger.debug(
+                "dropped voice contribution while stopping pid={!r} source={!r}",
+                participant_id,
+                ctx.metadata.source,
+            )
+            return
         state = self._states.get(participant_id)
         if state is None or state.task is None or state.task.done():
-            state = _ParticipantState(
-                queue=asyncio.Queue(maxsize=self._queue_capacity),
-            )
+            state = _ParticipantState()
             task = asyncio.create_task(
                 self._run_participant(participant_id, state),
                 name=f"voice-aggregation:{participant_id}",
@@ -139,13 +155,14 @@ class VoiceAggregationAgent(Agent):
                     completed,
                 )
             )
-        await state.queue.put(
+        self._enqueue(
+            state,
             _Contribution(
                 output=output,
                 ctx=ctx,
                 participant_id=participant_id,
                 source=ctx.metadata.source,
-            )
+            ),
         )
 
     async def stop(self) -> None:
@@ -153,15 +170,19 @@ class VoiceAggregationAgent(Agent):
 
         self._stopping = True
         tasks = tuple(
-            state.task
-            for state in self._states.values()
+            (participant_id, state, state.task)
+            for participant_id, state in self._states.items()
             if state.task is not None
         )
         self._states.clear()
-        for task in tasks:
+        for participant_id, state, task in tasks:
+            self._log_discarded(participant_id, state, reason="shutdown")
             task.cancel()
         if tasks:
-            await asyncio.gather(*tasks, return_exceptions=True)
+            await asyncio.gather(
+                *(task for _participant_id, _state, task in tasks),
+                return_exceptions=True,
+            )
 
     async def release(self, participant_id: str) -> None:
         """Cancel and release one departed participant's aggregation state."""
@@ -169,6 +190,7 @@ class VoiceAggregationAgent(Agent):
         state = self._states.pop(participant_id, None)
         if state is None or state.task is None:
             return
+        self._log_discarded(participant_id, state, reason="participant release")
         state.task.cancel()
         await asyncio.gather(state.task, return_exceptions=True)
 
@@ -180,26 +202,94 @@ class VoiceAggregationAgent(Agent):
         while True:
             try:
                 contribution = await asyncio.wait_for(
-                    self._next(state),
+                    self._wait_for_next(state),
                     timeout=self._participant_idle_timeout_s,
                 )
             except TimeoutError:
-                return
-            key = contribution.stream_key
-            if key is not None and key in state.discarded_streams:
-                if contribution.output.final:
-                    state.discarded_streams.discard(key)
-                continue
-            if key is not None and not contribution.output.final:
-                await self._forward_stream(participant_id, state, contribution)
-                continue
-            batch = await self._finite_batch(state, contribution)
-            await self._speak_batch(participant_id, state, batch)
+                contribution = self._pop_next(state)
+                if contribution is None:
+                    return
+            await self._process_contribution(participant_id, state, contribution)
 
-    async def _next(self, state: _ParticipantState) -> _Contribution:
-        if state.backlog:
-            return state.backlog.popleft()
-        return await state.queue.get()
+    async def _process_contribution(
+        self,
+        participant_id: str,
+        state: _ParticipantState,
+        contribution: _Contribution,
+    ) -> None:
+        key = contribution.stream_key
+        if key is not None and key in state.discarded_streams:
+            if contribution.output.final:
+                state.discarded_streams.discard(key)
+            return
+        if key is not None and not contribution.output.final:
+            await self._forward_stream(participant_id, state, contribution)
+            return
+        batch = await self._finite_batch(state, contribution)
+        await self._speak_batch(participant_id, state, batch)
+
+    def _enqueue(
+        self,
+        state: _ParticipantState,
+        contribution: _Contribution,
+    ) -> None:
+        if len(state.pending) >= self._queue_capacity:
+            victim_index = next(
+                (
+                    index
+                    for index, pending in enumerate(state.pending)
+                    if not pending.output.interrupt
+                    and pending.stream_key != state.active_stream
+                ),
+                0,
+            )
+            victim = state.pending[victim_index]
+            del state.pending[victim_index]
+            victim_key = victim.stream_key
+            if victim_key is not None and (
+                not victim.output.final or victim_key == state.active_stream
+            ):
+                self._discard_stream(state, victim_key)
+            logger.warning(
+                "dropped oldest pending voice contribution pid={!r} source={!r} "
+                "response_id={!r} capacity={}",
+                victim.participant_id,
+                victim.source,
+                victim.output.response_id,
+                self._queue_capacity,
+            )
+        state.pending.append(contribution)
+        state.changed.set()
+
+    def _discard_stream(
+        self,
+        state: _ParticipantState,
+        stream_key: tuple[str, str],
+    ) -> None:
+        if (
+            stream_key not in state.discarded_streams
+            and len(state.discarded_streams) >= self._queue_capacity
+        ):
+            state.discarded_streams.pop()
+        state.discarded_streams.add(stream_key)
+        state.changed.set()
+
+    @staticmethod
+    def _pop_next(state: _ParticipantState) -> _Contribution | None:
+        if not state.pending:
+            return None
+        return state.pending.popleft()
+
+    async def _wait_for_next(self, state: _ParticipantState) -> _Contribution:
+        while True:
+            contribution = self._pop_next(state)
+            if contribution is not None:
+                return contribution
+            state.changed.clear()
+            contribution = self._pop_next(state)
+            if contribution is not None:
+                return contribution
+            await state.changed.wait()
 
     async def _finite_batch(
         self,
@@ -210,7 +300,7 @@ class VoiceAggregationAgent(Agent):
             await asyncio.sleep(self._coalesce_window_s)
         batch = [first]
         while len(batch) < self._max_batch_size:
-            contribution = self._next_nowait(state)
+            contribution = self._pop_next(state)
             if contribution is None:
                 break
             key = contribution.stream_key
@@ -219,19 +309,11 @@ class VoiceAggregationAgent(Agent):
                     state.discarded_streams.discard(key)
                 continue
             if key is not None and not contribution.output.final:
-                state.backlog.appendleft(contribution)
+                state.pending.appendleft(contribution)
+                state.changed.set()
                 break
             batch.append(contribution)
         return batch
-
-    @staticmethod
-    def _next_nowait(state: _ParticipantState) -> _Contribution | None:
-        if state.backlog:
-            return state.backlog.popleft()
-        try:
-            return state.queue.get_nowait()
-        except asyncio.QueueEmpty:
-            return None
 
     async def _forward_stream(
         self,
@@ -244,56 +326,101 @@ class VoiceAggregationAgent(Agent):
         output_id = uuid.uuid4().hex
         started_at = asyncio.get_running_loop().time()
         spoken_text = first.output.text
-        await self._publish_stream(first, output_id, interrupt=first.output.interrupt)
+        state.active_stream = input_key
+        try:
+            await self._publish_stream(first, output_id, interrupt=first.output.interrupt)
 
-        while True:
-            try:
-                contribution = await asyncio.wait_for(
-                    state.queue.get(),
-                    timeout=self._stream_idle_timeout_s,
-                )
-            except TimeoutError:
-                logger.warning(
-                    "voice contribution stream timed out pid={!r} source={!r} response_id={!r}",
-                    participant_id,
-                    input_key[0],
-                    input_key[1],
-                )
-                state.discarded_streams.add(input_key)
-                await self._publish_stream_end(first, output_id)
-                return
-
-            if contribution.stream_key == input_key:
-                if contribution.output.interrupt:
+            while True:
+                try:
+                    contribution = await asyncio.wait_for(
+                        self._wait_for_stream_contribution(state, input_key),
+                        timeout=self._stream_idle_timeout_s,
+                    )
+                except TimeoutError:
                     logger.warning(
-                        "ignored interrupt on non-initial voice contribution chunk "
-                        "pid={!r} source={!r} response_id={!r}",
+                        "voice contribution stream timed out pid={!r} source={!r} "
+                        "response_id={!r}",
                         participant_id,
                         input_key[0],
                         input_key[1],
                     )
-                spoken_text += contribution.output.text
-                await self._publish_stream(
-                    contribution,
-                    output_id,
-                    interrupt=False,
-                    final=False,
-                )
-                if contribution.output.final:
-                    elapsed = asyncio.get_running_loop().time() - started_at
-                    remaining = max(0.0, self._playback_duration(spoken_text) - elapsed)
-                    if await self._hold_output(state, remaining):
-                        state.discarded_streams.add(input_key)
-                        return
+                    self._discard_stream(state, input_key)
                     await self._publish_stream_end(first, output_id)
                     return
-                continue
 
-            if contribution.output.interrupt:
-                state.discarded_streams.add(input_key)
-                state.backlog.appendleft(contribution)
+                if contribution is None:
+                    await self._publish_stream_end(first, output_id)
+                    return
+                if contribution.stream_key == input_key:
+                    if contribution.output.interrupt:
+                        logger.warning(
+                            "ignored interrupt on non-initial voice contribution chunk "
+                            "pid={!r} source={!r} response_id={!r}",
+                            participant_id,
+                            input_key[0],
+                            input_key[1],
+                        )
+                    spoken_text += contribution.output.text
+                    await self._publish_stream(
+                        contribution,
+                        output_id,
+                        interrupt=False,
+                        final=False,
+                    )
+                    if contribution.output.final:
+                        elapsed = asyncio.get_running_loop().time() - started_at
+                        remaining = max(
+                            0.0,
+                            self._playback_duration(spoken_text) - elapsed,
+                        )
+                        urgent = await self._hold_output(state, remaining)
+                        if urgent is not None:
+                            await self._dispatch_urgent(
+                                participant_id,
+                                state,
+                                urgent,
+                            )
+                            return
+                        await self._publish_stream_end(first, output_id)
+                        return
+                    continue
+
+                self._discard_stream(state, input_key)
+                await self._dispatch_urgent(participant_id, state, contribution)
                 return
-            state.backlog.append(contribution)
+        finally:
+            if state.active_stream == input_key:
+                state.active_stream = None
+
+    async def _wait_for_stream_contribution(
+        self,
+        state: _ParticipantState,
+        input_key: tuple[str, str],
+    ) -> _Contribution | None:
+        while True:
+            if input_key in state.discarded_streams:
+                return None
+            contribution = self._pop_stream_contribution(state, input_key)
+            if contribution is not None:
+                return contribution
+            state.changed.clear()
+            if input_key in state.discarded_streams:
+                return None
+            contribution = self._pop_stream_contribution(state, input_key)
+            if contribution is not None:
+                return contribution
+            await state.changed.wait()
+
+    @staticmethod
+    def _pop_stream_contribution(
+        state: _ParticipantState,
+        input_key: tuple[str, str],
+    ) -> _Contribution | None:
+        for index, contribution in enumerate(state.pending):
+            if contribution.output.interrupt or contribution.stream_key == input_key:
+                del state.pending[index]
+                return contribution
+        return None
 
     async def _publish_stream(
         self,
@@ -339,11 +466,45 @@ class VoiceAggregationAgent(Agent):
         state: _ParticipantState,
         batch: list[_Contribution],
     ) -> None:
-        text = (
-            batch[0].output.text.strip()
-            if len(batch) == 1
-            else await self._rewrite(participant_id, batch)
-        )
+        interrupts = any(contribution.output.interrupt for contribution in batch)
+        if len(batch) == 1:
+            text = batch[0].output.text.strip()
+        elif interrupts:
+            text = self._fallback_text(batch)
+        else:
+            rewrite = asyncio.create_task(
+                self._rewrite(participant_id, batch),
+                name=f"voice-aggregation-rewrite:{participant_id}",
+                context=nemo_relay.fork_asyncio_context(),
+            )
+            urgent = asyncio.create_task(
+                self._wait_for_interrupt(state),
+                name=f"voice-aggregation-interrupt:{participant_id}",
+            )
+            try:
+                done, _pending = await asyncio.wait(
+                    (rewrite, urgent),
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if urgent in done:
+                    logger.debug(
+                        "urgent voice contribution preempted rewrite pid={!r}",
+                        participant_id,
+                    )
+                    rewrite.cancel()
+                    await asyncio.gather(rewrite, return_exceptions=True)
+                    await self._dispatch_urgent(
+                        participant_id,
+                        state,
+                        urgent.result(),
+                    )
+                    return
+                text = rewrite.result()
+            finally:
+                for task in (rewrite, urgent):
+                    if not task.done():
+                        task.cancel()
+                await asyncio.gather(rewrite, urgent, return_exceptions=True)
         if not text:
             return
         timestamp_us = min(
@@ -360,10 +521,7 @@ class VoiceAggregationAgent(Agent):
                 text=text,
                 response_id=output_id,
                 final=False,
-                interrupt=any(
-                    contribution.output.interrupt
-                    for contribution in batch
-                ),
+                interrupt=interrupts,
                 timestamp_us=timestamp_us,
             ),
             ctx=batch[0].ctx,
@@ -375,7 +533,16 @@ class VoiceAggregationAgent(Agent):
             output_id,
             interrupt=output.output.interrupt,
         )
-        if await self._hold_output(state, self._playback_duration(text)):
+        urgent_contribution = await self._hold_output(
+            state,
+            self._playback_duration(text),
+        )
+        if urgent_contribution is not None:
+            await self._dispatch_urgent(
+                participant_id,
+                state,
+                urgent_contribution,
+            )
             return
         await self._publish_stream_end(output, output_id)
 
@@ -383,30 +550,68 @@ class VoiceAggregationAgent(Agent):
         self,
         state: _ParticipantState,
         duration_s: float,
-    ) -> bool:
-        """Buffer new updates while the current response is expected to play."""
+    ) -> _Contribution | None:
+        """Wait for playback pacing to expire or urgent output to supersede it."""
 
-        deadline = asyncio.get_running_loop().time() + duration_s
+        if duration_s <= 0:
+            return None
+        try:
+            return await asyncio.wait_for(
+                self._wait_for_interrupt(state),
+                timeout=duration_s,
+            )
+        except TimeoutError:
+            return None
+
+    async def _wait_for_interrupt(
+        self,
+        state: _ParticipantState,
+    ) -> _Contribution:
         while True:
-            remaining = deadline - asyncio.get_running_loop().time()
-            if remaining <= 0:
-                return False
-            try:
-                contribution = await asyncio.wait_for(
-                    state.queue.get(),
-                    timeout=remaining,
-                )
-            except TimeoutError:
-                return False
+            contribution = self._pop_interrupt(state)
+            if contribution is not None:
+                return contribution
+            state.changed.clear()
+            contribution = self._pop_interrupt(state)
+            if contribution is not None:
+                return contribution
+            await state.changed.wait()
+
+    @staticmethod
+    def _pop_interrupt(state: _ParticipantState) -> _Contribution | None:
+        for index, contribution in enumerate(state.pending):
             if contribution.output.interrupt:
-                state.backlog.appendleft(contribution)
-                return True
-            state.backlog.append(contribution)
+                del state.pending[index]
+                return contribution
+        return None
+
+    async def _dispatch_urgent(
+        self,
+        participant_id: str,
+        state: _ParticipantState,
+        contribution: _Contribution,
+    ) -> None:
+        key = contribution.stream_key
+        if key is not None and not contribution.output.final:
+            await self._forward_stream(participant_id, state, contribution)
+            return
+        await self._speak_batch(participant_id, state, [contribution])
 
     def _playback_duration(self, text: str) -> float:
         words = len(text.split())
         estimated_s = words * 60.0 / self._speech_rate_wpm
-        return min(30.0, max(self._minimum_playback_s, estimated_s))
+        return min(
+            self._maximum_playback_s,
+            max(self._minimum_playback_s, estimated_s),
+        )
+
+    @staticmethod
+    def _fallback_text(batch: list[_Contribution]) -> str:
+        return " ".join(
+            contribution.output.text.strip()
+            for contribution in batch
+            if contribution.output.text.strip()
+        )
 
     async def _rewrite(
         self,
@@ -421,7 +626,7 @@ class VoiceAggregationAgent(Agent):
             for contribution in batch
             if contribution.output.text.strip()
         ]
-        fallback = " ".join(update["text"] for update in updates)
+        fallback = self._fallback_text(batch)
         if len(updates) < 2:
             return fallback
         try:
@@ -437,6 +642,7 @@ class VoiceAggregationAgent(Agent):
                 max_tokens=self._max_tokens,
                 temperature=0.0,
                 enable_thinking=False,
+                timeout=self._rewrite_timeout_s,
             )
         except asyncio.CancelledError:
             raise
@@ -454,6 +660,28 @@ class VoiceAggregationAgent(Agent):
             )
             return fallback
         return text
+
+    @staticmethod
+    def _log_discarded(
+        participant_id: str,
+        state: _ParticipantState,
+        *,
+        reason: str,
+    ) -> None:
+        count = len(state.pending)
+        if count:
+            logger.warning(
+                "discarded pending voice contributions pid={!r} count={} reason={}",
+                participant_id,
+                count,
+                reason,
+            )
+        else:
+            logger.debug(
+                "released voice aggregation state pid={!r} reason={}",
+                participant_id,
+                reason,
+            )
 
     def _discard(
         self,

--- a/docs/source/components/agent-sdk.md
+++ b/docs/source/components/agent-sdk.md
@@ -63,8 +63,9 @@ Applications with multiple speech producers may place
 `VoiceAggregationAgent` before `VoiceAgent`. Producers publish candidate
 finite or incremental responses to `voice.contribution`; the aggregator owns
 participant-scoped ordering, preserves a lone stream, coalesces simultaneous
-finite updates through the configured `LLMService`, and publishes only the
-result to `voice.output`. This policy remains outside the private media
+finite updates through the configured `LLMService`, holds an active response
+for its estimated spoken duration, and publishes only the result to
+`voice.output`. This policy remains outside the private media
 pipeline so applications opt in explicitly and retain ownership of which
 events should become speech.
 

--- a/docs/source/components/agent-sdk.md
+++ b/docs/source/components/agent-sdk.md
@@ -64,8 +64,10 @@ Applications with multiple speech producers may place
 finite or incremental responses to `voice.contribution`; the aggregator owns
 participant-scoped ordering, preserves a lone stream, coalesces simultaneous
 finite updates through the configured `LLMService`, holds an active response
-for its estimated spoken duration, and publishes only the result to
-`voice.output`. This policy remains outside the private media
+for a bounded, open-loop estimate of its spoken duration, and publishes only
+the result to `voice.output`. Pending work is capacity-bounded with a
+drop-oldest policy, while urgent output bypasses or cancels rewriting and
+interrupts active speech. This policy remains outside the private media
 pipeline so applications opt in explicitly and retain ownership of which
 events should become speech.
 

--- a/docs/source/components/agent-sdk.md
+++ b/docs/source/components/agent-sdk.md
@@ -71,8 +71,8 @@ alert replaces the oldest pending routine update or, if necessary, the oldest
 alert. Urgent output bypasses coalescing and rewriting, retains displaced
 routine work encountered during coalescing or rewrite for a later batch, and
 interrupts active speech. Interrupted stream IDs remain quarantined through
-their terminator or idle expiry, and the
-agent enforces its rewrite deadline independently of the model transport. This
+their terminator or idle expiry, and the agent enforces its rewrite deadline
+independently of the model transport. This
 policy remains outside the private media pipeline so applications opt in
 explicitly and retain ownership of which events should become speech.
 

--- a/docs/source/components/agent-sdk.md
+++ b/docs/source/components/agent-sdk.md
@@ -59,6 +59,15 @@ loopback HTTP listener. It is not persistence, does not inspect every runtime
 topic, and does not enter model, voice, media, or hub authentication paths. The
 application selects which typed events to forward explicitly.
 
+Applications with multiple speech producers may place
+`VoiceAggregationAgent` before `VoiceAgent`. Producers publish candidate
+finite or incremental responses to `voice.contribution`; the aggregator owns
+participant-scoped ordering, preserves a lone stream, coalesces simultaneous
+finite updates through the configured `LLMService`, and publishes only the
+result to `voice.output`. This policy remains outside the private media
+pipeline so applications opt in explicitly and retain ownership of which
+events should become speech.
+
 `ProcessorEndpoint` is the minimal agent-side hub boundary. It receives data,
 audio, frame signals, and participant events and sends participant-routed return
 traffic. Video tools acquire frames on demand; raw pixels and media stay on the

--- a/docs/source/components/agent-sdk.md
+++ b/docs/source/components/agent-sdk.md
@@ -66,10 +66,14 @@ participant-scoped ordering, preserves a lone stream, coalesces simultaneous
 finite updates through the configured `LLMService`, holds an active response
 for a bounded, open-loop estimate of its spoken duration, and publishes only
 the result to `voice.output`. Pending work is capacity-bounded with a
-drop-oldest policy, while urgent output bypasses or cancels rewriting and
-interrupts active speech. This policy remains outside the private media
-pipeline so applications opt in explicitly and retain ownership of which
-events should become speech.
+priority-aware drop policy: routine work never displaces an alert, while a new
+alert replaces the oldest pending routine update or, if necessary, the oldest
+alert. Urgent output bypasses coalescing and rewriting, retains displaced
+routine work encountered during coalescing for a later batch, and interrupts active speech. Interrupted
+stream IDs remain quarantined through their terminator or idle expiry, and the
+agent enforces its rewrite deadline independently of the model transport. This
+policy remains outside the private media pipeline so applications opt in
+explicitly and retain ownership of which events should become speech.
 
 `ProcessorEndpoint` is the minimal agent-side hub boundary. It receives data,
 audio, frame signals, and participant events and sends participant-routed return

--- a/docs/source/components/agent-sdk.md
+++ b/docs/source/components/agent-sdk.md
@@ -69,8 +69,9 @@ the result to `voice.output`. Pending work is capacity-bounded with a
 priority-aware drop policy: routine work never displaces an alert, while a new
 alert replaces the oldest pending routine update or, if necessary, the oldest
 alert. Urgent output bypasses coalescing and rewriting, retains displaced
-routine work encountered during coalescing for a later batch, and interrupts active speech. Interrupted
-stream IDs remain quarantined through their terminator or idle expiry, and the
+routine work encountered during coalescing or rewrite for a later batch, and
+interrupts active speech. Interrupted stream IDs remain quarantined through
+their terminator or idle expiry, and the
 agent enforces its rewrite deadline independently of the model transport. This
 policy remains outside the private media pipeline so applications opt in
 explicitly and retain ownership of which events should become speech.

--- a/tests/test_voice_aggregation.py
+++ b/tests/test_voice_aggregation.py
@@ -1,0 +1,281 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contract tests for participant-scoped voice output aggregation."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from xr_ai_models import ChatMessage, ChatResponse
+from xr_ai_runtime import Agent, AgentRuntime, MessageMetadata, RuntimeContext, subscribe
+from xr_ai_voice import (
+    VOICE_CONTRIBUTION_TOPIC,
+    VOICE_OUTPUT_TOPIC,
+    VoiceAggregationAgent,
+    VoiceOutput,
+)
+
+
+class _LLM:
+    def __init__(self, content: str = "Combined update.", *, error: Exception | None = None) -> None:
+        self.content = content
+        self.error = error
+        self.calls: list[tuple[tuple[ChatMessage, ...], dict]] = []
+
+    async def chat(self, messages, **kwargs) -> ChatResponse:
+        self.calls.append((tuple(messages), kwargs))
+        if self.error is not None:
+            raise self.error
+        return ChatResponse(self.content, None, None, "stop", {})
+
+
+class _Recorder(Agent):
+    def __init__(self) -> None:
+        super().__init__()
+        self.outputs: list[tuple[VoiceOutput, MessageMetadata]] = []
+        self.changed = asyncio.Condition()
+
+    @subscribe(VOICE_OUTPUT_TOPIC)
+    async def record(self, output: VoiceOutput, ctx: RuntimeContext) -> None:
+        async with self.changed:
+            self.outputs.append((output, ctx.metadata))
+            self.changed.notify_all()
+
+    async def wait_for(self, count: int) -> None:
+        async with self.changed:
+            await asyncio.wait_for(
+                self.changed.wait_for(lambda: len(self.outputs) >= count),
+                1.0,
+            )
+
+
+async def _start(
+    llm: _LLM,
+    **kwargs,
+) -> tuple[AgentRuntime, VoiceAggregationAgent, _Recorder]:
+    runtime = AgentRuntime()
+    aggregator = runtime.register(
+        "voice-aggregation",
+        VoiceAggregationAgent(
+            llm=llm,  # type: ignore[arg-type]
+            coalesce_window_s=0.01,
+            participant_idle_timeout_s=1.0,
+            **kwargs,
+        ),
+    )
+    recorder = runtime.register("recorder", _Recorder())
+    await runtime.start()
+    return runtime, aggregator, recorder
+
+
+async def _stop(runtime: AgentRuntime, aggregator: VoiceAggregationAgent) -> None:
+    await aggregator.stop()
+    await runtime.stop()
+
+
+async def test_single_contribution_bypasses_llm() -> None:
+    llm = _LLM()
+    runtime, aggregator, recorder = await _start(llm)
+    try:
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="The timer is done.", timestamp_us=11),
+            participant_id="alice",
+            source="timer",
+        )
+        await recorder.wait_for(1)
+    finally:
+        await _stop(runtime, aggregator)
+
+    output, metadata = recorder.outputs[0]
+    assert output == VoiceOutput(text="The timer is done.", timestamp_us=11)
+    assert metadata.participant_id == "alice"
+    assert metadata.source == "voice-aggregation"
+    assert llm.calls == []
+
+
+async def test_simultaneous_contributions_are_rewritten_once() -> None:
+    llm = _LLM("Temperature rose to 24 degrees, and the timer is done.")
+    runtime, aggregator, recorder = await _start(llm)
+    try:
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="Temperature rose to 24 degrees.", timestamp_us=20),
+            participant_id="alice",
+            source="instrument-monitor",
+        )
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="The timer is done.", interrupt=True, timestamp_us=10),
+            participant_id="alice",
+            source="timer",
+        )
+        await recorder.wait_for(1)
+    finally:
+        await _stop(runtime, aggregator)
+
+    assert recorder.outputs[0][0] == VoiceOutput(
+        text="Temperature rose to 24 degrees, and the timer is done.",
+        interrupt=True,
+        timestamp_us=10,
+    )
+    assert len(llm.calls) == 1
+    messages, kwargs = llm.calls[0]
+    assert "instrument-monitor" in str(messages[-1].content)
+    assert "timer" in str(messages[-1].content)
+    assert kwargs == {
+        "max_tokens": 192,
+        "temperature": 0.0,
+        "enable_thinking": False,
+    }
+
+
+async def test_participants_aggregate_independently() -> None:
+    llm = _LLM()
+    runtime, aggregator, recorder = await _start(llm)
+    try:
+        await asyncio.gather(
+            runtime.publish(
+                VOICE_CONTRIBUTION_TOPIC,
+                VoiceOutput(text="Alice update."),
+                participant_id="alice",
+                source="monitor",
+            ),
+            runtime.publish(
+                VOICE_CONTRIBUTION_TOPIC,
+                VoiceOutput(text="Bob update."),
+                participant_id="bob",
+                source="monitor",
+            ),
+        )
+        await recorder.wait_for(2)
+    finally:
+        await _stop(runtime, aggregator)
+
+    assert {
+        (metadata.participant_id, output.text)
+        for output, metadata in recorder.outputs
+    } == {("alice", "Alice update."), ("bob", "Bob update.")}
+    assert llm.calls == []
+
+
+async def test_lone_stream_passes_through_while_pending_updates_coalesce() -> None:
+    llm = _LLM("Temperature changed, and the timer completed.")
+    runtime, aggregator, recorder = await _start(llm)
+    try:
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="I can see ", response_id="view", final=False),
+            participant_id="alice",
+            source="foreground",
+        )
+        await recorder.wait_for(1)
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="Temperature changed."),
+            participant_id="alice",
+            source="instrument-monitor",
+        )
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="The timer completed."),
+            participant_id="alice",
+            source="timer",
+        )
+        assert len(recorder.outputs) == 1
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="a beaker.", response_id="view"),
+            participant_id="alice",
+            source="foreground",
+        )
+        await recorder.wait_for(3)
+    finally:
+        await _stop(runtime, aggregator)
+
+    first, second, third = [output for output, _metadata in recorder.outputs]
+    assert first.text == "I can see "
+    assert first.final is False
+    assert first.response_id
+    assert first.response_id != "view"
+    assert second == VoiceOutput(text="a beaker.", response_id=first.response_id)
+    assert third == VoiceOutput(text="Temperature changed, and the timer completed.")
+    assert len(llm.calls) == 1
+
+
+async def test_urgent_contribution_interrupts_active_stream() -> None:
+    llm = _LLM()
+    runtime, aggregator, recorder = await _start(llm)
+    try:
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="A long description", response_id="view", final=False),
+            participant_id="alice",
+            source="foreground",
+        )
+        await recorder.wait_for(1)
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="Move away from the heater.", interrupt=True),
+            participant_id="alice",
+            source="safety-monitor",
+        )
+        await recorder.wait_for(2)
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(response_id="view"),
+            participant_id="alice",
+            source="foreground",
+        )
+        await asyncio.sleep(0)
+    finally:
+        await _stop(runtime, aggregator)
+
+    assert [output.text for output, _metadata in recorder.outputs] == [
+        "A long description",
+        "Move away from the heater.",
+    ]
+    assert recorder.outputs[-1][0].interrupt is True
+    assert llm.calls == []
+
+
+async def test_rewrite_failure_preserves_all_updates() -> None:
+    llm = _LLM(error=RuntimeError("model unavailable"))
+    runtime, aggregator, recorder = await _start(llm)
+    try:
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="First update."),
+            participant_id="alice",
+            source="one",
+        )
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="Second update."),
+            participant_id="alice",
+            source="two",
+        )
+        await recorder.wait_for(1)
+    finally:
+        await _stop(runtime, aggregator)
+
+    assert recorder.outputs[0][0].text == "First update. Second update."
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"prompt": " "}, "prompt"),
+        ({"coalesce_window_s": -1}, "window"),
+        ({"queue_capacity": 0}, "capacity"),
+        ({"max_batch_size": 1}, "batch size"),
+        ({"max_tokens": 0}, "token limit"),
+        ({"stream_idle_timeout_s": 0}, "stream idle timeout"),
+        ({"participant_idle_timeout_s": 0}, "participant idle timeout"),
+    ],
+)
+def test_configuration_validation(kwargs: dict, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        VoiceAggregationAgent(llm=_LLM(), **kwargs)  # type: ignore[arg-type]

--- a/tests/test_voice_aggregation.py
+++ b/tests/test_voice_aggregation.py
@@ -596,6 +596,37 @@ async def test_discarded_stream_can_restart_after_idle_expiry() -> None:
     ]
 
 
+async def test_expired_discarded_streams_are_pruned_by_finite_work() -> None:
+    llm = _LLM()
+    runtime, aggregator, recorder = await _start(
+        llm,
+        stream_idle_timeout_s=0.02,
+    )
+    try:
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="Current status."),
+            participant_id="alice",
+            source="monitor",
+        )
+        await recorder.wait_for(1)
+        state = aggregator._states["alice"]
+        state.discarded_streams[("stream", "stale")] = asyncio.get_running_loop().time() + 0.01
+        await asyncio.sleep(0.02)
+
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="Updated status."),
+            participant_id="alice",
+            source="monitor",
+        )
+        await recorder.wait_for(3)
+
+        assert state.discarded_streams == {}
+    finally:
+        await _stop(runtime, aggregator)
+
+
 async def test_release_cancels_only_departed_participant_state() -> None:
     llm = _LLM()
     runtime, aggregator, recorder = await _start(
@@ -749,12 +780,18 @@ async def test_urgent_contribution_cancels_in_flight_rewrite() -> None:
             source="safety",
         )
         await recorder.wait_for(1)
+        gate.set()
+        await recorder.wait_for(3)
     finally:
         await _stop(runtime, aggregator)
 
     assert llm.cancelled is True
     assert recorder.outputs[0][0].text == "Move away now."
     assert recorder.outputs[0][0].interrupt is True
+    assert recorder.outputs[2][0].text == "Combined update."
+    assert len(llm.calls) == 2
+    assert "First routine update." in str(llm.calls[1][0][-1].content)
+    assert "Second routine update." in str(llm.calls[1][0][-1].content)
 
 
 async def test_rewrite_failure_preserves_all_updates() -> None:

--- a/tests/test_voice_aggregation.py
+++ b/tests/test_voice_aggregation.py
@@ -55,6 +55,8 @@ async def _start(
     llm: _LLM,
     **kwargs,
 ) -> tuple[AgentRuntime, VoiceAggregationAgent, _Recorder]:
+    kwargs.setdefault("speech_rate_wpm", 60_000.0)
+    kwargs.setdefault("minimum_playback_s", 0.0)
     runtime = AgentRuntime()
     aggregator = runtime.register(
         "voice-aggregation",
@@ -90,7 +92,10 @@ async def test_single_contribution_bypasses_llm() -> None:
         await _stop(runtime, aggregator)
 
     output, metadata = recorder.outputs[0]
-    assert output == VoiceOutput(text="The timer is done.", timestamp_us=11)
+    assert output.text == "The timer is done."
+    assert output.timestamp_us == 11
+    assert output.final is False
+    assert output.response_id
     assert metadata.participant_id == "alice"
     assert metadata.source == "voice-aggregation"
     assert llm.calls == []
@@ -116,11 +121,12 @@ async def test_simultaneous_contributions_are_rewritten_once() -> None:
     finally:
         await _stop(runtime, aggregator)
 
-    assert recorder.outputs[0][0] == VoiceOutput(
-        text="Temperature rose to 24 degrees, and the timer is done.",
-        interrupt=True,
-        timestamp_us=10,
-    )
+    output = recorder.outputs[0][0]
+    assert output.text == "Temperature rose to 24 degrees, and the timer is done."
+    assert output.interrupt is True
+    assert output.timestamp_us == 10
+    assert output.final is False
+    assert output.response_id
     assert len(llm.calls) == 1
     messages, kwargs = llm.calls[0]
     assert "instrument-monitor" in str(messages[-1].content)
@@ -191,17 +197,70 @@ async def test_lone_stream_passes_through_while_pending_updates_coalesce() -> No
             participant_id="alice",
             source="foreground",
         )
-        await recorder.wait_for(3)
+        await recorder.wait_for(5)
     finally:
         await _stop(runtime, aggregator)
 
-    first, second, third = [output for output, _metadata in recorder.outputs]
+    first, second, stream_end, third, batch_end = [
+        output for output, _metadata in recorder.outputs
+    ]
     assert first.text == "I can see "
     assert first.final is False
     assert first.response_id
     assert first.response_id != "view"
-    assert second == VoiceOutput(text="a beaker.", response_id=first.response_id)
-    assert third == VoiceOutput(text="Temperature changed, and the timer completed.")
+    assert second == VoiceOutput(
+        text="a beaker.",
+        response_id=first.response_id,
+        final=False,
+    )
+    assert stream_end == VoiceOutput(response_id=first.response_id)
+    assert third.text == "Temperature changed, and the timer completed."
+    assert third.final is False
+    assert third.response_id
+    assert batch_end == VoiceOutput(response_id=third.response_id)
+    assert len(llm.calls) == 1
+
+
+async def test_updates_during_estimated_playback_coalesce_after_current_output() -> None:
+    llm = _LLM("Temperature changed, and the timer completed.")
+    runtime, aggregator, recorder = await _start(
+        llm,
+        speech_rate_wpm=6_000.0,
+        minimum_playback_s=0.1,
+    )
+    try:
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="This response remains active while it is spoken."),
+            participant_id="alice",
+            source="foreground",
+        )
+        await recorder.wait_for(1)
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="Temperature changed."),
+            participant_id="alice",
+            source="instrument-monitor",
+        )
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="The timer completed."),
+            participant_id="alice",
+            source="timer",
+        )
+        await recorder.wait_for(4)
+    finally:
+        await _stop(runtime, aggregator)
+
+    first, first_end, combined, combined_end = [
+        output for output, _metadata in recorder.outputs
+    ]
+    assert first.text == "This response remains active while it is spoken."
+    assert first.final is False
+    assert first_end == VoiceOutput(response_id=first.response_id)
+    assert combined.text == "Temperature changed, and the timer completed."
+    assert combined.final is False
+    assert combined_end == VoiceOutput(response_id=combined.response_id)
     assert len(llm.calls) == 1
 
 
@@ -274,6 +333,8 @@ async def test_rewrite_failure_preserves_all_updates() -> None:
         ({"max_tokens": 0}, "token limit"),
         ({"stream_idle_timeout_s": 0}, "stream idle timeout"),
         ({"participant_idle_timeout_s": 0}, "participant idle timeout"),
+        ({"speech_rate_wpm": 0}, "speech rate"),
+        ({"minimum_playback_s": -1}, "minimum playback"),
     ],
 )
 def test_configuration_validation(kwargs: dict, message: str) -> None:

--- a/tests/test_voice_aggregation.py
+++ b/tests/test_voice_aggregation.py
@@ -734,6 +734,54 @@ async def test_urgent_batch_speaks_alert_first_and_retains_routine_order() -> No
     )
 
 
+async def test_stream_boundary_does_not_hide_queued_urgent_output() -> None:
+    llm = _LLM()
+    runtime, aggregator, recorder = await _start(
+        llm,
+        coalesce_window_s=0.05,
+    )
+    try:
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="Routine."),
+            participant_id="alice",
+            source="monitor",
+        )
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="Stream start", response_id="foreground", final=False),
+            participant_id="alice",
+            source="foreground",
+        )
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="Move now.", interrupt=True),
+            participant_id="alice",
+            source="safety",
+        )
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="Stream end", response_id="foreground"),
+            participant_id="alice",
+            source="foreground",
+        )
+        await recorder.wait_for(7)
+    finally:
+        await _stop(runtime, aggregator)
+
+    assert [output.text for output, _metadata in recorder.outputs] == [
+        "Move now.",
+        "",
+        "Routine.",
+        "",
+        "Stream start",
+        "Stream end",
+        "",
+    ]
+    assert recorder.outputs[0][0].interrupt is True
+    assert llm.calls == []
+
+
 async def test_urgent_first_contribution_skips_coalescing_delay() -> None:
     llm = _LLM()
     runtime, aggregator, recorder = await _start(

--- a/tests/test_voice_aggregation.py
+++ b/tests/test_voice_aggregation.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 
 import pytest
+from loguru import logger
 from xr_ai_models import ChatMessage, ChatResponse
 from xr_ai_runtime import Agent, AgentRuntime, MessageMetadata, RuntimeContext, subscribe
 from xr_ai_voice import (
@@ -48,16 +49,19 @@ class _LLM:
 
 
 class _Recorder(Agent):
-    def __init__(self) -> None:
+    def __init__(self, gate: asyncio.Event | None = None) -> None:
         super().__init__()
         self.outputs: list[tuple[VoiceOutput, MessageMetadata]] = []
         self.changed = asyncio.Condition()
+        self.gate = gate
 
     @subscribe(VOICE_OUTPUT_TOPIC)
     async def record(self, output: VoiceOutput, ctx: RuntimeContext) -> None:
         async with self.changed:
             self.outputs.append((output, ctx.metadata))
             self.changed.notify_all()
+        if self.gate is not None:
+            await self.gate.wait()
 
     async def wait_for(self, count: int) -> None:
         async with self.changed:
@@ -69,21 +73,23 @@ class _Recorder(Agent):
 
 async def _start(
     llm: _LLM,
+    *,
+    output_gate: asyncio.Event | None = None,
     **kwargs,
 ) -> tuple[AgentRuntime, VoiceAggregationAgent, _Recorder]:
     kwargs.setdefault("speech_rate_wpm", 60_000.0)
     kwargs.setdefault("minimum_playback_s", 0.0)
+    kwargs.setdefault("coalesce_window_s", 0.01)
     runtime = AgentRuntime()
     aggregator = runtime.register(
         "voice-aggregation",
         VoiceAggregationAgent(
             llm=llm,  # type: ignore[arg-type]
-            coalesce_window_s=0.01,
             participant_idle_timeout_s=1.0,
             **kwargs,
         ),
     )
-    recorder = runtime.register("recorder", _Recorder())
+    recorder = runtime.register("recorder", _Recorder(output_gate))
     await runtime.start()
     return runtime, aggregator, recorder
 
@@ -177,10 +183,10 @@ async def test_participants_aggregate_independently() -> None:
     finally:
         await _stop(runtime, aggregator)
 
-    assert {
-        (metadata.participant_id, output.text)
-        for output, metadata in recorder.outputs
-    } == {("alice", "Alice update."), ("bob", "Bob update.")}
+    assert {(metadata.participant_id, output.text) for output, metadata in recorder.outputs} == {
+        ("alice", "Alice update."),
+        ("bob", "Bob update."),
+    }
     assert llm.calls == []
 
 
@@ -218,9 +224,7 @@ async def test_lone_stream_passes_through_while_pending_updates_coalesce() -> No
     finally:
         await _stop(runtime, aggregator)
 
-    first, second, stream_end, third, batch_end = [
-        output for output, _metadata in recorder.outputs
-    ]
+    first, second, stream_end, third, batch_end = [output for output, _metadata in recorder.outputs]
     assert first.text == "I can see "
     assert first.final is False
     assert first.response_id
@@ -351,9 +355,7 @@ async def test_updates_during_estimated_playback_coalesce_after_current_output()
     finally:
         await _stop(runtime, aggregator)
 
-    first, first_end, combined, combined_end = [
-        output for output, _metadata in recorder.outputs
-    ]
+    first, first_end, combined, combined_end = [output for output, _metadata in recorder.outputs]
     assert first.text == "This response remains active while it is spoken."
     assert first.final is False
     assert first_end == VoiceOutput(response_id=first.response_id)
@@ -393,6 +395,205 @@ async def test_pending_capacity_drops_oldest_across_all_buffered_work() -> None:
         ]
     finally:
         await _stop(runtime, aggregator)
+
+
+async def test_pending_capacity_preserves_urgent_work() -> None:
+    gate = asyncio.Event()
+    llm = _LLM()
+    runtime, aggregator, recorder = await _start(
+        llm,
+        output_gate=gate,
+        queue_capacity=2,
+    )
+    try:
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="Blocked output."),
+            participant_id="alice",
+            source="foreground",
+        )
+        await recorder.wait_for(1)
+        for text in ("Urgent one.", "Urgent two."):
+            await runtime.publish(
+                VOICE_CONTRIBUTION_TOPIC,
+                VoiceOutput(text=text, interrupt=True),
+                participant_id="alice",
+                source="safety",
+            )
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="Routine stream.", response_id="routine", final=False),
+            participant_id="alice",
+            source="monitor",
+        )
+
+        state = aggregator._states["alice"]
+        assert [item.output.text for item in state.pending] == [
+            "Urgent one.",
+            "Urgent two.",
+        ]
+        assert ("monitor", "routine") in state.discarded_streams
+
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="Urgent three.", interrupt=True),
+            participant_id="alice",
+            source="safety",
+        )
+        assert [item.output.text for item in state.pending] == [
+            "Urgent two.",
+            "Urgent three.",
+        ]
+    finally:
+        gate.set()
+        await _stop(runtime, aggregator)
+
+
+async def test_discarded_stream_does_not_resume_after_other_interrupts() -> None:
+    llm = _LLM()
+    runtime, aggregator, recorder = await _start(
+        llm,
+        queue_capacity=1,
+        stream_idle_timeout_s=0.2,
+    )
+    try:
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="A-start", response_id="A", final=False),
+            participant_id="alice",
+            source="stream",
+        )
+        await recorder.wait_for(1)
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(
+                text="B-start",
+                response_id="B",
+                final=False,
+                interrupt=True,
+            ),
+            participant_id="alice",
+            source="stream",
+        )
+        await recorder.wait_for(2)
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(
+                text="C-start",
+                response_id="C",
+                final=False,
+                interrupt=True,
+            ),
+            participant_id="alice",
+            source="stream",
+        )
+        await recorder.wait_for(3)
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="C-end", response_id="C"),
+            participant_id="alice",
+            source="stream",
+        )
+        await recorder.wait_for(5)
+
+        state = aggregator._states["alice"]
+        a_key = ("stream", "A")
+        old_expiry = state.discarded_streams[a_key]
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="A-stale-tail", response_id="A", final=False),
+            participant_id="alice",
+            source="stream",
+        )
+        await asyncio.sleep(0.02)
+        assert len(recorder.outputs) == 5
+        assert state.discarded_streams[a_key] > old_expiry
+
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(response_id="A"),
+            participant_id="alice",
+            source="stream",
+        )
+        for _ in range(100):
+            if a_key not in state.discarded_streams:
+                break
+            await asyncio.sleep(0.001)
+        assert a_key not in state.discarded_streams
+    finally:
+        await _stop(runtime, aggregator)
+
+    assert [output.text for output, _metadata in recorder.outputs] == [
+        "A-start",
+        "B-start",
+        "C-start",
+        "C-end",
+        "",
+    ]
+
+
+async def test_discarded_stream_can_restart_after_idle_expiry() -> None:
+    llm = _LLM()
+    runtime, aggregator, recorder = await _start(
+        llm,
+        queue_capacity=1,
+        stream_idle_timeout_s=0.03,
+    )
+    try:
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="A-old", response_id="A", final=False),
+            participant_id="alice",
+            source="stream",
+        )
+        await recorder.wait_for(1)
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(
+                text="B-start",
+                response_id="B",
+                final=False,
+                interrupt=True,
+            ),
+            participant_id="alice",
+            source="stream",
+        )
+        await recorder.wait_for(2)
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="B-end", response_id="B"),
+            participant_id="alice",
+            source="stream",
+        )
+        await recorder.wait_for(4)
+        await asyncio.sleep(0.04)
+
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="A-new", response_id="A", final=False),
+            participant_id="alice",
+            source="stream",
+        )
+        await recorder.wait_for(5)
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="A-end", response_id="A"),
+            participant_id="alice",
+            source="stream",
+        )
+        await recorder.wait_for(7)
+    finally:
+        await _stop(runtime, aggregator)
+
+    assert [output.text for output, _metadata in recorder.outputs] == [
+        "A-old",
+        "B-start",
+        "B-end",
+        "",
+        "A-new",
+        "A-end",
+        "",
+    ]
 
 
 async def test_release_cancels_only_departed_participant_state() -> None:
@@ -461,15 +662,21 @@ async def test_urgent_contribution_interrupts_active_stream() -> None:
     assert llm.calls == []
 
 
-async def test_urgent_batch_bypasses_rewrite() -> None:
-    llm = _LLM("This must not be used.")
+async def test_urgent_batch_speaks_alert_first_and_retains_routine_order() -> None:
+    llm = _LLM("Routine one, then routine two.")
     runtime, aggregator, recorder = await _start(llm)
     try:
         await runtime.publish(
             VOICE_CONTRIBUTION_TOPIC,
-            VoiceOutput(text="Routine update."),
+            VoiceOutput(text="Routine one."),
             participant_id="alice",
             source="monitor",
+        )
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="Routine two."),
+            participant_id="alice",
+            source="timer",
         )
         await runtime.publish(
             VOICE_CONTRIBUTION_TOPIC,
@@ -477,13 +684,44 @@ async def test_urgent_batch_bypasses_rewrite() -> None:
             participant_id="alice",
             source="safety",
         )
-        await recorder.wait_for(1)
+        await recorder.wait_for(4)
     finally:
         await _stop(runtime, aggregator)
 
-    assert recorder.outputs[0][0].text == "Routine update. Move away."
+    assert [output.text for output, _metadata in recorder.outputs] == [
+        "Move away.",
+        "",
+        "Routine one, then routine two.",
+        "",
+    ]
     assert recorder.outputs[0][0].interrupt is True
-    assert llm.calls == []
+    assert len(llm.calls) == 1
+    assert "Routine one." in str(llm.calls[0][0][-1].content)
+    assert "Routine two." in str(llm.calls[0][0][-1].content)
+    assert str(llm.calls[0][0][-1].content).index("Routine one.") < str(llm.calls[0][0][-1].content).index(
+        "Routine two."
+    )
+
+
+async def test_urgent_first_contribution_skips_coalescing_delay() -> None:
+    llm = _LLM()
+    runtime, aggregator, recorder = await _start(
+        llm,
+        coalesce_window_s=0.5,
+    )
+    try:
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="Move away.", interrupt=True),
+            participant_id="alice",
+            source="safety",
+        )
+        await asyncio.wait_for(recorder.wait_for(1), timeout=0.2)
+    finally:
+        await _stop(runtime, aggregator)
+
+    assert recorder.outputs[0][0].text == "Move away."
+    assert recorder.outputs[0][0].interrupt is True
 
 
 async def test_urgent_contribution_cancels_in_flight_rewrite() -> None:
@@ -540,6 +778,74 @@ async def test_rewrite_failure_preserves_all_updates() -> None:
         await _stop(runtime, aggregator)
 
     assert recorder.outputs[0][0].text == "First update. Second update."
+
+
+async def test_rewrite_timeout_is_enforced_around_service_call() -> None:
+    gate = asyncio.Event()
+    llm = _LLM(gate=gate)
+    runtime, aggregator, recorder = await _start(
+        llm,
+        rewrite_timeout_s=0.02,
+    )
+    try:
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="First update."),
+            participant_id="alice",
+            source="one",
+        )
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="Second update."),
+            participant_id="alice",
+            source="two",
+        )
+        await recorder.wait_for(1)
+    finally:
+        await _stop(runtime, aggregator)
+
+    assert llm.cancelled is True
+    assert recorder.outputs[0][0].text == "First update. Second update."
+    assert llm.calls[0][1]["timeout"] == 0.02
+
+
+@pytest.mark.parametrize("release", [False, True])
+async def test_shutdown_logs_prepublication_in_flight_work(release: bool) -> None:
+    gate = asyncio.Event()
+    llm = _LLM(gate=gate)
+    runtime, aggregator, _recorder = await _start(llm)
+    messages: list[str] = []
+    handler_id = logger.add(lambda message: messages.append(str(message)), level="WARNING")
+    try:
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="First update."),
+            participant_id="alice",
+            source="one",
+        )
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="Second update."),
+            participant_id="alice",
+            source="two",
+        )
+        await asyncio.wait_for(llm.started.wait(), 1.0)
+
+        if release:
+            await aggregator.release("alice")
+        else:
+            await aggregator.stop()
+    finally:
+        logger.remove(handler_id)
+        await aggregator.stop()
+        await runtime.stop()
+
+    reason = "participant release" if release else "shutdown"
+    assert any(
+        "discarded accepted voice contributions" in message and "count=2" in message and f"reason={reason}" in message
+        for message in messages
+    )
+    assert llm.cancelled is True
 
 
 async def test_contribution_after_stop_is_dropped_without_publisher_error() -> None:

--- a/tests/test_voice_aggregation.py
+++ b/tests/test_voice_aggregation.py
@@ -19,15 +19,31 @@ from xr_ai_voice import (
 
 
 class _LLM:
-    def __init__(self, content: str = "Combined update.", *, error: Exception | None = None) -> None:
+    def __init__(
+        self,
+        content: str = "Combined update.",
+        *,
+        error: Exception | None = None,
+        gate: asyncio.Event | None = None,
+    ) -> None:
         self.content = content
         self.error = error
+        self.gate = gate
+        self.started = asyncio.Event()
+        self.cancelled = False
         self.calls: list[tuple[tuple[ChatMessage, ...], dict]] = []
 
     async def chat(self, messages, **kwargs) -> ChatResponse:
         self.calls.append((tuple(messages), kwargs))
+        self.started.set()
         if self.error is not None:
             raise self.error
+        if self.gate is not None:
+            try:
+                await self.gate.wait()
+            except asyncio.CancelledError:
+                self.cancelled = True
+                raise
         return ChatResponse(self.content, None, None, "stop", {})
 
 
@@ -113,7 +129,7 @@ async def test_simultaneous_contributions_are_rewritten_once() -> None:
         )
         await runtime.publish(
             VOICE_CONTRIBUTION_TOPIC,
-            VoiceOutput(text="The timer is done.", interrupt=True, timestamp_us=10),
+            VoiceOutput(text="The timer is done.", timestamp_us=10),
             participant_id="alice",
             source="timer",
         )
@@ -123,7 +139,7 @@ async def test_simultaneous_contributions_are_rewritten_once() -> None:
 
     output = recorder.outputs[0][0]
     assert output.text == "Temperature rose to 24 degrees, and the timer is done."
-    assert output.interrupt is True
+    assert output.interrupt is False
     assert output.timestamp_us == 10
     assert output.final is False
     assert output.response_id
@@ -135,6 +151,7 @@ async def test_simultaneous_contributions_are_rewritten_once() -> None:
         "max_tokens": 192,
         "temperature": 0.0,
         "enable_thinking": False,
+        "timeout": 5.0,
     }
 
 
@@ -221,6 +238,88 @@ async def test_lone_stream_passes_through_while_pending_updates_coalesce() -> No
     assert len(llm.calls) == 1
 
 
+async def test_stream_buffered_during_playback_keeps_all_chunks() -> None:
+    llm = _LLM()
+    runtime, aggregator, recorder = await _start(
+        llm,
+        minimum_playback_s=0.08,
+    )
+    try:
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="Initial announcement."),
+            participant_id="alice",
+            source="foreground",
+        )
+        await recorder.wait_for(1)
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="Buffered ", response_id="view", final=False),
+            participant_id="alice",
+            source="foreground",
+        )
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="stream.", response_id="view"),
+            participant_id="alice",
+            source="foreground",
+        )
+        await recorder.wait_for(5)
+    finally:
+        await _stop(runtime, aggregator)
+
+    outputs = [output for output, _metadata in recorder.outputs]
+    assert outputs[1] == VoiceOutput(response_id=outputs[0].response_id)
+    assert outputs[2].text == "Buffered "
+    assert outputs[3] == VoiceOutput(
+        text="stream.",
+        response_id=outputs[2].response_id,
+        final=False,
+    )
+    assert outputs[4] == VoiceOutput(response_id=outputs[2].response_id)
+
+
+async def test_interleaved_streams_keep_each_stream_ordered() -> None:
+    llm = _LLM()
+    runtime, aggregator, recorder = await _start(llm)
+    try:
+        for source, response_id, text, final in (
+            ("one", "first", "First ", False),
+            ("two", "second", "Second ", False),
+            ("one", "first", "stream.", True),
+            ("two", "second", "stream.", True),
+        ):
+            await runtime.publish(
+                VOICE_CONTRIBUTION_TOPIC,
+                VoiceOutput(text=text, response_id=response_id, final=final),
+                participant_id="alice",
+                source=source,
+            )
+        await recorder.wait_for(6)
+    finally:
+        await _stop(runtime, aggregator)
+
+    outputs = [output for output, _metadata in recorder.outputs]
+    first_id = outputs[0].response_id
+    second_id = outputs[3].response_id
+    assert [output.text for output in outputs] == [
+        "First ",
+        "stream.",
+        "",
+        "Second ",
+        "stream.",
+        "",
+    ]
+    assert [output.response_id for output in outputs] == [
+        first_id,
+        first_id,
+        first_id,
+        second_id,
+        second_id,
+        second_id,
+    ]
+
+
 async def test_updates_during_estimated_playback_coalesce_after_current_output() -> None:
     llm = _LLM("Temperature changed, and the timer completed.")
     runtime, aggregator, recorder = await _start(
@@ -262,6 +361,38 @@ async def test_updates_during_estimated_playback_coalesce_after_current_output()
     assert combined.final is False
     assert combined_end == VoiceOutput(response_id=combined.response_id)
     assert len(llm.calls) == 1
+
+
+async def test_pending_capacity_drops_oldest_across_all_buffered_work() -> None:
+    llm = _LLM()
+    runtime, aggregator, recorder = await _start(
+        llm,
+        queue_capacity=2,
+        minimum_playback_s=0.2,
+    )
+    try:
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="Current response."),
+            participant_id="alice",
+            source="foreground",
+        )
+        await recorder.wait_for(1)
+        for index in range(5):
+            await runtime.publish(
+                VOICE_CONTRIBUTION_TOPIC,
+                VoiceOutput(text=f"Update {index}."),
+                participant_id="alice",
+                source="monitor",
+            )
+        state = aggregator._states["alice"]
+        assert len(state.pending) == 2
+        assert [item.output.text for item in state.pending] == [
+            "Update 3.",
+            "Update 4.",
+        ]
+    finally:
+        await _stop(runtime, aggregator)
 
 
 async def test_release_cancels_only_departed_participant_state() -> None:
@@ -330,6 +461,64 @@ async def test_urgent_contribution_interrupts_active_stream() -> None:
     assert llm.calls == []
 
 
+async def test_urgent_batch_bypasses_rewrite() -> None:
+    llm = _LLM("This must not be used.")
+    runtime, aggregator, recorder = await _start(llm)
+    try:
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="Routine update."),
+            participant_id="alice",
+            source="monitor",
+        )
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="Move away.", interrupt=True),
+            participant_id="alice",
+            source="safety",
+        )
+        await recorder.wait_for(1)
+    finally:
+        await _stop(runtime, aggregator)
+
+    assert recorder.outputs[0][0].text == "Routine update. Move away."
+    assert recorder.outputs[0][0].interrupt is True
+    assert llm.calls == []
+
+
+async def test_urgent_contribution_cancels_in_flight_rewrite() -> None:
+    gate = asyncio.Event()
+    llm = _LLM(gate=gate)
+    runtime, aggregator, recorder = await _start(llm)
+    try:
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="First routine update."),
+            participant_id="alice",
+            source="one",
+        )
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="Second routine update."),
+            participant_id="alice",
+            source="two",
+        )
+        await asyncio.wait_for(llm.started.wait(), 1.0)
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="Move away now.", interrupt=True),
+            participant_id="alice",
+            source="safety",
+        )
+        await recorder.wait_for(1)
+    finally:
+        await _stop(runtime, aggregator)
+
+    assert llm.cancelled is True
+    assert recorder.outputs[0][0].text == "Move away now."
+    assert recorder.outputs[0][0].interrupt is True
+
+
 async def test_rewrite_failure_preserves_all_updates() -> None:
     llm = _LLM(error=RuntimeError("model unavailable"))
     runtime, aggregator, recorder = await _start(llm)
@@ -353,6 +542,36 @@ async def test_rewrite_failure_preserves_all_updates() -> None:
     assert recorder.outputs[0][0].text == "First update. Second update."
 
 
+async def test_contribution_after_stop_is_dropped_without_publisher_error() -> None:
+    llm = _LLM()
+    runtime, aggregator, recorder = await _start(llm)
+    await aggregator.stop()
+    try:
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="Late update."),
+            participant_id="alice",
+            source="monitor",
+        )
+        await asyncio.sleep(0)
+    finally:
+        await runtime.stop()
+
+    assert recorder.outputs == []
+    assert aggregator._states == {}
+
+
+def test_playback_duration_uses_configured_ceiling() -> None:
+    aggregator = VoiceAggregationAgent(
+        llm=_LLM(),  # type: ignore[arg-type]
+        speech_rate_wpm=1.0,
+        minimum_playback_s=0.0,
+        maximum_playback_s=2.5,
+    )
+
+    assert aggregator._playback_duration("A very long response") == 2.5
+
+
 @pytest.mark.parametrize(
     ("kwargs", "message"),
     [
@@ -365,6 +584,12 @@ async def test_rewrite_failure_preserves_all_updates() -> None:
         ({"participant_idle_timeout_s": 0}, "participant idle timeout"),
         ({"speech_rate_wpm": 0}, "speech rate"),
         ({"minimum_playback_s": -1}, "minimum playback"),
+        ({"maximum_playback_s": 0}, "maximum playback"),
+        (
+            {"minimum_playback_s": 2, "maximum_playback_s": 1},
+            "minimum playback",
+        ),
+        ({"rewrite_timeout_s": 0}, "rewrite timeout"),
     ],
 )
 def test_configuration_validation(kwargs: dict, message: str) -> None:

--- a/tests/test_voice_aggregation.py
+++ b/tests/test_voice_aggregation.py
@@ -264,6 +264,36 @@ async def test_updates_during_estimated_playback_coalesce_after_current_output()
     assert len(llm.calls) == 1
 
 
+async def test_release_cancels_only_departed_participant_state() -> None:
+    llm = _LLM()
+    runtime, aggregator, recorder = await _start(
+        llm,
+        speech_rate_wpm=1.0,
+        minimum_playback_s=0.0,
+    )
+    try:
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="Long response for Alice."),
+            participant_id="alice",
+            source="foreground",
+        )
+        await runtime.publish(
+            VOICE_CONTRIBUTION_TOPIC,
+            VoiceOutput(text="Long response for Bob."),
+            participant_id="bob",
+            source="foreground",
+        )
+        await recorder.wait_for(2)
+
+        await aggregator.release("alice")
+
+        assert "alice" not in aggregator._states
+        assert "bob" in aggregator._states
+    finally:
+        await _stop(runtime, aggregator)
+
+
 async def test_urgent_contribution_interrupts_active_stream() -> None:
     llm = _LLM()
     runtime, aggregator, recorder = await _start(llm)


### PR DESCRIPTION
## Summary

- add an opt-in `VoiceAggregationAgent` and `VOICE_CONTRIBUTION_TOPIC`
- keep lone finite responses and urgent batches on a no-LLM fast path
- rewrite pending finite updates into one concise participant-scoped utterance
- pace active output with configurable bounded spoken-duration estimates
- preserve incremental stream ordering across buffered and interleaved contributions
- bound every participant's pending work with a priority-aware overflow policy
- let urgent output preempt active playback and cancel in-flight rewrites

## Why

`VoiceAgent` serializes responses per participant, but independent foreground, monitoring, timer, and alert agents can still enqueue unrelated utterances. Those messages may become stale or awkward before they are spoken. Applications need an explicit semantic layer before TTS that combines concurrent updates without moving application policy into the private media pipeline.

Producers opt in by publishing `VoiceOutput` payloads to `voice.contribution`; the aggregator is the only component that publishes the resulting stream to `voice.output`.

## Behavior

- aggregation state and pending capacity are independent per participant
- one finite contribution bypasses the LLM after a short coalescing window
- non-urgent updates arriving during estimated playback form the next batch
- multiple finite updates are rewritten once with bounded output, no thinking, and an explicit timeout
- urgent batches bypass rewriting; urgent arrival cancels an in-flight rewrite and supersedes active output
- a lone stream starts immediately with an aggregator-owned response ID
- matching stream chunks are found even when other contributions are interleaved in the bounded pending deque
- routine work never evicts urgent work; urgent-only overflow keeps the freshest alert
- discarded stream IDs remain quarantined through their terminator or a refreshed stream-idle expiry
- urgent finite output is spoken alone and first, with routine work restored in order
- idle exit is race-safe with concurrent enqueue
- shutdown and participant release count discarded pending and pre-publication in-flight work; contributions arriving after stop are logged and dropped
- model failures fall back to the original updates rather than dropping speech
- applications can call `release(participant_id)` for immediate participant cleanup

Pacing remains intentionally open-loop: the client/hub does not provide playback acknowledgements. Applications can configure `speech_rate_wpm`, `minimum_playback_s`, and `maximum_playback_s` for the selected TTS voice.

No sample is migrated in this PR. The viewer changes are being restored directly
to `main` in PR #389 after PR #386 was accidentally merged into this branch.
Sample PRs #363/#382 remain stacked above this PR and will be rebased after that
recovery lands.

## Review disposition

- buffered matching chunks and urgent interrupts are serviced without losing interleaved work
- `queue_capacity` now bounds the single pending deque; the unbounded backlog is removed
- urgent work bypasses/cancels rewriting
- idle-timeout enqueue races are closed
- shutdown/drop/discard accounting is explicit
- rewrites have a configurable deadline
- playback duration is configurable, validated, capped, and documented as an estimate
- priority-aware overload preserves urgent output and quarantines discarded stream tails deterministically
- urgent finite output is isolated from routine batches
- rewrite timeout is enforced locally even if a model implementation ignores the timeout parameter
- pre-publication in-flight work participates in shutdown/release discard accounting

## Validation

- `uv run --project tests pytest tests/test_voice_aggregation.py -q` — 36 passed
- Ruff 0.15.16 passes for the implementation and focused tests
- `git diff --check` passes
- the broader voice-runtime run passed its preceding ten tests before stalling in the unchanged `test_voice_agent_records_one_summary_for_finite_and_streamed_output`; no failure was observed
