### PR TITLE
Fix voice text delivery during playback pacing

### DIFF
--- a/agent-sdk/xr-ai-voice/README.md
+++ b/agent-sdk/xr-ai-voice/README.md
@@ -105,7 +105,10 @@ next batch instead of becoming separate queued utterances. This is open-loop
 pacing rather than a client playback acknowledgement. An estimate that is too
 short moves queuing downstream into TTS; one that is too long creates silence
 between utterances, but neither delays the completed-response data echo. Tune
-all three playback settings for the selected TTS voice.
+all three playback settings for the selected TTS voice. The echo represents the
+complete intended utterance, not a playback acknowledgement: a later urgent
+barge-in can interrupt its audio after the full text has already reached the
+client.
 
 Rewrites have an aggregator-enforced `rewrite_timeout_s` deadline, which is also
 passed to the model service. If a rewrite fails or times out, the original text

--- a/agent-sdk/xr-ai-voice/README.md
+++ b/agent-sdk/xr-ai-voice/README.md
@@ -95,14 +95,17 @@ rather than subscribing to one hard-coded topic name.
 
 Aggregation is participant-scoped. A lone finite contribution passes through
 without an LLM call after the short coalescing window. Two or more finite
-contributions in one batch are rewritten into a single concise utterance. The
-aggregator keeps each output open for an estimated spoken duration, based on
-`speech_rate_wpm` and clamped between `minimum_playback_s` and
+contributions in one batch are rewritten into a single concise utterance. As
+soon as raw or rewritten text is complete, the aggregator marks that response
+final so `VoiceAgent.text_topic` can update the client independently of audio
+playback. The aggregator separately reserves an estimated spoken duration,
+based on `speech_rate_wpm` and clamped between `minimum_playback_s` and
 `maximum_playback_s`, so updates produced while that output is playing form the
 next batch instead of becoming separate queued utterances. This is open-loop
 pacing rather than a client playback acknowledgement. An estimate that is too
-short moves queuing downstream into TTS; one that is too long creates silence.
-Tune all three playback settings for the selected TTS voice.
+short moves queuing downstream into TTS; one that is too long creates silence
+between utterances, but neither delays the completed-response data echo. Tune
+all three playback settings for the selected TTS voice.
 
 Rewrites have an aggregator-enforced `rewrite_timeout_s` deadline, which is also
 passed to the model service. If a rewrite fails or times out, the original text
@@ -120,15 +123,17 @@ have a bounded size; retained contributions remain ordered for following
 batches.
 
 A lone incremental contribution starts streaming immediately with a new
-aggregator-owned response ID. Other contributions wait behind that stream;
-finite updates that accumulated while it ran are coalesced when it finishes.
-An urgent contribution interrupts the active stream. A stream that stops
-producing chunks is closed after `stream_idle_timeout_s`, allowing pending
-updates to proceed. An interrupted or dropped stream ID remains quarantined
-until its terminator arrives. Each ignored fragment refreshes the quarantine;
-after a full `stream_idle_timeout_s` without another fragment, the ID may begin
-a new stream. This expiry bounds stale stream state independently from pending
-queue capacity.
+aggregator-owned response ID. Its final content chunk closes the downstream
+response immediately; the playback reservation continues only inside the
+aggregator's scheduler. Other contributions wait behind that reservation, and
+finite updates that accumulated while it ran are coalesced afterwards. An
+urgent contribution interrupts the active stream. A stream that stops producing
+chunks is closed after `stream_idle_timeout_s`, allowing pending updates to
+proceed. An interrupted or dropped stream ID remains quarantined until its
+terminator arrives. Each ignored fragment refreshes the quarantine; after a
+full `stream_idle_timeout_s` without another fragment, the ID may begin a new
+stream. This expiry bounds stale stream state independently from pending queue
+capacity.
 
 Call `stop()` before shutting down the runtime so the agent can cancel its
 participant-owned tasks. Contributions published after shutdown starts are

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_aggregation.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_aggregation.py
@@ -452,7 +452,6 @@ class VoiceAggregationAgent(Agent):
                         contribution,
                         output_id,
                         interrupt=False,
-                        final=contribution.output.final,
                     )
                     state.in_flight_count = 0
                     if contribution.output.final:
@@ -515,7 +514,6 @@ class VoiceAggregationAgent(Agent):
         response_id: str,
         *,
         interrupt: bool,
-        final: bool | None = None,
     ) -> None:
         try:
             await contribution.ctx.publish(
@@ -523,7 +521,7 @@ class VoiceAggregationAgent(Agent):
                 VoiceOutput(
                     text=contribution.output.text,
                     response_id=response_id,
-                    final=contribution.output.final if final is None else final,
+                    final=contribution.output.final,
                     interrupt=interrupt,
                     timestamp_us=contribution.output.timestamp_us,
                 ),

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_aggregation.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_aggregation.py
@@ -58,12 +58,13 @@ class VoiceAggregationAgent(Agent):
     """Serialize and coalesce candidate speech independently per participant.
 
     A lone finite contribution passes through without a model call after the
-    short coalescing window. The aggregator keeps that response open for its
-    estimated spoken duration, so updates arriving while it is being spoken
-    wait and coalesce instead of building a speech queue. Multiple pending
-    finite contributions are rewritten into one response. A lone incremental
-    response streams through immediately and uses the same playback estimate
-    after its final chunk. An urgent contribution interrupts the active output.
+    short coalescing window. Completed text is finalized downstream immediately,
+    while the aggregator independently reserves its estimated spoken duration
+    so later updates wait and coalesce instead of building a speech queue.
+    Multiple pending finite contributions are rewritten into one response. A
+    lone incremental response streams through immediately and uses the same
+    scheduling reservation after its final chunk. An urgent contribution
+    interrupts the active output.
     """
 
     def __init__(
@@ -444,11 +445,14 @@ class VoiceAggregationAgent(Agent):
                         )
                     spoken_text += contribution.output.text
                     state.in_flight_count = 1
+                    # Downstream finality follows content availability. The
+                    # playback reservation below is only scheduler state and
+                    # must not delay the client's completed-text echo.
                     await self._publish_stream(
                         contribution,
                         output_id,
                         interrupt=False,
-                        final=False,
+                        final=contribution.output.final,
                     )
                     state.in_flight_count = 0
                     if contribution.output.final:
@@ -465,7 +469,6 @@ class VoiceAggregationAgent(Agent):
                                 urgent,
                             )
                             return
-                        await self._publish_stream_end(first, output_id)
                         return
                     continue
 
@@ -609,7 +612,9 @@ class VoiceAggregationAgent(Agent):
             output=VoiceOutput(
                 text=text,
                 response_id=output_id,
-                final=False,
+                # The rewrite/raw batch is complete before playback pacing.
+                # Closing it here lets the data echo reach the client now.
+                final=True,
                 interrupt=interrupts,
                 timestamp_us=timestamp_us,
             ),
@@ -634,7 +639,6 @@ class VoiceAggregationAgent(Agent):
                 urgent_contribution,
             )
             return
-        await self._publish_stream_end(output, output_id)
 
     async def _hold_output(
         self,

--- a/docs/source/components/agent-sdk.md
+++ b/docs/source/components/agent-sdk.md
@@ -63,9 +63,11 @@ Applications with multiple speech producers may place
 `VoiceAggregationAgent` before `VoiceAgent`. Producers publish candidate
 finite or incremental responses to `voice.contribution`; the aggregator owns
 participant-scoped ordering, preserves a lone stream, coalesces simultaneous
-finite updates through the configured `LLMService`, holds an active response
-for a bounded, open-loop estimate of its spoken duration, and publishes only
-the result to `voice.output`. Pending work is capacity-bounded with a
+finite updates through the configured `LLMService`, publishes completed raw or
+rewritten text immediately, then reserves a bounded, open-loop estimate of its
+spoken duration only for scheduling subsequent speech. Consequently the
+client's completed-response data echo does not wait for playback pacing.
+Pending work is capacity-bounded with a
 priority-aware drop policy: routine work never displaces an alert, while a new
 alert replaces the oldest pending routine update or, if necessary, the oldest
 alert. Urgent output bypasses coalescing and rewriting, retains displaced

--- a/tests/test_voice_aggregation.py
+++ b/tests/test_voice_aggregation.py
@@ -116,7 +116,7 @@ async def test_single_contribution_bypasses_llm() -> None:
     output, metadata = recorder.outputs[0]
     assert output.text == "The timer is done."
     assert output.timestamp_us == 11
-    assert output.final is False
+    assert output.final is True
     assert output.response_id
     assert metadata.participant_id == "alice"
     assert metadata.source == "voice-aggregation"
@@ -125,7 +125,7 @@ async def test_single_contribution_bypasses_llm() -> None:
 
 async def test_simultaneous_contributions_are_rewritten_once() -> None:
     llm = _LLM("Temperature rose to 24 degrees, and the timer is done.")
-    runtime, aggregator, recorder = await _start(llm)
+    runtime, aggregator, recorder = await _start(llm, minimum_playback_s=0.2)
     try:
         await runtime.publish(
             VOICE_CONTRIBUTION_TOPIC,
@@ -140,6 +140,8 @@ async def test_simultaneous_contributions_are_rewritten_once() -> None:
             source="timer",
         )
         await recorder.wait_for(1)
+        assert aggregator._states["alice"].task is not None
+        assert not aggregator._states["alice"].task.done()
     finally:
         await _stop(runtime, aggregator)
 
@@ -147,7 +149,7 @@ async def test_simultaneous_contributions_are_rewritten_once() -> None:
     assert output.text == "Temperature rose to 24 degrees, and the timer is done."
     assert output.interrupt is False
     assert output.timestamp_us == 10
-    assert output.final is False
+    assert output.final is True
     assert output.response_id
     assert len(llm.calls) == 1
     messages, kwargs = llm.calls[0]
@@ -220,11 +222,11 @@ async def test_lone_stream_passes_through_while_pending_updates_coalesce() -> No
             participant_id="alice",
             source="foreground",
         )
-        await recorder.wait_for(5)
+        await recorder.wait_for(3)
     finally:
         await _stop(runtime, aggregator)
 
-    first, second, stream_end, third, batch_end = [output for output, _metadata in recorder.outputs]
+    first, second, third = [output for output, _metadata in recorder.outputs]
     assert first.text == "I can see "
     assert first.final is False
     assert first.response_id
@@ -232,13 +234,11 @@ async def test_lone_stream_passes_through_while_pending_updates_coalesce() -> No
     assert second == VoiceOutput(
         text="a beaker.",
         response_id=first.response_id,
-        final=False,
+        final=True,
     )
-    assert stream_end == VoiceOutput(response_id=first.response_id)
     assert third.text == "Temperature changed, and the timer completed."
-    assert third.final is False
+    assert third.final is True
     assert third.response_id
-    assert batch_end == VoiceOutput(response_id=third.response_id)
     assert len(llm.calls) == 1
 
 
@@ -268,19 +268,18 @@ async def test_stream_buffered_during_playback_keeps_all_chunks() -> None:
             participant_id="alice",
             source="foreground",
         )
-        await recorder.wait_for(5)
+        await recorder.wait_for(3)
     finally:
         await _stop(runtime, aggregator)
 
     outputs = [output for output, _metadata in recorder.outputs]
-    assert outputs[1] == VoiceOutput(response_id=outputs[0].response_id)
-    assert outputs[2].text == "Buffered "
-    assert outputs[3] == VoiceOutput(
+    assert outputs[0].final is True
+    assert outputs[1].text == "Buffered "
+    assert outputs[2] == VoiceOutput(
         text="stream.",
-        response_id=outputs[2].response_id,
-        final=False,
+        response_id=outputs[1].response_id,
+        final=True,
     )
-    assert outputs[4] == VoiceOutput(response_id=outputs[2].response_id)
 
 
 async def test_interleaved_streams_keep_each_stream_ordered() -> None:
@@ -299,29 +298,26 @@ async def test_interleaved_streams_keep_each_stream_ordered() -> None:
                 participant_id="alice",
                 source=source,
             )
-        await recorder.wait_for(6)
+        await recorder.wait_for(4)
     finally:
         await _stop(runtime, aggregator)
 
     outputs = [output for output, _metadata in recorder.outputs]
     first_id = outputs[0].response_id
-    second_id = outputs[3].response_id
+    second_id = outputs[2].response_id
     assert [output.text for output in outputs] == [
         "First ",
         "stream.",
-        "",
         "Second ",
         "stream.",
-        "",
     ]
     assert [output.response_id for output in outputs] == [
         first_id,
         first_id,
-        first_id,
-        second_id,
         second_id,
         second_id,
     ]
+    assert [output.final for output in outputs] == [False, True, False, True]
 
 
 async def test_updates_during_estimated_playback_coalesce_after_current_output() -> None:
@@ -351,17 +347,15 @@ async def test_updates_during_estimated_playback_coalesce_after_current_output()
             participant_id="alice",
             source="timer",
         )
-        await recorder.wait_for(4)
+        await recorder.wait_for(2)
     finally:
         await _stop(runtime, aggregator)
 
-    first, first_end, combined, combined_end = [output for output, _metadata in recorder.outputs]
+    first, combined = [output for output, _metadata in recorder.outputs]
     assert first.text == "This response remains active while it is spoken."
-    assert first.final is False
-    assert first_end == VoiceOutput(response_id=first.response_id)
+    assert first.final is True
     assert combined.text == "Temperature changed, and the timer completed."
-    assert combined.final is False
-    assert combined_end == VoiceOutput(response_id=combined.response_id)
+    assert combined.final is True
     assert len(llm.calls) == 1
 
 
@@ -494,7 +488,7 @@ async def test_discarded_stream_does_not_resume_after_other_interrupts() -> None
             participant_id="alice",
             source="stream",
         )
-        await recorder.wait_for(5)
+        await recorder.wait_for(4)
 
         state = aggregator._states["alice"]
         a_key = ("stream", "A")
@@ -506,7 +500,7 @@ async def test_discarded_stream_does_not_resume_after_other_interrupts() -> None
             source="stream",
         )
         await asyncio.sleep(0.02)
-        assert len(recorder.outputs) == 5
+        assert len(recorder.outputs) == 4
         assert state.discarded_streams[a_key] > old_expiry
 
         await runtime.publish(
@@ -528,8 +522,8 @@ async def test_discarded_stream_does_not_resume_after_other_interrupts() -> None
         "B-start",
         "C-start",
         "C-end",
-        "",
     ]
+    assert recorder.outputs[-1][0].final is True
 
 
 async def test_discarded_stream_can_restart_after_idle_expiry() -> None:
@@ -565,7 +559,7 @@ async def test_discarded_stream_can_restart_after_idle_expiry() -> None:
             participant_id="alice",
             source="stream",
         )
-        await recorder.wait_for(4)
+        await recorder.wait_for(3)
         await asyncio.sleep(0.04)
 
         await runtime.publish(
@@ -574,14 +568,14 @@ async def test_discarded_stream_can_restart_after_idle_expiry() -> None:
             participant_id="alice",
             source="stream",
         )
-        await recorder.wait_for(5)
+        await recorder.wait_for(4)
         await runtime.publish(
             VOICE_CONTRIBUTION_TOPIC,
             VoiceOutput(text="A-end", response_id="A"),
             participant_id="alice",
             source="stream",
         )
-        await recorder.wait_for(7)
+        await recorder.wait_for(5)
     finally:
         await _stop(runtime, aggregator)
 
@@ -589,11 +583,11 @@ async def test_discarded_stream_can_restart_after_idle_expiry() -> None:
         "A-old",
         "B-start",
         "B-end",
-        "",
         "A-new",
         "A-end",
-        "",
     ]
+    assert recorder.outputs[2][0].final is True
+    assert recorder.outputs[4][0].final is True
 
 
 async def test_expired_discarded_streams_are_pruned_by_finite_work() -> None:
@@ -620,7 +614,7 @@ async def test_expired_discarded_streams_are_pruned_by_finite_work() -> None:
             participant_id="alice",
             source="monitor",
         )
-        await recorder.wait_for(3)
+        await recorder.wait_for(2)
 
         assert state.discarded_streams == {}
     finally:
@@ -715,17 +709,16 @@ async def test_urgent_batch_speaks_alert_first_and_retains_routine_order() -> No
             participant_id="alice",
             source="safety",
         )
-        await recorder.wait_for(4)
+        await recorder.wait_for(2)
     finally:
         await _stop(runtime, aggregator)
 
     assert [output.text for output, _metadata in recorder.outputs] == [
         "Move away.",
-        "",
         "Routine one, then routine two.",
-        "",
     ]
     assert recorder.outputs[0][0].interrupt is True
+    assert all(output.final for output, _metadata in recorder.outputs)
     assert len(llm.calls) == 1
     assert "Routine one." in str(llm.calls[0][0][-1].content)
     assert "Routine two." in str(llm.calls[0][0][-1].content)
@@ -765,20 +758,18 @@ async def test_stream_boundary_does_not_hide_queued_urgent_output() -> None:
             participant_id="alice",
             source="foreground",
         )
-        await recorder.wait_for(7)
+        await recorder.wait_for(4)
     finally:
         await _stop(runtime, aggregator)
 
     assert [output.text for output, _metadata in recorder.outputs] == [
         "Move now.",
-        "",
         "Routine.",
-        "",
         "Stream start",
         "Stream end",
-        "",
     ]
     assert recorder.outputs[0][0].interrupt is True
+    assert recorder.outputs[-1][0].final is True
     assert llm.calls == []
 
 
@@ -829,14 +820,14 @@ async def test_urgent_contribution_cancels_in_flight_rewrite() -> None:
         )
         await recorder.wait_for(1)
         gate.set()
-        await recorder.wait_for(3)
+        await recorder.wait_for(2)
     finally:
         await _stop(runtime, aggregator)
 
     assert llm.cancelled is True
     assert recorder.outputs[0][0].text == "Move away now."
     assert recorder.outputs[0][0].interrupt is True
-    assert recorder.outputs[2][0].text == "Combined update."
+    assert recorder.outputs[1][0].text == "Combined update."
     assert len(llm.calls) == 2
     assert "First routine update." in str(llm.calls[1][0][-1].content)
     assert "Second routine update." in str(llm.calls[1][0][-1].content)


### PR DESCRIPTION
## Summary

- finalize raw streamed voice text as soon as its final contribution arrives
- finalize finite and LLM-rewritten speech as soon as the text is available
- keep the playback-duration reservation only in the aggregation scheduler, so later routine speech still waits and coalesces
- document that client text delivery is independent from open-loop audio pacing

## Root cause

`VoiceAggregationAgent` kept downstream `voice.output` responses open for its estimated playback duration. `VoiceAgent` emits the configured `agent.response` data message only when that downstream response closes, so an overestimated playback window delayed the Agent panel even after TTS audio had finished.

## Impact

The Agent panel now receives completed raw or rewritten text immediately. Audio overlap prevention, urgent interruption, participant isolation, and routine-output coalescing continue to use the existing playback reservation.

## Validation

- `36 passed`: `tests/test_voice_aggregation.py`
- `3 passed`: focused StreamingTTS data-echo and trailing-text tests
- Ruff 0.15.16 check and format check
- strict Sphinx build and generated public API reference check
- `git diff --check`
