### PR TITLE
Lift Android build's transitive Netty to 4.2.17

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -46,3 +46,6 @@ jobs:
 
       - name: Build debug APK
         run: ./gradlew assembleDebug
+
+      - name: Verify Netty pin
+        run: ./gradlew verifyNettyPin

--- a/client-samples/android/README.md
+++ b/client-samples/android/README.md
@@ -138,4 +138,4 @@ The app requests the following Android permissions:
 
 **Build-time only:** `build.gradle.kts` lifts transitive `io.netty` (pulled in by AGP's
 UTP test tooling) past known CVEs in its 4.1 line; the version lives in the `netty` catalog
-entry. Re-check after an AGP bump: `gradle buildEnvironment | grep netty`.
+entry. Re-check after an AGP bump: `./gradlew verifyNettyPin` (also run by CI).

--- a/client-samples/android/README.md
+++ b/client-samples/android/README.md
@@ -135,3 +135,7 @@ The app requests the following Android permissions:
 | Jetpack Compose BOM | 2024.11.00 | UI framework |
 | `androidx.lifecycle:lifecycle-viewmodel-compose` | 2.8.7 | ViewModel + Compose integration |
 | `androidx.activity:activity-compose` | 1.9.3 | `ComponentActivity` Compose entry-point |
+
+**Build-time only:** `build.gradle.kts` lifts transitive `io.netty` (pulled in by AGP's
+UTP test tooling) past known CVEs in its 4.1 line; the version lives in the `netty` catalog
+entry. Re-check after an AGP bump: `gradle buildEnvironment | grep netty`.

--- a/client-samples/android/build.gradle.kts
+++ b/client-samples/android/build.gradle.kts
@@ -6,3 +6,30 @@ plugins {
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
 }
+
+// AGP's UTP test tooling pulls io.netty 4.1.93.Final (via grpc-netty), which has known
+// CVEs; lift anything older to the pinned version. Buildscript and project configurations
+// resolve separately, so both need the rule.
+val nettyPin = libs.versions.netty.get()
+val nettyPinParts = nettyPin.split('.').mapNotNull { it.toIntOrNull() }
+
+fun belowNettyPin(version: String): Boolean {
+    if (!version.startsWith("4.")) return false
+    val parts = version.split('.').mapNotNull { it.toIntOrNull() }
+    nettyPinParts.forEachIndexed { i, pin ->
+        val requested = parts.getOrElse(i) { 0 }
+        if (requested != pin) return requested < pin
+    }
+    return false
+}
+
+fun Configuration.forceNettyVersion() = resolutionStrategy.eachDependency {
+    if (requested.group == "io.netty" && belowNettyPin(requested.version.orEmpty())) {
+        useVersion(nettyPin)
+    }
+}
+
+allprojects {
+    buildscript.configurations.configureEach { forceNettyVersion() }
+    configurations.configureEach { forceNettyVersion() }
+}

--- a/client-samples/android/build.gradle.kts
+++ b/client-samples/android/build.gradle.kts
@@ -33,3 +33,21 @@ allprojects {
     buildscript.configurations.configureEach { forceNettyVersion() }
     configurations.configureEach { forceNettyVersion() }
 }
+
+// CI runs this so the lift fails loudly if a Gradle or AGP change stops it applying.
+tasks.register("verifyNettyPin") {
+    doLast {
+        val offenders = allprojects.flatMap { p ->
+            (p.buildscript.configurations.toList() +
+                p.configurations.filter { it.name.contains("unified-test-platform") })
+                .filter { it.isCanBeResolved }
+                .flatMap { c ->
+                    runCatching { c.resolvedConfiguration.lenientConfiguration.allModuleDependencies }
+                        .getOrDefault(emptySet())
+                        .filter { it.moduleGroup == "io.netty" && belowNettyPin(it.moduleVersion) }
+                        .map { "${c.name}: ${it.moduleGroup}:${it.moduleName}:${it.moduleVersion}" }
+                }
+        }
+        check(offenders.isEmpty()) { "io.netty below $nettyPin:\n" + offenders.joinToString("\n") }
+    }
+}

--- a/client-samples/android/gradle/libs.versions.toml
+++ b/client-samples/android/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.9.3"
 composeBom = "2024.11.00"
 livekit = "2.7.0"
+netty = "4.2.17.Final"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
AGP's UTP test tooling pulls Netty 4.1.93.Final (via `grpc-netty`) onto the Android sample's build classpath; that line has known CVEs. Upgrading doesn't help: even AGP 9.3.0's UTP still resolves Netty 4.1.x.

Adds a resolution rule that lifts any `io.netty` 4.x below 4.2.17.Final up to it. It's a floor, not a pin: newer versions pass through, and non-4.x artifacts (`netty-tcnative`) are untouched. Build-time only; nothing Netty ships in the APK.

Verified: `buildEnvironment` and the UTP configurations resolve all Netty at 4.2.17.Final; a 4.2.16 request is lifted, 4.2.17+ and tcnative are left alone.
