### PR TITLE
fix(vision): harden stream cleanup and warm VLM

### DIFF
--- a/agent-samples/simple-vlm-example/README.md
+++ b/agent-samples/simple-vlm-example/README.md
@@ -60,7 +60,9 @@ The worker and orchestrator consume the deployment profile selected by
 - `models.omni.json` reuses the Nemotron-Omni VLM service on port 8108.
 
 The same profile owns model behavior, endpoints, credentials, readiness, and
-launcher process ownership.
+launcher process ownership. Before announcing readiness, the worker completes a
+small streaming request with a 1280x720 JPEG so the first user query does not
+pay the multimodal initialization cost.
 
 ## Relay visibility
 

--- a/agent-samples/simple-vlm-example/worker/simple_vlm_example_worker/app.py
+++ b/agent-samples/simple-vlm-example/worker/simple_vlm_example_worker/app.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import io
+import time
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -12,8 +14,9 @@ from threading import Lock
 
 import nemo_relay
 from loguru import logger
+from PIL import Image
 from xr_ai_logging import setup_logging
-from xr_ai_models import load_models_config, make_stt, make_tts, make_vlm
+from xr_ai_models import VLMService, load_models_config, make_stt, make_tts, make_vlm
 from xr_ai_runtime import AgentRuntime
 from xr_ai_tools.current_frame import CurrentFrameTool
 from xr_ai_tools.image import ImageRegistry
@@ -28,6 +31,56 @@ from .agent import (
     SimpleVlmAgent,
 )
 from .config import WorkerConfig
+
+_VLM_WARMUP_SIZE = (1280, 720)
+_VLM_WARMUP_MAX_TOKENS = 4
+_VLM_WARMUP_TIMEOUT_S = 120.0
+
+
+def _vlm_warmup_jpeg() -> bytes:
+    buffer = io.BytesIO()
+    with Image.new("RGB", _VLM_WARMUP_SIZE, color=(128, 128, 128)) as image:
+        image.save(buffer, format="JPEG", quality=90)
+    return buffer.getvalue()
+
+
+_VLM_WARMUP_IMAGE = _vlm_warmup_jpeg()
+
+
+async def _warm_vlm(vlm: VLMService) -> bool:
+    """Confirm readiness by exercising the production multimodal stream."""
+
+    try:
+        if not await vlm.health():
+            return False
+        started_at = time.monotonic()
+        logger.info(
+            "VLM warmup request started image={}x{} max_tokens={}",
+            *_VLM_WARMUP_SIZE,
+            _VLM_WARMUP_MAX_TOKENS,
+        )
+        first_token_at: float | None = None
+        async for _chunk in vlm.stream_images(
+            [_VLM_WARMUP_IMAGE],
+            "What is the dominant color?",
+            system_prompt="Answer with one word.",
+            max_tokens=_VLM_WARMUP_MAX_TOKENS,
+            timeout=_VLM_WARMUP_TIMEOUT_S,
+        ):
+            if first_token_at is None:
+                first_token_at = time.monotonic()
+                logger.info(
+                    "VLM warmup first token latency_ms={:.1f}",
+                    (first_token_at - started_at) * 1000,
+                )
+        logger.info(
+            "VLM warmup completed total_ms={:.1f}",
+            (time.monotonic() - started_at) * 1000,
+        )
+        return True
+    except Exception:
+        logger.exception("VLM warmup failed; readiness will retry")
+        return False
 
 
 @asynccontextmanager
@@ -83,7 +136,7 @@ async def run_app(
             silero_threshold=config.silero_threshold,
         ),
         voice_gate=voice_gate,
-        probes={"vlm": vlm.health},
+        probes={"vlm": lambda: _warm_vlm(vlm)},
         ready_file=ready_file,
         closeables=(vlm,),
         text_topic="vlm.response",

--- a/agent-samples/simple-vlm-example/worker/simple_vlm_example_worker/app.py
+++ b/agent-samples/simple-vlm-example/worker/simple_vlm_example_worker/app.py
@@ -60,7 +60,7 @@ async def _warm_vlm(vlm: VLMService) -> bool:
             _VLM_WARMUP_MAX_TOKENS,
         )
         first_token_at: float | None = None
-        async for _chunk in vlm.stream_images(
+        async for _ in vlm.stream_images(
             [_VLM_WARMUP_IMAGE],
             "What is the dominant color?",
             system_prompt="Answer with one word.",

--- a/agent-sdk/xr-ai-tools/xr_ai_tools/_vision.py
+++ b/agent-sdk/xr-ai-tools/xr_ai_tools/_vision.py
@@ -34,7 +34,12 @@ def image_sanitizer() -> Iterator[None]:
     try:
         yield
     finally:
-        nemo_relay.scope_local.deregister_llm_sanitize_request(handle, name)
+        try:
+            nemo_relay.scope_local.deregister_llm_sanitize_request(handle, name)
+        except RuntimeError as error:
+            # Popping the owner already removes all of its scope-local registrations.
+            if str(error) != f"not found: scope {handle.uuid} not found":
+                raise
 
 
 def relay_request(

--- a/agent-sdk/xr-ai-tools/xr_ai_tools/_vision.py
+++ b/agent-sdk/xr-ai-tools/xr_ai_tools/_vision.py
@@ -17,6 +17,14 @@ import nemo_relay
 VLM_CALL_NAME = "xr-ai-vlm"
 _IMAGE_REDACTION = "<redacted:image>"
 _IMAGE_SANITIZER_IDS = count()
+_MISSING_SCOPE_PREFIX = "not found: scope "
+
+
+def _owning_scope_is_missing(error: RuntimeError, owner_uuid: str) -> bool:
+    # Relay's native binding reports missing scopes as RuntimeError text.
+    owner_prefix = f"{_MISSING_SCOPE_PREFIX}{owner_uuid}"
+    message = str(error)
+    return message == owner_prefix or message.startswith(f"{owner_prefix} ")
 
 
 @contextmanager
@@ -38,7 +46,7 @@ def image_sanitizer() -> Iterator[None]:
             nemo_relay.scope_local.deregister_llm_sanitize_request(handle, name)
         except RuntimeError as error:
             # Popping the owner already removes all of its scope-local registrations.
-            if str(error) != f"not found: scope {handle.uuid} not found":
+            if not _owning_scope_is_missing(error, handle.uuid):
                 raise
 
 

--- a/agent-sdk/xr-ai-tools/xr_ai_tools/vision.py
+++ b/agent-sdk/xr-ai-tools/xr_ai_tools/vision.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from collections.abc import AsyncIterator, Sequence
 from typing import Any
 
@@ -167,6 +168,8 @@ class _ImageInference:
             yield ImageQueryChunk(text="Image input unavailable — please select it again.")
             return
         try:
+            started_at = time.monotonic()
+            _LOGGER.info("Image VLM stream request started image_count=%d", len(inputs))
             with image_sanitizer():
                 stream = await nemo_relay.llm.stream_execute(
                     VLM_CALL_NAME,
@@ -185,6 +188,12 @@ class _ImageInference:
                 async for chunk in stream:
                     text = stream_text(chunk)
                     if text:
+                        if not emitted_output:
+                            _LOGGER.info(
+                                "Image VLM stream first token latency_ms=%.1f image_count=%d",
+                                (time.monotonic() - started_at) * 1000,
+                                len(inputs),
+                            )
                         emitted_output = True
                         yield ImageQueryChunk(text=text)
         except Exception:

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -117,6 +117,7 @@ uv run simple_vlm_example
 ```
 
 The XR-Media-Hub, VLM, STT, and TTS start together (or reuse running services).
+Worker readiness includes a short 1280x720 streaming VLM warmup.
 The hub prints:
 
 ```

--- a/tests/test_image_tools.py
+++ b/tests/test_image_tools.py
@@ -6,8 +6,10 @@
 import asyncio
 import base64
 import io
+import logging
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, cast
 
 import nemo_relay
@@ -17,6 +19,7 @@ from pydantic import ValidationError
 from xr_ai_hub import FrameData, FrameSignal, PixelFormat, ProcessorEndpoint
 from xr_ai_models import ChatResponse, VLMService
 from xr_ai_tools._pixels import encode_image, frame_to_pil
+from xr_ai_tools._vision import image_sanitizer
 from xr_ai_tools.current_frame import (
     CurrentFrameRequest,
     CurrentFrameTool,
@@ -417,7 +420,7 @@ async def test_image_query_hides_reasoning_and_marks_failures_unavailable() -> N
     )
 
 
-async def test_streaming_image_query_yields_typed_chunks() -> None:
+async def test_streaming_image_query_yields_typed_chunks(caplog) -> None:
     images = ImageRegistry()
     image = images.put(b"image")
     vlm = _Vlm()
@@ -427,10 +430,74 @@ async def test_streaming_image_query_yields_typed_chunks() -> None:
         system_prompt="Answer briefly.",
     )
 
-    chunks = [chunk async for chunk in tool.stream(ImageQueryRequest(image=image, query="What is shown?"))]
+    with caplog.at_level(logging.INFO, logger="xr_ai_tools.vision"):
+        chunks = [
+            chunk
+            async for chunk in tool.stream(
+                ImageQueryRequest(image=image, query="What is shown?")
+            )
+        ]
 
     assert [chunk.text for chunk in chunks] == ["a ", "blue ", "square"]
     assert vlm.stream_calls[0][:3] == ([b"image"], "What is shown?", "Answer briefly.")
+    assert "Image VLM stream request started image_count=1" in caplog.text
+    assert "Image VLM stream first token latency_ms=" in caplog.text
+
+
+async def test_image_sanitizer_tolerates_parent_scope_teardown_after_partial_stream(
+    caplog,
+    monkeypatch,
+) -> None:
+    async def stream_execute(*_args, **_kwargs):
+        async def chunks():
+            yield {"choices": [{"delta": {"content": "a "}}]}
+            await asyncio.Event().wait()
+
+        return chunks()
+
+    monkeypatch.setattr(nemo_relay.llm, "stream_execute", stream_execute)
+    images = ImageRegistry()
+    tool = StreamingImageQueryTool(
+        images=images,
+        vlm=cast(VLMService, _Vlm()),
+    )
+    stream = tool.handler(
+        ImageQueryRequest(image=images.put(b"image"), query="What is shown?")
+    )
+
+    with caplog.at_level(logging.ERROR, logger="xr_ai_tools.vision"):
+        with nemo_relay.scope.scope("parent", nemo_relay.ScopeType.Agent):
+            assert (await anext(stream)).text == "a "
+        await stream.aclose()
+
+    assert "Image VLM stream failed" not in caplog.text
+
+
+def test_image_sanitizer_reraises_unrelated_deregistration_failure(
+    monkeypatch,
+) -> None:
+    def fail_deregistration(*_args) -> None:
+        raise RuntimeError("deregistration failed")
+
+    monkeypatch.setattr(
+        nemo_relay.scope,
+        "get_handle",
+        lambda: SimpleNamespace(uuid="owner"),
+    )
+    monkeypatch.setattr(
+        nemo_relay.scope_local,
+        "register_llm_sanitize_request",
+        lambda *_args: None,
+    )
+    monkeypatch.setattr(
+        nemo_relay.scope_local,
+        "deregister_llm_sanitize_request",
+        fail_deregistration,
+    )
+
+    with pytest.raises(RuntimeError, match="deregistration failed"):
+        with image_sanitizer():
+            pass
 
 
 async def test_streaming_image_query_stops_after_partial_failure() -> None:

--- a/tests/test_image_tools.py
+++ b/tests/test_image_tools.py
@@ -477,7 +477,7 @@ def test_image_sanitizer_reraises_unrelated_deregistration_failure(
     monkeypatch,
 ) -> None:
     def fail_deregistration(*_args) -> None:
-        raise RuntimeError("deregistration failed")
+        raise RuntimeError("not found: scope another-owner not found")
 
     monkeypatch.setattr(
         nemo_relay.scope,
@@ -495,9 +495,35 @@ def test_image_sanitizer_reraises_unrelated_deregistration_failure(
         fail_deregistration,
     )
 
-    with pytest.raises(RuntimeError, match="deregistration failed"):
+    with pytest.raises(RuntimeError, match="another-owner"):
         with image_sanitizer():
             pass
+
+
+def test_image_sanitizer_tolerates_changed_missing_owner_suffix(
+    monkeypatch,
+) -> None:
+    def fail_deregistration(*_args) -> None:
+        raise RuntimeError("not found: scope owner was already removed")
+
+    monkeypatch.setattr(
+        nemo_relay.scope,
+        "get_handle",
+        lambda: SimpleNamespace(uuid="owner"),
+    )
+    monkeypatch.setattr(
+        nemo_relay.scope_local,
+        "register_llm_sanitize_request",
+        lambda *_args: None,
+    )
+    monkeypatch.setattr(
+        nemo_relay.scope_local,
+        "deregister_llm_sanitize_request",
+        fail_deregistration,
+    )
+
+    with image_sanitizer():
+        pass
 
 
 async def test_streaming_image_query_stops_after_partial_failure() -> None:

--- a/tests/test_simple_vlm_example_worker.py
+++ b/tests/test_simple_vlm_example_worker.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import asyncio
+import io
 import sys
 import time
 from collections.abc import AsyncIterator
@@ -17,6 +18,7 @@ import nemo_relay
 import pytest
 import tomllib
 import yaml
+from PIL import Image
 from xr_ai_hub import FrameData, FrameSignal, FrameUnavailable, PixelFormat, ProcessorEndpoint
 from xr_ai_models import ChatResponse, VLMService
 from xr_ai_runtime import AgentRuntime
@@ -58,10 +60,25 @@ class _Service:
     def __init__(self) -> None:
         self.health_calls = 0
         self.close_calls = 0
+        self.stream_calls = []
 
     async def health(self) -> bool:
         self.health_calls += 1
         return True
+
+    async def stream_images(
+        self,
+        images,
+        question,
+        *,
+        system_prompt="",
+        max_tokens=None,
+        timeout=None,
+    ):
+        self.stream_calls.append(
+            (images, question, system_prompt, max_tokens, timeout)
+        )
+        yield "gray"
 
     async def close(self) -> None:
         self.close_calls += 1
@@ -582,6 +599,16 @@ async def test_app_wires_text_voice_cleanup_readiness_and_shutdown(
     assert "publish:voice.output" not in {event["name"] for event in relay_events}
     assert "agent:voice" not in {event["name"] for event in relay_events}
     assert stt.health_calls == tts.health_calls == vlm.health_calls == 1
+    assert len(vlm.stream_calls) == 1
+    warmup_images, question, system_prompt, max_tokens, timeout = vlm.stream_calls[0]
+    assert len(warmup_images) == 1
+    with Image.open(io.BytesIO(warmup_images[0])) as warmup_image:
+        assert warmup_image.format == "JPEG"
+        assert warmup_image.size == (1280, 720)
+    assert question == "What is the dominant color?"
+    assert system_prompt == "Answer with one word."
+    assert max_tokens == 4
+    assert timeout == 120.0
     assert stt.close_calls == tts.close_calls == vlm.close_calls == 1
     assert transport.shutdown_calls == 1
     assert sessions[0].text_topic == "vlm.response"

--- a/tests/test_simple_vlm_example_worker.py
+++ b/tests/test_simple_vlm_example_worker.py
@@ -24,6 +24,7 @@ from xr_ai_models import ChatResponse, VLMService
 from xr_ai_runtime import AgentRuntime
 from xr_ai_voice import UserQuery, VoiceAgent, VoiceInterrupted, VoiceOutput
 from xr_ai_voice import _runtime as voice_runtime_module
+from xr_ai_voice._readiness import wait_for_services
 from xr_ai_voice._session import _VoiceSession as VoiceSession
 from xr_ai_voicegate import VoiceGateConfig
 
@@ -82,6 +83,22 @@ class _Service:
 
     async def close(self) -> None:
         self.close_calls += 1
+
+
+class _FlakyWarmupService(_Service):
+    async def stream_images(
+        self,
+        images,
+        question,
+        *,
+        system_prompt="",
+        max_tokens=None,
+        timeout=None,
+    ):
+        self.stream_calls.append((images, question, system_prompt, max_tokens, timeout))
+        if len(self.stream_calls) == 1:
+            raise RuntimeError("still loading")
+        yield "gray"
 
 
 class _Transport:
@@ -504,6 +521,21 @@ async def test_cancelled_vlm_turn_does_not_publish_stream_terminator() -> None:
     assert closed.is_set()
     assert len(published) == 1
     assert published[0].final is False
+
+
+async def test_vlm_warmup_failure_is_retried_by_readiness() -> None:
+    vlm = _FlakyWarmupService()
+
+    await asyncio.wait_for(
+        wait_for_services(
+            {"vlm": lambda: app._warm_vlm(cast(VLMService, vlm))},
+            poll_interval=0,
+        ),
+        timeout=1,
+    )
+
+    assert vlm.health_calls == 2
+    assert len(vlm.stream_calls) == 2
 
 
 async def test_app_wires_text_voice_cleanup_readiness_and_shutdown(


### PR DESCRIPTION
## Summary

- treat Relay image-sanitizer cleanup as complete only when its owning scope has already been removed
- warm the active simple-vlm model profile with a representative 1280x720 JPEG streaming request before readiness
- log image-stream request start and first-token latency for VLM-server correlation
- cover partial-stream teardown, unrelated cleanup errors, timing, and warmup request shape

## Validation

- `uv run pytest -q test_image_tools.py test_simple_vlm_example_worker.py test_config_documentation.py` (47 passed)
- full CPU suite (1,071 passed; 10 GPU tests and 2 local ignored-directory layout checks deselected)
- Ruff 0.15.16, SPDX header check, and `git diff --check`
