### PR TITLE
fix(launcher): harden GPU profile detection and diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,10 @@ uv sync
 uv run model_servers
 ```
 
-GPU profiles are auto-detected (`dual_48G_ada` / `spark` / `96G_blackwell`).
+Known GPU profiles are auto-detected (`dual_48G_ada` / `spark` /
+`96G_blackwell`). Unsupported or ambiguous topologies stop with the complete
+inventory instead of assuming a profile; use `--gpu-profile NAME` only after
+copying and reviewing a custom YAML profile for that hardware.
 On first run the stack downloads tens of GB from Hugging Face and can take
 tens of minutes. On subsequent runs the containers restart in under a minute.
 

--- a/agent-samples/model-servers/main.py
+++ b/agent-samples/model-servers/main.py
@@ -45,6 +45,7 @@ import argparse
 from pathlib import Path
 
 from xr_ai_launcher import (
+    GPUInventoryError,
     Process,
     detect_gpu_config,
     load_deployment_profile,
@@ -55,6 +56,23 @@ from xr_ai_logging import setup_logging
 from xr_ai_vllm import stop_persistent_servers
 
 _BASE = Path(__file__).resolve().parent
+
+
+def _gpu_profile_names() -> tuple[str, ...]:
+    root = _BASE / "yaml"
+    if not root.is_dir():
+        return ()
+    return tuple(path.name for path in sorted(root.iterdir()) if path.is_dir())
+
+
+def _gpu_profile_name(value: str) -> str:
+    names = _gpu_profile_names()
+    if value not in names:
+        available = ", ".join(names) or "none"
+        raise argparse.ArgumentTypeError(
+            f"unknown GPU profile {value!r}; available profiles: {available}"
+        )
+    return value
 
 # service → (project, command, config basename, port). Order is launch
 # order: NIM containers precede local servers (speech NIMs allocate fixed
@@ -103,24 +121,33 @@ def _service_config(gpu_dir: str, config_base: str, profile_key: str) -> str:
     return f"{gpu_dir}/{config_base}.yaml"
 
 
-def _build_processes(selection: str) -> tuple[list[Process], tuple[str, ...]]:
+def _build_processes(
+    selection: str, gpu_profile: str | None = None,
+) -> tuple[list[Process], tuple[str, ...]]:
     profile_path = _profile_path(selection)
     deployment = load_deployment_profile(profile_path)
     unknown = deployment.services.keys() - _MODEL_SERVICES.keys()
     if unknown:
         raise ValueError(f"model profile declares unknown services: {sorted(unknown)}")
 
-    gpu_dir = f"yaml/{detect_gpu_config()}"
+    profile_name = gpu_profile or detect_gpu_config()
+    gpu_dir = f"yaml/{profile_name}"
     profile_key = profile_path.stem.removeprefix("models.")
-    processes = [
-        Process(
+    processes = []
+    for service, (project, command, config_base, port) in _MODEL_SERVICES.items():
+        if deployment.launch_mode(service) != "own":
+            continue
+        config = _service_config(gpu_dir, config_base, profile_key)
+        if not (_BASE / config).is_file():
+            raise ValueError(
+                f"GPU profile {profile_name!r} is incomplete: missing {config} "
+                f"for service {service!r}"
+            )
+        processes.append(Process(
             service, project, command,
-            config=_service_config(gpu_dir, config_base, profile_key),
+            config=config,
             launch_mode="persist", port=port,
-        )
-        for service, (project, command, config_base, port) in _MODEL_SERVICES.items()
-        if deployment.launch_mode(service) == "own"
-    ]
+        ))
     return processes, deployment.required_credentials
 
 
@@ -171,13 +198,26 @@ def run() -> None:
     p.add_argument("--allow-anonymous", action="store_true",
                    help="Start without HF_TOKEN (unauthenticated downloads "
                         "of the multi-GB checkpoints may stall indefinitely).")
+    p.add_argument(
+        "--gpu-profile", metavar="NAME", type=_gpu_profile_name,
+        help="Use a named YAML GPU profile instead of automatic detection. "
+             "Intended for explicitly reviewed custom hardware profiles.",
+    )
     ns, _ = p.parse_known_args()
 
     if ns.stop:
         _stop_models()
         return
 
-    processes, credentials = _build_processes(ns.models)
+    try:
+        processes, credentials = _build_processes(ns.models, ns.gpu_profile)
+    except GPUInventoryError as exc:
+        p.error(
+            f"{exc}\nUse --gpu-profile NAME to select an explicitly reviewed "
+            "custom YAML profile."
+        )
+    except ValueError as exc:
+        p.error(str(exc))
 
     # A missing HF_TOKEN silently stalls the multi-GB first-run download; see
     # docs/source/getting_started/credentials.md.

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -46,9 +46,13 @@ uv sync
 uv run model_servers
 ```
 
-GPU profiles are auto-detected (`dual_48G_ada`, `spark`, `96G_blackwell`). These
-are presets for common configurations; to run on a different GPU, refer to
+GPU profiles are auto-detected (`dual_48G_ada`, `spark`, `96G_blackwell`). The
+profiles are presets for common configurations; to run on a different GPU, refer to
 {doc}`Running on other GPUs </getting_started/requirements>`.
+Detection inventories every visible device. If `nvidia-smi` fails, returns
+malformed data, or reports a topology without an existing model-server
+configuration, startup stops with the detected per-GPU capacity instead of
+assuming a fallback.
 On first run each model downloads from HuggingFace (tens of GB; can take
 tens of minutes). On subsequent runs the containers restart in under a minute.
 

--- a/docs/source/getting_started/requirements.md
+++ b/docs/source/getting_started/requirements.md
@@ -130,6 +130,18 @@ and adjust those knobs to your hardware:
 3. On lower-VRAM GPUs, run fewer models concurrently, or lower `max_model_len` on
    the LLM and VLM servers to reduce the KV-cache footprint.
 
+Then select the reviewed profile explicitly:
+
+```bash
+uv run --project agent-samples/model-servers model_servers \
+  --gpu-profile <profile-directory-name>
+```
+
+Automatic detection intentionally accepts only bundled profiles whose hardware
+requirements are known to match. `--gpu-profile` bypasses that selection for a
+profile you have explicitly copied and tuned; it does not validate that the model
+servers fit the selected devices.
+
 ```{note}
 The model weights are independent of the GPU. Any NVIDIA GPU with enough VRAM for
 the models you load will run the stack; the profiles only encode where each server

--- a/docs/source/guides/troubleshooting.md
+++ b/docs/source/guides/troubleshooting.md
@@ -345,6 +345,17 @@ to skip CUDA graph capture. Eager mode starts faster but can reduce per-token
 throughput; keep the default when steady-state performance matters more than
 cold-start time.
 
+### vLLM exits before readiness with insufficient GPU memory
+
+**Symptom:** a vLLM container exits during startup with `CUDA out of memory`,
+`No available memory for the cache blocks`, or a negative available KV-cache
+value buried in its container log.
+
+**Fix:** the wrapper classifies these signatures as `INSUFFICIENT GPU MEMORY`
+and prints the configured utilization when available. Free memory held by other
+processes, reduce model context or concurrency, or use a device with more
+GPU-visible memory. The complete original error remains in the reported log file.
+
 ### `xr_render_demo` exits but VRAM is still pinned
 
 **By design.** The vLLM-backed servers (`nemotron_omni_llm_server`,

--- a/tests/test_cli_documentation.py
+++ b/tests/test_cli_documentation.py
@@ -33,6 +33,7 @@ def test_sample_command_catalog_matches_top_level_projects() -> None:
         ("--stop",),
         ("--models",),
         ("--allow-anonymous",),
+        ("--gpu-profile",),
     ]
     assert [argument.flags for argument in commands["simple_vlm_example"].arguments] == [
         ("--allow-anonymous",),
@@ -45,7 +46,8 @@ def test_catalog_builds_repository_root_invocation() -> None:
 
     assert commands["model_servers"].invocation == (
         "uv run --project agent-samples/model-servers model_servers "
-        "[--stop] [--models NAME_OR_PATH] [--allow-anonymous]"
+        "[--stop] [--models NAME_OR_PATH] [--allow-anonymous] "
+        "[--gpu-profile NAME]"
     )
 
 

--- a/tests/test_launcher_gpu.py
+++ b/tests/test_launcher_gpu.py
@@ -1,89 +1,203 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for xr_ai_launcher._gpu.detect_gpu_config."""
+"""Unit tests for strict per-device GPU inventory."""
 from __future__ import annotations
 
+import subprocess
 from unittest.mock import patch
 
-from xr_ai_launcher._gpu import detect_gpu_config
+import pytest
+from xr_ai_launcher import GPUInventoryError, detect_gpu_config
+from xr_ai_launcher._gpu import _query_gpu_inventory
 
 
-def _mock_smi(lines: list[str]):
-    """Return a context manager that patches check_output to return *lines*."""
-    output = "\n".join(lines)
-    return patch(
-        "xr_ai_launcher._gpu.subprocess.check_output",
-        return_value=output,
+def _row(
+    index: int,
+    name: str,
+    cap: float,
+    total_mib: float | str,
+    *,
+    free_mib: float | str | None = None,
+    used_mib: float | str = 0,
+) -> str:
+    if free_mib is not None:
+        free = free_mib
+    elif isinstance(total_mib, (float, int)) and isinstance(used_mib, (float, int)):
+        free = total_mib - used_mib
+    else:
+        free = "[N/A]"
+    return (
+        f"{index}, GPU-{index}, 00000000:{index:02x}:00.0, {name}, {cap}, "
+        f"{total_mib}, {free}, {used_mib}"
     )
 
 
-class TestDetectGpuConfig:
-    def test_nvidia_smi_unavailable_returns_default(self):
-        with patch(
-            "xr_ai_launcher._gpu.subprocess.check_output",
-            side_effect=FileNotFoundError,
-        ):
-            assert detect_gpu_config() == "dual_48G_ada"
+def _mock_smi(
+    lines: list[str],
+    process_lines: list[str] | None = None,
+    process_error: Exception | None = None,
+):
+    def output(command: list[str], **_kwargs) -> str:
+        if any("query-compute-apps" in value for value in command):
+            if process_error is not None:
+                raise process_error
+            return "\n".join(process_lines or [])
+        return "\n".join(lines)
 
-    def test_empty_output_returns_default(self):
-        with _mock_smi([]):
-            assert detect_gpu_config() == "dual_48G_ada"
+    return patch("xr_ai_launcher._gpu.subprocess.check_output", side_effect=output)
 
-    def test_unparseable_line_skipped(self):
-        # Only one valid line (an Ada GPU), the other is garbage.
-        with _mock_smi(["RTX 4090, 8.9, 24564 MiB", "not a valid line"]):
-            # one GPU, Ada (cap<10), <2, falls back to dual_48G_ada
-            result = detect_gpu_config()
-            assert result == "dual_48G_ada"
 
-    # ── Ada / dual-GPU scenarios ───────────────────────────────────────────────
+def test_inventory_records_each_gpu_capacity() -> None:
+    with _mock_smi(
+        [
+            _row(0, "NVIDIA L40S", 8.9, 46068, free_mib=45000, used_mib=1068),
+            _row(1, "NVIDIA L40S", 8.9, 46068, free_mib=44000, used_mib=2068),
+        ],
+    ):
+        inventory = _query_gpu_inventory()
 
-    def test_single_ada_gpu_returns_dual_48G_ada(self):
-        with _mock_smi(["RTX 6000 Ada, 8.9, 49140 MiB"]):
-            assert detect_gpu_config() == "dual_48G_ada"
+    assert [gpu.index for gpu in inventory] == [0, 1]
+    assert inventory[0].total_memory_gib == pytest.approx(44.988, abs=0.001)
+    assert inventory[1].free_memory_gib == pytest.approx(42.969, abs=0.001)
 
-    def test_dual_ada_gpus_returns_dual_48G_ada(self):
-        with _mock_smi([
-            "RTX 6000 Ada, 8.9, 49140 MiB",
-            "RTX 6000 Ada, 8.9, 49140 MiB",
-        ]):
-            assert detect_gpu_config() == "dual_48G_ada"
 
-    # ── Blackwell scenarios ────────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "error",
+    [FileNotFoundError(), subprocess.CalledProcessError(1, "nvidia-smi")],
+)
+def test_detection_failure_does_not_select_an_unsafe_default(error: Exception) -> None:
+    with patch("xr_ai_launcher._gpu.subprocess.check_output", side_effect=error):
+        with pytest.raises(GPUInventoryError, match="nvidia-smi"):
+            detect_gpu_config()
 
-    def test_blackwell_96gb_returns_96G_blackwell(self):
-        with _mock_smi(["RTX PRO 6000 Blackwell, 12.0, 98304 MiB"]):
-            assert detect_gpu_config() == "96G_blackwell"
 
-    def test_blackwell_large_vram_returns_spark(self):
-        # >=120 GiB total → spark profile
-        with _mock_smi(["GB200, 10.0, 131072 MiB"]):
-            assert detect_gpu_config() == "spark"
+def test_empty_inventory_is_rejected() -> None:
+    with _mock_smi([]), pytest.raises(GPUInventoryError, match="no GPUs"):
+        detect_gpu_config()
 
-    def test_spark_name_gb10_returns_spark(self):
-        with _mock_smi(["NVIDIA GB10, 10.0, 0 MiB"]):
-            assert detect_gpu_config() == "spark"
 
-    def test_spark_name_b10_returns_spark(self):
-        with _mock_smi(["NVIDIA B10, 10.0, 0 MiB"]):
-            assert detect_gpu_config() == "spark"
+def test_unparseable_inventory_is_rejected() -> None:
+    with _mock_smi(["not a valid row"]), pytest.raises(
+        GPUInventoryError, match="unparseable",
+    ):
+        detect_gpu_config()
 
-    def test_blackwell_no_mem_data_returns_spark(self):
-        # compute_cap >= 10 and no parseable mem → spark
-        with _mock_smi(["Blackwell GPU, 10.0, N/A"]):
-            assert detect_gpu_config() == "spark"
 
-    # ── Robustness ─────────────────────────────────────────────────────────────
+def test_failed_process_inventory_does_not_block_supported_topology() -> None:
+    error = subprocess.CalledProcessError(1, "nvidia-smi", stderr="not supported")
+    with _mock_smi([_row(0, "NVIDIA GB10", 10.0, 131072)], process_error=error):
+        assert detect_gpu_config() == "spark"
 
-    def test_extra_whitespace_tolerated(self):
-        with _mock_smi(["  RTX 6000 Ada  ,  8.9  ,  49140 MiB  "]):
-            assert detect_gpu_config() == "dual_48G_ada"
 
-    def test_subprocess_error_returns_default(self):
-        import subprocess
-        with patch(
-            "xr_ai_launcher._gpu.subprocess.check_output",
-            side_effect=subprocess.CalledProcessError(1, "nvidia-smi"),
-        ):
-            assert detect_gpu_config() == "dual_48G_ada"
+def test_failed_process_inventory_is_context_not_a_replacement_error() -> None:
+    error = subprocess.CalledProcessError(1, "nvidia-smi", stderr="not supported")
+    with _mock_smi(
+        [_row(0, "NVIDIA L40S", 8.9, 46068)], process_error=error,
+    ), pytest.raises(
+        GPUInventoryError,
+        match="no existing.*process inventory unavailable.*not supported",
+    ):
+        detect_gpu_config()
+
+
+def test_unparseable_process_inventory_is_nonfatal_context() -> None:
+    with _mock_smi(
+        [_row(0, "NVIDIA L40S", 8.9, 46068)],
+        ["not a valid process row"],
+    ), pytest.raises(
+        GPUInventoryError,
+        match="no existing.*process inventory unavailable.*unparseable",
+    ):
+        detect_gpu_config()
+
+
+def test_unsupported_topology_reports_active_compute_processes() -> None:
+    with _mock_smi(
+        [_row(0, "NVIDIA L40S", 8.9, 46068)],
+        ["GPU-0, 4321, python, 2048"],
+    ), pytest.raises(
+        GPUInventoryError, match=r"active compute processes: GPU 0 PID 4321 python \(2\.0 GiB\)",
+    ):
+        detect_gpu_config()
+
+
+def test_empty_memory_fields_are_rejected_as_inventory_error() -> None:
+    row = "0, GPU-0, 00000000:01:00.0, NVIDIA L40S, 8.9, , , "
+    with _mock_smi([row]), pytest.raises(GPUInventoryError, match="unparseable"):
+        detect_gpu_config()
+
+
+@pytest.mark.parametrize("sentinel", ["Not Supported", "[Not Supported]"])
+def test_not_supported_memory_fields_are_nullable(sentinel: str) -> None:
+    with _mock_smi([_row(
+        0, "NVIDIA GB10", 12.1, sentinel, free_mib=sentinel, used_mib=sentinel,
+    )]):
+        inventory = _query_gpu_inventory()
+        assert detect_gpu_config() == "spark"
+
+    assert inventory[0].total_memory_gib is None
+    assert inventory[0].free_memory_gib is None
+    assert inventory[0].used_memory_gib is None
+
+
+def test_single_ada_is_not_misclassified_as_dual() -> None:
+    with _mock_smi([_row(0, "NVIDIA L40S", 8.9, 46068)]), pytest.raises(
+        GPUInventoryError, match="no existing.*GPU 0.*L40S",
+    ):
+        detect_gpu_config()
+
+
+def test_dual_ada_requires_capacity_on_each_device() -> None:
+    with _mock_smi([
+        _row(0, "NVIDIA L40S", 8.9, 46068),
+        _row(1, "NVIDIA L40S", 8.9, 46068),
+    ]):
+        assert detect_gpu_config() == "dual_48G_ada"
+
+    with _mock_smi([
+        _row(0, "NVIDIA L40S", 8.9, 46068),
+        _row(1, "RTX 4090", 8.9, 24564),
+    ]), pytest.raises(GPUInventoryError, match="GPU 1.*24.0 GiB"):
+        detect_gpu_config()
+
+
+def test_single_large_blackwell_matches_workstation_config() -> None:
+    with _mock_smi([_row(0, "RTX PRO 6000 Blackwell", 12.0, 98304)]):
+        assert detect_gpu_config() == "96G_blackwell"
+
+
+def test_spark_name_matches_when_memory_fields_are_unavailable() -> None:
+    with _mock_smi([_row(
+        0, "NVIDIA GB10", 10.0, "[N/A]", free_mib="[N/A]", used_mib="[N/A]",
+    )]):
+        inventory = _query_gpu_inventory()
+        assert inventory[0].total_memory_gib is None
+        assert inventory[0].free_memory_gib is None
+        assert inventory[0].used_memory_gib is None
+        assert detect_gpu_config() == "spark"
+
+
+def test_capacity_match_rejects_unavailable_total_memory_cleanly() -> None:
+    with _mock_smi([_row(0, "Unknown Blackwell", 12.0, "[N/A]")]), pytest.raises(
+        GPUInventoryError, match=r"no existing.*N/A total",
+    ):
+        detect_gpu_config()
+
+
+def test_small_blackwell_does_not_match_96_gib_config() -> None:
+    with _mock_smi([_row(0, "NVIDIA GeForce RTX 5090", 12.0, 32768)]), pytest.raises(
+        GPUInventoryError, match=r"no existing.*32\.0 GiB",
+    ):
+        detect_gpu_config()
+
+
+@pytest.mark.parametrize("name", ["NVIDIA GB10", "NVIDIA B10"])
+def test_spark_name_matches_spark_config(name: str) -> None:
+    with _mock_smi([_row(0, name, 10.0, 131072)]):
+        assert detect_gpu_config() == "spark"
+
+
+def test_large_unnamed_blackwell_matches_spark_by_capacity() -> None:
+    with _mock_smi([_row(0, "NVIDIA Future Blackwell", 12.0, 131072)]):
+        assert detect_gpu_config() == "spark"

--- a/tests/test_model_servers.py
+++ b/tests/test_model_servers.py
@@ -49,6 +49,17 @@ def test_default_profile_uses_omni_and_cosmos(monkeypatch: pytest.MonkeyPatch) -
     assert credentials == ()
 
 
+def test_explicit_gpu_profile_bypasses_detection(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_detection() -> str:
+        raise AssertionError("automatic detection must not run for an explicit profile")
+
+    monkeypatch.setattr(_model_servers, "detect_gpu_config", fail_detection)
+
+    processes, _ = _model_servers._build_processes("default", "spark")
+
+    assert all(str(process.config).startswith("yaml/spark/") for process in processes)
+
+
 def test_nim_profile_mixes_nim_containers_and_local_servers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -191,7 +202,7 @@ def test_cli_selects_requested_profile(
     monkeypatch.setattr(_model_servers, "_stop_unselected_services", lambda _p: None)
     monkeypatch.setattr(
         _model_servers, "_build_processes",
-        lambda selection: (selected.append(selection) or [], ()),
+        lambda selection, _gpu_profile=None: (selected.append(selection) or [], ()),
     )
     monkeypatch.setattr(_model_servers, "run_stack", lambda *_a, **_k: None)
     monkeypatch.setattr(sys, "argv", ["model_servers", *argv])
@@ -199,6 +210,74 @@ def test_cli_selects_requested_profile(
     _model_servers.run()
 
     assert selected == [expected]
+
+
+def test_cli_passes_explicit_gpu_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    selected: list[tuple[str, str | None]] = []
+    monkeypatch.setattr(_model_servers, "setup_logging", lambda *_a, **_k: None)
+    monkeypatch.setattr(_model_servers, "require_credentials", lambda *_a, **_k: None)
+    monkeypatch.setattr(_model_servers, "_stop_unselected_services", lambda _p: None)
+    monkeypatch.setattr(
+        _model_servers,
+        "_build_processes",
+        lambda selection, gpu_profile=None: (
+            selected.append((selection, gpu_profile)) or [], ()
+        ),
+    )
+    monkeypatch.setattr(_model_servers, "run_stack", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        sys, "argv", ["model_servers", "--gpu-profile", "dual_48G_ada"],
+    )
+
+    _model_servers.run()
+
+    assert selected == [("default", "dual_48G_ada")]
+
+
+def test_invalid_gpu_profile_name_is_rejected() -> None:
+    with pytest.raises(
+        _model_servers.argparse.ArgumentTypeError, match="unknown GPU profile",
+    ):
+        _model_servers._gpu_profile_name("does-not-exist")
+
+
+def test_gpu_profile_discovery_tolerates_missing_yaml_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_model_servers, "_BASE", tmp_path)
+
+    assert _model_servers._gpu_profile_names() == ()
+
+
+def test_custom_gpu_profile_must_contain_every_selected_service_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "yaml" / "custom").mkdir(parents=True)
+    profile = _REPO_ROOT / "agent-samples/model-servers/yaml/models.default.json"
+    monkeypatch.setattr(_model_servers, "_BASE", tmp_path)
+
+    with pytest.raises(ValueError, match="profile 'custom' is incomplete.*stt_server"):
+        _model_servers._build_processes(str(profile), "custom")
+
+
+def test_cli_reports_gpu_inventory_error_without_traceback(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    def fail_inventory(*_args, **_kwargs):
+        raise _model_servers.GPUInventoryError("GPU memory telemetry unavailable")
+
+    monkeypatch.setattr(_model_servers, "setup_logging", lambda *_a, **_k: None)
+    monkeypatch.setattr(_model_servers, "_build_processes", fail_inventory)
+    monkeypatch.setattr(sys, "argv", ["model_servers"])
+
+    with pytest.raises(SystemExit) as error:
+        _model_servers.run()
+
+    assert error.value.code == 2
+    stderr = capsys.readouterr().err
+    assert "model_servers: error: GPU memory telemetry unavailable" in stderr
+    assert "--gpu-profile NAME" in stderr
+    assert "Traceback" not in stderr
 
 
 def test_build_processes_rejects_unknown_services(tmp_path, monkeypatch) -> None:
@@ -241,7 +320,7 @@ def test_cli_requires_profile_credentials(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(_model_servers, "_stop_unselected_services", lambda _p: None)
     monkeypatch.setattr(
         _model_servers, "_build_processes",
-        lambda _selection: ([], ("NGC_API_KEY",)),
+        lambda _selection, _gpu_profile=None: ([], ("NGC_API_KEY",)),
     )
     monkeypatch.setattr(_model_servers, "run_stack", lambda *_a, **_k: None)
     monkeypatch.setattr(sys, "argv", ["model_servers", "--models", "vlm_llm_nim"])
@@ -259,7 +338,8 @@ def test_cli_aborts_when_unselected_services_cannot_stop(
     monkeypatch.setattr(_model_servers, "require_credentials", lambda *_a, **_k: None)
     monkeypatch.setattr(_model_servers, "stop_persistent_servers", lambda _services: False)
     monkeypatch.setattr(
-        _model_servers, "_build_processes", lambda _selection: ([], ()),
+        _model_servers, "_build_processes",
+        lambda _selection, _gpu_profile=None: ([], ()),
     )
     monkeypatch.setattr(_model_servers, "run_stack", lambda *_a, **_k: started.append(True))
     monkeypatch.setattr(sys, "argv", ["model_servers"])

--- a/tests/test_nim_docker.py
+++ b/tests/test_nim_docker.py
@@ -112,6 +112,7 @@ def test_serve_nim_uses_world_writable_per_container_cache(tmp_path, monkeypatch
     leaf = tmp_path / "nim" / "xr-ai-nim-llama"
     assert leaf.stat().st_mode & 0o777 == 0o777
     assert f"{leaf}:/opt/nim/.cache" in captured["argv"]
+    assert "diagnostic_argv" not in captured
 
 
 def test_serve_nim_tolerates_foreign_cache_dir_if_world_writable(

--- a/tests/test_vllm_diagnostics.py
+++ b/tests/test_vllm_diagnostics.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for actionable vLLM startup-failure classifications."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from xr_ai_vllm._diagnostics import classify_vllm_failure
+
+
+def test_negative_kv_cache_is_classified_as_insufficient_gpu_memory(
+    tmp_path: Path,
+) -> None:
+    log = tmp_path / "vllm.log"
+    log.write_text(
+        "Available KV cache memory: -0.17 GiB\n"
+        "ValueError: No available memory for the cache blocks.\n"
+    )
+
+    diagnosis = classify_vllm_failure(
+        log, ["vllm", "--gpu-memory-utilization", "0.78"],
+    )
+
+    assert diagnosis is not None
+    assert diagnosis.startswith("INSUFFICIENT GPU MEMORY")
+    assert "-0.17 GiB" in diagnosis
+    assert "0.78" in diagnosis
+
+
+def test_cuda_oom_is_classified(tmp_path: Path) -> None:
+    log = tmp_path / "vllm.log"
+    log.write_text("torch.OutOfMemoryError: CUDA out of memory")
+
+    diagnosis = classify_vllm_failure(log, ["vllm", "serve", "model"])
+
+    assert diagnosis is not None
+    assert diagnosis.startswith("INSUFFICIENT GPU MEMORY")
+
+
+def test_conflicting_process_memory_is_classified(tmp_path: Path) -> None:
+    log = tmp_path / "vllm.log"
+    log.write_text(
+        "Free memory on device (10.0/45.0 GiB) at startup is less than desired "
+        "GPU memory utilization (0.78, 35.1 GiB)."
+    )
+
+    diagnosis = classify_vllm_failure(
+        log, ["vllm", "serve", "model", "--gpu-memory-utilization", "0.78"],
+    )
+
+    assert diagnosis is not None
+    assert diagnosis.startswith("INSUFFICIENT FREE GPU MEMORY")
+    assert "0.78" in diagnosis
+
+
+def test_unrelated_failure_has_no_gpu_memory_diagnosis(tmp_path: Path) -> None:
+    log = tmp_path / "vllm.log"
+    log.write_text("ValueError: unsupported architecture")
+
+    assert classify_vllm_failure(log, ["vllm", "serve", "model"]) is None

--- a/tests/test_vllm_docker.py
+++ b/tests/test_vllm_docker.py
@@ -433,6 +433,31 @@ def _expected_fingerprint(kwargs):
 
 
 class TestRun:
+    def test_preserves_original_vllm_argv_for_failure_diagnostics(
+        self, tmp_path, monkeypatch,
+    ):
+        kwargs = _run_kwargs(tmp_path)
+        captured: dict = {}
+        monkeypatch.setattr(
+            _docker, "run_container", lambda **values: captured.update(values),
+        )
+
+        run(**kwargs)
+
+        assert captured["argv"] == build_run_argv(
+            image=kwargs["image"],
+            container_name=kwargs["container_name"],
+            port=kwargs["port"],
+            model_cache=kwargs["model_cache"],
+            hf_token=kwargs["hf_token"],
+            cuda_visible_devices=kwargs["cuda_visible_devices"],
+            extra_env=kwargs["extra_env"],
+            extra_pip=kwargs["extra_pip"],
+            vllm_argv=kwargs["vllm_argv"],
+        )
+        assert "--gpu-memory-utilization" not in captured["argv"]
+        assert captured["diagnostic_argv"] == kwargs["vllm_argv"]
+
     def test_healthy_unowned_listener_is_rejected(self, tmp_path):
         kwargs = _run_kwargs(tmp_path)
         with (
@@ -885,6 +910,57 @@ class TestRunContainer:
         kwargs = self._kwargs(tmp_path)
         _docker.run_container(**kwargs)
         assert evictions == [1]
+
+    @pytest.mark.parametrize("with_vllm_context", [False, True])
+    def test_failure_diagnostics_are_vllm_only(
+        self, monkeypatch, tmp_path, with_vllm_context,
+    ):
+        self._common_stubs(monkeypatch, _docker)
+        monkeypatch.setattr(_docker._lifecycle, "health_ok", lambda url, **kw: False)
+
+        def fail_startup(*_args, **_kwargs):
+            raise SystemExit(1)
+
+        monkeypatch.setattr(
+            _docker._lifecycle,
+            "wait_until_healthy",
+            fail_startup,
+        )
+
+        class _FakeProc:
+            def poll(self):
+                return None
+
+        class _Streamer:
+            log_path = tmp_path / "container.log"
+
+            def __init__(self, _name):
+                self.log_path.write_text("CUDA out of memory", encoding="utf-8")
+
+            def stop(self):
+                pass
+
+        monkeypatch.setattr(_docker.subprocess, "Popen", lambda *_a, **_kw: _FakeProc())
+        monkeypatch.setattr(_docker, "_LogStreamer", _Streamer)
+        monkeypatch.setattr(_docker, "_append_post_mortem", lambda *_a, **_kw: None)
+        monkeypatch.setattr(_docker.time, "sleep", lambda _seconds: None)
+        captured: list[list[str]] = []
+        monkeypatch.setattr(
+            _docker._diagnostics,
+            "classify_vllm_failure",
+            lambda _path, argv: captured.append(argv) or "diagnosis",
+        )
+        kwargs = self._kwargs(tmp_path)
+        diagnostic_argv = [
+            "vllm", "serve", "model", "--gpu-memory-utilization", "0.78",
+        ]
+        if with_vllm_context:
+            kwargs["diagnostic_argv"] = diagnostic_argv
+
+        with pytest.raises(SystemExit, match="1"):
+            _docker.run_container(**kwargs)
+
+        assert captured == ([diagnostic_argv] if with_vllm_context else [])
 
 
 class TestEvictLocalListener:

--- a/utils/xr-ai-launcher/xr_ai_launcher/__init__.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/__init__.py
@@ -40,7 +40,7 @@ from ._credentials import (
     require_credentials,
     warn_if_missing,
 )
-from ._gpu import detect_gpu_config
+from ._gpu import GPUInventoryError, detect_gpu_config
 from ._models import ModelDeployment, load_deployment_profile, load_model_deployment
 from ._processes import ManagedProcess
 from ._stack import Parallel, Process, run_stack
@@ -50,7 +50,7 @@ __all__ = [
     "NATIVE_DEVICE_PROFILES", "is_native_profile", "read_device_profile",
     "ensure_credentials", "load_credentials", "require_credentials", "warn_if_missing",
     "read_config_scalar",
-    "detect_gpu_config",
+    "GPUInventoryError", "detect_gpu_config",
     "ModelDeployment", "load_deployment_profile", "load_model_deployment",
     "ManagedProcess",
     "Parallel", "Process", "run_stack",

--- a/utils/xr-ai-launcher/xr_ai_launcher/_gpu.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/_gpu.py
@@ -1,83 +1,223 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""GPU profile auto-detection via nvidia-smi (stdlib-only)."""
+"""Strict per-device GPU inventory and existing config selection."""
 from __future__ import annotations
 
 import logging
+import re
 import subprocess
+from dataclasses import dataclass
 
 log = logging.getLogger(__name__)
 
+_MIB_PER_GIB = 1024.0
+_SPARK_NAME = re.compile(r"(?i)\b(?:GB10|B10)\b")
+_BLACKWELL_96_MIN_GIB = 90.0
+_SPARK_MIN_GIB = 120.0
 
-def detect_gpu_config() -> str:
-    """Return the GPU config profile by querying nvidia-smi.
 
-    Profiles
-    --------
-    dual_48G_ada   — 2× ADA 48 GB (default / current dev box)
-    spark          — 1× Blackwell GB10 (DGX Spark; ~96 GiB GPU-visible HBM)
-    96G_blackwell  — 1× Blackwell ~96 GB
+class GPUInventoryError(RuntimeError):
+    """Raised when visible GPUs cannot be inventoried or safely classified."""
 
-    Falls back to ``dual_48G_ada`` on any detection failure.
-    """
+
+@dataclass(frozen=True)
+class _GPUProcess:
+    """One compute process reported by ``nvidia-smi``."""
+
+    gpu_uuid: str
+    pid: int
+    name: str
+    used_memory_gib: float | None
+
+
+@dataclass(frozen=True)
+class _GPUDevice:
+    """Physical GPU capacity and current availability."""
+
+    index: int
+    uuid: str
+    pci_bus_id: str
+    name: str
+    compute_capability: float
+    total_memory_gib: float | None
+    free_memory_gib: float | None
+    used_memory_gib: float | None
+
+
+def _parse_mib(value: str) -> float | None:
+    text = value.strip()
+    if text in {"N/A", "[N/A]", "Not Supported", "[Not Supported]"}:
+        return None
+    if not text:
+        raise ValueError("empty memory field")
+    return float(text.split()[0]) / _MIB_PER_GIB
+
+
+def _format_gib(value: float | None) -> str:
+    return "N/A" if value is None else f"{value:.1f} GiB"
+
+
+def _query_compute_processes() -> dict[str, list[_GPUProcess]]:
     try:
         raw = subprocess.check_output(
-            ["nvidia-smi", "--query-gpu=name,compute_cap,memory.total",
-             "--format=csv,noheader"],
-            text=True, stderr=subprocess.DEVNULL,
-        ).strip().splitlines()
-    except Exception as exc:
-        log.warning("nvidia-smi unavailable (%s) — using dual_48G_ada", exc)
-        return "dual_48G_ada"
+            [
+                "nvidia-smi",
+                "--query-compute-apps=gpu_uuid,pid,process_name,used_gpu_memory",
+                "--format=csv,noheader,nounits",
+            ],
+            text=True,
+            stderr=subprocess.PIPE,
+        ).strip()
+    except FileNotFoundError as exc:
+        raise GPUInventoryError(
+            "nvidia-smi is unavailable while inspecting GPU compute processes"
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or "").strip()
+        suffix = f": {detail}" if detail else ""
+        raise GPUInventoryError(
+            f"nvidia-smi compute-process inventory failed{suffix}"
+        ) from exc
 
-    _SPARK_NAMES = {"gb10", "b10"}
-
-    gpus: list[tuple[str, float, float]] = []
-    for line in raw:
-        parts = [p.strip() for p in line.split(",")]
-        if len(parts) < 3:
-            continue
-        name, cap_str, mem_str = parts[0], parts[1], parts[2]
+    result: dict[str, list[_GPUProcess]] = {}
+    for line in raw.splitlines():
+        parts = [part.strip() for part in line.split(",", maxsplit=3)]
+        if len(parts) != 4:
+            raise GPUInventoryError(f"unparseable nvidia-smi process row: {line!r}")
+        uuid, pid_text, name, memory_text = parts
         try:
-            cap = float(cap_str)
-        except ValueError:
+            pid = int(pid_text)
+        except ValueError as exc:
+            raise GPUInventoryError(
+                f"unparseable nvidia-smi process row: {line!r}"
+            ) from exc
+        try:
+            used = _parse_mib(memory_text)
+        except ValueError as exc:
+            raise GPUInventoryError(
+                f"unparseable nvidia-smi process row: {line!r}"
+            ) from exc
+        result.setdefault(uuid, []).append(_GPUProcess(uuid, pid, name, used))
+    return result
+
+
+def _format_compute_processes(devices: tuple[_GPUDevice, ...]) -> str:
+    """Return best-effort process context for an unsupported topology."""
+    try:
+        processes = _query_compute_processes()
+    except GPUInventoryError as exc:
+        return f"compute-process inventory unavailable ({exc})"
+
+    by_uuid = {gpu.uuid: gpu for gpu in devices}
+    details = []
+    for uuid, entries in processes.items():
+        gpu = by_uuid.get(uuid)
+        if gpu is None:
             continue
-        mem = 0.0
-        for tok in mem_str.split():
-            try:
-                mem = float(tok)
-                break
-            except ValueError:
-                pass
-        gpus.append((name.lower(), cap, mem))
+        for process in entries:
+            used = _format_gib(process.used_memory_gib)
+            details.append(
+                f"GPU {gpu.index} PID {process.pid} {process.name} ({used})"
+            )
+    return ", ".join(details) if details else "none"
 
-    if not gpus:
-        log.warning("GPU detection returned no parseable data — using dual_48G_ada")
-        return "dual_48G_ada"
 
-    n_gpus       = len(gpus)
-    first_name   = gpus[0][0]
-    first_cap    = gpus[0][1]
-    is_blackwell = first_cap >= 10.0
-    is_spark     = any(s in first_name for s in _SPARK_NAMES)
-    known_mem    = [m for _, _, m in gpus if m > 0]
-    total_mem_gb = sum(known_mem) / 1024 if known_mem else 0.0
+def _query_gpu_inventory() -> tuple[_GPUDevice, ...]:
+    """Return exact per-device GPU facts or fail without an assumed fallback."""
+    try:
+        raw = subprocess.check_output(
+            [
+                "nvidia-smi",
+                "--query-gpu=index,uuid,pci.bus_id,name,compute_cap,memory.total,"
+                "memory.free,memory.used",
+                "--format=csv,noheader,nounits",
+            ],
+            text=True,
+            stderr=subprocess.PIPE,
+        ).strip()
+    except FileNotFoundError as exc:
+        raise GPUInventoryError(
+            "nvidia-smi is unavailable; XR-AI cannot inspect GPU capacity"
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or "").strip()
+        suffix = f": {detail}" if detail else ""
+        raise GPUInventoryError(f"nvidia-smi GPU inventory failed{suffix}") from exc
 
-    if is_blackwell and (is_spark or (not known_mem)):
-        cfg = "spark"
-    elif is_blackwell and total_mem_gb >= 120:
-        cfg = "spark"
-    elif is_blackwell:
-        cfg = "96G_blackwell"
-    elif n_gpus >= 2:
-        cfg = "dual_48G_ada"
+    devices: list[_GPUDevice] = []
+    for line in raw.splitlines():
+        parts = [part.strip() for part in line.split(",", maxsplit=7)]
+        if len(parts) != 8:
+            raise GPUInventoryError(f"unparseable nvidia-smi GPU row: {line!r}")
+        try:
+            device = _GPUDevice(
+                index=int(parts[0]),
+                uuid=parts[1],
+                pci_bus_id=parts[2],
+                name=parts[3],
+                compute_capability=float(parts[4]),
+                total_memory_gib=_parse_mib(parts[5]),
+                free_memory_gib=_parse_mib(parts[6]),
+                used_memory_gib=_parse_mib(parts[7]),
+            )
+        except ValueError as exc:
+            raise GPUInventoryError(f"unparseable nvidia-smi GPU row: {line!r}") from exc
+        devices.append(device)
+
+    if not devices:
+        raise GPUInventoryError("nvidia-smi returned no GPUs")
+    return tuple(devices)
+
+
+def detect_gpu_config() -> str:
+    """Select an existing config only when the complete topology is supported.
+
+    This compatibility bridge remains until capability-based service planning
+    replaces named config selection. It deliberately has no fallback.
+    """
+    devices = _query_gpu_inventory()
+    if len(devices) == 1:
+        gpu = devices[0]
+        if gpu.compute_capability >= 10.0:
+            if _SPARK_NAME.search(gpu.name) or (
+                gpu.total_memory_gib is not None
+                and gpu.total_memory_gib >= _SPARK_MIN_GIB
+            ):
+                config = "spark"
+            elif (
+                gpu.total_memory_gib is not None
+                and gpu.total_memory_gib >= _BLACKWELL_96_MIN_GIB
+            ):
+                config = "96G_blackwell"
+            else:
+                config = ""
+        else:
+            config = ""
+    elif (
+        len(devices) == 2
+        and all(8.9 <= gpu.compute_capability < 10.0 for gpu in devices)
+        and all(
+            gpu.total_memory_gib is not None and gpu.total_memory_gib >= 44.0
+            for gpu in devices
+        )
+    ):
+        config = "dual_48G_ada"
     else:
-        cfg = "dual_48G_ada"
+        config = ""
 
-    mem_display = f"{total_mem_gb:.0f} GiB" if known_mem else "unified memory"
-    log.info(
-        "GPU config: %s  (%dx %s, %s, SM%.1f)",
-        cfg, n_gpus, gpus[0][0].upper(), mem_display, first_cap,
+    topology = "; ".join(
+        f"GPU {gpu.index}: {gpu.name}, SM{gpu.compute_capability:.1f}, "
+        f"{_format_gib(gpu.total_memory_gib)} total, "
+        f"{_format_gib(gpu.free_memory_gib)} free"
+        for gpu in devices
     )
-    return cfg
+    if not config:
+        process_context = _format_compute_processes(tuple(devices))
+        raise GPUInventoryError(
+            "no existing XR-AI model-server configuration matches the visible "
+            f"GPU topology: {topology}; active compute processes: {process_context}"
+        )
+    log.info("GPU config: %s", config)
+    log.info("GPU inventory: %s", topology)
+    return config

--- a/utils/xr-ai-vllm/xr_ai_vllm/_diagnostics.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/_diagnostics.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Actionable classifications for common vLLM startup failures."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def _argument_value(argv: list[str], option: str) -> str | None:
+    try:
+        return argv[argv.index(option) + 1]
+    except (ValueError, IndexError):
+        return None
+
+
+def classify_vllm_failure(log_path: str | Path, argv: list[str]) -> str | None:
+    """Return a clear diagnosis when *log_path* contains a GPU-memory failure."""
+    try:
+        body = Path(log_path).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    lowered = body.lower()
+    utilization = _argument_value(argv, "--gpu-memory-utilization")
+    budget = (
+        f" (configured gpu_memory_utilization={utilization})"
+        if utilization else ""
+    )
+
+    if (
+        "no available memory for the cache blocks" in lowered
+        or (
+            "available kv cache memory" in lowered
+            and re.search(r"available kv cache memory[^\n]*-\d", lowered)
+        )
+    ):
+        available = re.search(
+            r"available kv cache memory[^\n]*?(-?\d+(?:\.\d+)?)\s*gib",
+            lowered,
+        )
+        detail = f"; vLLM reported {available.group(1)} GiB available" if available else ""
+        return (
+            "INSUFFICIENT GPU MEMORY: model weights and runtime allocations left "
+            f"no capacity for the KV cache{detail}{budget}. Reduce the configured "
+            "model/context/concurrency, free GPU memory, or use a larger device."
+        )
+
+    if "cuda out of memory" in lowered or "torch.outofmemoryerror" in lowered:
+        return (
+            "INSUFFICIENT GPU MEMORY: CUDA allocation failed during vLLM startup"
+            f"{budget}. Free GPU memory, reduce the configured model/context/"
+            "concurrency, or use a larger device."
+        )
+
+    if "free memory on device" in lowered and "desired gpu memory utilization" in lowered:
+        return (
+            "INSUFFICIENT FREE GPU MEMORY: another process is using memory required "
+            f"by this vLLM service{budget}. Stop the conflicting process or lower "
+            "the service memory budget."
+        )
+    return None

--- a/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
@@ -32,7 +32,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
-from . import _lifecycle
+from . import _diagnostics, _lifecycle
 
 log = logging.getLogger(__name__)
 
@@ -615,6 +615,7 @@ def run(
         reuse_banner=f"vLLM already running on port {port} — reusing",
         ready_banner=f"Ready  →  http://localhost:{port}/v1  (docker: {container_name})",
         ready_file=ready_file,
+        diagnostic_argv=vllm_argv,
     )
 
 
@@ -630,6 +631,7 @@ def run_container(
     reuse_banner: str,
     ready_banner: str,
     ready_file: Path | None,
+    diagnostic_argv: list[str] | None = None,
 ) -> None:
     """Shared container lifecycle for the vLLM docker backend and NIMs.
 
@@ -812,6 +814,12 @@ def run_container(
         time.sleep(0.5)
         streamer.stop()
         _append_post_mortem(container_name, streamer.log_path)
+        diagnosis = (
+            _diagnostics.classify_vllm_failure(streamer.log_path, diagnostic_argv)
+            if diagnostic_argv is not None else None
+        )
+        if diagnosis:
+            log.error("%s", diagnosis)
         log.error("container %s failed — see %s", container_name, streamer.log_path)
         raise
 


### PR DESCRIPTION
## Summary

Make GPU-profile selection fail safely and make model startup failures actionable.

- inventory each visible GPU independently, including compute capability and nullable total/free/used GPU memory
- remove the unsafe `dual_48G_ada` fallback when GPU inspection fails or the topology is unsupported
- select bundled profiles only when the complete topology is known to match, including rejecting undersized Blackwell GPUs
- preserve GB10/B10 Spark detection when `nvidia-smi` reports `[N/A]` for unified-memory fields
- add `model_servers --gpu-profile NAME` for explicitly reviewed, complete custom YAML profiles while keeping automatic detection strict
- add best-effort active-process context to unsupported-topology errors without making process inspection a startup dependency
- classify common vLLM startup failures, including insufficient GPU memory, while preserving original vLLM and NIM container logs
- pass the original vLLM arguments into diagnostics so configured `gpu_memory_utilization` appears in the failure report
- report GPU-detection failures as clean `model_servers` CLI errors without Python tracebacks
- keep the inventory records and query implementation private until a production caller requires a public contract

## Scope

This PR retains the existing named model-server profiles as a compatibility bridge. Measured per-service GPU-memory requirements, derived utilization, and capacity preflight are intentionally separate follow-up changes.

## Testing

- focused launcher, model-server, vLLM/NIM diagnostic/lifecycle, service-layout, and CLI-documentation suite: `156 passed`
- Ruff passes for every changed Python file
- regression coverage includes a 32 GiB RTX 5090, GB10 with unavailable memory telemetry, empty memory fields, best-effort process inspection, custom-profile validation, vLLM-only diagnostic arguments, and traceback-free CLI errors

Full non-GPU collection is currently blocked in this checkout by missing optional `stt_server` and `openxr_service` packages.
