### PR TITLE
feat(runtime): add live web events viewer

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -126,6 +126,17 @@ change, even when an individual dependency publishes newer Python wheels.
 - Optional dependency groups: none
 - Commands: none
 
+#### `xr-ai-web-events` — [`agent-sdk/xr-ai-web-events/`](agent-sdk/xr-ai-web-events/)
+
+- Python: `>=3.11,<3.13`
+- Build dependencies:
+  - `hatchling`
+- Runtime dependencies:
+  - `pydantic>=2.10`
+  - `xr-ai-agent-runtime` → [`xr-ai-agent-runtime`](agent-sdk/xr-ai-runtime/) (local, editable)
+- Optional dependency groups: none
+- Commands: none
+
 ### Utilities
 
 #### `xr-ai-launcher` — [`utils/xr-ai-launcher/`](utils/xr-ai-launcher/)
@@ -514,6 +525,7 @@ change, even when an individual dependency publishes newer Python wheels.
   - `xr-ai-models[riva]` → [`xr-ai-models`](agent-sdk/xr-ai-models/) (local, editable)
   - `xr-ai-tools[frames,image-editing,marker-tracking,services,vision]` → [`xr-ai-tools`](agent-sdk/xr-ai-tools/) (local, editable)
   - `xr-ai-voice` → [`xr-ai-voice`](agent-sdk/xr-ai-voice/) (local, editable)
+  - `xr-ai-web-events` → [`xr-ai-web-events`](agent-sdk/xr-ai-web-events/) (local, editable)
   - `xr-media-hub` → [`xr-media-hub`](services/xr-media-hub/) (local, editable)
   - `xr-ai-launcher` → [`xr-ai-launcher`](utils/xr-ai-launcher/) (local, editable)
   - `xr-ai-logging` → [`xr-ai-logging`](utils/xr-ai-logging/) (local, editable)

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -456,6 +456,7 @@ change, even when an individual dependency publishes newer Python wheels.
   - `xr-ai-models[riva]` → [`xr-ai-models`](agent-sdk/xr-ai-models/) (local, editable)
   - `xr-ai-tools[frames,vision]` → [`xr-ai-tools`](agent-sdk/xr-ai-tools/) (local, editable)
   - `xr-ai-voice` → [`xr-ai-voice`](agent-sdk/xr-ai-voice/) (local, editable)
+  - `xr-ai-web-events` → [`xr-ai-web-events`](agent-sdk/xr-ai-web-events/) (local, editable)
   - `xr-ai-voicegate` → [`xr-ai-voicegate`](utils/xr-ai-voicegate/) (local, editable)
   - `loguru>=0.7`
   - `pyyaml>=6.0`
@@ -503,6 +504,7 @@ change, even when an individual dependency publishes newer Python wheels.
   - `xr-ai-models` → [`xr-ai-models`](agent-sdk/xr-ai-models/) (local, editable)
   - `xr-ai-tools[frames,services,vision]` → [`xr-ai-tools`](agent-sdk/xr-ai-tools/) (local, editable)
   - `xr-ai-voice` → [`xr-ai-voice`](agent-sdk/xr-ai-voice/) (local, editable)
+  - `xr-ai-web-events` → [`xr-ai-web-events`](agent-sdk/xr-ai-web-events/) (local, editable)
   - `xr-ai-voicegate` → [`xr-ai-voicegate`](utils/xr-ai-voicegate/) (local, editable)
   - `xr-ai-logging` → [`xr-ai-logging`](utils/xr-ai-logging/) (local, editable)
   - `xr-render-scene` → [`xr-render-scene`](agent-samples/xr-render-demo/scene/) (local, editable)

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ frames are dropped if it is closed.
 | Agent runtime | `agent-sdk/xr-ai-runtime/` | Agent registration and typed pub/sub routing |
 | Models | `agent-sdk/xr-ai-models/` | Typed model protocols and OpenAI-compatible clients |
 | Voice | `agent-sdk/xr-ai-voice/` | Voice agent, session, transport, and pipeline |
+| Web events | `agent-sdk/xr-ai-web-events/` | Live participant/topic browser views over selected agent events |
 | Agent tools | `agent-sdk/xr-ai-tools/` | Toolkit-independent Relay-managed native tools, including QR-code extraction |
 | Reusable services | `services/` | Model-serving and typed capability processes |
 | Agent demos | `agent-samples/` | End-to-end agent pipelines |

--- a/agent-samples/simple-vlm-example/README.md
+++ b/agent-samples/simple-vlm-example/README.md
@@ -43,7 +43,9 @@ uv run simple_vlm_example
 ```
 
 Open the web client shown in the hub banner, connect, and then speak or type a
-question.
+question. The worker also serves a live participant-aware conversation view at
+`http://127.0.0.1:8092`; `web_events_host` and `web_events_port` in
+`yaml/simple_vlm_example_worker.yaml` configure that listener.
 
 The worker and orchestrator consume the deployment profile selected by
 `models_config` in `yaml/simple_vlm_example_worker.yaml`:

--- a/agent-samples/simple-vlm-example/worker/pyproject.toml
+++ b/agent-samples/simple-vlm-example/worker/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "xr-ai-models[riva]",
     "xr-ai-tools[frames,vision]",
     "xr-ai-voice",
+    "xr-ai-web-events",
     "xr-ai-voicegate",
     "loguru>=0.7",
     "pyyaml>=6.0",
@@ -29,6 +30,7 @@ xr-ai-logging   = { path = "../../../utils/xr-ai-logging", editable = true }
 xr-ai-models    = { path = "../../../agent-sdk/xr-ai-models", editable = true }
 xr-ai-tools     = { path = "../../../agent-sdk/xr-ai-tools", editable = true }
 xr-ai-voice     = { path = "../../../agent-sdk/xr-ai-voice", editable = true }
+xr-ai-web-events = { path = "../../../agent-sdk/xr-ai-web-events", editable = true }
 xr-ai-voicegate = { path = "../../../utils/xr-ai-voicegate", editable = true }
 
 [project.scripts]

--- a/agent-samples/simple-vlm-example/worker/simple_vlm_example_worker/app.py
+++ b/agent-samples/simple-vlm-example/worker/simple_vlm_example_worker/app.py
@@ -14,12 +14,20 @@ import nemo_relay
 from loguru import logger
 from xr_ai_logging import setup_logging
 from xr_ai_models import load_models_config, make_stt, make_tts, make_vlm
-from xr_ai_runtime import AgentRuntime
+from xr_ai_runtime import Agent, AgentRuntime, RuntimeContext, subscribe
 from xr_ai_tools.current_frame import CurrentFrameTool
 from xr_ai_tools.image import ImageRegistry
 from xr_ai_tools.vision import StreamingImageQueryTool
-from xr_ai_voice import HubVoiceTransport, VadConfig, VoiceAgent
+from xr_ai_voice import (
+    VOICE_OUTPUT_TOPIC,
+    HubVoiceTransport,
+    UserQuery,
+    VadConfig,
+    VoiceAgent,
+    VoiceOutput,
+)
 from xr_ai_voicegate import load_voice_gate_config
+from xr_ai_web_events import WEB_EVENT_TOPIC, WebEvent, WebEventsAgent
 
 from .agent import (
     INTERRUPTED_TOPIC,
@@ -28,6 +36,38 @@ from .agent import (
     SimpleVlmAgent,
 )
 from .config import WorkerConfig
+
+
+class _SimpleVlmWebEvents(Agent):
+    """Select user-visible conversation events for the live viewer."""
+
+    @subscribe(USER_QUERY_TOPIC)
+    async def user_query(self, query: UserQuery, ctx: RuntimeContext) -> None:
+        await ctx.publish(
+            WEB_EVENT_TOPIC,
+            WebEvent(
+                topic="simple-vlm.query",
+                title="User queries",
+                payload={"text": query.text},
+            ),
+        )
+
+    @subscribe(VOICE_OUTPUT_TOPIC)
+    async def assistant_output(
+        self,
+        output: VoiceOutput,
+        ctx: RuntimeContext,
+    ) -> None:
+        if not output.text:
+            return
+        await ctx.publish(
+            WEB_EVENT_TOPIC,
+            WebEvent(
+                topic="simple-vlm.response",
+                title="VLM responses",
+                payload={"text": output.text, "final": output.final},
+            ),
+        )
 
 
 @asynccontextmanager
@@ -116,13 +156,24 @@ async def run_app(
         ),
     )
     runtime.register("voice", voice)
+    viewer = runtime.register(
+        "web-events",
+        WebEventsAgent(
+            host=config.web_events_host,
+            port=config.web_events_port,
+            title="Simple VLM events",
+        ),
+    )
+    runtime.register("web-events-publisher", _SimpleVlmWebEvents())
 
     logger.info("Relay events → {}", log_file.parent / "relay-events.jsonl")
     logger.info("simple-vlm-example starting")
     async with _relay_event_log(log_file):
-        async with runtime:
-            try:
-                await voice.run(runtime)
-            finally:
-                await simple_vlm.stop()
+        async with viewer:
+            logger.info("Web events → {}", viewer.url)
+            async with runtime:
+                try:
+                    await voice.run(runtime)
+                finally:
+                    await simple_vlm.stop()
     logger.info("simple-vlm-example stopped")

--- a/agent-samples/simple-vlm-example/worker/simple_vlm_example_worker/config.py
+++ b/agent-samples/simple-vlm-example/worker/simple_vlm_example_worker/config.py
@@ -27,6 +27,8 @@ class WorkerConfig:
     min_speech: float
     silero_threshold: float
     idle_timeout_secs: float | None
+    web_events_host: str
+    web_events_port: int
 
 
 def _resolve(config_path: Path | None, raw: str) -> Path:
@@ -78,4 +80,6 @@ def load_config(path: Path | None) -> WorkerConfig:
         min_speech=float(data.get("min_speech", 0.1)),
         silero_threshold=float(data.get("silero_threshold", 0.5)),
         idle_timeout_secs=float(idle_timeout) if idle_timeout else None,
+        web_events_host=str(data.get("web_events_host", "127.0.0.1")),
+        web_events_port=int(data.get("web_events_port", 8092)),
     )

--- a/agent-samples/simple-vlm-example/yaml/simple_vlm_example_worker.yaml
+++ b/agent-samples/simple-vlm-example/yaml/simple_vlm_example_worker.yaml
@@ -37,3 +37,8 @@ min_speech:        0.1    # minimum seconds of speech before STT is called
 # (e.g. 300 for 5 min) to opt in; the worker then tears the pipeline down
 # after that long idle. Applied by VoiceAgent.
 idle_timeout_secs: 0
+
+# Live conversation event viewer. Keep the default loopback binding and use an
+# SSH tunnel for remote development; see docs/source/getting_started/networking.md.
+web_events_host: 127.0.0.1
+web_events_port: 8092

--- a/agent-samples/xr-render-demo/worker/pyproject.toml
+++ b/agent-samples/xr-render-demo/worker/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "xr-ai-models",
     "xr-ai-tools[frames,services,vision]",
     "xr-ai-voice",
+    "xr-ai-web-events",
     "xr-ai-voicegate",
     "xr-ai-logging",
     "xr-render-scene",
@@ -28,6 +29,7 @@ xr-ai-hub-client        = { path = "../../../agent-sdk/xr-ai-hub",              
 xr-ai-models       = { path = "../../../agent-sdk/xr-ai-models",       editable = true }
 xr-ai-tools        = { path = "../../../agent-sdk/xr-ai-tools",        editable = true }
 xr-ai-voice        = { path = "../../../agent-sdk/xr-ai-voice",        editable = true }
+xr-ai-web-events   = { path = "../../../agent-sdk/xr-ai-web-events",   editable = true }
 xr-ai-voicegate    = { path = "../../../utils/xr-ai-voicegate",        editable = true }
 xr-ai-logging      = { path = "../../../utils/xr-ai-logging",          editable = true }
 xr-render-scene    = { path = "../scene",                              editable = true }

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/__main__.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/__main__.py
@@ -13,14 +13,18 @@ from pathlib import Path
 from loguru import logger
 from xr_ai_logging import setup_logging
 from xr_ai_models import ChatMessage, load_models_config, make_llm, make_stt, make_tts, make_vlm
-from xr_ai_runtime import AgentRuntime
+from xr_ai_runtime import Agent, AgentRuntime, RuntimeContext, subscribe
 from xr_ai_tools.tool_calling import tool_definitions
 from xr_ai_voice import (
+    VOICE_OUTPUT_TOPIC,
     HubVoiceTransport,
+    UserQuery,
     VadConfig,
     VoiceAgent,
+    VoiceOutput,
 )
 from xr_ai_voicegate import load_voice_gate_config
+from xr_ai_web_events import WEB_EVENT_TOPIC, WebEvent, WebEventsAgent
 
 from .agent import (
     INTERRUPTED_TOPIC,
@@ -41,6 +45,38 @@ from .tools import NativeCapabilities
 _TRACE_FILE = "/tmp/xr-agent-trace.log"
 
 _PROMPT_FILE = Path(__file__).resolve().parent / "prompts" / "system.txt"
+
+
+class _RenderWebEvents(Agent):
+    """Select XR requests and spoken agent output for the live viewer."""
+
+    @subscribe(USER_QUERY_TOPIC)
+    async def user_query(self, query: UserQuery, ctx: RuntimeContext) -> None:
+        await ctx.publish(
+            WEB_EVENT_TOPIC,
+            WebEvent(
+                topic="xr-render.query",
+                title="XR requests",
+                payload={"text": query.text},
+            ),
+        )
+
+    @subscribe(VOICE_OUTPUT_TOPIC)
+    async def assistant_output(
+        self,
+        output: VoiceOutput,
+        ctx: RuntimeContext,
+    ) -> None:
+        if not output.text:
+            return
+        await ctx.publish(
+            WEB_EVENT_TOPIC,
+            WebEvent(
+                topic="xr-render.response",
+                title="XR agent responses",
+                payload={"text": output.text, "final": output.final},
+            ),
+        )
 
 
 async def _probe_warmed_llm(llm, *, warmup: bool) -> bool:
@@ -159,6 +195,15 @@ async def main(
         runtime = AgentRuntime()
         runtime.register("voice", voice)
         render = runtime.register("xr-render", RenderAgent(scene_loop))
+        viewer = runtime.register(
+            "web-events",
+            WebEventsAgent(
+                host=cfg.web_events_host,
+                port=cfg.web_events_port,
+                title="XR render events",
+            ),
+        )
+        runtime.register("web-events-publisher", _RenderWebEvents())
         # The endpoint retains this bound callback for the worker lifetime.
         XRSessionLifecycle(
             transport=transport,
@@ -169,12 +214,14 @@ async def main(
         )
 
         logger.info("xr_render_demo starting")
-        async with runtime:
-            try:
-                voice_run_started = True
-                await voice.run(runtime)
-            finally:
-                await render.stop()
+        async with viewer:
+            logger.info("Web events → {}", viewer.url)
+            async with runtime:
+                try:
+                    voice_run_started = True
+                    await voice.run(runtime)
+                finally:
+                    await render.stop()
     finally:
         cleanup = [
             capabilities.close(),

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/config.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/config.py
@@ -31,6 +31,9 @@ class WorkerConfig:
     # session is never cancelled for inactivity. A positive value opts in.
     idle_timeout_secs: float | None
 
+    web_events_host: str
+    web_events_port: int
+
 
 def load_models(path: pathlib.Path | None) -> ModelsConfig:
     """Effective models config for the worker YAML at ``path``.
@@ -64,6 +67,8 @@ def load_config(path: pathlib.Path | None) -> WorkerConfig:
         # 0 / unset → disabled (None); a positive value opts into idle cancel.
         idle_timeout_secs = (float(data["idle_timeout_secs"])
                              if data.get("idle_timeout_secs") else None),
+        web_events_host = str(data.get("web_events_host", "127.0.0.1")),
+        web_events_port = int(data.get("web_events_port", 8092)),
     )
 
 

--- a/agent-samples/xr-render-demo/yaml/xr_render_demo_worker.yaml
+++ b/agent-samples/xr-render-demo/yaml/xr_render_demo_worker.yaml
@@ -60,3 +60,8 @@ silero_threshold:  0.3
 # (e.g. 300 for 5 min) to opt in; the worker then tears the pipeline down
 # after that long idle. VoiceAgent owns the timeout.
 idle_timeout_secs: 0
+
+# Live request/response event viewer. Keep the default loopback binding and use
+# an SSH tunnel for remote development; see docs/source/getting_started/networking.md.
+web_events_host: 127.0.0.1
+web_events_port: 8092

--- a/agent-sdk/xr-ai-web-events/README.md
+++ b/agent-sdk/xr-ai-web-events/README.md
@@ -49,6 +49,10 @@ and topic views. `/api/events?after=<sequence>` reports cursor rollover so a
 browser can recover after falling behind the bounded store. `/healthz` reports
 whether the HTTP listener can answer requests.
 
+The shipped `simple-vlm-example` worker publishes participant-scoped VLM queries
+and response chunks, while `xr-render-demo` publishes XR requests and spoken
+agent output. Both configure and start their viewer from the sample worker YAML.
+
 The listener has no application authentication or TLS. Its loopback default is
 intentional because payloads may contain speech transcripts or camera-derived
 text. For remote development, keep it on loopback and use an SSH tunnel:

--- a/agent-sdk/xr-ai-web-events/README.md
+++ b/agent-sdk/xr-ai-web-events/README.md
@@ -59,4 +59,6 @@ ssh -L 8092:127.0.0.1:8092 user@xr-host
 
 Do not bind it to `0.0.0.0` on an untrusted network. A remotely exposed viewer
 needs an authenticated TLS reverse proxy chosen by the deployment owner; it
-does not reuse the media hub's participant credentials.
+does not reuse the media hub's participant credentials. The server also rejects
+unrecognized HTTP `Host` names. A reverse proxy must preserve a configured host,
+use a literal listener address, or rewrite `Host` to `127.0.0.1`.

--- a/agent-sdk/xr-ai-web-events/README.md
+++ b/agent-sdk/xr-ai-web-events/README.md
@@ -1,0 +1,62 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# xr-ai-web-events
+
+`xr-ai-web-events` provides a read-only browser view for selected typed runtime
+events. It groups live output by participant and presentation topic without
+tailing application files or entering model, voice, or media paths. The bounded
+in-memory history is for observation only; durable output remains an
+application responsibility.
+
+Applications opt in explicitly by publishing compact JSON-compatible payloads
+to `WEB_EVENT_TOPIC`:
+
+```python
+from xr_ai_web_events import WEB_EVENT_TOPIC, WebEvent, WebEventsAgent
+
+viewer = runtime.register(
+    "web-events",
+    WebEventsAgent(title="Lab instrument events"),
+)
+
+
+async def report_reading(reading, ctx) -> None:
+    await ctx.publish(
+        WEB_EVENT_TOPIC,
+        WebEvent(
+            topic="instruments.readings",
+            title="Instrument readings",
+            payload=reading.model_dump(mode="json"),
+        ),
+    )
+
+
+async with viewer:
+    async with runtime:
+        await run_application()
+```
+
+The server defaults to `http://127.0.0.1:8092`. Start it before the worker
+announces readiness so a bind failure fails the worker instead of leaving a
+partially ready stack. `start()` and `stop()` are idempotent, and the agent is
+also an async context manager.
+
+The page polls the same-origin read-only API and dynamically creates participant
+and topic views. `/api/events?after=<sequence>` reports cursor rollover so a
+browser can recover after falling behind the bounded store. `/healthz` reports
+whether the HTTP listener can answer requests.
+
+The listener has no application authentication or TLS. Its loopback default is
+intentional because payloads may contain speech transcripts or camera-derived
+text. For remote development, keep it on loopback and use an SSH tunnel:
+
+```bash
+ssh -L 8092:127.0.0.1:8092 user@xr-host
+```
+
+Do not bind it to `0.0.0.0` on an untrusted network. A remotely exposed viewer
+needs an authenticated TLS reverse proxy chosen by the deployment owner; it
+does not reuse the media hub's participant credentials.

--- a/agent-sdk/xr-ai-web-events/pyproject.toml
+++ b/agent-sdk/xr-ai-web-events/pyproject.toml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "xr-ai-web-events"
+version = "0.1.0"
+description = "Live browser viewer for typed XR AI agent events."
+requires-python = ">=3.11,<3.13"
+dependencies = [
+    "pydantic>=2.10",
+    "xr-ai-agent-runtime",
+]
+
+[tool.uv.sources]
+xr-ai-agent-runtime = { path = "../xr-ai-runtime", editable = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["xr_ai_web_events"]

--- a/agent-sdk/xr-ai-web-events/xr_ai_web_events/__init__.py
+++ b/agent-sdk/xr-ai-web-events/xr_ai_web_events/__init__.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Live, participant-aware browser views over typed agent events."""
+
+from ._agent import WebEventsAgent
+from ._models import WEB_EVENT_TOPIC, WebEvent
+
+__all__ = [
+    "WEB_EVENT_TOPIC",
+    "WebEvent",
+    "WebEventsAgent",
+]

--- a/agent-sdk/xr-ai-web-events/xr_ai_web_events/_agent.py
+++ b/agent-sdk/xr-ai-web-events/xr_ai_web_events/_agent.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Agent and lifecycle for the live web-events viewer."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from types import TracebackType
+
+from xr_ai_runtime import Agent, RuntimeContext, subscribe
+
+from ._models import WEB_EVENT_TOPIC, WebEvent
+from ._server import _WebEventsServer
+from ._store import _EventStore
+
+
+class WebEventsAgent(Agent):
+    """Serve selected runtime events in a bounded participant-aware web view."""
+
+    def __init__(
+        self,
+        *,
+        host: str = "127.0.0.1",
+        port: int = 8092,
+        max_events: int = 5_000,
+        title: str = "XR AI Agent Events",
+    ) -> None:
+        if not host.strip():
+            raise ValueError("web-events host must not be empty")
+        if not 0 <= port <= 65_535:
+            raise ValueError("web-events port must be between 0 and 65535")
+        if max_events <= 0:
+            raise ValueError("web-events max_events must be positive")
+        if not title.strip():
+            raise ValueError("web-events title must not be empty")
+        super().__init__()
+        self.host = host.strip()
+        self.port = port
+        self.max_events = max_events
+        self.title = title.strip()
+        self._store = _EventStore(max_events)
+        self._server: _WebEventsServer | None = None
+        self._thread: threading.Thread | None = None
+        self._lifecycle_lock = asyncio.Lock()
+
+    @property
+    def running(self) -> bool:
+        """Whether the HTTP server is currently running."""
+
+        thread = self._thread
+        return self._server is not None and thread is not None and thread.is_alive()
+
+    @property
+    def url(self) -> str:
+        """Return the configured or currently bound HTTP URL."""
+
+        server = self._server
+        if server is None:
+            host, port = self.host, self.port
+        else:
+            host, port = server.server_address[:2]
+        return f"http://{host}:{port}"
+
+    async def start(self) -> None:
+        """Bind the HTTP listener and start serving the viewer."""
+
+        async with self._lifecycle_lock:
+            if self.running:
+                return
+            server = _WebEventsServer(
+                (self.host, self.port),
+                store=self._store,
+                title=self.title,
+            )
+            thread = threading.Thread(
+                target=server.serve_forever,
+                kwargs={"poll_interval": 0.1},
+                name="xr-ai-web-events",
+                daemon=True,
+            )
+            try:
+                thread.start()
+            except Exception:
+                server.server_close()
+                raise
+            self._server = server
+            self._thread = thread
+
+    async def stop(self) -> None:
+        """Stop the HTTP listener without discarding retained events."""
+
+        async with self._lifecycle_lock:
+            server = self._server
+            thread = self._thread
+            if server is None:
+                return
+            self._server = None
+            self._thread = None
+            if thread is not None and thread.is_alive():
+                await asyncio.to_thread(server.shutdown)
+            server.server_close()
+            if thread is not None:
+                await asyncio.to_thread(thread.join)
+
+    async def __aenter__(self) -> WebEventsAgent:
+        """Start the viewer and return this agent."""
+
+        await self.start()
+        return self
+
+    async def __aexit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        _exc: BaseException | None,
+        _traceback: TracebackType | None,
+    ) -> None:
+        """Stop the viewer when its application scope exits."""
+
+        await self.stop()
+
+    @subscribe(WEB_EVENT_TOPIC)
+    async def _capture(self, event: WebEvent, ctx: RuntimeContext) -> None:
+        self._store.append(event, ctx.metadata)
+
+
+__all__ = ["WebEventsAgent"]

--- a/agent-sdk/xr-ai-web-events/xr_ai_web_events/_agent.py
+++ b/agent-sdk/xr-ai-web-events/xr_ai_web_events/_agent.py
@@ -96,10 +96,32 @@ class WebEventsAgent(Agent):
             thread = self._thread
             if server is None:
                 return
-            self._server = None
-            self._thread = None
+            cleanup = asyncio.create_task(
+                self._close_server(server, thread),
+                name="xr-ai-web-events-stop",
+            )
+            try:
+                await asyncio.shield(cleanup)
+            except asyncio.CancelledError:
+                # The listener owns potentially sensitive in-memory data. Do
+                # not abandon its socket when the surrounding worker is being
+                # cancelled; finish cleanup before propagating cancellation.
+                await cleanup
+                raise
+            finally:
+                if cleanup.done():
+                    self._server = None
+                    self._thread = None
+
+    @staticmethod
+    async def _close_server(
+        server: _WebEventsServer,
+        thread: threading.Thread | None,
+    ) -> None:
+        try:
             if thread is not None and thread.is_alive():
                 await asyncio.to_thread(server.shutdown)
+        finally:
             server.server_close()
             if thread is not None:
                 await asyncio.to_thread(thread.join)

--- a/agent-sdk/xr-ai-web-events/xr_ai_web_events/_models.py
+++ b/agent-sdk/xr-ai-web-events/xr_ai_web_events/_models.py
@@ -10,7 +10,7 @@ from xr_ai_runtime import Topic
 class WebEvent(BaseModel):
     """One application event selected for the live browser view."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", allow_inf_nan=False)
 
     topic: str = Field(min_length=1, max_length=160)
     """Stable presentation topic used to group the event in the browser."""

--- a/agent-sdk/xr-ai-web-events/xr_ai_web_events/_models.py
+++ b/agent-sdk/xr-ai-web-events/xr_ai_web_events/_models.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed input accepted by the web-events viewer."""
+
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, field_validator
+from xr_ai_runtime import Topic
+
+
+class WebEvent(BaseModel):
+    """One application event selected for the live browser view."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    topic: str = Field(min_length=1, max_length=160)
+    """Stable presentation topic used to group the event in the browser."""
+
+    payload: dict[str, JsonValue] = Field(default_factory=dict)
+    """JSON-compatible application payload rendered by the browser."""
+
+    title: str | None = Field(default=None, min_length=1, max_length=120)
+    """Optional human-readable title for the presentation topic."""
+
+    @field_validator("topic", "title")
+    @classmethod
+    def _strip_nonempty(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("web event topic and title must not be blank")
+        return stripped
+
+
+WEB_EVENT_TOPIC = Topic("web-events.event", WebEvent, telemetry="none")
+"""Shared runtime topic consumed by :class:`WebEventsAgent`."""
+
+
+__all__ = ["WEB_EVENT_TOPIC", "WebEvent"]

--- a/agent-sdk/xr-ai-web-events/xr_ai_web_events/_server.py
+++ b/agent-sdk/xr-ai-web-events/xr_ai_web_events/_server.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from ipaddress import ip_address
 from pathlib import Path
 from typing import Any, cast
 from urllib.parse import parse_qs, urlparse
@@ -25,6 +26,29 @@ _CSP = (
     "frame-ancestors 'none'; img-src 'self' data:; object-src 'none'; "
     "script-src 'self'; style-src 'self'"
 )
+_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+_WILDCARD_HOSTS = frozenset({"", "0.0.0.0", "::"})
+
+
+def _normalized_host(value: str) -> str:
+    return value.strip().lower().rstrip(".").strip("[]")
+
+
+def _is_ip_literal(value: str) -> bool:
+    try:
+        ip_address(value)
+    except ValueError:
+        return False
+    return True
+
+
+def _is_loopback(value: str) -> bool:
+    if value in _LOOPBACK_HOSTS:
+        return True
+    try:
+        return ip_address(value).is_loopback
+    except ValueError:
+        return False
 
 
 class _WebEventsServer(ThreadingHTTPServer):
@@ -40,6 +64,23 @@ class _WebEventsServer(ThreadingHTTPServer):
         self.store = store
         self.viewer_title = title
         super().__init__(address, _WebEventsHandler)
+        self.listener_host = _normalized_host(address[0])
+        self.bound_host = _normalized_host(str(self.server_address[0]))
+
+    def _host_is_allowed(self, requested_host: str) -> bool:
+        """Reject DNS names that were not selected as listener identities."""
+
+        host = _normalized_host(requested_host)
+        if not host:
+            return False
+        if self.listener_host in _WILDCARD_HOSTS:
+            # A wildcard listener has no single external identity. Permit
+            # literal addresses for direct private-network access, but reject
+            # arbitrary DNS names that can be rebound to this listener.
+            return host == "localhost" or _is_ip_literal(host)
+        if _is_loopback(self.listener_host):
+            return _is_loopback(host)
+        return host in {self.listener_host, self.bound_host}
 
 
 class _WebEventsHandler(BaseHTTPRequestHandler):
@@ -47,6 +88,9 @@ class _WebEventsHandler(BaseHTTPRequestHandler):
     sys_version = ""
 
     def do_GET(self) -> None:  # noqa: N802
+        if not self._valid_host():
+            self.send_error(HTTPStatus.BAD_REQUEST, "unrecognized Host header")
+            return
         request = urlparse(self.path)
         if request.path == "/healthz":
             self._json({"status": "ok"})
@@ -75,6 +119,29 @@ class _WebEventsHandler(BaseHTTPRequestHandler):
 
     def log_message(self, _format: str, *_args: object) -> None:
         return
+
+    def _valid_host(self) -> bool:
+        values = self.headers.get_all("Host", failobj=[])
+        if len(values) != 1:
+            return False
+        raw_host = values[0].strip()
+        try:
+            parsed = urlparse(f"//{raw_host}")
+            # Reading .port validates a numeric, in-range port when supplied.
+            _ = parsed.port
+        except ValueError:
+            return False
+        if (
+            parsed.hostname is None
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.path
+            or parsed.query
+            or parsed.fragment
+        ):
+            return False
+        server = cast(_WebEventsServer, self.server)
+        return server._host_is_allowed(parsed.hostname)
 
     def _events(self, query: str) -> None:
         values = parse_qs(query)

--- a/agent-sdk/xr-ai-web-events/xr_ai_web_events/_server.py
+++ b/agent-sdk/xr-ai-web-events/xr_ai_web_events/_server.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Read-only HTTP server for the live web-events page."""
+
+from __future__ import annotations
+
+import json
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, cast
+from urllib.parse import parse_qs, urlparse
+
+from ._store import _EventStore
+
+_STATIC = Path(__file__).with_name("static")
+_ASSETS = {
+    "/": ("index.html", "text/html; charset=utf-8"),
+    "/app.js": ("app.js", "text/javascript; charset=utf-8"),
+    "/style.css": ("style.css", "text/css; charset=utf-8"),
+}
+_CSP = (
+    "default-src 'self'; base-uri 'none'; connect-src 'self'; "
+    "frame-ancestors 'none'; img-src 'self' data:; object-src 'none'; "
+    "script-src 'self'; style-src 'self'"
+)
+
+
+class _WebEventsServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(
+        self,
+        address: tuple[str, int],
+        *,
+        store: _EventStore,
+        title: str,
+    ) -> None:
+        self.store = store
+        self.viewer_title = title
+        super().__init__(address, _WebEventsHandler)
+
+
+class _WebEventsHandler(BaseHTTPRequestHandler):
+    server_version = "XR-AI-Web-Events"
+    sys_version = ""
+
+    def do_GET(self) -> None:  # noqa: N802
+        request = urlparse(self.path)
+        if request.path == "/healthz":
+            self._json({"status": "ok"})
+            return
+        if request.path == "/api/events":
+            self._events(request.query)
+            return
+        asset = _ASSETS.get(request.path)
+        if asset is None:
+            self.send_error(HTTPStatus.NOT_FOUND)
+            return
+        name, content_type = asset
+        payload = (_STATIC / name).read_bytes()
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def end_headers(self) -> None:
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Security-Policy", _CSP)
+        self.send_header("Referrer-Policy", "no-referrer")
+        self.send_header("X-Content-Type-Options", "nosniff")
+        super().end_headers()
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+    def _events(self, query: str) -> None:
+        values = parse_qs(query)
+        raw_after = values.get("after", ["0"])[0]
+        try:
+            after = int(raw_after)
+        except ValueError:
+            self.send_error(HTTPStatus.BAD_REQUEST, "after must be an integer")
+            return
+        if after < 0:
+            self.send_error(HTTPStatus.BAD_REQUEST, "after must not be negative")
+            return
+        server = cast(_WebEventsServer, self.server)
+        response = server.store.after(after)
+        response["title"] = server.viewer_title
+        self._json(response)
+
+    def _json(self, value: dict[str, Any]) -> None:
+        payload = json.dumps(
+            value,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode()
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)

--- a/agent-sdk/xr-ai-web-events/xr_ai_web_events/_store.py
+++ b/agent-sdk/xr-ai-web-events/xr_ai_web_events/_store.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bounded thread-safe storage for live web events."""
+
+from __future__ import annotations
+
+import threading
+from collections import deque
+from dataclasses import dataclass
+from typing import Any
+
+from xr_ai_runtime import MessageMetadata
+
+from ._models import WebEvent
+
+
+@dataclass(frozen=True, slots=True)
+class _StoredEvent:
+    sequence: int
+    event: WebEvent
+    metadata: MessageMetadata
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "sequence": self.sequence,
+            "topic": self.event.topic,
+            "title": self.event.title,
+            "participant_id": self.metadata.participant_id,
+            "source": self.metadata.source,
+            "timestamp_us": self.metadata.timestamp_us,
+            "message_id": self.metadata.message_id,
+            "correlation_id": self.metadata.correlation_id,
+            "parent_message_id": self.metadata.parent_message_id,
+            "payload": self.event.payload,
+        }
+
+
+class _EventStore:
+    def __init__(self, capacity: int) -> None:
+        self._events: deque[_StoredEvent] = deque(maxlen=capacity)
+        self._next_sequence = 1
+        self._lock = threading.Lock()
+
+    def append(self, event: WebEvent, metadata: MessageMetadata) -> None:
+        with self._lock:
+            self._events.append(
+                _StoredEvent(
+                    sequence=self._next_sequence,
+                    event=event.model_copy(deep=True),
+                    metadata=metadata,
+                )
+            )
+            self._next_sequence += 1
+
+    def after(self, sequence: int) -> dict[str, Any]:
+        with self._lock:
+            latest = self._next_sequence - 1
+            oldest = self._events[0].sequence if self._events else self._next_sequence
+            reset = sequence > latest or sequence < oldest - 1
+            threshold = oldest - 1 if reset else sequence
+            events = [item.as_dict() for item in self._events if item.sequence > threshold]
+            return {
+                "events": events,
+                "cursor": latest,
+                "oldest": oldest,
+                "reset": reset,
+            }

--- a/agent-sdk/xr-ai-web-events/xr_ai_web_events/static/app.js
+++ b/agent-sdk/xr-ai-web-events/xr_ai_web_events/static/app.js
@@ -14,6 +14,8 @@ const viewerTitle = document.querySelector('#viewer-title');
 const MAX_BROWSER_EVENTS = 2000;
 let events = [];
 let cursor = 0;
+const paneKeys = new WeakMap();
+const scrollPositions = new Map();
 
 function participantName(event) {
   return event.participant_id || 'Global';
@@ -43,6 +45,16 @@ function topicKey(event) {
 
 function render() {
   refreshParticipantOptions();
+  if (!follow.checked) {
+    grid.querySelectorAll('.topic-pane').forEach((pane) => {
+      const key = paneKeys.get(pane);
+      if (key) scrollPositions.set(key, pane.querySelector('.feed').scrollTop);
+    });
+  }
+  const retainedKeys = new Set(events.map(topicKey));
+  for (const key of scrollPositions.keys()) {
+    if (!retainedKeys.has(key)) scrollPositions.delete(key);
+  }
   grid.querySelectorAll('.topic-pane').forEach((pane) => pane.remove());
   const selected = participantFilter.value;
   const visible = selected === '*' ? events : events.filter((event) => participantName(event) === selected);
@@ -54,9 +66,10 @@ function render() {
   });
   empty.hidden = groups.size > 0;
 
-  [...groups.entries()].sort(([left], [right]) => left.localeCompare(right)).forEach(([, topicEvents]) => {
+  [...groups.entries()].sort(([left], [right]) => left.localeCompare(right)).forEach(([key, topicEvents]) => {
     const latest = topicEvents[topicEvents.length - 1];
     const pane = topicTemplate.content.firstElementChild.cloneNode(true);
+    paneKeys.set(pane, key);
     pane.querySelector('h2').textContent = latest.title || latest.topic;
     pane.querySelector('.count').textContent = String(topicEvents.length);
     const feed = pane.querySelector('.feed');
@@ -69,12 +82,13 @@ function render() {
       feed.append(node);
     });
     grid.append(pane);
-    if (follow.checked) feed.scrollTop = feed.scrollHeight;
+    feed.scrollTop = follow.checked ? feed.scrollHeight : (scrollPositions.get(key) || 0);
   });
 }
 
 document.querySelector('#clear').addEventListener('click', () => {
   events = [];
+  scrollPositions.clear();
   render();
 });
 participantFilter.addEventListener('change', render);

--- a/agent-sdk/xr-ai-web-events/xr_ai_web_events/static/app.js
+++ b/agent-sdk/xr-ai-web-events/xr_ai_web_events/static/app.js
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const eventTemplate = document.querySelector('#event-template');
+const topicTemplate = document.querySelector('#topic-template');
+const grid = document.querySelector('#topic-grid');
+const empty = document.querySelector('#empty');
+const follow = document.querySelector('#follow');
+const participantFilter = document.querySelector('#participant-filter');
+const status = document.querySelector('#status');
+const statusDot = document.querySelector('#status-dot');
+const viewerTitle = document.querySelector('#viewer-title');
+
+const MAX_BROWSER_EVENTS = 2000;
+let events = [];
+let cursor = 0;
+
+function participantName(event) {
+  return event.participant_id || 'Global';
+}
+
+function presentation(event) {
+  const payload = event.payload;
+  const candidates = ['text', 'message', 'response', 'summary', 'caption', 'delta', 'meter_reading'];
+  for (const key of candidates) {
+    if (typeof payload[key] === 'string' && payload[key]) return payload[key];
+  }
+  const kind = payload.record_type || payload.event_type || payload.type || payload.event;
+  return typeof kind === 'string' ? kind.replaceAll('_', ' ') : JSON.stringify(payload);
+}
+
+function refreshParticipantOptions() {
+  const selected = participantFilter.value;
+  const names = [...new Set(events.map(participantName))].sort();
+  participantFilter.replaceChildren(new Option('All', '*'));
+  names.forEach((name) => participantFilter.add(new Option(name, name)));
+  participantFilter.value = names.includes(selected) || selected === '*' ? selected : '*';
+}
+
+function topicKey(event) {
+  return `${participantName(event)}\u0000${event.topic}`;
+}
+
+function render() {
+  refreshParticipantOptions();
+  grid.querySelectorAll('.topic-pane').forEach((pane) => pane.remove());
+  const selected = participantFilter.value;
+  const visible = selected === '*' ? events : events.filter((event) => participantName(event) === selected);
+  const groups = new Map();
+  visible.forEach((event) => {
+    const key = topicKey(event);
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(event);
+  });
+  empty.hidden = groups.size > 0;
+
+  [...groups.entries()].sort(([left], [right]) => left.localeCompare(right)).forEach(([, topicEvents]) => {
+    const latest = topicEvents[topicEvents.length - 1];
+    const pane = topicTemplate.content.firstElementChild.cloneNode(true);
+    pane.querySelector('h2').textContent = latest.title || latest.topic;
+    pane.querySelector('.count').textContent = String(topicEvents.length);
+    const feed = pane.querySelector('.feed');
+    topicEvents.forEach((event) => {
+      const node = eventTemplate.content.firstElementChild.cloneNode(true);
+      node.querySelector('.participant').textContent = `${participantName(event)} · ${event.source}`;
+      node.querySelector('time').textContent = new Date(event.timestamp_us / 1000).toLocaleTimeString();
+      node.querySelector('.primary').textContent = presentation(event);
+      node.querySelector('pre').textContent = JSON.stringify(event.payload, null, 2);
+      feed.append(node);
+    });
+    grid.append(pane);
+    if (follow.checked) feed.scrollTop = feed.scrollHeight;
+  });
+}
+
+document.querySelector('#clear').addEventListener('click', () => {
+  events = [];
+  render();
+});
+participantFilter.addEventListener('change', render);
+
+async function poll() {
+  try {
+    const response = await fetch(`/api/events?after=${cursor}`, { cache: 'no-store' });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const payload = await response.json();
+    viewerTitle.textContent = payload.title;
+    document.title = payload.title;
+    if (payload.reset) {
+      events = [];
+      render();
+    }
+    if (payload.events.length) {
+      events.push(...payload.events);
+      if (events.length > MAX_BROWSER_EVENTS) events = events.slice(-MAX_BROWSER_EVENTS);
+      render();
+    }
+    cursor = payload.cursor;
+    status.textContent = 'Live';
+    statusDot.classList.add('live');
+  } catch (_error) {
+    status.textContent = 'Reconnecting';
+    statusDot.classList.remove('live');
+  } finally {
+    window.setTimeout(poll, 500);
+  }
+}
+
+poll();

--- a/agent-sdk/xr-ai-web-events/xr_ai_web_events/static/app.js
+++ b/agent-sdk/xr-ai-web-events/xr_ai_web_events/static/app.js
@@ -18,7 +18,15 @@ const paneKeys = new WeakMap();
 const scrollPositions = new Map();
 
 function participantName(event) {
-  return event.participant_id || 'Global';
+  return event.participant_id == null ? 'Global' : event.participant_id;
+}
+
+function participantKey(event) {
+  return event.participant_id == null ? 'global:' : `participant:${event.participant_id}`;
+}
+
+function participantOptionName(event) {
+  return event.participant_id == null ? 'Global (unscoped)' : event.participant_id;
 }
 
 function presentation(event) {
@@ -33,14 +41,19 @@ function presentation(event) {
 
 function refreshParticipantOptions() {
   const selected = participantFilter.value;
-  const names = [...new Set(events.map(participantName))].sort();
+  const participants = new Map(
+    events.map((event) => [participantKey(event), participantOptionName(event)]),
+  );
+  const options = [...participants.entries()].sort((left, right) => (
+    left[1].localeCompare(right[1]) || left[0].localeCompare(right[0])
+  ));
   participantFilter.replaceChildren(new Option('All', '*'));
-  names.forEach((name) => participantFilter.add(new Option(name, name)));
-  participantFilter.value = names.includes(selected) || selected === '*' ? selected : '*';
+  options.forEach(([key, name]) => participantFilter.add(new Option(name, key)));
+  participantFilter.value = participants.has(selected) || selected === '*' ? selected : '*';
 }
 
 function topicKey(event) {
-  return `${participantName(event)}\u0000${event.topic}`;
+  return `${participantKey(event)}\u0000${event.topic}`;
 }
 
 function render() {
@@ -57,7 +70,7 @@ function render() {
   }
   grid.querySelectorAll('.topic-pane').forEach((pane) => pane.remove());
   const selected = participantFilter.value;
-  const visible = selected === '*' ? events : events.filter((event) => participantName(event) === selected);
+  const visible = selected === '*' ? events : events.filter((event) => participantKey(event) === selected);
   const groups = new Map();
   visible.forEach((event) => {
     const key = topicKey(event);

--- a/agent-sdk/xr-ai-web-events/xr_ai_web_events/static/index.html
+++ b/agent-sdk/xr-ai-web-events/xr_ai_web_events/static/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>XR AI Agent Events</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <header>
+    <div>
+      <p class="eyebrow">NVIDIA XR AI</p>
+      <h1 id="viewer-title">Agent events</h1>
+      <p class="subtitle">Live application output grouped by participant and topic</p>
+    </div>
+    <div class="controls">
+      <span class="connection"><span id="status-dot"></span><span id="status">Connecting</span></span>
+      <label>Participant <select id="participant-filter"><option value="*">All</option></select></label>
+      <label><input id="follow" type="checkbox" checked> Follow</label>
+      <button id="clear" type="button">Clear view</button>
+    </div>
+  </header>
+
+  <main id="topic-grid">
+    <div id="empty">Waiting for agent events</div>
+  </main>
+
+  <template id="topic-template">
+    <section class="topic-pane">
+      <div class="topic-head">
+        <div><span class="marker"></span><h2></h2></div>
+        <span class="count">0</span>
+      </div>
+      <div class="feed"></div>
+    </section>
+  </template>
+
+  <template id="event-template">
+    <article class="event">
+      <div class="event-head"><span class="participant"></span><time></time></div>
+      <p class="primary"></p>
+      <details>
+        <summary>Details</summary>
+        <pre></pre>
+      </details>
+    </article>
+  </template>
+
+  <script type="module" src="/app.js"></script>
+</body>
+</html>

--- a/agent-sdk/xr-ai-web-events/xr_ai_web_events/static/style.css
+++ b/agent-sdk/xr-ai-web-events/xr_ai_web_events/static/style.css
@@ -1,0 +1,116 @@
+/*
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+*/
+:root {
+  color-scheme: dark;
+  --background: #090d0a;
+  --panel: #111712;
+  --panel-raised: #182019;
+  --line: #2b382d;
+  --text: #f4f7f4;
+  --muted: #9ca99e;
+  --green: #76b900;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top right, #182417 0, var(--background) 42%);
+  color: var(--text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, sans-serif;
+}
+
+header, main { width: min(1800px, calc(100% - 32px)); margin-inline: auto; }
+
+header {
+  display: flex;
+  min-height: 118px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.eyebrow { margin: 0 0 4px; color: var(--green); font-size: 11px; font-weight: 800; letter-spacing: .18em; }
+h1 { margin: 0; font-size: clamp(26px, 3vw, 40px); letter-spacing: -.04em; }
+.subtitle { margin: 6px 0 0; color: var(--muted); }
+.controls, .connection, label { display: flex; align-items: center; gap: 8px; }
+.controls { flex-wrap: wrap; justify-content: flex-end; }
+.connection, label { color: var(--muted); }
+#status-dot { width: 9px; height: 9px; border-radius: 50%; background: #f5a623; }
+#status-dot.live { background: var(--green); box-shadow: 0 0 12px #76b90088; }
+
+button, select {
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  padding: 8px 12px;
+  background: var(--panel-raised);
+  color: var(--text);
+  font: inherit;
+}
+button { cursor: pointer; }
+
+main {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 12px;
+  padding-bottom: 16px;
+}
+
+#empty {
+  grid-column: 1 / -1;
+  padding: 80px 16px;
+  border: 1px dashed var(--line);
+  border-radius: 14px;
+  color: var(--muted);
+  text-align: center;
+}
+
+.topic-pane {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  min-width: 0;
+  height: min(62vh, 680px);
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: #101610dd;
+}
+
+.topic-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 13px 15px;
+  border-bottom: 1px solid var(--line);
+}
+.topic-head > div { display: flex; min-width: 0; align-items: center; gap: 9px; }
+.marker { width: 8px; height: 8px; flex: none; border-radius: 50%; background: var(--green); }
+h2 { overflow: hidden; margin: 0; font-size: 15px; text-overflow: ellipsis; white-space: nowrap; }
+.count { color: var(--muted); font-size: 12px; }
+.feed { overflow-y: auto; padding: 10px; scrollbar-color: var(--line) transparent; }
+
+.event {
+  margin-bottom: 8px;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--green);
+  border-radius: 10px;
+  background: linear-gradient(110deg, var(--panel-raised), var(--panel));
+}
+.event-head { display: flex; gap: 8px; align-items: center; color: var(--muted); font-size: 10px; }
+.participant { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+time { margin-left: auto; white-space: nowrap; }
+.primary { margin: 8px 0 0; font-size: 14px; line-height: 1.4; }
+details { margin-top: 9px; color: var(--muted); }
+summary { cursor: pointer; font-size: 11px; }
+pre { overflow-x: auto; margin: 7px 0 0; white-space: pre-wrap; color: #c8d0c9; font: 11px/1.4 monospace; }
+
+@media (max-width: 760px) {
+  header { align-items: flex-start; flex-direction: column; padding: 20px 0; }
+  .controls { justify-content: flex-start; }
+  main { grid-template-columns: 1fr; }
+  .topic-pane { height: 58vh; }
+}

--- a/docs/source/_api_contract.py
+++ b/docs/source/_api_contract.py
@@ -16,6 +16,7 @@ API_PACKAGE_DIRS = (
     _REPOSITORY_ROOT / "agent-sdk" / "xr-ai-runtime" / "xr_ai_runtime",
     _REPOSITORY_ROOT / "agent-sdk" / "xr-ai-tools" / "xr_ai_tools",
     _REPOSITORY_ROOT / "agent-sdk" / "xr-ai-voice" / "xr_ai_voice",
+    _REPOSITORY_ROOT / "agent-sdk" / "xr-ai-web-events" / "xr_ai_web_events",
     _REPOSITORY_ROOT / "utils" / "xr-ai-launcher" / "xr_ai_launcher",
     _REPOSITORY_ROOT / "utils" / "xr-ai-logging" / "xr_ai_logging",
     _REPOSITORY_ROOT / "utils" / "xr-ai-vad" / "xr_ai_vad",

--- a/docs/source/components/agent-sdk.md
+++ b/docs/source/components/agent-sdk.md
@@ -16,11 +16,13 @@ installation.
 | `xr-ai-runtime` | `xr_ai_runtime` | Agent registration and typed participant-scoped fan-out |
 | `xr-ai-tools` | `xr_ai_tools` | Relay-managed tools and model tool-call helpers |
 | `xr-ai-voice` | `xr_ai_voice` | Voice agent, transport, and private media pipeline |
+| `xr-ai-web-events` | `xr_ai_web_events` | Bounded live browser views over selected application events |
 
 Package guides are versioned with this site:
 {doc}`/reference/agent-sdk-hub`, {doc}`/reference/agent-sdk-models`,
-{doc}`/reference/agent-sdk-runtime`, {doc}`/reference/agent-sdk-tools`, and
-{doc}`/reference/agent-sdk-voice`. The generated {doc}`/reference/python/index`
+{doc}`/reference/agent-sdk-runtime`, {doc}`/reference/agent-sdk-tools`,
+{doc}`/reference/agent-sdk-voice`, and {doc}`/reference/agent-sdk-web-events`.
+The generated {doc}`/reference/python/index`
 is the source of truth for public names, signatures, types, defaults, fields,
 and method-level behavior.
 
@@ -62,6 +64,11 @@ drop-oldest policy, while urgent output bypasses or cancels rewriting and
 interrupts active speech. This policy remains outside the private media
 pipeline so applications opt in explicitly and retain ownership of which
 events should become speech.
+
+Applications may publish selected compact payloads to `WEB_EVENT_TOPIC` for a
+`WebEventsAgent` to display. The viewer owns only a bounded live history and a
+loopback HTTP listener. It is not persistence, does not inspect every runtime
+topic, and does not enter model, voice, media, or hub authentication paths.
 
 `ProcessorEndpoint` is the minimal agent-side hub boundary. It receives data,
 audio, frame signals, and participant events and sends participant-routed return

--- a/docs/source/components/agent-sdk.md
+++ b/docs/source/components/agent-sdk.md
@@ -68,7 +68,9 @@ events should become speech.
 Applications may publish selected compact payloads to `WEB_EVENT_TOPIC` for a
 `WebEventsAgent` to display. The viewer owns only a bounded live history and a
 loopback HTTP listener. It is not persistence, does not inspect every runtime
-topic, and does not enter model, voice, media, or hub authentication paths.
+topic, and does not enter model, voice, media, or hub authentication paths. The
+`simple-vlm-example` and `xr-render-demo` workers are concrete consumers: each
+selects its application-level requests and response chunks for the viewer.
 
 `ProcessorEndpoint` is the minimal agent-side hub boundary. It receives data,
 audio, frame signals, and participant events and sends participant-routed return

--- a/docs/source/getting_started/networking.md
+++ b/docs/source/getting_started/networking.md
@@ -78,8 +78,9 @@ ssh -L 8092:127.0.0.1:8092 user@xr-host
 
 Then open `http://127.0.0.1:8092` locally.
 
-For direct access on a trusted private network, explicitly change the sample
-worker configuration:
+For direct access on a trusted private network, explicitly change the worker
+configuration in `agent-samples/simple-vlm-example/yaml/simple_vlm_example_worker.yaml`
+or `agent-samples/xr-render-demo/yaml/xr_render_demo_worker.yaml`:
 
 ```yaml
 web_events_host: 0.0.0.0

--- a/docs/source/getting_started/networking.md
+++ b/docs/source/getting_started/networking.md
@@ -96,7 +96,9 @@ sudo ufw reload
 ```
 
 Apply the equivalent source-restricted rule to the cloud security group when
-the host is behind a provider firewall.
+the host is behind a provider firewall. The viewer rejects unrecognized HTTP
+`Host` names to prevent DNS rebinding. Connect using a literal server address;
+an authenticated reverse proxy can instead rewrite `Host` to `127.0.0.1`.
 
 ```{warning}
 The live event viewer does not provide authentication or TLS, and its payloads

--- a/docs/source/getting_started/networking.md
+++ b/docs/source/getting_started/networking.md
@@ -5,8 +5,8 @@
 
 # Networking and firewall
 
-The XR-Media-Hub and CloudXR runtime use the following ports. Open them permanently
-if a firewall is active.
+XR-Media-Hub, CloudXR, and optional application viewers use the following
+ports. Open only the externally reachable ports required by the deployment.
 
 | Port | Protocol | Purpose |
 |------|----------|---------|
@@ -14,6 +14,7 @@ if a firewall is active.
 | 7881 | TCP | LiveKit WebRTC TCP fallback (DTLS/SRTP — already encrypted) |
 | 7882 | UDP | LiveKit WebRTC UDP media (DTLS/SRTP — already encrypted) |
 | 8080 | TCP | Web client + token server + wss:// /rtc proxy (HTTPS — the single entry point for browser, Android, iOS, and visionOS clients) |
+| 8092 | TCP | Optional live agent-event viewer (plain HTTP — bound to 127.0.0.1 by default; do not expose to an untrusted network) |
 | 48322 | TCP | CloudXR WSS proxy (XR headset or client connection) |
 
 ## Ubuntu or Debian (`ufw`)
@@ -62,6 +63,46 @@ sudo firewall-cmd --permanent --add-port=7882/udp
 sudo firewall-cmd --permanent --add-port=8080/tcp
 sudo firewall-cmd --permanent --add-port=48322/tcp
 sudo firewall-cmd --reload
+```
+
+## Live agent-event viewer
+
+Samples that use `WebEventsAgent` serve their live event page at
+`http://127.0.0.1:8092` by default. Because the listener is loopback-only, no
+firewall rule is needed when the browser runs on the XR-AI host. For access
+from a development machine, keep the loopback binding and use an SSH tunnel:
+
+```bash
+ssh -L 8092:127.0.0.1:8092 user@xr-host
+```
+
+Then open `http://127.0.0.1:8092` locally.
+
+For direct access on a trusted private network, explicitly change the sample
+worker configuration:
+
+```yaml
+web_events_host: 0.0.0.0
+web_events_port: 8092
+```
+
+Restrict the firewall rule to the client subnet instead of opening the port to
+every source. For example, with `ufw` and a `192.168.1.0/24` development
+network:
+
+```bash
+sudo ufw allow from 192.168.1.0/24 to any port 8092 proto tcp
+sudo ufw reload
+```
+
+Apply the equivalent source-restricted rule to the cloud security group when
+the host is behind a provider firewall.
+
+```{warning}
+The live event viewer does not provide authentication or TLS, and its payloads
+can include transcripts and camera-derived text. Do not expose port 8092 to
+the public Internet. Use the loopback binding with an SSH tunnel, or put the
+viewer behind an authenticated TLS reverse proxy.
 ```
 
 ## TLS for the web client

--- a/docs/source/reference/agent-sdk-web-events.md
+++ b/docs/source/reference/agent-sdk-web-events.md
@@ -1,0 +1,11 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# xr-ai-web-events
+
+```{include} ../../../agent-sdk/xr-ai-web-events/README.md
+:start-after: "# xr-ai-web-events"
+:relative-docs: ../../../agent-sdk/xr-ai-web-events/
+```

--- a/docs/source/reference/xr-render-demo.md
+++ b/docs/source/reference/xr-render-demo.md
@@ -82,7 +82,9 @@ the XR compositor and the agentic LLM do not share a card.
 
 The worker reads two config files:
 
-- `yaml/xr_render_demo_worker.yaml` — native capability endpoints, text-memory directory, and VAD tunables.
+- `yaml/xr_render_demo_worker.yaml` — native capability endpoints, text-memory
+  directory, VAD tunables, and the `web_events_host` / `web_events_port` live
+  viewer listener.
 - `yaml/models.local.json` (deployment profile set by `models_config:` in the
   worker YAML): model endpoint and deployment declarations consumed by
   `xr-ai-models` and the orchestrator.  Each entry maps a logical name
@@ -240,6 +242,9 @@ On each accepted `xr-render.user-query` event or lifecycle notice:
    context in future turns so the model understands "fix that", "undo",
    "the one I just added". Final messages are also persisted through native
    text memory without model scratch output or tool traces.
+
+The worker mirrors accepted XR requests and non-empty `voice.output` chunks to
+its live event viewer at `http://127.0.0.1:8092` by default.
 
 ## Native capability composition
 

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "xr-ai-models[riva]",
     "xr-ai-tools[frames,image-editing,marker-tracking,services,vision]",
     "xr-ai-voice",
+    "xr-ai-web-events",
     "xr-media-hub",
     "xr-ai-launcher",
     "xr-ai-logging",
@@ -42,6 +43,7 @@ xr-ai-hub-client           = { path = "../agent-sdk/xr-ai-hub",                 
 xr-ai-models          = { path = "../agent-sdk/xr-ai-models",           editable = true }
 xr-ai-tools           = { path = "../agent-sdk/xr-ai-tools",            editable = true }
 xr-ai-voice           = { path = "../agent-sdk/xr-ai-voice",            editable = true }
+xr-ai-web-events      = { path = "../agent-sdk/xr-ai-web-events",       editable = true }
 xr-media-hub          = { path = "../services/xr-media-hub",             editable = true }
 xr-ai-launcher        = { path = "../utils/xr-ai-launcher",             editable = true }
 xr-ai-logging         = { path = "../utils/xr-ai-logging",              editable = true }

--- a/tests/test_simple_vlm_example_worker.py
+++ b/tests/test_simple_vlm_example_worker.py
@@ -9,6 +9,7 @@ import asyncio
 import sys
 import time
 from collections.abc import AsyncIterator
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
@@ -19,11 +20,18 @@ import tomllib
 import yaml
 from xr_ai_hub import FrameData, FrameSignal, FrameUnavailable, PixelFormat, ProcessorEndpoint
 from xr_ai_models import ChatResponse, VLMService
-from xr_ai_runtime import AgentRuntime
-from xr_ai_voice import UserQuery, VoiceAgent, VoiceInterrupted, VoiceOutput
+from xr_ai_runtime import Agent, AgentRuntime, RuntimeContext, subscribe
+from xr_ai_voice import (
+    VOICE_OUTPUT_TOPIC,
+    UserQuery,
+    VoiceAgent,
+    VoiceInterrupted,
+    VoiceOutput,
+)
 from xr_ai_voice import _runtime as voice_runtime_module
 from xr_ai_voice._session import _VoiceSession as VoiceSession
 from xr_ai_voicegate import VoiceGateConfig
+from xr_ai_web_events import WEB_EVENT_TOPIC, WebEvent
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _SAMPLE_DIR = _REPO_ROOT / "agent-samples" / "simple-vlm-example"
@@ -194,6 +202,56 @@ class _StreamingVlm:
             yield token
 
 
+class _WebEventRecorder(Agent):
+    def __init__(self) -> None:
+        super().__init__()
+        self.events: list[tuple[WebEvent, str | None]] = []
+
+    @subscribe(WEB_EVENT_TOPIC)
+    async def capture(self, event: WebEvent, ctx: RuntimeContext) -> None:
+        self.events.append((event, ctx.metadata.participant_id))
+
+
+async def test_simple_vlm_publishes_selected_conversation_web_events() -> None:
+    recorder = _WebEventRecorder()
+    runtime = AgentRuntime()
+    runtime.register("web-events-publisher", app._SimpleVlmWebEvents())  # noqa: SLF001
+    runtime.register("web-events-recorder", recorder)
+
+    async with runtime:
+        await runtime.publish(
+            USER_QUERY_TOPIC,
+            UserQuery(text="What is shown?", timestamp_us=123),
+            participant_id="alice",
+            source="test-input",
+        )
+        await runtime.publish(
+            VOICE_OUTPUT_TOPIC,
+            VoiceOutput(
+                text="A blue square.",
+                response_id="response-1",
+                final=False,
+            ),
+            participant_id="alice",
+            source="simple-vlm",
+        )
+        await runtime.publish(
+            VOICE_OUTPUT_TOPIC,
+            VoiceOutput(response_id="response-1"),
+            participant_id="alice",
+            source="simple-vlm",
+        )
+
+    assert [(event.topic, event.payload) for event, _ in recorder.events] == [
+        ("simple-vlm.query", {"text": "What is shown?"}),
+        (
+            "simple-vlm.response",
+            {"text": "A blue square.", "final": False},
+        ),
+    ]
+    assert {participant_id for _, participant_id in recorder.events} == {"alice"}
+
+
 def test_worker_is_a_package_with_module_and_console_entry_points() -> None:
     project = tomllib.loads((_WORKER_DIR / "pyproject.toml").read_text())
     package = _WORKER_DIR / "simple_vlm_example_worker"
@@ -218,6 +276,10 @@ def test_worker_is_a_package_with_module_and_console_entry_points() -> None:
     assert "xr-ai-tools[frames,vision]" in dependencies
     assert all("[vision" not in dependency and "[voice" not in dependency for dependency in dependencies)
     assert "xr-ai-voice" in dependencies
+    assert "xr-ai-web-events" in dependencies
+    assert project["tool"]["uv"]["sources"]["xr-ai-web-events"]["path"] == (
+        "../../../agent-sdk/xr-ai-web-events"
+    )
     assert "xr-ai-pipecat" not in dependencies
     assert all("mcp" not in dependency.lower() for dependency in dependencies)
     assert project["tool"]["hatch"]["build"]["targets"]["wheel"]["packages"] == ["simple_vlm_example_worker"]
@@ -287,6 +349,8 @@ def test_shipped_config_preserves_models_and_prompt_behavior() -> None:
     assert config.frame_max_age_s == 5.0
     assert config.frame_timeout_s == 5.0
     assert config.idle_timeout_secs is None
+    assert config.web_events_host == "127.0.0.1"
+    assert config.web_events_port == 8092
     assert "system_prompt_file" not in raw
 
 
@@ -493,7 +557,10 @@ async def test_app_wires_text_voice_cleanup_readiness_and_shutdown(
     monkeypatch,
     tmp_path,
 ) -> None:
-    config = load_config(_SAMPLE_DIR / "yaml" / "simple_vlm_example_worker.yaml")
+    config = replace(
+        load_config(_SAMPLE_DIR / "yaml" / "simple_vlm_example_worker.yaml"),
+        web_events_port=0,
+    )
     ready_file = tmp_path / "ready"
     stt = _Service()
     vlm = _Service()

--- a/tests/test_web_events.py
+++ b/tests/test_web_events.py
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+from urllib.error import HTTPError
+from urllib.request import urlopen
+
+import pytest
+from pydantic import ValidationError
+from xr_ai_runtime import AgentRuntime
+from xr_ai_web_events import WEB_EVENT_TOPIC, WebEvent, WebEventsAgent
+
+
+def _request(url: str) -> tuple[int, dict[str, str], bytes]:
+    with urlopen(url, timeout=2) as response:  # noqa: S310
+        return response.status, dict(response.headers.items()), response.read()
+
+
+async def _get(url: str) -> tuple[int, dict[str, str], bytes]:
+    return await asyncio.to_thread(_request, url)
+
+
+def test_web_event_contract_is_strict_and_untraced() -> None:
+    event = WebEvent(topic=" monitor.changes ", title=" Changes ", payload={"changed": True})
+
+    assert event.topic == "monitor.changes"
+    assert event.title == "Changes"
+    assert WEB_EVENT_TOPIC.message_type is WebEvent
+    assert WEB_EVENT_TOPIC.telemetry == "none"
+    with pytest.raises(ValidationError):
+        WebEvent(topic=" ")
+    with pytest.raises(ValidationError):
+        WebEvent(topic="ok", unexpected=True)
+
+
+async def test_viewer_serves_runtime_events_and_reports_rollover() -> None:
+    runtime = AgentRuntime()
+    viewer = runtime.register(
+        "web-events",
+        WebEventsAgent(port=0, max_events=2, title="Test events"),
+    )
+
+    async with viewer:
+        async with runtime:
+            for value in (1, 2, 3):
+                await runtime.publish(
+                    WEB_EVENT_TOPIC,
+                    WebEvent(
+                        topic="instruments.reading",
+                        title="Readings",
+                        payload={"value": value},
+                    ),
+                    participant_id="glasses-1",
+                    source="instrument-monitor",
+                )
+
+            status, headers, body = await _get(f"{viewer.url}/api/events?after=0")
+            result = json.loads(body)
+            assert status == 200
+            assert result["title"] == "Test events"
+            assert result["cursor"] == 3
+            assert result["oldest"] == 2
+            assert result["reset"] is True
+            assert [event["sequence"] for event in result["events"]] == [2, 3]
+            assert [event["payload"] for event in result["events"]] == [
+                {"value": 2},
+                {"value": 3},
+            ]
+            last = result["events"][-1]
+            assert last["topic"] == "instruments.reading"
+            assert last["title"] == "Readings"
+            assert last["participant_id"] == "glasses-1"
+            assert last["source"] == "instrument-monitor"
+            assert last["message_id"] == last["correlation_id"]
+            assert last["parent_message_id"] is None
+            assert last["timestamp_us"] > 0
+            assert headers["Cache-Control"] == "no-store"
+            assert "default-src 'self'" in headers["Content-Security-Policy"]
+
+            _, _, body = await _get(f"{viewer.url}/api/events?after=2")
+            incremental = json.loads(body)
+            assert incremental["reset"] is False
+            assert [event["sequence"] for event in incremental["events"]] == [3]
+
+            _, _, body = await _get(f"{viewer.url}/api/events?after=99")
+            future = json.loads(body)
+            assert future["reset"] is True
+            assert [event["sequence"] for event in future["events"]] == [2, 3]
+
+
+async def test_viewer_serves_health_and_packaged_page() -> None:
+    viewer = WebEventsAgent(port=0)
+
+    async with viewer:
+        assert viewer.running
+        status, headers, body = await _get(f"{viewer.url}/healthz")
+        assert status == 200
+        assert json.loads(body) == {"status": "ok"}
+        assert headers["X-Content-Type-Options"] == "nosniff"
+
+        status, headers, body = await _get(f"{viewer.url}/")
+        assert status == 200
+        assert headers["Content-Type"].startswith("text/html")
+        assert b'id="topic-grid"' in body
+
+        status, _, body = await _get(f"{viewer.url}/app.js")
+        assert status == 200
+        assert b"/api/events?after=" in body
+
+        with pytest.raises(HTTPError) as invalid:
+            await _get(f"{viewer.url}/api/events?after=invalid")
+        assert invalid.value.code == 400
+
+    assert not viewer.running
+
+
+async def test_viewer_lifecycle_is_idempotent_and_bind_failure_is_visible() -> None:
+    viewer = WebEventsAgent(port=0)
+    await viewer.start()
+    first_url = viewer.url
+    await viewer.start()
+    assert viewer.url == first_url
+    await viewer.stop()
+    await viewer.stop()
+
+    with socket.socket() as occupied:
+        occupied.bind(("127.0.0.1", 0))
+        occupied.listen()
+        port = occupied.getsockname()[1]
+        blocked = WebEventsAgent(port=port)
+        with pytest.raises(OSError):
+            await blocked.start()
+        assert not blocked.running
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"host": " "}, "host"),
+        ({"port": -1}, "port"),
+        ({"port": 65_536}, "port"),
+        ({"max_events": 0}, "max_events"),
+        ({"title": " "}, "title"),
+    ],
+)
+def test_viewer_rejects_invalid_configuration(kwargs: dict[str, object], message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        WebEventsAgent(**kwargs)

--- a/tests/test_web_events.py
+++ b/tests/test_web_events.py
@@ -7,6 +7,7 @@ import asyncio
 import json
 import math
 import socket
+import threading
 from urllib.error import HTTPError
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
@@ -182,6 +183,37 @@ async def test_viewer_lifecycle_is_idempotent_and_bind_failure_is_visible() -> N
         with pytest.raises(OSError):
             await blocked.start()
         assert not blocked.running
+
+
+async def test_viewer_cancellation_finishes_listener_cleanup(monkeypatch) -> None:
+    viewer = WebEventsAgent(port=0)
+    await viewer.start()
+    server = viewer._server  # noqa: SLF001
+    assert server is not None
+    host, port = server.server_address[:2]
+    shutdown_started = threading.Event()
+    allow_shutdown = threading.Event()
+    original_shutdown = server.shutdown
+
+    def delayed_shutdown() -> None:
+        shutdown_started.set()
+        allow_shutdown.wait()
+        original_shutdown()
+
+    monkeypatch.setattr(server, "shutdown", delayed_shutdown)
+    stop = asyncio.create_task(viewer.stop())
+    await asyncio.wait_for(asyncio.to_thread(shutdown_started.wait), 1.0)
+    stop.cancel()
+    allow_shutdown.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await stop
+
+    assert not viewer.running
+    assert viewer._server is None  # noqa: SLF001
+    assert viewer._thread is None  # noqa: SLF001
+    with socket.socket() as rebound:
+        rebound.bind((host, port))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_web_events.py
+++ b/tests/test_web_events.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 
 import asyncio
 import json
+import math
 import socket
 from urllib.error import HTTPError
-from urllib.request import urlopen
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
 
 import pytest
 from pydantic import ValidationError
@@ -15,13 +17,22 @@ from xr_ai_runtime import AgentRuntime
 from xr_ai_web_events import WEB_EVENT_TOPIC, WebEvent, WebEventsAgent
 
 
-def _request(url: str) -> tuple[int, dict[str, str], bytes]:
-    with urlopen(url, timeout=2) as response:  # noqa: S310
+def _request(
+    url: str, *, host: str | None = None
+) -> tuple[int, dict[str, str], bytes]:
+    request = Request(url, headers={"Host": host}) if host is not None else url
+    with urlopen(request, timeout=2) as response:  # noqa: S310
         return response.status, dict(response.headers.items()), response.read()
 
 
 async def _get(url: str) -> tuple[int, dict[str, str], bytes]:
     return await asyncio.to_thread(_request, url)
+
+
+async def _get_with_host(
+    url: str, host: str
+) -> tuple[int, dict[str, str], bytes]:
+    return await asyncio.to_thread(_request, url, host=host)
 
 
 def test_web_event_contract_is_strict_and_untraced() -> None:
@@ -35,6 +46,19 @@ def test_web_event_contract_is_strict_and_untraced() -> None:
         WebEvent(topic=" ")
     with pytest.raises(ValidationError):
         WebEvent(topic="ok", unexpected=True)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"value": math.nan},
+        {"value": math.inf},
+        {"nested": [{"value": -math.inf}]},
+    ],
+)
+def test_web_event_rejects_non_finite_json_numbers(payload: dict) -> None:
+    with pytest.raises(ValidationError, match="finite number"):
+        WebEvent(topic="measurements", payload=payload)
 
 
 async def test_viewer_serves_runtime_events_and_reports_rollover() -> None:
@@ -116,6 +140,29 @@ async def test_viewer_serves_health_and_packaged_page() -> None:
         assert invalid.value.code == 400
 
     assert not viewer.running
+
+
+async def test_viewer_rejects_unrecognized_host_before_serving_routes() -> None:
+    viewer = WebEventsAgent(port=0)
+
+    async with viewer:
+        port = urlparse(viewer.url).port
+        assert port is not None
+        for host in (
+            "localhost",
+            f"localhost:{port}",
+            "127.0.0.1",
+            f"127.0.0.1:{port}",
+            "[::1]",
+            f"[::1]:{port}",
+        ):
+            status, _, _ = await _get_with_host(f"{viewer.url}/healthz", host)
+            assert status == 200
+
+        for path in ("/healthz", "/api/events?after=0", "/"):
+            with pytest.raises(HTTPError) as rejected:
+                await _get_with_host(f"{viewer.url}{path}", "rebind.example")
+            assert rejected.value.code == 400
 
 
 async def test_viewer_lifecycle_is_idempotent_and_bind_failure_is_visible() -> None:

--- a/tests/test_xr_render_agent.py
+++ b/tests/test_xr_render_agent.py
@@ -28,6 +28,7 @@ from xr_ai_voice import (
     VoiceParticipantLeft,
     VoiceStreamClosedError,
 )
+from xr_ai_web_events import WEB_EVENT_TOPIC, WebEvent
 from xr_render_scene import EmptyRequest
 
 _WORKER_DIR = (
@@ -38,6 +39,7 @@ _WORKER_DIR = (
 )
 sys.path.insert(0, str(_WORKER_DIR))
 
+from xr_render_demo_worker.__main__ import _RenderWebEvents  # noqa: E402
 from xr_render_demo_worker.agent import (  # noqa: E402
     INTERRUPTED_TOPIC,
     PARTICIPANT_LEFT_TOPIC,
@@ -187,6 +189,56 @@ class _VoiceRecorder(Agent):
 
     def abort_all(self) -> None:
         self.open_responses.clear()
+
+
+class _WebEventRecorder(Agent):
+    def __init__(self) -> None:
+        super().__init__()
+        self.events: list[tuple[WebEvent, MessageMetadata]] = []
+
+    @subscribe(WEB_EVENT_TOPIC)
+    async def record(self, event: WebEvent, ctx: RuntimeContext) -> None:
+        self.events.append((event, ctx.metadata))
+
+
+async def test_xr_render_publishes_selected_request_and_response_web_events() -> None:
+    recorder = _WebEventRecorder()
+    runtime = AgentRuntime()
+    runtime.register("web-events-publisher", _RenderWebEvents())
+    runtime.register("web-events-recorder", recorder)
+
+    async with runtime:
+        await runtime.publish(
+            USER_QUERY_TOPIC,
+            UserQuery(text="Add a cube.", timestamp_us=123),
+            participant_id="alice",
+            source="test-input",
+        )
+        await runtime.publish(
+            VOICE_OUTPUT_TOPIC,
+            VoiceOutput(
+                text="I added a cube.",
+                response_id="response-1",
+                final=False,
+            ),
+            participant_id="alice",
+            source="xr-render",
+        )
+        await runtime.publish(
+            VOICE_OUTPUT_TOPIC,
+            VoiceOutput(response_id="response-1"),
+            participant_id="alice",
+            source="xr-render",
+        )
+
+    assert [(event.topic, event.payload) for event, _ in recorder.events] == [
+        ("xr-render.query", {"text": "Add a cube."}),
+        (
+            "xr-render.response",
+            {"text": "I added a cube.", "final": False},
+        ),
+    ]
+    assert {metadata.participant_id for _, metadata in recorder.events} == {"alice"}
 
 
 async def test_render_agent_publishes_incremental_voice_output() -> None:

--- a/tests/test_xr_render_demo_wire.py
+++ b/tests/test_xr_render_demo_wire.py
@@ -15,6 +15,7 @@ import asyncio
 import json
 import runpy
 import sys
+import tomllib
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -116,6 +117,17 @@ def test_worker_config_idle_timeout_disabled_by_default() -> None:
     )
     cfg = load_config(worker_yaml)
     assert cfg.idle_timeout_secs is None
+    assert cfg.web_events_host == "127.0.0.1"
+    assert cfg.web_events_port == 8092
+
+
+def test_worker_depends_on_web_events_sdk() -> None:
+    project = tomllib.loads((_WORKER_DIR / "pyproject.toml").read_text())
+
+    assert "xr-ai-web-events" in project["project"]["dependencies"]
+    assert project["tool"]["uv"]["sources"]["xr-ai-web-events"]["path"] == (
+        "../../../agent-sdk/xr-ai-web-events"
+    )
 
 
 def test_worker_config_idle_timeout_opt_in(tmp_path) -> None:


### PR DESCRIPTION
## Summary

- add a small `xr-ai-web-events` SDK package with a typed `WebEvent` topic and `WebEventsAgent`
- serve a bounded, live in-memory event view grouped by participant and topic
- provide a rollover-aware polling API, health endpoint, and packaged static browser UI
- document explicit sample integration, localhost-only defaults, SSH-tunnel access, and source-restricted trusted-LAN firewall configuration

## Why

The lab-instrument and tea-making samples already persist durable JSONL records, but watching those files is inconvenient during live runs. This gives applications an explicit, read-only browser view over selected runtime events without adding file tailing, a wildcard runtime tap, or media-hub coupling.

The viewer is intentionally separate from `agent.response`: spoken assistant text continues to use the existing voice-to-client accessibility channel, while this page is operational telemetry.

## Behavior and safety

- applications explicitly publish only the events they want exposed
- bounded memory; JSONL remains the durable record
- defaults to `127.0.0.1:8092`
- no CORS, no authentication, and no TLS; remote development uses an SSH tunnel
- lifecycle is idempotent and a bind failure fails startup

## Validation

- `uv run --project tests pytest tests/test_web_events.py tests/test_agent_runtime.py -q` — 24 passed after restacking
- full focused package/runtime suite from the implementation worktree — 33 passed
- Ruff 0.15.16 — clean
- dependency-map check — current
- strict Sphinx/public API check — passed
- wheel build/static asset packaging — passed
- SPDX and `git diff --check` — clean
