### PR TITLE
fix(stt): harden cold-start lifecycle

### DIFF
--- a/agent-samples/model-servers/yaml/96G_blackwell/stt_server.yaml
+++ b/agent-samples/model-servers/yaml/96G_blackwell/stt_server.yaml
@@ -6,4 +6,5 @@ model: nvidia/parakeet-tdt-0.6b-v3
 device: auto
 port: 8103
 host: "0.0.0.0"
+startup_timeout_s: 600
 model_cache: ../../../../models

--- a/agent-samples/model-servers/yaml/dual_48G_ada/stt_server.yaml
+++ b/agent-samples/model-servers/yaml/dual_48G_ada/stt_server.yaml
@@ -18,6 +18,7 @@ cuda_visible_devices: "1"
 
 port: 8103
 host: "0.0.0.0"
+startup_timeout_s: 600
 
 # NeMo + HuggingFace weight cache — resolved relative to this YAML file.
 model_cache: ../../../../models

--- a/agent-samples/model-servers/yaml/spark/stt_server.yaml
+++ b/agent-samples/model-servers/yaml/spark/stt_server.yaml
@@ -6,4 +6,5 @@ model: nvidia/parakeet-tdt-0.6b-v3
 device: auto
 port: 8103
 host: "0.0.0.0"
+startup_timeout_s: 600
 model_cache: ../../../../models

--- a/agent-samples/simple-vlm-example/yaml/stt_server.yaml
+++ b/agent-samples/simple-vlm-example/yaml/stt_server.yaml
@@ -7,4 +7,5 @@
 model:       nvidia/parakeet-tdt-0.6b-v3
 device:      auto
 port:        8103
+startup_timeout_s: 600
 model_cache: ../../../models

--- a/agent-samples/xr-render-demo/yaml/stt_server.yaml
+++ b/agent-samples/xr-render-demo/yaml/stt_server.yaml
@@ -8,4 +8,5 @@
 model:       nvidia/parakeet-tdt-0.6b-v3
 device:      auto
 port:        8103
+startup_timeout_s: 600
 model_cache: ../../../models

--- a/agent-sdk/xr-ai-hub/xr_ai_hub/_shm.py
+++ b/agent-sdk/xr-ai-hub/xr_ai_hub/_shm.py
@@ -205,12 +205,12 @@ class ShmRingBuffer:
             pass
 
     def unlink(self) -> None:
-        """Remove the shared-memory segment, tolerating repeated cleanup."""
+        """Remove the segment, tolerating repeated cleanup by this process."""
         try:
             self._shm.unlink()
         except FileNotFoundError:
-            # Shutdown paths can converge after one owner has already removed
-            # the segment. Treat repeated cleanup as complete.
+            # The creating owner can reach cleanup more than once. Unrelated
+            # processes must not unlink a segment they did not create.
             pass
 
     def __enter__(self):

--- a/agent-sdk/xr-ai-hub/xr_ai_hub/_shm.py
+++ b/agent-sdk/xr-ai-hub/xr_ai_hub/_shm.py
@@ -205,8 +205,13 @@ class ShmRingBuffer:
             pass
 
     def unlink(self) -> None:
-        """Remove the shared-memory segment; call once from its creating owner."""
-        self._shm.unlink()
+        """Remove the shared-memory segment, tolerating repeated cleanup."""
+        try:
+            self._shm.unlink()
+        except FileNotFoundError:
+            # Shutdown paths can converge after one owner has already removed
+            # the segment. Treat repeated cleanup as complete.
+            pass
 
     def __enter__(self):
         """Return this ring buffer from a context manager."""

--- a/docs/source/components/ai-services.md
+++ b/docs/source/components/ai-services.md
@@ -491,9 +491,11 @@ cleanup.
   ignored. Its persistent wrapper allows 900 seconds for a cold start by
   default because that path can include importing NeMo, downloading weights,
   initializing CUDA, and loading the model. Set `startup_timeout_s` in the STT
-  YAML to tune the budget. A child that exits before readiness is reported
-  immediately, and a child that exceeds the budget is terminated before the
-  wrapper exits so a retry cannot collide with an orphaned server.
+  YAML to a positive finite number to tune the budget. A child that exits
+  before readiness is reported immediately, and a child that exceeds the
+  budget is terminated before the wrapper exits so a retry cannot collide with
+  an orphaned server. After startup, three consecutive failed health checks
+  terminate a child known to this wrapper; an isolated failed check is retried.
 - **magpie-tts** loads magpie_tts_multilingual_357m via NeMo TTS in-process.
 - **piper-tts** serves any rhasspy/piper-voices ONNX voice; ~100 ms/sentence on CPU.
   All inference runs in a thread pool so the asyncio loop is never blocked.

--- a/docs/source/components/ai-services.md
+++ b/docs/source/components/ai-services.md
@@ -487,7 +487,13 @@ cleanup.
   swap backends. Hosting backend is selectable per YAML (refer to *Choosing the
   vLLM runtime*); persists across stack restarts in both pip and docker modes.
 - **stt-server** loads parakeet-tdt-0.6b-v3 via NeMo ASR in-process.
-  English-only; the `language` and `temperature` form fields are accepted but ignored.
+  English-only; the `language` and `temperature` form fields are accepted but
+  ignored. Its persistent wrapper allows 900 seconds for a cold start by
+  default because that path can include importing NeMo, downloading weights,
+  initializing CUDA, and loading the model. Set `startup_timeout_s` in the STT
+  YAML to tune the budget. A child that exits before readiness is reported
+  immediately, and a child that exceeds the budget is terminated before the
+  wrapper exits so a retry cannot collide with an orphaned server.
 - **magpie-tts** loads magpie_tts_multilingual_357m via NeMo TTS in-process.
 - **piper-tts** serves any rhasspy/piper-voices ONNX voice; ~100 ms/sentence on CPU.
   All inference runs in a thread pool so the asyncio loop is never blocked.

--- a/docs/source/components/ai-services.md
+++ b/docs/source/components/ai-services.md
@@ -488,14 +488,8 @@ cleanup.
   vLLM runtime*); persists across stack restarts in both pip and docker modes.
 - **stt-server** loads parakeet-tdt-0.6b-v3 via NeMo ASR in-process.
   English-only; the `language` and `temperature` form fields are accepted but
-  ignored. Its persistent wrapper allows 600 seconds for a cold start by
-  default because that path can include importing NeMo, downloading weights,
-  initializing CUDA, and loading the model. Set `startup_timeout_s` in the STT
-  YAML to a positive finite number to tune the budget. A child that exits
-  before readiness is reported immediately, and a child that exceeds the
-  budget is terminated before the wrapper exits so a retry cannot collide with
-  an orphaned server. After startup, three consecutive failed health checks
-  terminate a child known to this wrapper; an isolated failed check is retried.
+  ignored. Set `startup_timeout_s` to a positive finite number to override the
+  600-second cold-start budget.
 - **magpie-tts** loads magpie_tts_multilingual_357m via NeMo TTS in-process.
 - **piper-tts** serves any rhasspy/piper-voices ONNX voice; ~100 ms/sentence on CPU.
   All inference runs in a thread pool so the asyncio loop is never blocked.

--- a/docs/source/components/ai-services.md
+++ b/docs/source/components/ai-services.md
@@ -488,7 +488,7 @@ cleanup.
   vLLM runtime*); persists across stack restarts in both pip and docker modes.
 - **stt-server** loads parakeet-tdt-0.6b-v3 via NeMo ASR in-process.
   English-only; the `language` and `temperature` form fields are accepted but
-  ignored. Its persistent wrapper allows 900 seconds for a cold start by
+  ignored. Its persistent wrapper allows 600 seconds for a cold start by
   default because that path can include importing NeMo, downloading weights,
   initializing CUDA, and loading the model. Set `startup_timeout_s` in the STT
   YAML to a positive finite number to tune the budget. A child that exits

--- a/services/stt-server/stt_server.yaml
+++ b/services/stt-server/stt_server.yaml
@@ -16,5 +16,9 @@ device: auto
 port: 8103
 host: "0.0.0.0"
 
+# A cold start imports NeMo, downloads weights when absent, initializes CUDA,
+# and loads the model before /health opens. Increase this on slow links.
+startup_timeout_s: 900
+
 # NeMo + HuggingFace weight cache — resolved relative to this YAML file.
 model_cache: ../../models

--- a/services/stt-server/stt_server.yaml
+++ b/services/stt-server/stt_server.yaml
@@ -17,7 +17,8 @@ port: 8103
 host: "0.0.0.0"
 
 # A cold start imports NeMo, downloads weights when absent, initializes CUDA,
-# and loads the model before /health opens. Increase this on slow links.
+# and loads the model before /health opens. Use a positive finite number, and
+# increase it on slow links.
 startup_timeout_s: 900
 
 # NeMo + HuggingFace weight cache — resolved relative to this YAML file.

--- a/services/stt-server/stt_server.yaml
+++ b/services/stt-server/stt_server.yaml
@@ -19,7 +19,7 @@ host: "0.0.0.0"
 # A cold start imports NeMo, downloads weights when absent, initializes CUDA,
 # and loads the model before /health opens. Use a positive finite number, and
 # increase it on slow links.
-startup_timeout_s: 900
+startup_timeout_s: 600
 
 # NeMo + HuggingFace weight cache — resolved relative to this YAML file.
 model_cache: ../../models

--- a/services/stt-server/stt_server/__main__.py
+++ b/services/stt-server/stt_server/__main__.py
@@ -24,6 +24,7 @@ Config keys
 """
 import argparse
 import asyncio
+import math
 import os
 import subprocess
 import sys
@@ -52,6 +53,22 @@ from xr_ai_logging import setup_logging
 _DEFAULT_PORT              = 8103
 _DEFAULT_STARTUP_TIMEOUT_S = 900.0
 _PROCESS_STOP_TIMEOUT_S    = 10.0
+_IDLE_HEALTH_FAILURE_LIMIT = 3
+
+
+def _parse_startup_timeout(value: object) -> float:
+    """Return a positive finite startup timeout from user configuration."""
+    try:
+        timeout_s = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "'startup_timeout_s' must be a finite number greater than zero"
+        ) from exc
+    if not math.isfinite(timeout_s) or timeout_s <= 0:
+        raise ValueError(
+            "'startup_timeout_s' must be a finite number greater than zero"
+        )
+    return timeout_s
 
 
 def _resolve_model_cache(cfg: dict, yaml_dir: Path) -> Path:
@@ -323,6 +340,7 @@ def _idle_until_stopped(
     poll_s: float = 5.0,
 ) -> None:
     """Keep the wrapper alive while the persisted server is still running."""
+    health_failures = 0
     while True:
         if process is None:
             time.sleep(poll_s)
@@ -338,11 +356,28 @@ def _idle_until_stopped(
                     )
                 return
 
-        if not _health_url_ok(health_url):
-            # Any urlopen failure — connection refused, timeout, socket
-            # error — means the persisted server is gone; exit so the
-            # wrapper subprocess can be reaped.
+        if _health_url_ok(health_url):
+            health_failures = 0
+            continue
+
+        if process is None:
+            # A reused server has no child handle for this wrapper to manage.
             return
+
+        health_failures += 1
+        if health_failures < _IDLE_HEALTH_FAILURE_LIMIT:
+            print(
+                f"[stt_server] health endpoint unreachable "
+                f"({health_failures}/{_IDLE_HEALTH_FAILURE_LIMIT}); retrying",
+                flush=True,
+            )
+            continue
+
+        _terminate_process(process)
+        raise SystemExit(
+            f"[stt_server] persistent server failed "
+            f"{_IDLE_HEALTH_FAILURE_LIMIT} consecutive health checks; terminated"
+        )
 
 
 def run() -> None:
@@ -371,12 +406,14 @@ def run() -> None:
         return
 
     # ── wrapper mode ──────────────────────────────────────────────────────────
-    port              = int(cfg.get("port", _DEFAULT_PORT))
-    startup_timeout_s = float(cfg.get("startup_timeout_s", _DEFAULT_STARTUP_TIMEOUT_S))
-    health_url        = f"http://127.0.0.1:{port}/health"
-
-    if startup_timeout_s <= 0:
-        sys.exit("[stt_server] 'startup_timeout_s' must be greater than zero")
+    port = int(cfg.get("port", _DEFAULT_PORT))
+    try:
+        startup_timeout_s = _parse_startup_timeout(
+            cfg.get("startup_timeout_s", _DEFAULT_STARTUP_TIMEOUT_S)
+        )
+    except ValueError as exc:
+        raise SystemExit(f"[stt_server] {exc}") from exc
+    health_url = f"http://127.0.0.1:{port}/health"
 
     # Reuse an already-running server (survived a previous stack shutdown).
     already_up = _health_url_ok(health_url)

--- a/services/stt-server/stt_server/__main__.py
+++ b/services/stt-server/stt_server/__main__.py
@@ -14,12 +14,13 @@ Accepts --config <path>.yaml (auto-passed by xr-ai-launcher).
 
 Config keys
 -----------
-    model:        str   NeMo / HuggingFace model name (required)
-    device:       str   "cuda" | "cpu" | "auto" (default: "auto")
-    port:         int   HTTP port (default: 8103)
-    host:         str   Bind address (default: "0.0.0.0")
-    model_cache:  str   NeMo + HF weight cache.  Resolved relative to this YAML.
-                        Default: ../../models
+    model:             str    NeMo / HuggingFace model name (required)
+    device:            str    "cuda" | "cpu" | "auto" (default: "auto")
+    port:              int    HTTP port (default: 8103)
+    host:              str    Bind address (default: "0.0.0.0")
+    startup_timeout_s: float  Seconds allowed for a cold start (default: 900)
+    model_cache:       str    NeMo + HF weight cache.  Resolved relative to this YAML.
+                              Default: ../../models
 """
 import argparse
 import asyncio
@@ -48,7 +49,9 @@ import yaml
 from loguru import logger
 from xr_ai_logging import setup_logging
 
-_DEFAULT_PORT = 8103
+_DEFAULT_PORT              = 8103
+_DEFAULT_STARTUP_TIMEOUT_S = 900.0
+_PROCESS_STOP_TIMEOUT_S    = 10.0
 
 
 def _resolve_model_cache(cfg: dict, yaml_dir: Path) -> Path:
@@ -181,9 +184,13 @@ def _build_app(cfg: dict, model_cache: Path):
 
 def _health_ok(port: int) -> bool:
     """Return True if an STT server is already answering /health on *port*."""
+    return _health_url_ok(f"http://127.0.0.1:{port}/health")
+
+
+def _health_url_ok(health_url: str) -> bool:
+    """Return True if *health_url* answers successfully."""
     try:
-        import urllib.request
-        with urllib.request.urlopen(f"http://127.0.0.1:{port}/health", timeout=2) as r:
+        with urllib.request.urlopen(health_url, timeout=2) as r:
             return r.status == 200
     except Exception:
         return False
@@ -240,15 +247,98 @@ async def _run(cfg: dict, yaml_dir: Path, ready_file: Path | None = None) -> Non
     logger.info("Stopped.")
 
 
-def _idle_until_stopped(health_url: str) -> None:
+def _wait_until_healthy(
+    process: subprocess.Popen,
+    health_url: str,
+    timeout_s: float,
+    poll_s: float = 1.0,
+) -> None:
+    """Wait for health while reporting a detached server crash immediately."""
+    deadline = time.monotonic() + timeout_s
+    while True:
+        returncode = process.poll()
+        if returncode is not None:
+            raise RuntimeError(
+                f"server exited with status {returncode} before becoming healthy"
+            )
+        if _health_url_ok(health_url):
+            return
+
+        remaining_s = deadline - time.monotonic()
+        if remaining_s <= 0:
+            raise TimeoutError(
+                f"server did not become healthy within {timeout_s:g} seconds"
+            )
+
+        # Waiting on the process, rather than sleeping blindly, wakes the
+        # wrapper as soon as a failed import, download, or CUDA load exits.
+        try:
+            returncode = process.wait(timeout=min(poll_s, remaining_s))
+        except subprocess.TimeoutExpired:
+            continue
+        raise RuntimeError(
+            f"server exited with status {returncode} before becoming healthy"
+        )
+
+
+def _terminate_process(
+    process: subprocess.Popen,
+    timeout_s: float = _PROCESS_STOP_TIMEOUT_S,
+) -> None:
+    """Terminate and reap a detached server, escalating if it does not stop."""
+    if process.poll() is not None:
+        return
+    try:
+        process.terminate()
+    except ProcessLookupError:
+        pass
+    try:
+        process.wait(timeout=timeout_s)
+    except subprocess.TimeoutExpired:
+        try:
+            process.kill()
+        except ProcessLookupError:
+            pass
+        process.wait()
+
+
+def _start_persistent_server(
+    cmd: list[str],
+    health_url: str,
+    startup_timeout_s: float,
+) -> subprocess.Popen:
+    """Start the detached server and return it once its health check passes."""
+    process = subprocess.Popen(cmd, start_new_session=True)
+    try:
+        _wait_until_healthy(process, health_url, startup_timeout_s)
+    except TimeoutError:
+        _terminate_process(process)
+        raise
+    return process
+
+
+def _idle_until_stopped(
+    health_url: str,
+    process: subprocess.Popen | None = None,
+    poll_s: float = 5.0,
+) -> None:
     """Keep the wrapper alive while the persisted server is still running."""
     while True:
-        time.sleep(5)
-        try:
-            with urllib.request.urlopen(health_url, timeout=2) as r:
-                if r.status != 200:
-                    return
-        except Exception:
+        if process is None:
+            time.sleep(poll_s)
+        else:
+            try:
+                returncode = process.wait(timeout=poll_s)
+            except subprocess.TimeoutExpired:
+                pass
+            else:
+                if returncode != 0:
+                    raise SystemExit(
+                        f"[stt_server] persistent server exited with status {returncode}"
+                    )
+                return
+
+        if not _health_url_ok(health_url):
             # Any urlopen failure — connection refused, timeout, socket
             # error — means the persisted server is gone; exit so the
             # wrapper subprocess can be reaped.
@@ -281,15 +371,15 @@ def run() -> None:
         return
 
     # ── wrapper mode ──────────────────────────────────────────────────────────
-    port       = int(cfg.get("port", _DEFAULT_PORT))
-    health_url = f"http://127.0.0.1:{port}/health"
+    port              = int(cfg.get("port", _DEFAULT_PORT))
+    startup_timeout_s = float(cfg.get("startup_timeout_s", _DEFAULT_STARTUP_TIMEOUT_S))
+    health_url        = f"http://127.0.0.1:{port}/health"
+
+    if startup_timeout_s <= 0:
+        sys.exit("[stt_server] 'startup_timeout_s' must be greater than zero")
 
     # Reuse an already-running server (survived a previous stack shutdown).
-    try:
-        with urllib.request.urlopen(health_url, timeout=3) as r:
-            already_up = r.status == 200
-    except Exception:
-        already_up = False
+    already_up = _health_url_ok(health_url)
 
     if already_up:
         print(f"[stt_server] already running on port {port} — reusing", flush=True)
@@ -303,28 +393,20 @@ def run() -> None:
     cmd = [sys.executable, "-m", "stt_server", "--_serve"]
     if ns.config:
         cmd += ["--config", str(ns.config)]
-    subprocess.Popen(cmd, start_new_session=True)
-
-    # Poll until healthy (model load takes ~20 s).
-    print(f"[stt_server] starting persistent server on port {port}…", flush=True)
-    for _ in range(120):
-        time.sleep(1)
-        try:
-            with urllib.request.urlopen(health_url, timeout=2) as r:
-                if r.status == 200:
-                    break
-        except Exception:
-            # Server still coming up — connection refused / timeout is the
-            # expected case for the first ~20s while NeMo loads. Retry
-            # silently; the for/else below handles the hard timeout.
-            pass
-    else:
-        sys.exit("[stt_server] timed out waiting for server to become healthy")
+    print(
+        f"[stt_server] starting persistent server on port {port} "
+        f"(startup timeout: {startup_timeout_s:g}s)…",
+        flush=True,
+    )
+    try:
+        process = _start_persistent_server(cmd, health_url, startup_timeout_s)
+    except (RuntimeError, TimeoutError) as exc:
+        raise SystemExit(f"[stt_server] {exc}") from exc
 
     print(f"[stt_server] Ready  →  http://localhost:{port}/v1", flush=True)
     if ns.ready_file:
         ns.ready_file.touch()
-    _idle_until_stopped(health_url)
+    _idle_until_stopped(health_url, process)
 
 
 if __name__ == "__main__":

--- a/services/stt-server/stt_server/__main__.py
+++ b/services/stt-server/stt_server/__main__.py
@@ -26,6 +26,7 @@ import argparse
 import asyncio
 import math
 import os
+import signal
 import subprocess
 import sys
 import tempfile
@@ -33,6 +34,7 @@ import threading
 import time
 import urllib.request
 import warnings
+from contextlib import suppress
 from pathlib import Path
 
 # Silence verbose third-party startup chatter that floods the launcher's
@@ -305,17 +307,13 @@ def _terminate_process(
     """Terminate and reap a detached server, escalating if it does not stop."""
     if process.poll() is not None:
         return
-    try:
+    with suppress(ProcessLookupError):
         process.terminate()
-    except ProcessLookupError:
-        pass
     try:
         process.wait(timeout=timeout_s)
     except subprocess.TimeoutExpired:
-        try:
+        with suppress(ProcessLookupError):
             process.kill()
-        except ProcessLookupError:
-            pass
         process.wait()
 
 
@@ -325,12 +323,40 @@ def _start_persistent_server(
     startup_timeout_s: float,
 ) -> subprocess.Popen:
     """Start the detached server and return it once its health check passes."""
-    process = subprocess.Popen(cmd, start_new_session=True)
+    process: subprocess.Popen | None = None
+    pending_signal: int | None = None
+
+    def _abort_startup(signum, _frame) -> None:
+        nonlocal pending_signal
+        # SystemExit is not swallowed by health probes that intentionally catch
+        # ordinary connection errors. Cleanup runs after the interrupted wait
+        # unwinds, so subprocess internals cannot be re-entered by this handler.
+        if pending_signal is not None:
+            return
+        pending_signal = signum
+        if process is not None:
+            raise SystemExit(128 + signum)
+
+    previous_handlers = {}
     try:
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            previous_handlers[sig] = signal.signal(sig, _abort_startup)
+        process = subprocess.Popen(cmd, start_new_session=True)
+        if pending_signal is not None:
+            raise SystemExit(128 + pending_signal)
         _wait_until_healthy(process, health_url, startup_timeout_s)
-    except TimeoutError:
-        _terminate_process(process)
+    except (Exception, KeyboardInterrupt, SystemExit):
+        # Until readiness, every wrapper exit must take its detached child with
+        # it. Ignore repeated signals during the bounded cleanup; after this
+        # function returns, persistence is intentional.
+        pending_signal = pending_signal or 0
+        if process is not None:
+            _terminate_process(process)
         raise
+    finally:
+        for sig, handler in previous_handlers.items():
+            signal.signal(sig, handler)
+    assert process is not None
     return process
 
 

--- a/services/stt-server/stt_server/__main__.py
+++ b/services/stt-server/stt_server/__main__.py
@@ -18,7 +18,7 @@ Config keys
     device:            str    "cuda" | "cpu" | "auto" (default: "auto")
     port:              int    HTTP port (default: 8103)
     host:              str    Bind address (default: "0.0.0.0")
-    startup_timeout_s: float  Seconds allowed for a cold start (default: 900)
+    startup_timeout_s: float  Seconds allowed for a cold start (default: 600)
     model_cache:       str    NeMo + HF weight cache.  Resolved relative to this YAML.
                               Default: ../../models
 """
@@ -51,7 +51,7 @@ from loguru import logger
 from xr_ai_logging import setup_logging
 
 _DEFAULT_PORT              = 8103
-_DEFAULT_STARTUP_TIMEOUT_S = 900.0
+_DEFAULT_STARTUP_TIMEOUT_S = 600.0
 _PROCESS_STOP_TIMEOUT_S    = 10.0
 _IDLE_HEALTH_FAILURE_LIMIT = 3
 

--- a/tests/test_shm_ring_buffer.py
+++ b/tests/test_shm_ring_buffer.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared-memory ring-buffer lifecycle regressions."""
+from __future__ import annotations
+
+import uuid
+
+from xr_ai_hub import ShmRingBuffer
+
+
+def test_unlink_tolerates_already_removed_segment():
+    ring = ShmRingBuffer(
+        name=f"xr_test_{uuid.uuid4().hex[:12]}",
+        num_slots=1,
+        max_frame_bytes=64,
+        create=True,
+    )
+    try:
+        ring.unlink()
+        ring.unlink()
+    finally:
+        ring.close()

--- a/tests/test_shm_ring_buffer.py
+++ b/tests/test_shm_ring_buffer.py
@@ -9,7 +9,7 @@ import uuid
 from xr_ai_hub import ShmRingBuffer
 
 
-def test_unlink_tolerates_already_removed_segment():
+def test_unlink_tolerates_repeated_same_process_cleanup():
     ring = ShmRingBuffer(
         name=f"xr_test_{uuid.uuid4().hex[:12]}",
         num_slots=1,

--- a/tests/test_shm_ring_buffer.py
+++ b/tests/test_shm_ring_buffer.py
@@ -10,14 +10,11 @@ from xr_ai_hub import ShmRingBuffer
 
 
 def test_unlink_tolerates_repeated_same_process_cleanup():
-    ring = ShmRingBuffer(
+    with ShmRingBuffer(
         name=f"xr_test_{uuid.uuid4().hex[:12]}",
         num_slots=1,
         max_frame_bytes=64,
         create=True,
-    )
-    try:
+    ) as ring:
         ring.unlink()
         ring.unlink()
-    finally:
-        ring.close()

--- a/tests/test_stt_server_endpoint.py
+++ b/tests/test_stt_server_endpoint.py
@@ -9,7 +9,7 @@ boots the real model lives in test_gpu_stt_server.py.
 """
 from __future__ import annotations
 
-from unittest.mock import Mock
+from unittest.mock import Mock, call
 
 import pytest
 from fastapi.testclient import TestClient
@@ -67,6 +67,31 @@ def test_default_startup_timeout_allows_cold_download():
     assert stt_main._DEFAULT_STARTUP_TIMEOUT_S >= 900
 
 
+@pytest.mark.parametrize(
+    "value",
+    [float("nan"), float("inf"), float("-inf"), "nan", "inf", "-inf"],
+)
+def test_startup_timeout_rejects_non_finite_values(value):
+    with pytest.raises(ValueError, match="finite number greater than zero"):
+        stt_main._parse_startup_timeout(value)
+
+
+def test_start_persistent_server_returns_healthy_child(monkeypatch):
+    process = Mock()
+    process.poll.return_value = None
+    popen = Mock(return_value=process)
+    monkeypatch.setattr(stt_main.subprocess, "Popen", popen)
+    monkeypatch.setattr(stt_main, "_health_url_ok", lambda _url: True)
+
+    result = stt_main._start_persistent_server(
+        ["stt", "--_serve"], "http://health", startup_timeout_s=900
+    )
+
+    assert result is process
+    popen.assert_called_once_with(["stt", "--_serve"], start_new_session=True)
+    process.wait.assert_not_called()
+
+
 def test_wait_until_healthy_reports_detached_child_exit(monkeypatch):
     process = Mock()
     process.poll.return_value = 17
@@ -97,6 +122,42 @@ def test_idle_reports_detached_child_crash_without_health_delay(monkeypatch):
     process.wait.assert_called_once_with(timeout=5)
 
 
+def test_idle_retries_transient_health_failures(monkeypatch):
+    process = Mock()
+    process.wait.side_effect = [
+        stt_main.subprocess.TimeoutExpired("stt", 5),
+        stt_main.subprocess.TimeoutExpired("stt", 5),
+        stt_main.subprocess.TimeoutExpired("stt", 5),
+        0,
+    ]
+    health = Mock(side_effect=[False, False, True])
+    terminate = Mock()
+    monkeypatch.setattr(stt_main, "_health_url_ok", health)
+    monkeypatch.setattr(stt_main, "_terminate_process", terminate)
+
+    stt_main._idle_until_stopped("http://health", process, poll_s=5)
+
+    assert health.call_count == 3
+    terminate.assert_not_called()
+
+
+def test_idle_terminates_child_after_consecutive_health_failures(monkeypatch):
+    process = Mock()
+    process.wait.side_effect = [
+        stt_main.subprocess.TimeoutExpired("stt", 5)
+        for _ in range(stt_main._IDLE_HEALTH_FAILURE_LIMIT)
+    ]
+    terminate = Mock()
+    monkeypatch.setattr(stt_main, "_health_url_ok", lambda _url: False)
+    monkeypatch.setattr(stt_main, "_terminate_process", terminate)
+
+    with pytest.raises(SystemExit, match="consecutive health checks; terminated"):
+        stt_main._idle_until_stopped("http://health", process, poll_s=5)
+
+    assert process.wait.call_count == stt_main._IDLE_HEALTH_FAILURE_LIMIT
+    terminate.assert_called_once_with(process)
+
+
 def test_startup_timeout_terminates_detached_child(monkeypatch):
     process = Mock()
     process.poll.return_value = None
@@ -115,3 +176,21 @@ def test_startup_timeout_terminates_detached_child(monkeypatch):
     popen.assert_called_once_with(["stt", "--_serve"], start_new_session=True)
     process.terminate.assert_called_once_with()
     process.wait.assert_called_once_with(timeout=stt_main._PROCESS_STOP_TIMEOUT_S)
+
+
+def test_terminate_process_escalates_to_kill():
+    process = Mock()
+    process.poll.return_value = None
+    process.wait.side_effect = [
+        stt_main.subprocess.TimeoutExpired("stt", stt_main._PROCESS_STOP_TIMEOUT_S),
+        0,
+    ]
+
+    stt_main._terminate_process(process)
+
+    process.terminate.assert_called_once_with()
+    process.kill.assert_called_once_with()
+    assert process.wait.call_args_list == [
+        call(timeout=stt_main._PROCESS_STOP_TIMEOUT_S),
+        call(),
+    ]

--- a/tests/test_stt_server_endpoint.py
+++ b/tests/test_stt_server_endpoint.py
@@ -64,7 +64,7 @@ def test_transcription_text_format_success(app_and_backend, monkeypatch):
 
 
 def test_default_startup_timeout_allows_cold_download():
-    assert stt_main._DEFAULT_STARTUP_TIMEOUT_S >= 900
+    assert stt_main._DEFAULT_STARTUP_TIMEOUT_S == 600
 
 
 @pytest.mark.parametrize(
@@ -84,7 +84,7 @@ def test_start_persistent_server_returns_healthy_child(monkeypatch):
     monkeypatch.setattr(stt_main, "_health_url_ok", lambda _url: True)
 
     result = stt_main._start_persistent_server(
-        ["stt", "--_serve"], "http://health", startup_timeout_s=900
+        ["stt", "--_serve"], "http://health", startup_timeout_s=600
     )
 
     assert result is process
@@ -102,7 +102,7 @@ def test_wait_until_healthy_reports_detached_child_exit(monkeypatch):
     )
 
     with pytest.raises(RuntimeError, match="exited with status 17"):
-        stt_main._wait_until_healthy(process, "http://health", timeout_s=900)
+        stt_main._wait_until_healthy(process, "http://health", timeout_s=600)
 
     process.wait.assert_not_called()
 
@@ -171,7 +171,7 @@ def test_startup_timeout_terminates_detached_child(monkeypatch):
     monkeypatch.setattr(stt_main, "_wait_until_healthy", _timeout)
 
     with pytest.raises(TimeoutError, match="cold start exceeded budget"):
-        stt_main._start_persistent_server(["stt", "--_serve"], "http://health", 900)
+        stt_main._start_persistent_server(["stt", "--_serve"], "http://health", 600)
 
     popen.assert_called_once_with(["stt", "--_serve"], start_new_session=True)
     process.terminate.assert_called_once_with()

--- a/tests/test_stt_server_endpoint.py
+++ b/tests/test_stt_server_endpoint.py
@@ -9,8 +9,11 @@ boots the real model lives in test_gpu_stt_server.py.
 """
 from __future__ import annotations
 
+from unittest.mock import Mock
+
 import pytest
 from fastapi.testclient import TestClient
+from stt_server import __main__ as stt_main
 from stt_server.__main__ import _build_app
 
 _WAV = ("file", ("audio.wav", b"RIFF....WAVE", "audio/wav"))
@@ -58,3 +61,57 @@ def test_transcription_text_format_success(app_and_backend, monkeypatch):
     assert resp.status_code == 200
     assert resp.text == "hello world"
     assert resp.headers["content-type"].startswith("text/plain")
+
+
+def test_default_startup_timeout_allows_cold_download():
+    assert stt_main._DEFAULT_STARTUP_TIMEOUT_S >= 900
+
+
+def test_wait_until_healthy_reports_detached_child_exit(monkeypatch):
+    process = Mock()
+    process.poll.return_value = 17
+    monkeypatch.setattr(
+        stt_main,
+        "_health_url_ok",
+        lambda _url: pytest.fail("health should not be probed after child exit"),
+    )
+
+    with pytest.raises(RuntimeError, match="exited with status 17"):
+        stt_main._wait_until_healthy(process, "http://health", timeout_s=900)
+
+    process.wait.assert_not_called()
+
+
+def test_idle_reports_detached_child_crash_without_health_delay(monkeypatch):
+    process = Mock()
+    process.wait.return_value = 23
+    monkeypatch.setattr(
+        stt_main,
+        "_health_url_ok",
+        lambda _url: pytest.fail("health should not delay child exit reporting"),
+    )
+
+    with pytest.raises(SystemExit, match="exited with status 23"):
+        stt_main._idle_until_stopped("http://health", process, poll_s=5)
+
+    process.wait.assert_called_once_with(timeout=5)
+
+
+def test_startup_timeout_terminates_detached_child(monkeypatch):
+    process = Mock()
+    process.poll.return_value = None
+    process.wait.return_value = 0
+    popen = Mock(return_value=process)
+    monkeypatch.setattr(stt_main.subprocess, "Popen", popen)
+
+    def _timeout(*_args, **_kwargs):
+        raise TimeoutError("cold start exceeded budget")
+
+    monkeypatch.setattr(stt_main, "_wait_until_healthy", _timeout)
+
+    with pytest.raises(TimeoutError, match="cold start exceeded budget"):
+        stt_main._start_persistent_server(["stt", "--_serve"], "http://health", 900)
+
+    popen.assert_called_once_with(["stt", "--_serve"], start_new_session=True)
+    process.terminate.assert_called_once_with()
+    process.wait.assert_called_once_with(timeout=stt_main._PROCESS_STOP_TIMEOUT_S)

--- a/tests/test_stt_server_endpoint.py
+++ b/tests/test_stt_server_endpoint.py
@@ -9,14 +9,26 @@ boots the real model lives in test_gpu_stt_server.py.
 """
 from __future__ import annotations
 
+import signal
+from pathlib import Path
 from unittest.mock import Mock, call
 
 import pytest
+import yaml
 from fastapi.testclient import TestClient
 from stt_server import __main__ as stt_main
 from stt_server.__main__ import _build_app
 
 _WAV = ("file", ("audio.wav", b"RIFF....WAVE", "audio/wav"))
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_STT_CONFIGS = (
+    "services/stt-server/stt_server.yaml",
+    "agent-samples/simple-vlm-example/yaml/stt_server.yaml",
+    "agent-samples/xr-render-demo/yaml/stt_server.yaml",
+    "agent-samples/model-servers/yaml/spark/stt_server.yaml",
+    "agent-samples/model-servers/yaml/96G_blackwell/stt_server.yaml",
+    "agent-samples/model-servers/yaml/dual_48G_ada/stt_server.yaml",
+)
 
 
 @pytest.fixture()
@@ -67,6 +79,12 @@ def test_default_startup_timeout_allows_cold_download():
     assert stt_main._DEFAULT_STARTUP_TIMEOUT_S == 600
 
 
+@pytest.mark.parametrize("relative_path", _STT_CONFIGS)
+def test_shipped_stt_configs_expose_startup_timeout(relative_path):
+    config = yaml.safe_load((_REPO_ROOT / relative_path).read_text())
+    assert config["startup_timeout_s"] == stt_main._DEFAULT_STARTUP_TIMEOUT_S
+
+
 @pytest.mark.parametrize(
     "value",
     [float("nan"), float("inf"), float("-inf"), "nan", "inf", "-inf"],
@@ -90,6 +108,71 @@ def test_start_persistent_server_returns_healthy_child(monkeypatch):
     assert result is process
     popen.assert_called_once_with(["stt", "--_serve"], start_new_session=True)
     process.wait.assert_not_called()
+
+
+@pytest.mark.parametrize("signum", [signal.SIGINT, signal.SIGTERM])
+def test_startup_signal_terminates_child_and_restores_handlers(monkeypatch, signum):
+    process = Mock()
+    popen = Mock(return_value=process)
+    terminate = Mock()
+    original_handlers = {
+        signal.SIGINT: object(),
+        signal.SIGTERM: object(),
+    }
+    installed_handlers = dict(original_handlers)
+
+    def _signal(sig, handler):
+        previous = installed_handlers[sig]
+        installed_handlers[sig] = handler
+        return previous
+
+    def _interrupt_wait(*_args, **_kwargs):
+        installed_handlers[signum](signum, None)
+
+    monkeypatch.setattr(stt_main.subprocess, "Popen", popen)
+    monkeypatch.setattr(stt_main.signal, "signal", _signal)
+    monkeypatch.setattr(stt_main, "_wait_until_healthy", _interrupt_wait)
+    monkeypatch.setattr(stt_main, "_terminate_process", terminate)
+
+    with pytest.raises(SystemExit) as exc_info:
+        stt_main._start_persistent_server(["stt", "--_serve"], "http://health", 600)
+
+    assert exc_info.value.code == 128 + signum
+    terminate.assert_called_once_with(process)
+    assert installed_handlers == original_handlers
+
+
+def test_signal_during_spawn_terminates_child_before_health_wait(monkeypatch):
+    process = Mock()
+    terminate = Mock()
+    wait_until_healthy = Mock()
+    original_handlers = {
+        signal.SIGINT: object(),
+        signal.SIGTERM: object(),
+    }
+    installed_handlers = dict(original_handlers)
+
+    def _signal(sig, handler):
+        previous = installed_handlers[sig]
+        installed_handlers[sig] = handler
+        return previous
+
+    def _popen(*_args, **_kwargs):
+        installed_handlers[signal.SIGTERM](signal.SIGTERM, None)
+        return process
+
+    monkeypatch.setattr(stt_main.signal, "signal", _signal)
+    monkeypatch.setattr(stt_main.subprocess, "Popen", _popen)
+    monkeypatch.setattr(stt_main, "_wait_until_healthy", wait_until_healthy)
+    monkeypatch.setattr(stt_main, "_terminate_process", terminate)
+
+    with pytest.raises(SystemExit) as exc_info:
+        stt_main._start_persistent_server(["stt", "--_serve"], "http://health", 600)
+
+    assert exc_info.value.code == 128 + signal.SIGTERM
+    terminate.assert_called_once_with(process)
+    wait_until_healthy.assert_not_called()
+    assert installed_handlers == original_handlers
 
 
 def test_wait_until_healthy_reports_detached_child_exit(monkeypatch):


### PR DESCRIPTION
## Summary

- make the STT cold-start timeout configurable with a 600-second default and reject non-finite or non-positive values
- retain and monitor the detached STT server so startup and runtime crashes surface immediately
- terminate and reap the detached child on timeout or a wrapper SIGINT/SIGTERM during startup
- retry transient post-start health failures, then terminate a known child after three consecutive failures
- expose the startup timeout in every shipped sample and model-server STT configuration
- make shared-memory unlink cleanup idempotent within the creating process

## Testing

- focused STT, configuration, and shared-memory regressions: 27 passed
- Ruff 0.15.16 on changed Python files: passed
- broad non-GPU suite: 1015 passed, with only the 2 known stale-directory layout assertions excluded
