### PR TITLE
feat: add dual 32 GB Blackwell model profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ uv sync
 uv run model_servers
 ```
 
-GPU profiles are auto-detected (`dual_48G_ada` / `spark` / `96G_blackwell`).
+GPU profiles are auto-detected (`dual_32G_blackwell` / `dual_48G_ada` /
+`spark` / `96G_blackwell`).
 On first run the stack downloads tens of GB from Hugging Face and can take
 tens of minutes. On subsequent runs the containers restart in under a minute.
 

--- a/agent-samples/model-servers/yaml/dual_32G_blackwell/embedding_server.yaml
+++ b/agent-samples/model-servers/yaml/dual_32G_blackwell/embedding_server.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+model: nvidia/llama-nemotron-embed-1b-v2
+host: "0.0.0.0"
+port: 8109
+served_model_name: embed
+model_cache: ../../../../models
+cuda_visible_devices: "1"
+max_num_seqs: 32
+max_model_len: 8192
+gpu_memory_utilization: 0.08
+enforce_eager: true
+vllm_backend: docker
+vllm_image: nvcr.io/nvidia/vllm:26.04-py3

--- a/agent-samples/model-servers/yaml/dual_32G_blackwell/nemotron_omni_llm_server.yaml
+++ b/agent-samples/model-servers/yaml/dual_32G_blackwell/nemotron_omni_llm_server.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Experimental dual-32 GB Blackwell allocation. NVFP4 Omni owns GPU 0;
+# Cosmos, embedding, and STT share GPU 1. The shorter context limits KV cache
+# while this profile is validated on Brev.
+host: "0.0.0.0"
+port: 8108
+hf_token: ""
+model_cache: ../../../../models
+cuda_visible_devices: "0"
+max_num_seqs: 4
+tensor_parallel_size: 1
+max_model_len: 16384
+gpu_memory_utilization: 0.88
+enforce_eager: false
+video_pruning_rate: 0.5
+video_fps: 2
+video_num_frames: 64
+moe_backend: triton
+vllm_backend: docker
+vllm_image: vllm/vllm-openai:v0.20.0
+extra_pip: []

--- a/agent-samples/model-servers/yaml/dual_32G_blackwell/nim_llm_server.yaml
+++ b/agent-samples/model-servers/yaml/dual_32G_blackwell/nim_llm_server.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# UNTESTED ESTIMATE: the LLM NIM owns GPU 0.
+image: nvcr.io/nim/nvidia/nemotron-3-nano:2.0.10
+http_port: 8110
+nim_cache: ../../../../models/nim
+cuda_visible_devices: "0"
+env:
+  NIM_MAX_MODEL_LEN: "16384"
+  NIM_KVCACHE_PERCENT: "0.85"
+  NIM_PASSTHROUGH_ARGS: "--enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser nemotron_v3"

--- a/agent-samples/model-servers/yaml/dual_32G_blackwell/nim_stt_server.yaml
+++ b/agent-samples/model-servers/yaml/dual_32G_blackwell/nim_stt_server.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# UNTESTED ESTIMATE: Riva speech NIMs share GPU 0 in vlm_speech_nim.
+image: nvcr.io/nim/nvidia/parakeet-tdt-0.6b-v2:1.2.0
+http_port: 9010
+grpc_port: 50051
+nim_cache: ../../../../models/nim
+cuda_visible_devices: "0"
+env:
+  NIM_USE_MULTIPROCESSING_FOR_INFERENCE: "false"

--- a/agent-samples/model-servers/yaml/dual_32G_blackwell/nim_tts_server.yaml
+++ b/agent-samples/model-servers/yaml/dual_32G_blackwell/nim_tts_server.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# UNTESTED ESTIMATE: Riva speech NIMs share GPU 0 in vlm_speech_nim.
+image: nvcr.io/nim/nvidia/magpie-tts-multilingual:1.9.0
+http_port: 9011
+grpc_port: 50052
+nim_cache: ../../../../models/nim
+cuda_visible_devices: "0"

--- a/agent-samples/model-servers/yaml/dual_32G_blackwell/nim_vlm_server.yaml
+++ b/agent-samples/model-servers/yaml/dual_32G_blackwell/nim_vlm_server.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# UNTESTED ESTIMATE: Cosmos NIM shares GPU 1 with local STT and embedding.
+image: nvcr.io/nim/nvidia/cosmos-reason1-7b:1.4.1
+http_port: 8100
+nim_cache: ../../../../models/nim
+cuda_visible_devices: "1"
+env:
+  NIM_MAX_MODEL_LEN: "8192"
+  NIM_KVCACHE_PERCENT: "0.70"

--- a/agent-samples/model-servers/yaml/dual_32G_blackwell/nim_vlm_server_vlm_speech_nim.yaml
+++ b/agent-samples/model-servers/yaml/dual_32G_blackwell/nim_vlm_server_vlm_speech_nim.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# UNTESTED ESTIMATE: speech NIMs own GPU 0; Cosmos and embedding share GPU 1.
+image: nvcr.io/nim/nvidia/cosmos-reason1-7b:1.4.1
+http_port: 8100
+nim_cache: ../../../../models/nim
+cuda_visible_devices: "1"
+env:
+  NIM_MAX_MODEL_LEN: "8192"
+  NIM_KVCACHE_PERCENT: "0.75"

--- a/agent-samples/model-servers/yaml/dual_32G_blackwell/stt_server.yaml
+++ b/agent-samples/model-servers/yaml/dual_32G_blackwell/stt_server.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+model: nvidia/parakeet-tdt-0.6b-v3
+device: auto
+cuda_visible_devices: "1"
+port: 8103
+host: "0.0.0.0"
+model_cache: ../../../../models

--- a/agent-samples/model-servers/yaml/dual_32G_blackwell/vlm_server.yaml
+++ b/agent-samples/model-servers/yaml/dual_32G_blackwell/vlm_server.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Cosmos needs a measured 22.1 GiB budget. On a nominal 32 GB GPU, 0.70
+# reserves that capacity while leaving room for embedding, STT, and runtime.
+model: nvidia/Cosmos3-Nano
+hf_overrides:
+  architectures:
+    - Cosmos3ForConditionalGeneration
+hf_token: ""
+port: 8100
+host: "0.0.0.0"
+cuda_visible_devices: "1"
+model_cache: ../../../../models
+gpu_memory_utilization: 0.70
+max_num_seqs: 4
+enforce_eager: true
+async_scheduling: true
+mm_encoder_tp_mode: data
+max_videos_per_prompt: 0
+max_images_per_prompt: 4
+vllm_backend: docker
+vllm_image: nvcr.io/nvidia/vllm:26.07-py3

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -35,8 +35,9 @@ uv sync
 uv run model_servers
 ```
 
-GPU profiles are auto-detected (`dual_48G_ada`, `spark`, `96G_blackwell`). These
-are presets for common configurations; to run on a different GPU, refer to
+GPU profiles are auto-detected (`dual_32G_blackwell`, `dual_48G_ada`, `spark`,
+`96G_blackwell`). These are presets for common configurations; to run on a
+different GPU, refer to
 {doc}`Running on other GPUs </getting_started/requirements>`.
 On first run each model downloads from HuggingFace (tens of GB; can take
 tens of minutes). On subsequent runs the containers restart in under a minute.

--- a/docs/source/getting_started/requirements.md
+++ b/docs/source/getting_started/requirements.md
@@ -7,11 +7,11 @@
 
 ## Hardware
 
-The bundled GPU profiles target a single NVIDIA RTX PRO 6000 Blackwell workstation
-GPU or an NVIDIA DGX Spark, both of which have enough VRAM to run the full model
-stack locally. These profiles are turnkey presets, not a hardware allowlist: you
-can run on other NVIDIA GPUs by tuning the per-server GPU-memory split. Refer to
-[Running on other GPUs](#running-on-other-gpus) below.
+The bundled GPU profiles target a single NVIDIA RTX PRO 6000 Blackwell
+workstation GPU, NVIDIA DGX Spark, dual 48 GB Ada GPUs, and an experimental
+dual 32 GB Blackwell configuration. These profiles are presets, not a hardware
+allowlist: you can run on other NVIDIA GPUs by tuning the per-server GPU-memory
+split. Refer to [Running on other GPUs](#running-on-other-gpus) below.
 
 If you prefer not to run models on local hardware, model endpoints are plain
 URLs: point the worker configuration at a cloud NIM or model endpoint and no

--- a/tests/test_launcher_gpu.py
+++ b/tests/test_launcher_gpu.py
@@ -52,6 +52,13 @@ class TestDetectGpuConfig:
 
     # ── Blackwell scenarios ────────────────────────────────────────────────────
 
+    def test_dual_32gb_blackwell_returns_dual_profile(self):
+        with _mock_smi([
+            "GeForce RTX 5090, 12.0, 32607 MiB",
+            "GeForce RTX 5090, 12.0, 32607 MiB",
+        ]):
+            assert detect_gpu_config() == "dual_32G_blackwell"
+
     def test_blackwell_96gb_returns_96G_blackwell(self):
         with _mock_smi(["RTX PRO 6000 Blackwell, 12.0, 98304 MiB"]):
             assert detect_gpu_config() == "96G_blackwell"

--- a/tests/test_model_servers.py
+++ b/tests/test_model_servers.py
@@ -103,7 +103,45 @@ def test_dual_ada_configs_follow_profile_gpu_layout(
     assert yaml.safe_load(config_path.read_text())["cuda_visible_devices"] == gpu
 
 
-@pytest.mark.parametrize("profile", ["96G_blackwell", "dual_48G_ada", "spark"])
+@pytest.mark.parametrize(
+    ("service", "gpu"),
+    [("stt", "1"), ("omni", "0"), ("vlm", "1"), ("embedding", "1")],
+)
+def test_dual_32g_blackwell_splits_default_stack(
+    monkeypatch: pytest.MonkeyPatch,
+    service: str,
+    gpu: str,
+) -> None:
+    monkeypatch.setattr(
+        _model_servers, "detect_gpu_config", lambda: "dual_32G_blackwell"
+    )
+
+    processes, _ = _model_servers._build_processes("default")
+    process = next(p for p in processes if p.name == service)
+    config_path = _REPO_ROOT / "agent-samples/model-servers" / str(process.config)
+
+    assert yaml.safe_load(config_path.read_text())["cuda_visible_devices"] == gpu
+
+
+@pytest.mark.parametrize("selection", ["default", "vlm_llm_nim", "vlm_speech_nim"])
+def test_dual_32g_blackwell_covers_every_deployment_profile(
+    monkeypatch: pytest.MonkeyPatch,
+    selection: str,
+) -> None:
+    monkeypatch.setattr(
+        _model_servers, "detect_gpu_config", lambda: "dual_32G_blackwell"
+    )
+
+    processes, _ = _model_servers._build_processes(selection)
+
+    for process in processes:
+        config_path = _REPO_ROOT / "agent-samples/model-servers" / str(process.config)
+        assert config_path.is_file(), config_path
+
+
+@pytest.mark.parametrize(
+    "profile", ["96G_blackwell", "dual_32G_blackwell", "dual_48G_ada", "spark"]
+)
 def test_omni_profiles_select_supported_vllm_images(profile: str) -> None:
     profile_path = (
         _REPO_ROOT
@@ -117,7 +155,7 @@ def test_omni_profiles_select_supported_vllm_images(profile: str) -> None:
     assert config["vllm_backend"] == "docker"
     assert config["vllm_image"] == "vllm/vllm-openai:v0.20.0"
     assert config["extra_pip"] == []
-    if profile == "96G_blackwell":
+    if profile in {"96G_blackwell", "dual_32G_blackwell"}:
         assert config["moe_backend"] == "triton"
     else:
         assert "moe_backend" not in config

--- a/tests/test_vlm_server_config.py
+++ b/tests/test_vlm_server_config.py
@@ -20,6 +20,7 @@ _LOCAL_VLM_CONFIGS = (
     _SERVER_YAML,
     _SAMPLES / "simple-vlm-example" / "yaml" / "vlm_server.yaml",
     _MODEL_PROFILES / "96G_blackwell" / "vlm_server.yaml",
+    _MODEL_PROFILES / "dual_32G_blackwell" / "vlm_server.yaml",
     _MODEL_PROFILES / "dual_48G_ada" / "vlm_server.yaml",
     _MODEL_PROFILES / "spark" / "vlm_server.yaml",
 )
@@ -88,8 +89,12 @@ def test_hardware_profiles_reserve_measured_reasoner_memory() -> None:
     dual_ada = yaml.safe_load(
         (_MODEL_PROFILES / "dual_48G_ada" / "vlm_server.yaml").read_text()
     )
+    dual_blackwell = yaml.safe_load(
+        (_MODEL_PROFILES / "dual_32G_blackwell" / "vlm_server.yaml").read_text()
+    )
 
     assert blackwell["gpu_memory_utilization"] == 0.23
+    assert dual_blackwell["gpu_memory_utilization"] == 0.70
     assert dual_ada["gpu_memory_utilization"] == 0.47
 
 

--- a/utils/xr-ai-launcher/xr_ai_launcher/_gpu.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/_gpu.py
@@ -16,6 +16,7 @@ def detect_gpu_config() -> str:
     Profiles
     --------
     dual_48G_ada   — 2× ADA 48 GB (default / current dev box)
+    dual_32G_blackwell — 2× Blackwell 32 GB
     spark          — 1× Blackwell GB10 (DGX Spark; ~96 GiB GPU-visible HBM)
     96G_blackwell  — 1× Blackwell ~96 GB
 
@@ -63,8 +64,13 @@ def detect_gpu_config() -> str:
     is_spark     = any(s in first_name for s in _SPARK_NAMES)
     known_mem    = [m for _, _, m in gpus if m > 0]
     total_mem_gb = sum(known_mem) / 1024 if known_mem else 0.0
+    dual_32_blackwell = n_gpus == 2 and all(
+        cap >= 10.0 and 30_000 <= mem < 40_000 for _, cap, mem in gpus
+    )
 
-    if is_blackwell and (is_spark or (not known_mem)):
+    if dual_32_blackwell:
+        cfg = "dual_32G_blackwell"
+    elif is_blackwell and (is_spark or (not known_mem)):
         cfg = "spark"
     elif is_blackwell and total_mem_gb >= 120:
         cfg = "spark"


### PR DESCRIPTION
## Summary
- detect dual 32 GB Blackwell GPU pairs as a dedicated hardware profile
- split the default model stack across both GPUs with bounded memory budgets
- provide configuration coverage for local and NIM deployment profiles
- document the experimental profile and add detector/configuration tests

## Validation
- 49 focused tests passed
- all 9 profile YAML files parsed successfully
- Ruff and SPDX checks passed
- full test collection is blocked locally by unrelated missing optional packages: OpenCV, web-events, STT, and OpenXR test modules

## Brev validation
Pending on dual 32 GB Blackwell hardware. This remains a draft until model startup, readiness, concurrent inference, NVENC, and CloudXR headroom are verified.