### PR TITLE
Fix render worker startup and align dependency rule

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -600,7 +600,9 @@ Keep non-obvious fan-out in the same change:
   server-side packages.
 - `agent-sdk/xr-ai-models/` depends only on `xr-ai-logging`, `httpx`, and
   `pyyaml`. In-tree backends use typed OpenAI-compatible HTTP rather than vendor
-  SDKs.
+  SDKs, with one scoped exception: the optional `riva` extra adds
+  `nvidia-riva-client` for gRPC-only Riva speech NIMs (see AGENTS.md); the
+  base install is unchanged.
 - `agent-sdk/xr-ai-tools/` keeps capability-specific dependencies optional;
   spatial math remains CPU-only.
 - Agent workers use public SDK packages and task-specific libraries. They never

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/__main__.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/__main__.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 from loguru import logger
 from xr_ai_logging import setup_logging
-from xr_ai_models import ChatMessage, load_models_config, make_llm, make_stt, make_tts, make_vlm
+from xr_ai_models import ChatMessage, make_llm, make_stt, make_tts, make_vlm
 from xr_ai_runtime import AgentRuntime
 from xr_ai_tools.tool_calling import tool_definitions
 from xr_ai_voice import (
@@ -28,7 +28,7 @@ from .agent import (
     USER_QUERY_TOPIC,
     RenderAgent,
 )
-from .config import WorkerConfig, load_config
+from .config import WorkerConfig, load_config, load_models
 from .lifecycle import XRSessionLifecycle
 from .scene_loop import (
     LIVE_PERCEPTION_TOOL,
@@ -62,6 +62,18 @@ async def _probe_warmed_llm(llm, *, warmup: bool) -> bool:
     return True
 
 
+def _make_model_services(config_path: pathlib.Path | None):
+    """Model clients for the profile selected by the worker YAML at *config_path*."""
+    models_cfg = load_models(config_path)
+    return models_cfg, (
+        make_llm(models_cfg, "llm"),
+        make_llm(models_cfg, "agent_llm"),
+        make_stt(models_cfg, "stt"),
+        make_tts(models_cfg, "tts"),
+        make_vlm(models_cfg, "vlm"),
+    )
+
+
 async def main(
     cfg: WorkerConfig,
     config_path: pathlib.Path | None = None,
@@ -83,12 +95,7 @@ async def main(
     )
     logger.bind(trace=True).info("=== trace started ===")
 
-    models_cfg = load_models_config(cfg.models_yaml)
-    llm = make_llm(models_cfg, "llm")
-    agent_llm = make_llm(models_cfg, "agent_llm")
-    stt = make_stt(models_cfg, "stt")
-    tts = make_tts(models_cfg, "tts")
-    vlm_service = make_vlm(models_cfg, "vlm")
+    models_cfg, (llm, agent_llm, stt, tts, vlm_service) = _make_model_services(config_path)
 
     async def llm_probe() -> bool:
         return await _probe_warmed_llm(

--- a/tests/test_xr_render_demo_wire.py
+++ b/tests/test_xr_render_demo_wire.py
@@ -1255,6 +1255,8 @@ async def test_worker_main_resolves_models_from_config_path(monkeypatch) -> None
 
     monkeypatch.setattr(worker_main, "_make_model_services", _capture)
     monkeypatch.setattr(worker_main, "setup_logging", lambda *_a, **_k: None)
+    # main() registers a process-global trace sink; keep it out of the test run.
+    monkeypatch.setattr(worker_main.logger, "add", lambda *_a, **_k: 0)
     with pytest.raises(_Abort):
         await worker_main.main(cfg, config_path=config_path)
     assert seen == [config_path]

--- a/tests/test_xr_render_demo_wire.py
+++ b/tests/test_xr_render_demo_wire.py
@@ -1218,3 +1218,23 @@ def test_scene_loop_bounds_participant_state_as_one_lru_unit() -> None:
     for state in (brain._history, brain._recent_moves,  # noqa: SLF001
                   brain._pre_move_positions):  # noqa: SLF001
         assert set(state) == {"alice", "carol"}
+
+
+async def test_worker_builds_model_services_from_shipped_config() -> None:
+    # Regression: main() must construct every model client from the shipped
+    # worker YAML via load_models(config_path) (a stale WorkerConfig field
+    # reference here once crashed the worker at startup).
+    from xr_render_demo_worker.__main__ import _make_model_services
+
+    config_path = (
+        _WORKER_DIR.parent / "yaml" / "xr_render_demo_worker.yaml"
+    )
+    models_cfg, services = _make_model_services(config_path)
+    try:
+        assert models_cfg.llm("llm").base_url
+        assert len(services) == 5
+        assert all(service is not None for service in services)
+    finally:
+        await asyncio.gather(
+            *(service.close() for service in services), return_exceptions=True
+        )

--- a/tests/test_xr_render_demo_wire.py
+++ b/tests/test_xr_render_demo_wire.py
@@ -1221,9 +1221,8 @@ def test_scene_loop_bounds_participant_state_as_one_lru_unit() -> None:
 
 
 async def test_worker_builds_model_services_from_shipped_config() -> None:
-    # Regression: main() must construct every model client from the shipped
-    # worker YAML via load_models(config_path) (a stale WorkerConfig field
-    # reference here once crashed the worker at startup).
+    # The worker must construct every model client from the profile selected
+    # by its worker YAML.
     from xr_render_demo_worker.__main__ import _make_model_services
 
     config_path = (
@@ -1238,3 +1237,24 @@ async def test_worker_builds_model_services_from_shipped_config() -> None:
         await asyncio.gather(
             *(service.close() for service in services), return_exceptions=True
         )
+
+
+async def test_worker_main_resolves_models_from_config_path(monkeypatch) -> None:
+    from xr_render_demo_worker import __main__ as worker_main
+
+    config_path = _WORKER_DIR.parent / "yaml" / "xr_render_demo_worker.yaml"
+    cfg = worker_main.load_config(config_path)
+    seen: list[object] = []
+
+    class _Abort(Exception):
+        pass
+
+    def _capture(path):
+        seen.append(path)
+        raise _Abort
+
+    monkeypatch.setattr(worker_main, "_make_model_services", _capture)
+    monkeypatch.setattr(worker_main, "setup_logging", lambda *_a, **_k: None)
+    with pytest.raises(_Abort):
+        await worker_main.main(cfg, config_path=config_path)
+    assert seen == [config_path]


### PR DESCRIPTION
The render worker crashed at startup with `AttributeError: 'WorkerConfig' object has no attribute 'models_yaml'`: `__main__.py` still read the `models_yaml` field that the deployment-profile conversion (#329) removed from `WorkerConfig`, replacing it with the `load_models(config_path)` helper.

- The worker now builds its model clients through `load_models(config_path)`, extracted into `_make_model_services()` so the exact wiring `main()` uses is testable.
- Adds a worker-startup regression test that constructs every model client from the shipped worker YAML; it fails with the `AttributeError` on unfixed main.
- Aligns the curated dependency rule in `DEPENDENCIES.md` with the approved `xr-ai-models[riva]` exception already recorded in `AGENTS.md` (the curated rule predated that approval and still stated the unamended contract).

Verified: full non-GPU suite passes; the render demo stack was started end-to-end on hardware with the shipped default profile — worker reaches ready and serves.
