### PR TITLE
feat(launcher): preflight service GPU memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,10 @@ uv sync
 uv run model_servers
 ```
 
-GPU profiles are auto-detected (`dual_48G_ada` / `spark` / `96G_blackwell`).
+Known GPU profiles are auto-detected (`dual_48G_ada` / `spark` /
+`96G_blackwell`). Unsupported or ambiguous topologies stop with the complete
+inventory instead of assuming a profile; use `--gpu-profile NAME` only after
+copying and reviewing a custom YAML profile for that hardware.
 On first run the stack downloads tens of GB from Hugging Face and can take
 tens of minutes. On subsequent runs the containers restart in under a minute.
 

--- a/agent-samples/model-servers/main.py
+++ b/agent-samples/model-servers/main.py
@@ -45,6 +45,7 @@ import argparse
 from pathlib import Path
 
 from xr_ai_launcher import (
+    GPUInventoryError,
     Process,
     detect_gpu_config,
     load_deployment_profile,
@@ -55,6 +56,23 @@ from xr_ai_logging import setup_logging
 from xr_ai_vllm import stop_persistent_servers
 
 _BASE = Path(__file__).resolve().parent
+
+
+def _gpu_profile_names() -> tuple[str, ...]:
+    root = _BASE / "yaml"
+    if not root.is_dir():
+        return ()
+    return tuple(path.name for path in sorted(root.iterdir()) if path.is_dir())
+
+
+def _gpu_profile_name(value: str) -> str:
+    names = _gpu_profile_names()
+    if value not in names:
+        available = ", ".join(names) or "none"
+        raise argparse.ArgumentTypeError(
+            f"unknown GPU profile {value!r}; available profiles: {available}"
+        )
+    return value
 
 # service → (project, command, config basename, port). Order is launch
 # order: NIM containers precede local servers (speech NIMs allocate fixed
@@ -103,24 +121,33 @@ def _service_config(gpu_dir: str, config_base: str, profile_key: str) -> str:
     return f"{gpu_dir}/{config_base}.yaml"
 
 
-def _build_processes(selection: str) -> tuple[list[Process], tuple[str, ...]]:
+def _build_processes(
+    selection: str, gpu_profile: str | None = None,
+) -> tuple[list[Process], tuple[str, ...]]:
     profile_path = _profile_path(selection)
     deployment = load_deployment_profile(profile_path)
     unknown = deployment.services.keys() - _MODEL_SERVICES.keys()
     if unknown:
         raise ValueError(f"model profile declares unknown services: {sorted(unknown)}")
 
-    gpu_dir = f"yaml/{detect_gpu_config()}"
+    profile_name = gpu_profile or detect_gpu_config()
+    gpu_dir = f"yaml/{profile_name}"
     profile_key = profile_path.stem.removeprefix("models.")
-    processes = [
-        Process(
+    processes = []
+    for service, (project, command, config_base, port) in _MODEL_SERVICES.items():
+        if deployment.launch_mode(service) != "own":
+            continue
+        config = _service_config(gpu_dir, config_base, profile_key)
+        if not (_BASE / config).is_file():
+            raise ValueError(
+                f"GPU profile {profile_name!r} is incomplete: missing {config} "
+                f"for service {service!r}"
+            )
+        processes.append(Process(
             service, project, command,
-            config=_service_config(gpu_dir, config_base, profile_key),
+            config=config,
             launch_mode="persist", port=port,
-        )
-        for service, (project, command, config_base, port) in _MODEL_SERVICES.items()
-        if deployment.launch_mode(service) == "own"
-    ]
+        ))
     return processes, deployment.required_credentials
 
 
@@ -171,13 +198,26 @@ def run() -> None:
     p.add_argument("--allow-anonymous", action="store_true",
                    help="Start without HF_TOKEN (unauthenticated downloads "
                         "of the multi-GB checkpoints may stall indefinitely).")
+    p.add_argument(
+        "--gpu-profile", metavar="NAME", type=_gpu_profile_name,
+        help="Use a named YAML GPU profile instead of automatic detection. "
+             "Intended for explicitly reviewed custom hardware profiles.",
+    )
     ns, _ = p.parse_known_args()
 
     if ns.stop:
         _stop_models()
         return
 
-    processes, credentials = _build_processes(ns.models)
+    try:
+        processes, credentials = _build_processes(ns.models, ns.gpu_profile)
+    except GPUInventoryError as exc:
+        p.error(
+            f"{exc}\nUse --gpu-profile NAME to select an explicitly reviewed "
+            "custom YAML profile."
+        )
+    except ValueError as exc:
+        p.error(str(exc))
 
     # A missing HF_TOKEN silently stalls the multi-GB first-run download; see
     # docs/source/getting_started/credentials.md.

--- a/agent-samples/model-servers/main.py
+++ b/agent-samples/model-servers/main.py
@@ -49,6 +49,7 @@ from xr_ai_launcher import (
     Process,
     detect_gpu_config,
     load_deployment_profile,
+    read_service_port,
     require_credentials,
     run_stack,
 )
@@ -74,35 +75,32 @@ def _gpu_profile_name(value: str) -> str:
         )
     return value
 
-# service → (project, command, config basename, port). Order is launch
+# service → (project, command, config basename). Order is launch
 # order: NIM containers precede local servers (speech NIMs allocate fixed
 # VRAM while LLM/VLM NIMs grab most of their GPU's free VRAM for KV cache);
 # agent-llm precedes the VLM so its FlashInfer MoE JIT compilation runs with
 # the full GPU free on single-GPU profiles.
-_MODEL_SERVICES: dict[str, tuple[str, str, str, int]] = {
-    "stt-nim":   ("../../services/nim-server", "nim_server", "nim_stt_server", 9010),
-    "tts-nim":   ("../../services/nim-server", "nim_server", "nim_tts_server", 9011),
-    "llm-nim":   ("../../services/nim-server", "nim_server", "nim_llm_server", 8110),
-    "vlm-nim":   ("../../services/nim-server", "nim_server", "nim_vlm_server", 8100),
-    "stt":       ("../../services/stt-server", "stt_server", "stt_server", 8103),
+_MODEL_SERVICES: dict[str, tuple[str, str, str]] = {
+    "stt-nim":   ("../../services/nim-server", "nim_server", "nim_stt_server"),
+    "tts-nim":   ("../../services/nim-server", "nim_server", "nim_tts_server"),
+    "llm-nim":   ("../../services/nim-server", "nim_server", "nim_llm_server"),
+    "vlm-nim":   ("../../services/nim-server", "nim_server", "nim_vlm_server"),
+    "stt":       ("../../services/stt-server", "stt_server", "stt_server"),
     "agent-llm": (
         "../../services/nemotron3-nano-llm",
         "nemotron3_nano_llm_server",
         "nemotron3_nano_llm_server",
-        8107,
     ),
     "omni": (
         "../../services/nemotron-omni-llm",
         "nemotron_omni_llm_server",
         "nemotron_omni_llm_server",
-        8108,
     ),
-    "vlm":       ("../../services/vlm-server", "vlm_server", "vlm_server", 8100),
+    "vlm":       ("../../services/vlm-server", "vlm_server", "vlm_server"),
     "embedding": (
         "../../services/embedding-server",
         "embedding_server",
         "embedding_server",
-        8109,
     ),
 }
 
@@ -133,32 +131,44 @@ def _build_processes(
     profile_name = gpu_profile or detect_gpu_config()
     gpu_dir = f"yaml/{profile_name}"
     profile_key = profile_path.stem.removeprefix("models.")
-    processes = []
-    for service, (project, command, config_base, port) in _MODEL_SERVICES.items():
+    processes: list[Process] = []
+    for service, (project, command, config_base) in _MODEL_SERVICES.items():
         if deployment.launch_mode(service) != "own":
             continue
         config = _service_config(gpu_dir, config_base, profile_key)
-        if not (_BASE / config).is_file():
+        config_path = _BASE / config
+        if not config_path.is_file():
             raise ValueError(
                 f"GPU profile {profile_name!r} is incomplete: missing {config} "
                 f"for service {service!r}"
             )
+        port = read_service_port(config_path)
+        if port is None:
+            raise ValueError(f"{config_path}: service config must declare port or http_port")
         processes.append(Process(
-            service, project, command,
-            config=config,
+            service, project, command, config=config,
             launch_mode="persist", port=port,
         ))
     return processes, deployment.required_credentials
+
+
+def _known_service_ports() -> list[tuple[str, int]]:
+    """Discover cleanup targets from the YAML files that own their ports."""
+    targets: set[tuple[str, int]] = set()
+    for service, (project, _, config_base) in _MODEL_SERVICES.items():
+        configs = list((_BASE / "yaml").glob(f"*/{config_base}*.yaml"))
+        configs.append((_BASE / project / f"{config_base}.yaml").resolve())
+        for config in configs:
+            if config.is_file() and (port := read_service_port(config)) is not None:
+                targets.add((service, port))
+    return sorted(targets)
 
 
 def _stop_models() -> None:
     # Surface docker/ss/lsof failures so operators see why --stop aborted
     # instead of a silent traceback exit.
     try:
-        stop_persistent_servers([
-            (service, port)
-            for service, (_, _, _, port) in _MODEL_SERVICES.items()
-        ])
+        stop_persistent_servers(_known_service_ports())
     except Exception as exc:
         print(f"model-servers: failed to stop persistent servers: {exc}", flush=True)
 
@@ -173,7 +183,7 @@ def _stop_unselected_services(processes: list[Process]) -> None:
     selected_ports = {process.port for process in processes}
     unselected = [
         (service, port)
-        for service, (_, _, _, port) in _MODEL_SERVICES.items()
+        for service, port in _known_service_ports()
         if port not in selected_ports
     ]
     if not stop_persistent_servers(unselected):

--- a/agent-samples/model-servers/main.py
+++ b/agent-samples/model-servers/main.py
@@ -42,16 +42,25 @@ To stop all model servers:
     uv run --project agent-samples/model-servers model_servers --stop
 """
 import argparse
+import urllib.request
+from dataclasses import replace
 from pathlib import Path
 
 from xr_ai_launcher import (
+    GPU_MEMORY_UTILIZATION_ENV,
     GPUInventoryError,
     Process,
     detect_gpu_config,
+    format_gpu_memory_preflight,
     load_deployment_profile,
+    preflight_gpu_memory,
+    query_gpu_inventory,
     read_service_port,
     require_credentials,
+    require_gpu_memory_preflight,
+    resolve_gpu_memory_plan,
     run_stack,
+    utilization_overrides,
 )
 from xr_ai_logging import setup_logging
 from xr_ai_vllm import stop_persistent_servers
@@ -103,6 +112,7 @@ _MODEL_SERVICES: dict[str, tuple[str, str, str]] = {
         "embedding_server",
     ),
 }
+_VLLM_SERVICES = {"agent-llm", "omni", "vlm", "embedding"}
 
 
 def _profile_path(selection: str) -> Path:
@@ -162,6 +172,52 @@ def _known_service_ports() -> list[tuple[str, int]]:
             if config.is_file() and (port := read_service_port(config)) is not None:
                 targets.add((service, port))
     return sorted(targets)
+
+
+def _service_is_ready(port: int) -> bool:
+    for path in ("/health", "/v1/health/ready"):
+        try:
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{port}{path}", timeout=0.5,
+            ) as response:
+                if response.status == 200:
+                    return True
+        except Exception:
+            continue
+    return False
+
+
+def _apply_gpu_memory_plan(processes: list[Process], selection: str) -> list[Process]:
+    """Preflight selected service YAML requirements and inject vLLM budgets."""
+    inventory = query_gpu_inventory()
+    configs = {
+        process.name: ((_BASE / process.config).resolve(), process.name in _VLLM_SERVICES)
+        for process in processes
+        if process.config is not None
+    }
+    plan = resolve_gpu_memory_plan(
+        stack=f"model-servers/{selection}",
+        inventory=inventory,
+        service_configs=configs,
+    )
+    active = frozenset(
+        process.name for process in processes
+        if process.port is not None and _service_is_ready(process.port)
+    )
+    results = preflight_gpu_memory(plan, inventory, active_services=active)
+    print(format_gpu_memory_preflight(plan, results), flush=True)
+    require_gpu_memory_preflight(results)
+    overrides = utilization_overrides(plan, inventory)
+    return [
+        replace(
+            process,
+            environment=process.environment + (
+                (GPU_MEMORY_UTILIZATION_ENV, overrides[process.name]),
+            ),
+        )
+        if process.name in overrides else process
+        for process in processes
+    ]
 
 
 def _stop_models() -> None:
@@ -235,6 +291,7 @@ def run() -> None:
     for credential in credentials:
         require_credentials(credential)
     _stop_unselected_services(processes)
+    processes = _apply_gpu_memory_plan(processes, ns.models)
     run_stack(processes, _BASE, exit_after_ready=True)
 
 

--- a/agent-samples/model-servers/yaml/96G_blackwell/embedding_server.yaml
+++ b/agent-samples/model-servers/yaml/96G_blackwell/embedding_server.yaml
@@ -4,11 +4,11 @@
 model: nvidia/llama-nemotron-embed-1b-v2
 host: "0.0.0.0"
 port: 8109
+gpu_memory_reservation_gib: 8.0
 served_model_name: embed
 model_cache: ../../../../models
 max_num_seqs: 32
 max_model_len: 8192
-gpu_memory_utilization: 0.08
 enforce_eager: true
 vllm_backend: docker
 vllm_image: nvcr.io/nvidia/vllm:26.04-py3

--- a/agent-samples/model-servers/yaml/96G_blackwell/nemotron_omni_llm_server.yaml
+++ b/agent-samples/model-servers/yaml/96G_blackwell/nemotron_omni_llm_server.yaml
@@ -7,13 +7,13 @@
 
 host: "0.0.0.0"
 port: 8108
+gpu_memory_reservation_gib: 34.0
 hf_token: ""
 model_cache: ../../../../models
 
 max_num_seqs: 8
 tensor_parallel_size: 1
 max_model_len: 32768
-gpu_memory_utilization: 0.35
 enforce_eager: false
 
 video_pruning_rate: 0.5

--- a/agent-samples/model-servers/yaml/96G_blackwell/nim_llm_server.yaml
+++ b/agent-samples/model-servers/yaml/96G_blackwell/nim_llm_server.yaml
@@ -8,6 +8,7 @@
 # UNTESTED ESTIMATE for this GPU profile; validated values are dual_48G_ada's.
 image:     nvcr.io/nim/nvidia/nemotron-3-nano:2.0.10
 http_port: 8110
+gpu_memory_reservation_gib: 45.0
 
 nim_cache: ../../../../models/nim
 

--- a/agent-samples/model-servers/yaml/96G_blackwell/nim_stt_server.yaml
+++ b/agent-samples/model-servers/yaml/96G_blackwell/nim_stt_server.yaml
@@ -6,6 +6,7 @@
 # UNTESTED ESTIMATE for this GPU profile; validated values are dual_48G_ada's.
 image:     nvcr.io/nim/nvidia/parakeet-tdt-0.6b-v2:1.2.0
 http_port: 9010
+gpu_memory_reservation_gib: 10.0
 grpc_port: 50051
 
 nim_cache: ../../../../models/nim
@@ -13,5 +14,5 @@ nim_cache: ../../../../models/nim
 cuda_visible_devices: "0"
 env:
   # Single-process inference: the default multiprocessing mode runs two
-  # CUDA processes; one is plenty for demo traffic. ~14 GB VRAM either way.
+  # CUDA processes; one is plenty for demo traffic.
   NIM_USE_MULTIPROCESSING_FOR_INFERENCE: "false"

--- a/agent-samples/model-servers/yaml/96G_blackwell/nim_tts_server.yaml
+++ b/agent-samples/model-servers/yaml/96G_blackwell/nim_tts_server.yaml
@@ -6,6 +6,7 @@
 # UNTESTED ESTIMATE for this GPU profile; validated values are dual_48G_ada's.
 image:     nvcr.io/nim/nvidia/magpie-tts-multilingual:1.9.0
 http_port: 9011
+gpu_memory_reservation_gib: 10.0
 grpc_port: 50052
 
 nim_cache: ../../../../models/nim

--- a/agent-samples/model-servers/yaml/96G_blackwell/nim_vlm_server.yaml
+++ b/agent-samples/model-servers/yaml/96G_blackwell/nim_vlm_server.yaml
@@ -9,6 +9,7 @@
 # UNTESTED ESTIMATE for this GPU profile; validated values are dual_48G_ada's.
 image:     nvcr.io/nim/nvidia/cosmos-reason1-7b:1.4.1
 http_port: 8100
+gpu_memory_reservation_gib: 30.0
 
 nim_cache: ../../../../models/nim
 

--- a/agent-samples/model-servers/yaml/96G_blackwell/stt_server.yaml
+++ b/agent-samples/model-servers/yaml/96G_blackwell/stt_server.yaml
@@ -5,6 +5,8 @@
 model: nvidia/parakeet-tdt-0.6b-v3
 device: auto
 port: 8103
+cuda_visible_devices: "0"
+gpu_memory_reservation_gib: 3.0
 host: "0.0.0.0"
 startup_timeout_s: 600
 model_cache: ../../../../models

--- a/agent-samples/model-servers/yaml/96G_blackwell/vlm_server.yaml
+++ b/agent-samples/model-servers/yaml/96G_blackwell/vlm_server.yaml
@@ -5,8 +5,9 @@
 #
 # vlm is THIRD in load order: STT → Omni → vlm.
 # free_at_startup ≈ 96 − 34 (Omni) − 2 (STT) ≈ 60 GiB.
-# 0.23 × 96 = 22.1 GiB cap: 16.8 GiB measured Reasoner weights plus
-# multimodal encoder profiling, runtime overhead, and KV cache.
+# 22 GiB requirement: 16.8 GiB Reasoner weights plus multimodal encoder
+# profiling, runtime overhead, and KV cache. The launcher derives vLLM's
+# utilization fraction from the detected device total.
 # hf_overrides selects the Reasoner runtime; details are documented in
 # docs/source/components/ai-services.md#per-server-notes.
 
@@ -16,9 +17,10 @@ hf_overrides:
     - Cosmos3ForConditionalGeneration
 hf_token: ""
 port: 8100
+cuda_visible_devices: "0"
+gpu_memory_reservation_gib: 22.0
 host: "0.0.0.0"
 model_cache: ../../../../models
-gpu_memory_utilization: 0.23
 max_num_seqs: 4
 enforce_eager: true
 async_scheduling: true

--- a/agent-samples/model-servers/yaml/dual_48G_ada/embedding_server.yaml
+++ b/agent-samples/model-servers/yaml/dual_48G_ada/embedding_server.yaml
@@ -4,12 +4,12 @@
 model: nvidia/llama-nemotron-embed-1b-v2
 host: "0.0.0.0"
 port: 8109
+gpu_memory_reservation_gib: 4.0
 served_model_name: embed
 model_cache: ../../../../models
 cuda_visible_devices: "0"
 max_num_seqs: 32
 max_model_len: 8192
-gpu_memory_utilization: 0.08
 enforce_eager: true
 vllm_backend: docker
 vllm_image: nvcr.io/nvidia/vllm:26.04-py3

--- a/agent-samples/model-servers/yaml/dual_48G_ada/nemotron_omni_llm_server.yaml
+++ b/agent-samples/model-servers/yaml/dual_48G_ada/nemotron_omni_llm_server.yaml
@@ -6,6 +6,7 @@
 
 host: "0.0.0.0"
 port: 8108
+gpu_memory_reservation_gib: 37.0
 hf_token: ""
 model_cache: ../../../../models
 
@@ -13,7 +14,6 @@ cuda_visible_devices: "1"
 max_num_seqs: 8
 tensor_parallel_size: 1
 max_model_len: 32768
-gpu_memory_utilization: 0.78
 enforce_eager: false
 
 video_pruning_rate: 0.5

--- a/agent-samples/model-servers/yaml/dual_48G_ada/nim_llm_server.yaml
+++ b/agent-samples/model-servers/yaml/dual_48G_ada/nim_llm_server.yaml
@@ -7,6 +7,7 @@
 # any LLM NIM from https://catalog.ngc.nvidia.com.
 image:     nvcr.io/nim/nvidia/nemotron-3-nano:2.0.10
 http_port: 8110
+gpu_memory_reservation_gib: 39.0
 
 nim_cache: ../../../../models/nim
 

--- a/agent-samples/model-servers/yaml/dual_48G_ada/nim_stt_server.yaml
+++ b/agent-samples/model-servers/yaml/dual_48G_ada/nim_stt_server.yaml
@@ -5,6 +5,7 @@
 # riva_grpc model kind; http_port serves /v1/health/ready only.
 image:     nvcr.io/nim/nvidia/parakeet-tdt-0.6b-v2:1.2.0
 http_port: 9010
+gpu_memory_reservation_gib: 8.0
 grpc_port: 50051
 
 nim_cache: ../../../../models/nim
@@ -12,5 +13,5 @@ nim_cache: ../../../../models/nim
 cuda_visible_devices: "0"
 env:
   # Single-process inference: the default multiprocessing mode runs two
-  # CUDA processes; one is plenty for demo traffic. ~14 GB VRAM either way.
+  # CUDA processes; one is plenty for demo traffic.
   NIM_USE_MULTIPROCESSING_FOR_INFERENCE: "false"

--- a/agent-samples/model-servers/yaml/dual_48G_ada/nim_tts_server.yaml
+++ b/agent-samples/model-servers/yaml/dual_48G_ada/nim_tts_server.yaml
@@ -5,6 +5,7 @@
 # riva_grpc model kind; http_port serves /v1/health/ready only.
 image:     nvcr.io/nim/nvidia/magpie-tts-multilingual:1.9.0
 http_port: 9011
+gpu_memory_reservation_gib: 8.0
 grpc_port: 50052
 
 nim_cache: ../../../../models/nim

--- a/agent-samples/model-servers/yaml/dual_48G_ada/nim_vlm_server.yaml
+++ b/agent-samples/model-servers/yaml/dual_48G_ada/nim_vlm_server.yaml
@@ -10,6 +10,7 @@
 # Nemotron NIM and local STT share GPU 1.
 image:     nvcr.io/nim/nvidia/cosmos-reason1-7b:1.4.1
 http_port: 8100
+gpu_memory_reservation_gib: 30.0
 
 nim_cache: ../../../../models/nim
 

--- a/agent-samples/model-servers/yaml/dual_48G_ada/nim_vlm_server_vlm_speech_nim.yaml
+++ b/agent-samples/model-servers/yaml/dual_48G_ada/nim_vlm_server_vlm_speech_nim.yaml
@@ -9,6 +9,7 @@
 # vlm_speech_nim placement: Riva speech NIMs own GPU 0, Cosmos gets GPU 1.
 image:     nvcr.io/nim/nvidia/cosmos-reason1-7b:1.4.1
 http_port: 8100
+gpu_memory_reservation_gib: 40.0
 
 nim_cache: ../../../../models/nim
 

--- a/agent-samples/model-servers/yaml/dual_48G_ada/stt_server.yaml
+++ b/agent-samples/model-servers/yaml/dual_48G_ada/stt_server.yaml
@@ -6,7 +6,7 @@
 # OpenAI-compatible API at http://localhost:8103/v1
 
 # NeMo model name.
-# nvidia/parakeet-tdt-0.6b-v3  — 0.6B TDT model; CC-BY-4.0; ~1.5 GB VRAM; English only
+# nvidia/parakeet-tdt-0.6b-v3  — 0.6B TDT model; CC-BY-4.0; English only
 # nvidia/parakeet-rnnt-1.1b    — stronger, larger; same CC-BY-4.0 license
 model: nvidia/parakeet-tdt-0.6b-v3
 
@@ -17,6 +17,7 @@ device: auto
 cuda_visible_devices: "1"
 
 port: 8103
+gpu_memory_reservation_gib: 3.0
 host: "0.0.0.0"
 startup_timeout_s: 600
 

--- a/agent-samples/model-servers/yaml/dual_48G_ada/vlm_server.yaml
+++ b/agent-samples/model-servers/yaml/dual_48G_ada/vlm_server.yaml
@@ -20,15 +20,16 @@ hf_overrides:
 hf_token: ""
 
 port: 8100
+gpu_memory_reservation_gib: 22.0
 host: "0.0.0.0"
 cuda_visible_devices: "0"   # share GPU 0 with embeddings; Nemotron/STT use GPU 1
 
 model_cache: ../../../../models
 
-# 0.47 × 47 = 22.1 GiB budget: 16.8 GiB Reasoner weights plus multimodal
-# encoder profiling, runtime overhead, and KV cache.
+# 22 GiB budget: 16.8 GiB Reasoner weights plus multimodal encoder
+# profiling, runtime overhead, and KV cache. The launcher derives vLLM's
+# utilization fraction from this requirement and the detected device total.
 # Single-image queries have short context so the KV budget is adequate.
-gpu_memory_utilization: 0.47
 enforce_eager: true
 async_scheduling: true
 mm_encoder_tp_mode: data

--- a/agent-samples/model-servers/yaml/spark/embedding_server.yaml
+++ b/agent-samples/model-servers/yaml/spark/embedding_server.yaml
@@ -4,11 +4,11 @@
 model: nvidia/llama-nemotron-embed-1b-v2
 host: "0.0.0.0"
 port: 8109
+gpu_memory_reservation_gib: 9.6
 served_model_name: embed
 model_cache: ../../../../models
 max_num_seqs: 32
 max_model_len: 8192
-gpu_memory_utilization: 0.08
 enforce_eager: true
 vllm_backend: docker
 vllm_image: nvcr.io/nvidia/vllm:26.04-py3

--- a/agent-samples/model-servers/yaml/spark/nemotron_omni_llm_server.yaml
+++ b/agent-samples/model-servers/yaml/spark/nemotron_omni_llm_server.yaml
@@ -7,13 +7,13 @@
 
 host: "0.0.0.0"
 port: 8108
+gpu_memory_reservation_gib: 30.0
 hf_token: ""
 model_cache: ../../../../models
 
 max_num_seqs: 8
 tensor_parallel_size: 1
 max_model_len: 32768
-gpu_memory_utilization: 0.25
 enforce_eager: false
 
 video_pruning_rate: 0.5

--- a/agent-samples/model-servers/yaml/spark/nim_llm_server.yaml
+++ b/agent-samples/model-servers/yaml/spark/nim_llm_server.yaml
@@ -8,6 +8,7 @@
 # UNTESTED ESTIMATE for this GPU profile; validated values are dual_48G_ada's.
 image:     nvcr.io/nim/nvidia/nemotron-3-nano:2.0.10
 http_port: 8110
+gpu_memory_reservation_gib: 42.0
 
 nim_cache: ../../../../models/nim
 

--- a/agent-samples/model-servers/yaml/spark/nim_stt_server.yaml
+++ b/agent-samples/model-servers/yaml/spark/nim_stt_server.yaml
@@ -6,6 +6,7 @@
 # UNTESTED ESTIMATE for this GPU profile; validated values are dual_48G_ada's.
 image:     nvcr.io/nim/nvidia/parakeet-tdt-0.6b-v2:1.2.0
 http_port: 9010
+gpu_memory_reservation_gib: 10.0
 grpc_port: 50051
 
 nim_cache: ../../../../models/nim
@@ -13,5 +14,5 @@ nim_cache: ../../../../models/nim
 cuda_visible_devices: "0"
 env:
   # Single-process inference: the default multiprocessing mode runs two
-  # CUDA processes; one is plenty for demo traffic. ~14 GB VRAM either way.
+  # CUDA processes; one is plenty for demo traffic.
   NIM_USE_MULTIPROCESSING_FOR_INFERENCE: "false"

--- a/agent-samples/model-servers/yaml/spark/nim_tts_server.yaml
+++ b/agent-samples/model-servers/yaml/spark/nim_tts_server.yaml
@@ -6,6 +6,7 @@
 # UNTESTED ESTIMATE for this GPU profile; validated values are dual_48G_ada's.
 image:     nvcr.io/nim/nvidia/magpie-tts-multilingual:1.9.0
 http_port: 9011
+gpu_memory_reservation_gib: 10.0
 grpc_port: 50052
 
 nim_cache: ../../../../models/nim

--- a/agent-samples/model-servers/yaml/spark/nim_vlm_server.yaml
+++ b/agent-samples/model-servers/yaml/spark/nim_vlm_server.yaml
@@ -9,6 +9,7 @@
 # UNTESTED ESTIMATE for this GPU profile; validated values are dual_48G_ada's.
 image:     nvcr.io/nim/nvidia/cosmos-reason1-7b:1.4.1
 http_port: 8100
+gpu_memory_reservation_gib: 25.0
 
 nim_cache: ../../../../models/nim
 

--- a/agent-samples/model-servers/yaml/spark/stt_server.yaml
+++ b/agent-samples/model-servers/yaml/spark/stt_server.yaml
@@ -5,6 +5,8 @@
 model: nvidia/parakeet-tdt-0.6b-v3
 device: auto
 port: 8103
+cuda_visible_devices: "0"
+gpu_memory_reservation_gib: 3.0
 host: "0.0.0.0"
 startup_timeout_s: 600
 model_cache: ../../../../models

--- a/agent-samples/model-servers/yaml/spark/vlm_server.yaml
+++ b/agent-samples/model-servers/yaml/spark/vlm_server.yaml
@@ -5,7 +5,10 @@
 #
 # vlm is THIRD in load order: STT → Omni → vlm.
 # free_at_startup ≈ 120 − 30 (Omni) − 2 (STT) ≈ 88 GiB.
-# 0.20 × 120 = 24 GiB cap: ~16 GiB Cosmos3 Reasoner weights + ~8 GiB KV.
+# Initial 24 GiB budget preserves the previous 0.20 fraction at the profile's
+# nominal 120 GiB GPU-visible capacity. It is not a measured requirement;
+# measurement must replace or validate it. The launcher derives vLLM's
+# utilization fraction from the detected device total.
 # hf_overrides selects the Reasoner runtime; details are documented in
 # docs/source/components/ai-services.md#per-server-notes.
 
@@ -15,9 +18,10 @@ hf_overrides:
     - Cosmos3ForConditionalGeneration
 hf_token: ""
 port: 8100
+cuda_visible_devices: "0"
+gpu_memory_reservation_gib: 24.0
 host: "0.0.0.0"
 model_cache: ../../../../models
-gpu_memory_utilization: 0.20
 max_num_seqs: 4
 enforce_eager: true
 async_scheduling: true

--- a/agent-samples/simple-vlm-example/README.md
+++ b/agent-samples/simple-vlm-example/README.md
@@ -46,7 +46,13 @@ uv run simple_vlm_example
 (see [`credentials.md`](../../docs/source/getting_started/credentials.md)).
 
 The VLM and STT keep running after you exit so the next run skips the model
-reload; free the VRAM with `cd ../model-servers && uv run model_servers --stop`.
+reload; free the GPU memory with
+`cd ../model-servers && uv run model_servers --stop`.
+
+For the local profile, the orchestrator reads device placement and absolute
+GPU-memory requirements from `yaml/vlm_server.yaml` and `yaml/stt_server.yaml`.
+It prints a per-device preflight before loading either model and derives vLLM's
+utilization from the detected device total.
 
 Open the web client shown in the hub banner, connect, and then speak or type a
 question.

--- a/agent-samples/simple-vlm-example/main.py
+++ b/agent-samples/simple-vlm-example/main.py
@@ -27,11 +27,18 @@ from dataclasses import replace
 from pathlib import Path
 
 from xr_ai_launcher import (
+    GPU_MEMORY_UTILIZATION_ENV,
     Process,
     ensure_credentials,
+    format_gpu_memory_preflight,
     load_model_deployment,
+    preflight_gpu_memory,
+    query_gpu_inventory,
     require_credentials,
+    require_gpu_memory_preflight,
+    resolve_gpu_memory_plan,
     run_stack,
+    utilization_overrides,
 )
 from xr_ai_logging import setup_logging
 
@@ -95,6 +102,35 @@ def _build_processes() -> tuple[list[Process], tuple[str, ...]]:
     return procs, deployment.required_credentials
 
 
+def _apply_local_gpu_memory_plan(processes: list[Process]) -> list[Process]:
+    """Preflight GPU services owned by the local deployment."""
+    inventory = query_gpu_inventory()
+    configs = {
+        process.name: ((_BASE / process.config).resolve(), process.name == "vlm")
+        for process in processes
+        if process.config is not None and process.name in {"vlm", "stt"}
+    }
+    plan = resolve_gpu_memory_plan(
+        stack="simple-vlm-example/local",
+        inventory=inventory,
+        service_configs=configs,
+    )
+    results = preflight_gpu_memory(plan, inventory)
+    print(format_gpu_memory_preflight(plan, results), flush=True)
+    require_gpu_memory_preflight(results)
+    overrides = utilization_overrides(plan, inventory)
+    return [
+        replace(
+            process,
+            environment=process.environment + (
+                (GPU_MEMORY_UTILIZATION_ENV, overrides[process.name]),
+            ),
+        )
+        if process.name in overrides else process
+        for process in processes
+    ]
+
+
 def run() -> None:
     setup_logging("orchestrator", namespace="simple-vlm-example")
 
@@ -105,6 +141,9 @@ def run() -> None:
     ns, _ = p.parse_known_args()
 
     processes, credentials = _build_processes()
+    deployment = load_model_deployment(_BASE / _WORKER_CONFIG)
+    if deployment.profile_path.stem == "models.local":
+        processes = _apply_local_gpu_memory_plan(processes)
     # A missing HF_TOKEN silently stalls the multi-GB first-run download; see
     # docs/source/getting_started/credentials.md.
     require_credentials("HF_TOKEN", allow_missing=ns.allow_anonymous)

--- a/agent-samples/simple-vlm-example/yaml/stt_server.yaml
+++ b/agent-samples/simple-vlm-example/yaml/stt_server.yaml
@@ -7,5 +7,7 @@
 model:       nvidia/parakeet-tdt-0.6b-v3
 device:      auto
 port:        8103
+cuda_visible_devices: "0"
+gpu_memory_reservation_gib: 3.0
 startup_timeout_s: 600
 model_cache: ../../../models

--- a/agent-samples/simple-vlm-example/yaml/vlm_server.yaml
+++ b/agent-samples/simple-vlm-example/yaml/vlm_server.yaml
@@ -11,6 +11,8 @@ hf_overrides:
   architectures:
     - Cosmos3ForConditionalGeneration
 port:        8100
+cuda_visible_devices: "0"
+gpu_memory_reservation_gib: 24.0
 model_cache: ../../../models
 async_scheduling: true
 mm_encoder_tp_mode: data

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -46,9 +46,13 @@ uv sync
 uv run model_servers
 ```
 
-GPU profiles are auto-detected (`dual_48G_ada`, `spark`, `96G_blackwell`). These
-are presets for common configurations; to run on a different GPU, refer to
+GPU profiles are auto-detected (`dual_48G_ada`, `spark`, `96G_blackwell`). The
+profiles are presets for common configurations; to run on a different GPU, refer to
 {doc}`Running on other GPUs </getting_started/requirements>`.
+Detection inventories every visible device. If `nvidia-smi` fails, returns
+malformed data, or reports a topology without an existing model-server
+configuration, startup stops with the detected per-GPU capacity instead of
+assuming a fallback.
 On first run each model downloads from HuggingFace (tens of GB; can take
 tens of minutes). On subsequent runs the containers restart in under a minute.
 

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -53,6 +53,10 @@ Detection inventories every visible device. If `nvidia-smi` fails, returns
 malformed data, or reports a topology without an existing model-server
 configuration, startup stops with the detected per-GPU capacity instead of
 assuming a fallback.
+After selecting the configuration, a second preflight prints every service's
+absolute GPU-memory requirement per device and stops before model loading when
+the complete stack plus safety reserve cannot fit. vLLM utilization is derived
+from that requirement and the detected device total.
 On first run each model downloads from HuggingFace (tens of GB; can take
 tens of minutes). On subsequent runs the containers restart in under a minute.
 

--- a/docs/source/getting_started/requirements.md
+++ b/docs/source/getting_started/requirements.md
@@ -130,6 +130,18 @@ and adjust those knobs to your hardware:
 3. On lower-VRAM GPUs, run fewer models concurrently, or lower `max_model_len` on
    the LLM and VLM servers to reduce the KV-cache footprint.
 
+Then select the reviewed profile explicitly:
+
+```bash
+uv run --project agent-samples/model-servers model_servers \
+  --gpu-profile <profile-directory-name>
+```
+
+Automatic detection intentionally accepts only bundled profiles whose hardware
+requirements are known to match. `--gpu-profile` bypasses that selection for a
+profile you have explicitly copied and tuned; it does not validate that the model
+servers fit the selected devices.
+
 ```{note}
 The model weights are independent of the GPU. Any NVIDIA GPU with enough VRAM for
 the models you load will run the stack; the profiles only encode where each server

--- a/docs/source/getting_started/requirements.md
+++ b/docs/source/getting_started/requirements.md
@@ -8,7 +8,7 @@
 ## Hardware
 
 The bundled GPU profiles target a single NVIDIA RTX PRO 6000 Blackwell workstation
-GPU or an NVIDIA DGX Spark, both of which have enough VRAM to run the full model
+GPU or an NVIDIA DGX Spark, both of which have enough GPU-visible memory to run the full model
 stack locally. These profiles are turnkey presets, not a hardware allowlist: you
 can run on other NVIDIA GPUs by tuning the per-server GPU-memory split. Refer to
 [Running on other GPUs](#running-on-other-gpus) below.
@@ -17,7 +17,7 @@ If you prefer not to run models on local hardware, model endpoints are plain
 URLs: point the worker configuration at a cloud NIM or model endpoint and no
 local GPU is required for the agent or XR-Media-Hub.
 
-| Sample | Local VRAM needed |
+| Sample | Local GPU memory needed |
 |---|---|
 | model-servers (all models) | ~55 GB |
 | simple-vlm-example (standalone) | ~23 GB |
@@ -110,24 +110,28 @@ setups:
 
 ## Running on other GPUs
 
-A profile (`agent-samples/model-servers/yaml/<profile>/`) is a convenience preset
-that pins two knobs per model server so the stack fits a known configuration:
+A profile (`agent-samples/model-servers/yaml/<profile>/`) is a convenience layout
+that pins each model server to a device. The service's existing YAML also owns
+its memory requirement:
 
 - `cuda_visible_devices` — which physical GPU each server runs on (for example,
   the `dual_48G_ada` profile places some servers on GPU `0` and others on GPU `1`).
-- `gpu_memory_utilization` — the fraction of that GPU's VRAM the server may use.
-  Several servers share one GPU, so each takes a slice (for example, `0.43`), and
-  the slices on a given GPU must sum to less than `1.0`.
+- `gpu_memory_reservation_gib` — the service's absolute GPU-memory requirement.
+
+Before launch, XR-AI sums the selected services on each device, retains a safety
+reserve, and compares that requirement with the device's current free memory.
+For vLLM services, it derives `gpu_memory_utilization` from the absolute GiB
+requirement and the detected device total. Existing custom YAML that declares
+only `gpu_memory_utilization` remains supported as a compatibility fallback.
 
 To run on a GPU that is not one of the presets, copy the closest profile directory
 and adjust those knobs to your hardware:
 
 1. Set `cuda_visible_devices` in each server's YAML to your GPU index, or spread
    the servers across the GPUs you have.
-2. Tune `gpu_memory_utilization` per server so the slices on each GPU fit its VRAM.
-   Lower the values if a server fails to start with an out-of-memory error; raise
-   them if you have spare VRAM.
-3. On lower-VRAM GPUs, run fewer models concurrently, or lower `max_model_len` on
+2. Set `gpu_memory_reservation_gib` from repeated peak and steady-state
+   measurements of that exact model configuration, including a safety margin.
+3. On lower-memory GPUs, run fewer models concurrently, or lower `max_model_len` on
    the LLM and VLM servers to reduce the KV-cache footprint.
 
 Then select the reviewed profile explicitly:
@@ -143,9 +147,9 @@ profile you have explicitly copied and tuned; it does not validate that the mode
 servers fit the selected devices.
 
 ```{note}
-The model weights are independent of the GPU. Any NVIDIA GPU with enough VRAM for
-the models you load will run the stack; the profiles only encode where each server
-lands and how much memory it claims.
+The GPU-memory preflight does not require a particular GPU product name. Model
+and runtime compatibility remains the responsibility of the selected service
+configuration until XR-AI has a validated capability matrix.
 ```
 
 ## Network

--- a/docs/source/guides/troubleshooting.md
+++ b/docs/source/guides/troubleshooting.md
@@ -345,6 +345,17 @@ to skip CUDA graph capture. Eager mode starts faster but can reduce per-token
 throughput; keep the default when steady-state performance matters more than
 cold-start time.
 
+### vLLM exits before readiness with insufficient GPU memory
+
+**Symptom:** a vLLM container exits during startup with `CUDA out of memory`,
+`No available memory for the cache blocks`, or a negative available KV-cache
+value buried in its container log.
+
+**Fix:** the wrapper classifies these signatures as `INSUFFICIENT GPU MEMORY`
+and prints the configured utilization when available. Free memory held by other
+processes, reduce model context or concurrency, or use a device with more
+GPU-visible memory. The complete original error remains in the reported log file.
+
 ### `xr_render_demo` exits but VRAM is still pinned
 
 **By design.** The vLLM-backed servers (`nemotron_omni_llm_server`,

--- a/services/embedding-server/embedding_server/__main__.py
+++ b/services/embedding-server/embedding_server/__main__.py
@@ -34,6 +34,7 @@ import sys
 from xr_ai_logging import setup_logging
 from xr_ai_vllm import (
     DEFAULT_IMAGE,
+    gpu_memory_utilization,
     load_config,
     resolve_model_cache,
     serve,
@@ -68,7 +69,7 @@ def run() -> None:
     max_seqs     = int(cfg.get("max_num_seqs",     _DEFAULT_SEQS))
     tp_size      = int(cfg.get("tensor_parallel_size", _DEFAULT_TP))
     max_ctx      = int(cfg.get("max_model_len",    _DEFAULT_CTX))
-    gpu_mem      = float(cfg.get("gpu_memory_utilization", _DEFAULT_GPU_MEM))
+    gpu_mem      = gpu_memory_utilization(cfg, _DEFAULT_GPU_MEM)
     enforce_eager = bool(cfg.get("enforce_eager",  _DEFAULT_EAGER))
     backend      = cfg.get("vllm_backend",         "pip")
     image        = cfg.get("vllm_image",           DEFAULT_IMAGE)

--- a/services/llama-nemotron-llm/llama_nemotron_llm_server/__main__.py
+++ b/services/llama-nemotron-llm/llama_nemotron_llm_server/__main__.py
@@ -37,6 +37,7 @@ from loguru import logger
 from xr_ai_logging import setup_logging
 from xr_ai_vllm import (
     DEFAULT_IMAGE,
+    gpu_memory_utilization,
     load_config,
     resolve_model_cache,
     serve,
@@ -73,7 +74,7 @@ def run() -> None:
     max_seqs           = int(cfg.get("max_num_seqs",     _DEFAULT_SEQS))
     tp_size            = int(cfg.get("tensor_parallel_size", _DEFAULT_TP))
     max_ctx            = int(cfg.get("max_model_len",    _DEFAULT_CTX))
-    gpu_mem            = float(cfg.get("gpu_memory_utilization", _DEFAULT_GPU_MEM))
+    gpu_mem            = gpu_memory_utilization(cfg, _DEFAULT_GPU_MEM)
     enforce_eager      = bool(cfg.get("enforce_eager",   _DEFAULT_EAGER))
     tool_call_parser   = cfg.get("tool_call_parser",     _DEFAULT_TOOL_CALL_PARSER)
     enable_tool_choice = bool(cfg.get("enable_tool_choice", _DEFAULT_ENABLE_TOOL_CHOICE))

--- a/services/nemotron-omni-llm/nemotron_omni_llm_server/__main__.py
+++ b/services/nemotron-omni-llm/nemotron_omni_llm_server/__main__.py
@@ -47,6 +47,7 @@ from xr_ai_logging import setup_logging
 from xr_ai_vllm import (
     DEFAULT_IMAGE,
     gpu_compute_major,
+    gpu_memory_utilization,
     load_config,
     resolve_model_cache,
     serve,
@@ -104,7 +105,7 @@ def run() -> None:
     max_seqs      = int(cfg.get("max_num_seqs",     _DEFAULT_SEQS))
     tp_size       = int(cfg.get("tensor_parallel_size", _DEFAULT_TP))
     max_ctx       = int(cfg.get("max_model_len",    _DEFAULT_CTX))
-    gpu_mem       = float(cfg.get("gpu_memory_utilization", _DEFAULT_GPU_MEM))
+    gpu_mem       = gpu_memory_utilization(cfg, _DEFAULT_GPU_MEM)
     enforce_eager = bool(cfg.get("enforce_eager",   _DEFAULT_EAGER))
     prune_rate    = float(cfg.get("video_pruning_rate", _DEFAULT_PRUNE))
     video_fps     = int(cfg.get("video_fps",        _DEFAULT_FPS))

--- a/services/nemotron3-nano-llm/nemotron3_nano_llm_server/__main__.py
+++ b/services/nemotron3-nano-llm/nemotron3_nano_llm_server/__main__.py
@@ -39,6 +39,7 @@ from xr_ai_logging import setup_logging
 from xr_ai_vllm import (
     DEFAULT_IMAGE,
     gpu_compute_major,
+    gpu_memory_utilization,
     load_config,
     resolve_model_cache,
     serve,
@@ -99,7 +100,7 @@ def run() -> None:
     max_seqs      = int(cfg.get("max_num_seqs",    _DEFAULT_SEQS))
     tp_size       = int(cfg.get("tensor_parallel_size", _DEFAULT_TP))
     max_ctx       = int(cfg.get("max_model_len",   _DEFAULT_CTX))
-    gpu_mem       = float(cfg.get("gpu_memory_utilization", _DEFAULT_GPU_MEM))
+    gpu_mem       = gpu_memory_utilization(cfg, _DEFAULT_GPU_MEM)
     enforce_eager = bool(cfg.get("enforce_eager",  _DEFAULT_EAGER))
     parser_url    = cfg.get("parser_url",          _PARSER_URL_DEFAULT)
     backend       = cfg.get("vllm_backend",        "pip")

--- a/services/vlm-server/vlm_server/__main__.py
+++ b/services/vlm-server/vlm_server/__main__.py
@@ -45,6 +45,7 @@ import sys
 from loguru import logger
 from xr_ai_logging import setup_logging
 from xr_ai_vllm import (
+    gpu_memory_utilization,
     load_config,
     resolve_model_cache,
     serve,
@@ -86,7 +87,7 @@ def run() -> None:
     max_seqs      = int(cfg.get("max_num_seqs",     _DEFAULT_SEQS))
     tp_size       = int(cfg.get("tensor_parallel_size", _DEFAULT_TP))
     max_ctx       = int(cfg.get("max_model_len",    _DEFAULT_CTX))
-    gpu_mem       = float(cfg.get("gpu_memory_utilization", _DEFAULT_GPU_MEM))
+    gpu_mem       = gpu_memory_utilization(cfg, _DEFAULT_GPU_MEM)
     enforce_eager = bool(cfg.get("enforce_eager",   _DEFAULT_EAGER))
     async_sched   = bool(cfg.get("async_scheduling", _DEFAULT_ASYNC))
     hf_overrides  = cfg.get("hf_overrides")

--- a/tests/test_cli_documentation.py
+++ b/tests/test_cli_documentation.py
@@ -33,6 +33,7 @@ def test_sample_command_catalog_matches_top_level_projects() -> None:
         ("--stop",),
         ("--models",),
         ("--allow-anonymous",),
+        ("--gpu-profile",),
     ]
     assert [argument.flags for argument in commands["simple_vlm_example"].arguments] == [
         ("--allow-anonymous",),
@@ -45,7 +46,8 @@ def test_catalog_builds_repository_root_invocation() -> None:
 
     assert commands["model_servers"].invocation == (
         "uv run --project agent-samples/model-servers model_servers "
-        "[--stop] [--models NAME_OR_PATH] [--allow-anonymous]"
+        "[--stop] [--models NAME_OR_PATH] [--allow-anonymous] "
+        "[--gpu-profile NAME]"
     )
 
 

--- a/tests/test_launcher_config.py
+++ b/tests/test_launcher_config.py
@@ -7,12 +7,45 @@ import json
 from pathlib import Path
 
 import pytest
-from xr_ai_launcher import load_deployment_profile, load_model_deployment
+from xr_ai_launcher import (
+    load_deployment_profile,
+    load_model_deployment,
+    read_service_port,
+)
 from xr_ai_models import load_models_config
 
 _ROOT = Path(__file__).resolve().parents[1]
 _SIMPLE_VLM_YAML = _ROOT / "agent-samples" / "simple-vlm-example" / "yaml"
 _RENDER_YAML = _ROOT / "agent-samples" / "xr-render-demo" / "yaml"
+
+
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        ("port: 8100\n", 8100),
+        ("http_port: 9010\n", 9010),
+        ("port: '8109' # API\n", 8109),
+        ("host: 0.0.0.0\n", None),
+    ],
+)
+def test_read_service_port_uses_top_level_yaml(
+    tmp_path: Path, body: str, expected: int | None,
+) -> None:
+    config = tmp_path / "service.yaml"
+    config.write_text(body, encoding="utf-8")
+
+    assert read_service_port(config) == expected
+
+
+@pytest.mark.parametrize("value", ["not-a-port", "0", "65536"])
+def test_read_service_port_rejects_invalid_values(
+    tmp_path: Path, value: str,
+) -> None:
+    config = tmp_path / "service.yaml"
+    config.write_text(f"port: {value}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="port"):
+        read_service_port(config)
 
 
 def _write_profile(path: Path, *, credential: str | None = None) -> None:

--- a/tests/test_launcher_gpu.py
+++ b/tests/test_launcher_gpu.py
@@ -1,89 +1,203 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for xr_ai_launcher._gpu.detect_gpu_config."""
+"""Unit tests for strict per-device GPU inventory."""
 from __future__ import annotations
 
+import subprocess
 from unittest.mock import patch
 
-from xr_ai_launcher._gpu import detect_gpu_config
+import pytest
+from xr_ai_launcher import GPUInventoryError, detect_gpu_config
+from xr_ai_launcher._gpu import _query_gpu_inventory
 
 
-def _mock_smi(lines: list[str]):
-    """Return a context manager that patches check_output to return *lines*."""
-    output = "\n".join(lines)
-    return patch(
-        "xr_ai_launcher._gpu.subprocess.check_output",
-        return_value=output,
+def _row(
+    index: int,
+    name: str,
+    cap: float,
+    total_mib: float | str,
+    *,
+    free_mib: float | str | None = None,
+    used_mib: float | str = 0,
+) -> str:
+    if free_mib is not None:
+        free = free_mib
+    elif isinstance(total_mib, (float, int)) and isinstance(used_mib, (float, int)):
+        free = total_mib - used_mib
+    else:
+        free = "[N/A]"
+    return (
+        f"{index}, GPU-{index}, 00000000:{index:02x}:00.0, {name}, {cap}, "
+        f"{total_mib}, {free}, {used_mib}"
     )
 
 
-class TestDetectGpuConfig:
-    def test_nvidia_smi_unavailable_returns_default(self):
-        with patch(
-            "xr_ai_launcher._gpu.subprocess.check_output",
-            side_effect=FileNotFoundError,
-        ):
-            assert detect_gpu_config() == "dual_48G_ada"
+def _mock_smi(
+    lines: list[str],
+    process_lines: list[str] | None = None,
+    process_error: Exception | None = None,
+):
+    def output(command: list[str], **_kwargs) -> str:
+        if any("query-compute-apps" in value for value in command):
+            if process_error is not None:
+                raise process_error
+            return "\n".join(process_lines or [])
+        return "\n".join(lines)
 
-    def test_empty_output_returns_default(self):
-        with _mock_smi([]):
-            assert detect_gpu_config() == "dual_48G_ada"
+    return patch("xr_ai_launcher._gpu.subprocess.check_output", side_effect=output)
 
-    def test_unparseable_line_skipped(self):
-        # Only one valid line (an Ada GPU), the other is garbage.
-        with _mock_smi(["RTX 4090, 8.9, 24564 MiB", "not a valid line"]):
-            # one GPU, Ada (cap<10), <2, falls back to dual_48G_ada
-            result = detect_gpu_config()
-            assert result == "dual_48G_ada"
 
-    # ── Ada / dual-GPU scenarios ───────────────────────────────────────────────
+def test_inventory_records_each_gpu_capacity() -> None:
+    with _mock_smi(
+        [
+            _row(0, "NVIDIA L40S", 8.9, 46068, free_mib=45000, used_mib=1068),
+            _row(1, "NVIDIA L40S", 8.9, 46068, free_mib=44000, used_mib=2068),
+        ],
+    ):
+        inventory = _query_gpu_inventory()
 
-    def test_single_ada_gpu_returns_dual_48G_ada(self):
-        with _mock_smi(["RTX 6000 Ada, 8.9, 49140 MiB"]):
-            assert detect_gpu_config() == "dual_48G_ada"
+    assert [gpu.index for gpu in inventory] == [0, 1]
+    assert inventory[0].total_memory_gib == pytest.approx(44.988, abs=0.001)
+    assert inventory[1].free_memory_gib == pytest.approx(42.969, abs=0.001)
 
-    def test_dual_ada_gpus_returns_dual_48G_ada(self):
-        with _mock_smi([
-            "RTX 6000 Ada, 8.9, 49140 MiB",
-            "RTX 6000 Ada, 8.9, 49140 MiB",
-        ]):
-            assert detect_gpu_config() == "dual_48G_ada"
 
-    # ── Blackwell scenarios ────────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "error",
+    [FileNotFoundError(), subprocess.CalledProcessError(1, "nvidia-smi")],
+)
+def test_detection_failure_does_not_select_an_unsafe_default(error: Exception) -> None:
+    with patch("xr_ai_launcher._gpu.subprocess.check_output", side_effect=error):
+        with pytest.raises(GPUInventoryError, match="nvidia-smi"):
+            detect_gpu_config()
 
-    def test_blackwell_96gb_returns_96G_blackwell(self):
-        with _mock_smi(["RTX PRO 6000 Blackwell, 12.0, 98304 MiB"]):
-            assert detect_gpu_config() == "96G_blackwell"
 
-    def test_blackwell_large_vram_returns_spark(self):
-        # >=120 GiB total → spark profile
-        with _mock_smi(["GB200, 10.0, 131072 MiB"]):
-            assert detect_gpu_config() == "spark"
+def test_empty_inventory_is_rejected() -> None:
+    with _mock_smi([]), pytest.raises(GPUInventoryError, match="no GPUs"):
+        detect_gpu_config()
 
-    def test_spark_name_gb10_returns_spark(self):
-        with _mock_smi(["NVIDIA GB10, 10.0, 0 MiB"]):
-            assert detect_gpu_config() == "spark"
 
-    def test_spark_name_b10_returns_spark(self):
-        with _mock_smi(["NVIDIA B10, 10.0, 0 MiB"]):
-            assert detect_gpu_config() == "spark"
+def test_unparseable_inventory_is_rejected() -> None:
+    with _mock_smi(["not a valid row"]), pytest.raises(
+        GPUInventoryError, match="unparseable",
+    ):
+        detect_gpu_config()
 
-    def test_blackwell_no_mem_data_returns_spark(self):
-        # compute_cap >= 10 and no parseable mem → spark
-        with _mock_smi(["Blackwell GPU, 10.0, N/A"]):
-            assert detect_gpu_config() == "spark"
 
-    # ── Robustness ─────────────────────────────────────────────────────────────
+def test_failed_process_inventory_does_not_block_supported_topology() -> None:
+    error = subprocess.CalledProcessError(1, "nvidia-smi", stderr="not supported")
+    with _mock_smi([_row(0, "NVIDIA GB10", 10.0, 131072)], process_error=error):
+        assert detect_gpu_config() == "spark"
 
-    def test_extra_whitespace_tolerated(self):
-        with _mock_smi(["  RTX 6000 Ada  ,  8.9  ,  49140 MiB  "]):
-            assert detect_gpu_config() == "dual_48G_ada"
 
-    def test_subprocess_error_returns_default(self):
-        import subprocess
-        with patch(
-            "xr_ai_launcher._gpu.subprocess.check_output",
-            side_effect=subprocess.CalledProcessError(1, "nvidia-smi"),
-        ):
-            assert detect_gpu_config() == "dual_48G_ada"
+def test_failed_process_inventory_is_context_not_a_replacement_error() -> None:
+    error = subprocess.CalledProcessError(1, "nvidia-smi", stderr="not supported")
+    with _mock_smi(
+        [_row(0, "NVIDIA L40S", 8.9, 46068)], process_error=error,
+    ), pytest.raises(
+        GPUInventoryError,
+        match="no existing.*process inventory unavailable.*not supported",
+    ):
+        detect_gpu_config()
+
+
+def test_unparseable_process_inventory_is_nonfatal_context() -> None:
+    with _mock_smi(
+        [_row(0, "NVIDIA L40S", 8.9, 46068)],
+        ["not a valid process row"],
+    ), pytest.raises(
+        GPUInventoryError,
+        match="no existing.*process inventory unavailable.*unparseable",
+    ):
+        detect_gpu_config()
+
+
+def test_unsupported_topology_reports_active_compute_processes() -> None:
+    with _mock_smi(
+        [_row(0, "NVIDIA L40S", 8.9, 46068)],
+        ["GPU-0, 4321, python, 2048"],
+    ), pytest.raises(
+        GPUInventoryError, match=r"active compute processes: GPU 0 PID 4321 python \(2\.0 GiB\)",
+    ):
+        detect_gpu_config()
+
+
+def test_empty_memory_fields_are_rejected_as_inventory_error() -> None:
+    row = "0, GPU-0, 00000000:01:00.0, NVIDIA L40S, 8.9, , , "
+    with _mock_smi([row]), pytest.raises(GPUInventoryError, match="unparseable"):
+        detect_gpu_config()
+
+
+@pytest.mark.parametrize("sentinel", ["Not Supported", "[Not Supported]"])
+def test_not_supported_memory_fields_are_nullable(sentinel: str) -> None:
+    with _mock_smi([_row(
+        0, "NVIDIA GB10", 12.1, sentinel, free_mib=sentinel, used_mib=sentinel,
+    )]):
+        inventory = _query_gpu_inventory()
+        assert detect_gpu_config() == "spark"
+
+    assert inventory[0].total_memory_gib is None
+    assert inventory[0].free_memory_gib is None
+    assert inventory[0].used_memory_gib is None
+
+
+def test_single_ada_is_not_misclassified_as_dual() -> None:
+    with _mock_smi([_row(0, "NVIDIA L40S", 8.9, 46068)]), pytest.raises(
+        GPUInventoryError, match="no existing.*GPU 0.*L40S",
+    ):
+        detect_gpu_config()
+
+
+def test_dual_ada_requires_capacity_on_each_device() -> None:
+    with _mock_smi([
+        _row(0, "NVIDIA L40S", 8.9, 46068),
+        _row(1, "NVIDIA L40S", 8.9, 46068),
+    ]):
+        assert detect_gpu_config() == "dual_48G_ada"
+
+    with _mock_smi([
+        _row(0, "NVIDIA L40S", 8.9, 46068),
+        _row(1, "RTX 4090", 8.9, 24564),
+    ]), pytest.raises(GPUInventoryError, match="GPU 1.*24.0 GiB"):
+        detect_gpu_config()
+
+
+def test_single_large_blackwell_matches_workstation_config() -> None:
+    with _mock_smi([_row(0, "RTX PRO 6000 Blackwell", 12.0, 98304)]):
+        assert detect_gpu_config() == "96G_blackwell"
+
+
+def test_spark_name_matches_when_memory_fields_are_unavailable() -> None:
+    with _mock_smi([_row(
+        0, "NVIDIA GB10", 10.0, "[N/A]", free_mib="[N/A]", used_mib="[N/A]",
+    )]):
+        inventory = _query_gpu_inventory()
+        assert inventory[0].total_memory_gib is None
+        assert inventory[0].free_memory_gib is None
+        assert inventory[0].used_memory_gib is None
+        assert detect_gpu_config() == "spark"
+
+
+def test_capacity_match_rejects_unavailable_total_memory_cleanly() -> None:
+    with _mock_smi([_row(0, "Unknown Blackwell", 12.0, "[N/A]")]), pytest.raises(
+        GPUInventoryError, match=r"no existing.*N/A total",
+    ):
+        detect_gpu_config()
+
+
+def test_small_blackwell_does_not_match_96_gib_config() -> None:
+    with _mock_smi([_row(0, "NVIDIA GeForce RTX 5090", 12.0, 32768)]), pytest.raises(
+        GPUInventoryError, match=r"no existing.*32\.0 GiB",
+    ):
+        detect_gpu_config()
+
+
+@pytest.mark.parametrize("name", ["NVIDIA GB10", "NVIDIA B10"])
+def test_spark_name_matches_spark_config(name: str) -> None:
+    with _mock_smi([_row(0, name, 10.0, 131072)]):
+        assert detect_gpu_config() == "spark"
+
+
+def test_large_unnamed_blackwell_matches_spark_by_capacity() -> None:
+    with _mock_smi([_row(0, "NVIDIA Future Blackwell", 12.0, 131072)]):
+        assert detect_gpu_config() == "spark"

--- a/tests/test_launcher_gpu.py
+++ b/tests/test_launcher_gpu.py
@@ -8,8 +8,7 @@ import subprocess
 from unittest.mock import patch
 
 import pytest
-from xr_ai_launcher import GPUInventoryError, detect_gpu_config
-from xr_ai_launcher._gpu import _query_gpu_inventory
+from xr_ai_launcher import GPUInventoryError, detect_gpu_config, query_gpu_inventory
 
 
 def _row(
@@ -55,7 +54,7 @@ def test_inventory_records_each_gpu_capacity() -> None:
             _row(1, "NVIDIA L40S", 8.9, 46068, free_mib=44000, used_mib=2068),
         ],
     ):
-        inventory = _query_gpu_inventory()
+        inventory = query_gpu_inventory()
 
     assert [gpu.index for gpu in inventory] == [0, 1]
     assert inventory[0].total_memory_gib == pytest.approx(44.988, abs=0.001)
@@ -133,7 +132,7 @@ def test_not_supported_memory_fields_are_nullable(sentinel: str) -> None:
     with _mock_smi([_row(
         0, "NVIDIA GB10", 12.1, sentinel, free_mib=sentinel, used_mib=sentinel,
     )]):
-        inventory = _query_gpu_inventory()
+        inventory = query_gpu_inventory()
         assert detect_gpu_config() == "spark"
 
     assert inventory[0].total_memory_gib is None
@@ -171,7 +170,7 @@ def test_spark_name_matches_when_memory_fields_are_unavailable() -> None:
     with _mock_smi([_row(
         0, "NVIDIA GB10", 10.0, "[N/A]", free_mib="[N/A]", used_mib="[N/A]",
     )]):
-        inventory = _query_gpu_inventory()
+        inventory = query_gpu_inventory()
         assert inventory[0].total_memory_gib is None
         assert inventory[0].free_memory_gib is None
         assert inventory[0].used_memory_gib is None

--- a/tests/test_launcher_gpu_memory.py
+++ b/tests/test_launcher_gpu_memory.py
@@ -1,0 +1,175 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Service-YAML GPU-memory requirement and preflight tests."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from xr_ai_launcher import (
+    GPUDevice,
+    GPUMemoryError,
+    derive_gpu_memory_utilization,
+    format_gpu_memory_preflight,
+    load_service_gpu_requirement,
+    preflight_gpu_memory,
+    require_gpu_memory_preflight,
+    resolve_gpu_memory_plan,
+    utilization_overrides,
+)
+from xr_ai_vllm import gpu_memory_utilization
+
+_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _gpu(
+    index: int, *, total: float = 45.0, free: float = 44.0, capability: float = 8.9,
+) -> GPUDevice:
+    return GPUDevice(
+        index=index,
+        uuid=f"GPU-{index}",
+        pci_bus_id=f"0000:{index:02x}:00.0",
+        name="NVIDIA L40S",
+        compute_capability=capability,
+        total_memory_gib=total,
+        free_memory_gib=free,
+        used_memory_gib=total - free,
+    )
+
+
+def _service(tmp_path: Path, name: str, gpu: int, memory: float) -> Path:
+    path = tmp_path / f"{name}.yaml"
+    path.write_text(
+        f"port: 8100\ncuda_visible_devices: {gpu}\n"
+        f"gpu_memory_reservation_gib: {memory}\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _plan(tmp_path: Path, omni_memory: float = 37.0):
+    inventory = (_gpu(0), _gpu(1))
+    return resolve_gpu_memory_plan(
+        stack="test",
+        inventory=inventory,
+        service_configs={
+            "omni": (_service(tmp_path, "omni", 1, omni_memory), True),
+            "stt": (_service(tmp_path, "stt", 1, 3.0), False),
+        },
+    )
+
+
+def test_preflight_accounts_for_complete_per_gpu_stack(tmp_path: Path) -> None:
+    plan = _plan(tmp_path)
+    results = preflight_gpu_memory(plan, (_gpu(0), _gpu(1)))
+
+    assert results[0].incremental_required_gib == 40.0
+    assert results[0].remaining_gib == 2.0
+    require_gpu_memory_preflight(results)
+    assert "Result: PASS" in format_gpu_memory_preflight(plan, results)
+
+
+def test_preflight_fails_cleanly_when_free_memory_telemetry_is_unavailable(
+    tmp_path: Path,
+) -> None:
+    plan = _plan(tmp_path)
+    unavailable = GPUDevice(
+        index=1,
+        uuid="GPU-1",
+        pci_bus_id="0000:01:00.0",
+        name="NVIDIA GB10",
+        compute_capability=10.0,
+        total_memory_gib=None,
+        free_memory_gib=None,
+        used_memory_gib=None,
+    )
+
+    with pytest.raises(GPUMemoryError, match="free GPU memory telemetry is unavailable"):
+        preflight_gpu_memory(plan, (_gpu(0), unavailable))
+
+
+def test_preflight_reports_shortfall_without_double_counting_active_service(
+    tmp_path: Path,
+) -> None:
+    plan = _plan(tmp_path, 42.0)
+    inventory = (_gpu(0), _gpu(1))
+
+    with pytest.raises(GPUMemoryError, match=r"shortfall 3\.0 GiB"):
+        require_gpu_memory_preflight(preflight_gpu_memory(plan, inventory))
+    require_gpu_memory_preflight(preflight_gpu_memory(
+        plan, inventory, active_services=frozenset({"omni"}),
+    ))
+
+
+def test_legacy_gpu_memory_utilization_remains_supported(tmp_path: Path) -> None:
+    config = tmp_path / "legacy.yaml"
+    config.write_text(
+        "cuda_visible_devices: 0\ngpu_memory_utilization: 0.20\n",
+        encoding="utf-8",
+    )
+
+    requirement = load_service_gpu_requirement(
+        "vlm", config, (_gpu(0),), vllm=True,
+    )
+
+    assert requirement.memory_gib == 9.0
+
+
+def test_vllm_utilization_is_derived_from_absolute_gib(tmp_path: Path) -> None:
+    plan = _plan(tmp_path)
+    inventory = (_gpu(0), _gpu(1, total=45.7))
+
+    assert derive_gpu_memory_utilization(37.0, 45.7) == 0.8097
+    assert utilization_overrides(plan, inventory) == {"omni": "0.8097"}
+
+
+def test_service_prefers_launcher_derived_utilization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("XR_AI_GPU_MEMORY_UTILIZATION", "0.8123")
+
+    assert gpu_memory_utilization({"gpu_memory_utilization": 0.5}, 0.85) == 0.8123
+
+
+def test_simple_vlm_contract_fits_one_45_gib_l40s() -> None:
+    sample = _ROOT / "agent-samples/simple-vlm-example/yaml"
+    inventory = (_gpu(0, total=45.0, free=45.0),)
+    plan = resolve_gpu_memory_plan(
+        stack="simple-vlm-example/local",
+        inventory=inventory,
+        service_configs={
+            "vlm": (sample / "vlm_server.yaml", True),
+            "stt": (sample / "stt_server.yaml", False),
+        },
+    )
+
+    results = preflight_gpu_memory(plan, inventory)
+    require_gpu_memory_preflight(results)
+    assert results[0].incremental_required_gib == 27.0
+    assert results[0].remaining_gib == 16.0
+
+
+@pytest.mark.parametrize("directory", ["dual_48G_ada", "96G_blackwell", "spark"])
+def test_bundled_model_server_yaml_declares_gpu_memory(directory: str) -> None:
+    root = _ROOT / "agent-samples/model-servers/yaml" / directory
+    for config in root.glob("*_server*.yaml"):
+        body = config.read_text(encoding="utf-8")
+        assert "gpu_memory_reservation_gib:" in body, config
+
+
+def test_spark_absolute_requirements_preserve_previous_utilization_budgets() -> None:
+    root = _ROOT / "agent-samples/model-servers/yaml/spark"
+    expected = {
+        "vlm_server.yaml": 24.0,
+        "nemotron_omni_llm_server.yaml": 30.0,
+        "embedding_server.yaml": 9.6,
+    }
+    for filename, memory_gib in expected.items():
+        requirement = load_service_gpu_requirement(
+            filename,
+            root / filename,
+            (_gpu(0, total=120.0, free=120.0, capability=10.0),),
+            vllm=True,
+        )
+        assert requirement.memory_gib == memory_gib

--- a/tests/test_launcher_stack.py
+++ b/tests/test_launcher_stack.py
@@ -19,6 +19,7 @@ class TestProcessDataclass:
         assert p.command == "xr_media_hub"
         assert p.config is None
         assert p.gpu is None
+        assert p.environment == ()
         assert p.launch_mode == "own"
         assert p.port is None
 
@@ -27,11 +28,13 @@ class TestProcessDataclass:
             "vlm", "../../services/vlm-server", "vlm_server",
             config="yaml/vlm.yaml",
             gpu="0",
+            environment=(("GPU_BUDGET", "0.8"),),
             launch_mode="persist",
             port=8100,
         )
         assert p.config == "yaml/vlm.yaml"
         assert p.gpu == "0"
+        assert p.environment == (("GPU_BUDGET", "0.8"),)
         assert p.launch_mode == "persist"
         assert p.port == 8100
 

--- a/tests/test_model_servers.py
+++ b/tests/test_model_servers.py
@@ -49,6 +49,17 @@ def test_default_profile_uses_omni_and_cosmos(monkeypatch: pytest.MonkeyPatch) -
     assert credentials == ()
 
 
+def test_explicit_gpu_profile_bypasses_detection(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_detection() -> str:
+        raise AssertionError("automatic detection must not run for an explicit profile")
+
+    monkeypatch.setattr(_model_servers, "detect_gpu_config", fail_detection)
+
+    processes, _ = _model_servers._build_processes("default", "spark")
+
+    assert all(str(process.config).startswith("yaml/spark/") for process in processes)
+
+
 def test_nim_profile_mixes_nim_containers_and_local_servers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -191,7 +202,7 @@ def test_cli_selects_requested_profile(
     monkeypatch.setattr(_model_servers, "_stop_unselected_services", lambda _p: None)
     monkeypatch.setattr(
         _model_servers, "_build_processes",
-        lambda selection: (selected.append(selection) or [], ()),
+        lambda selection, _gpu_profile=None: (selected.append(selection) or [], ()),
     )
     monkeypatch.setattr(_model_servers, "run_stack", lambda *_a, **_k: None)
     monkeypatch.setattr(sys, "argv", ["model_servers", *argv])
@@ -199,6 +210,74 @@ def test_cli_selects_requested_profile(
     _model_servers.run()
 
     assert selected == [expected]
+
+
+def test_cli_passes_explicit_gpu_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    selected: list[tuple[str, str | None]] = []
+    monkeypatch.setattr(_model_servers, "setup_logging", lambda *_a, **_k: None)
+    monkeypatch.setattr(_model_servers, "require_credentials", lambda *_a, **_k: None)
+    monkeypatch.setattr(_model_servers, "_stop_unselected_services", lambda _p: None)
+    monkeypatch.setattr(
+        _model_servers,
+        "_build_processes",
+        lambda selection, gpu_profile=None: (
+            selected.append((selection, gpu_profile)) or [], ()
+        ),
+    )
+    monkeypatch.setattr(_model_servers, "run_stack", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        sys, "argv", ["model_servers", "--gpu-profile", "dual_48G_ada"],
+    )
+
+    _model_servers.run()
+
+    assert selected == [("default", "dual_48G_ada")]
+
+
+def test_invalid_gpu_profile_name_is_rejected() -> None:
+    with pytest.raises(
+        _model_servers.argparse.ArgumentTypeError, match="unknown GPU profile",
+    ):
+        _model_servers._gpu_profile_name("does-not-exist")
+
+
+def test_gpu_profile_discovery_tolerates_missing_yaml_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_model_servers, "_BASE", tmp_path)
+
+    assert _model_servers._gpu_profile_names() == ()
+
+
+def test_custom_gpu_profile_must_contain_every_selected_service_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "yaml" / "custom").mkdir(parents=True)
+    profile = _REPO_ROOT / "agent-samples/model-servers/yaml/models.default.json"
+    monkeypatch.setattr(_model_servers, "_BASE", tmp_path)
+
+    with pytest.raises(ValueError, match="profile 'custom' is incomplete.*stt_server"):
+        _model_servers._build_processes(str(profile), "custom")
+
+
+def test_cli_reports_gpu_inventory_error_without_traceback(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    def fail_inventory(*_args, **_kwargs):
+        raise _model_servers.GPUInventoryError("GPU memory telemetry unavailable")
+
+    monkeypatch.setattr(_model_servers, "setup_logging", lambda *_a, **_k: None)
+    monkeypatch.setattr(_model_servers, "_build_processes", fail_inventory)
+    monkeypatch.setattr(sys, "argv", ["model_servers"])
+
+    with pytest.raises(SystemExit) as error:
+        _model_servers.run()
+
+    assert error.value.code == 2
+    stderr = capsys.readouterr().err
+    assert "model_servers: error: GPU memory telemetry unavailable" in stderr
+    assert "--gpu-profile NAME" in stderr
+    assert "Traceback" not in stderr
 
 
 def test_build_processes_rejects_unknown_services(tmp_path, monkeypatch) -> None:
@@ -241,7 +320,7 @@ def test_cli_requires_profile_credentials(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(_model_servers, "_stop_unselected_services", lambda _p: None)
     monkeypatch.setattr(
         _model_servers, "_build_processes",
-        lambda _selection: ([], ("NGC_API_KEY",)),
+        lambda _selection, _gpu_profile=None: ([], ("NGC_API_KEY",)),
     )
     monkeypatch.setattr(_model_servers, "run_stack", lambda *_a, **_k: None)
     monkeypatch.setattr(sys, "argv", ["model_servers", "--models", "vlm_llm_nim"])
@@ -259,7 +338,8 @@ def test_cli_aborts_when_unselected_services_cannot_stop(
     monkeypatch.setattr(_model_servers, "require_credentials", lambda *_a, **_k: None)
     monkeypatch.setattr(_model_servers, "stop_persistent_servers", lambda _services: False)
     monkeypatch.setattr(
-        _model_servers, "_build_processes", lambda _selection: ([], ()),
+        _model_servers, "_build_processes",
+        lambda _selection, _gpu_profile=None: ([], ()),
     )
     monkeypatch.setattr(_model_servers, "run_stack", lambda *_a, **_k: started.append(True))
     monkeypatch.setattr(sys, "argv", ["model_servers"])

--- a/tests/test_model_servers.py
+++ b/tests/test_model_servers.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from xr_ai_launcher import GPUDevice
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _MAIN_PATH = _REPO_ROOT / "agent-samples/model-servers/main.py"
@@ -76,6 +77,73 @@ def test_known_ports_are_discovered_from_service_yaml() -> None:
         ("vlm", 8100),
         ("embedding", 8109),
     }
+
+
+def test_gpu_memory_plan_derives_vllm_budget_from_selected_yaml(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_model_servers, "detect_gpu_config", lambda: "dual_48G_ada")
+    inventory = tuple(
+        GPUDevice(
+            index=index,
+            uuid=f"GPU-{index}",
+            pci_bus_id=f"0000:{index:02x}:00.0",
+            name="NVIDIA L40S",
+            compute_capability=8.9,
+            total_memory_gib=45.0,
+            free_memory_gib=45.0,
+            used_memory_gib=0.0,
+        )
+        for index in (0, 1)
+    )
+    monkeypatch.setattr(_model_servers, "query_gpu_inventory", lambda: inventory)
+    monkeypatch.setattr(_model_servers, "_service_is_ready", lambda _port: False)
+    processes, _ = _model_servers._build_processes("default")
+
+    planned = _model_servers._apply_gpu_memory_plan(processes, "default")
+
+    by_name = {process.name: dict(process.environment) for process in planned}
+    assert by_name["vlm"]["XR_AI_GPU_MEMORY_UTILIZATION"] == "0.4889"
+    assert by_name["omni"]["XR_AI_GPU_MEMORY_UTILIZATION"] == "0.8223"
+    assert by_name["stt"] == {}
+
+
+@pytest.mark.parametrize(
+    ("gpu_config", "gpu_count", "total_gib", "capability"),
+    [
+        ("dual_48G_ada", 2, 45.0, 8.9),
+        ("96G_blackwell", 1, 96.0, 10.0),
+        ("spark", 1, 120.0, 10.0),
+    ],
+)
+@pytest.mark.parametrize("selection", ["default", "vlm_llm_nim", "vlm_speech_nim"])
+def test_bundled_stack_requirements_fit_their_target_capacity(
+    monkeypatch: pytest.MonkeyPatch,
+    gpu_config: str,
+    gpu_count: int,
+    total_gib: float,
+    capability: float,
+    selection: str,
+) -> None:
+    monkeypatch.setattr(_model_servers, "detect_gpu_config", lambda: gpu_config)
+    inventory = tuple(
+        GPUDevice(
+            index=index,
+            uuid=f"GPU-{index}",
+            pci_bus_id=f"0000:{index:02x}:00.0",
+            name="test GPU",
+            compute_capability=capability,
+            total_memory_gib=total_gib,
+            free_memory_gib=total_gib,
+            used_memory_gib=0.0,
+        )
+        for index in range(gpu_count)
+    )
+    monkeypatch.setattr(_model_servers, "query_gpu_inventory", lambda: inventory)
+    monkeypatch.setattr(_model_servers, "_service_is_ready", lambda _port: False)
+    processes, _ = _model_servers._build_processes(selection)
+
+    assert _model_servers._apply_gpu_memory_plan(processes, selection)
 
 
 def test_nim_profile_mixes_nim_containers_and_local_servers(
@@ -219,6 +287,11 @@ def test_cli_selects_requested_profile(
     monkeypatch.setattr(_model_servers, "require_credentials", lambda *_a, **_k: None)
     monkeypatch.setattr(_model_servers, "_stop_unselected_services", lambda _p: None)
     monkeypatch.setattr(
+        _model_servers,
+        "_apply_gpu_memory_plan",
+        lambda processes, _selection: processes,
+    )
+    monkeypatch.setattr(
         _model_servers, "_build_processes",
         lambda selection, _gpu_profile=None: (selected.append(selection) or [], ()),
     )
@@ -241,6 +314,9 @@ def test_cli_passes_explicit_gpu_profile(monkeypatch: pytest.MonkeyPatch) -> Non
         lambda selection, gpu_profile=None: (
             selected.append((selection, gpu_profile)) or [], ()
         ),
+    )
+    monkeypatch.setattr(
+        _model_servers, "_apply_gpu_memory_plan", lambda processes, _selection: processes,
     )
     monkeypatch.setattr(_model_servers, "run_stack", lambda *_a, **_k: None)
     monkeypatch.setattr(
@@ -336,6 +412,11 @@ def test_cli_requires_profile_credentials(monkeypatch: pytest.MonkeyPatch) -> No
         lambda name, **kw: required.append(name),
     )
     monkeypatch.setattr(_model_servers, "_stop_unselected_services", lambda _p: None)
+    monkeypatch.setattr(
+        _model_servers,
+        "_apply_gpu_memory_plan",
+        lambda processes, _selection: processes,
+    )
     monkeypatch.setattr(
         _model_servers, "_build_processes",
         lambda _selection, _gpu_profile=None: ([], ("NGC_API_KEY",)),

--- a/tests/test_model_servers.py
+++ b/tests/test_model_servers.py
@@ -60,6 +60,24 @@ def test_explicit_gpu_profile_bypasses_detection(monkeypatch: pytest.MonkeyPatch
     assert all(str(process.config).startswith("yaml/spark/") for process in processes)
 
 
+def test_service_catalog_does_not_duplicate_yaml_ports() -> None:
+    assert all(len(service) == 3 for service in _model_servers._MODEL_SERVICES.values())
+
+
+def test_known_ports_are_discovered_from_service_yaml() -> None:
+    assert set(_model_servers._known_service_ports()) == {
+        ("stt-nim", 9010),
+        ("tts-nim", 9011),
+        ("llm-nim", 8110),
+        ("vlm-nim", 8100),
+        ("stt", 8103),
+        ("agent-llm", 8107),
+        ("omni", 8108),
+        ("vlm", 8100),
+        ("embedding", 8109),
+    }
+
+
 def test_nim_profile_mixes_nim_containers_and_local_servers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_nim_docker.py
+++ b/tests/test_nim_docker.py
@@ -112,6 +112,7 @@ def test_serve_nim_uses_world_writable_per_container_cache(tmp_path, monkeypatch
     leaf = tmp_path / "nim" / "xr-ai-nim-llama"
     assert leaf.stat().st_mode & 0o777 == 0o777
     assert f"{leaf}:/opt/nim/.cache" in captured["argv"]
+    assert "diagnostic_argv" not in captured
 
 
 def test_serve_nim_tolerates_foreign_cache_dir_if_world_writable(

--- a/tests/test_vllm_diagnostics.py
+++ b/tests/test_vllm_diagnostics.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for actionable vLLM startup-failure classifications."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from xr_ai_vllm._diagnostics import classify_vllm_failure
+
+
+def test_negative_kv_cache_is_classified_as_insufficient_gpu_memory(
+    tmp_path: Path,
+) -> None:
+    log = tmp_path / "vllm.log"
+    log.write_text(
+        "Available KV cache memory: -0.17 GiB\n"
+        "ValueError: No available memory for the cache blocks.\n"
+    )
+
+    diagnosis = classify_vllm_failure(
+        log, ["vllm", "--gpu-memory-utilization", "0.78"],
+    )
+
+    assert diagnosis is not None
+    assert diagnosis.startswith("INSUFFICIENT GPU MEMORY")
+    assert "-0.17 GiB" in diagnosis
+    assert "0.78" in diagnosis
+
+
+def test_cuda_oom_is_classified(tmp_path: Path) -> None:
+    log = tmp_path / "vllm.log"
+    log.write_text("torch.OutOfMemoryError: CUDA out of memory")
+
+    diagnosis = classify_vllm_failure(log, ["vllm", "serve", "model"])
+
+    assert diagnosis is not None
+    assert diagnosis.startswith("INSUFFICIENT GPU MEMORY")
+
+
+def test_conflicting_process_memory_is_classified(tmp_path: Path) -> None:
+    log = tmp_path / "vllm.log"
+    log.write_text(
+        "Free memory on device (10.0/45.0 GiB) at startup is less than desired "
+        "GPU memory utilization (0.78, 35.1 GiB)."
+    )
+
+    diagnosis = classify_vllm_failure(
+        log, ["vllm", "serve", "model", "--gpu-memory-utilization", "0.78"],
+    )
+
+    assert diagnosis is not None
+    assert diagnosis.startswith("INSUFFICIENT FREE GPU MEMORY")
+    assert "0.78" in diagnosis
+
+
+def test_unrelated_failure_has_no_gpu_memory_diagnosis(tmp_path: Path) -> None:
+    log = tmp_path / "vllm.log"
+    log.write_text("ValueError: unsupported architecture")
+
+    assert classify_vllm_failure(log, ["vllm", "serve", "model"]) is None

--- a/tests/test_vllm_docker.py
+++ b/tests/test_vllm_docker.py
@@ -433,6 +433,31 @@ def _expected_fingerprint(kwargs):
 
 
 class TestRun:
+    def test_preserves_original_vllm_argv_for_failure_diagnostics(
+        self, tmp_path, monkeypatch,
+    ):
+        kwargs = _run_kwargs(tmp_path)
+        captured: dict = {}
+        monkeypatch.setattr(
+            _docker, "run_container", lambda **values: captured.update(values),
+        )
+
+        run(**kwargs)
+
+        assert captured["argv"] == build_run_argv(
+            image=kwargs["image"],
+            container_name=kwargs["container_name"],
+            port=kwargs["port"],
+            model_cache=kwargs["model_cache"],
+            hf_token=kwargs["hf_token"],
+            cuda_visible_devices=kwargs["cuda_visible_devices"],
+            extra_env=kwargs["extra_env"],
+            extra_pip=kwargs["extra_pip"],
+            vllm_argv=kwargs["vllm_argv"],
+        )
+        assert "--gpu-memory-utilization" not in captured["argv"]
+        assert captured["diagnostic_argv"] == kwargs["vllm_argv"]
+
     def test_healthy_unowned_listener_is_rejected(self, tmp_path):
         kwargs = _run_kwargs(tmp_path)
         with (
@@ -885,6 +910,57 @@ class TestRunContainer:
         kwargs = self._kwargs(tmp_path)
         _docker.run_container(**kwargs)
         assert evictions == [1]
+
+    @pytest.mark.parametrize("with_vllm_context", [False, True])
+    def test_failure_diagnostics_are_vllm_only(
+        self, monkeypatch, tmp_path, with_vllm_context,
+    ):
+        self._common_stubs(monkeypatch, _docker)
+        monkeypatch.setattr(_docker._lifecycle, "health_ok", lambda url, **kw: False)
+
+        def fail_startup(*_args, **_kwargs):
+            raise SystemExit(1)
+
+        monkeypatch.setattr(
+            _docker._lifecycle,
+            "wait_until_healthy",
+            fail_startup,
+        )
+
+        class _FakeProc:
+            def poll(self):
+                return None
+
+        class _Streamer:
+            log_path = tmp_path / "container.log"
+
+            def __init__(self, _name):
+                self.log_path.write_text("CUDA out of memory", encoding="utf-8")
+
+            def stop(self):
+                pass
+
+        monkeypatch.setattr(_docker.subprocess, "Popen", lambda *_a, **_kw: _FakeProc())
+        monkeypatch.setattr(_docker, "_LogStreamer", _Streamer)
+        monkeypatch.setattr(_docker, "_append_post_mortem", lambda *_a, **_kw: None)
+        monkeypatch.setattr(_docker.time, "sleep", lambda _seconds: None)
+        captured: list[list[str]] = []
+        monkeypatch.setattr(
+            _docker._diagnostics,
+            "classify_vllm_failure",
+            lambda _path, argv: captured.append(argv) or "diagnosis",
+        )
+        kwargs = self._kwargs(tmp_path)
+        diagnostic_argv = [
+            "vllm", "serve", "model", "--gpu-memory-utilization", "0.78",
+        ]
+        if with_vllm_context:
+            kwargs["diagnostic_argv"] = diagnostic_argv
+
+        with pytest.raises(SystemExit, match="1"):
+            _docker.run_container(**kwargs)
+
+        assert captured == ([diagnostic_argv] if with_vllm_context else [])
 
 
 class TestEvictLocalListener:

--- a/tests/test_vlm_server_config.py
+++ b/tests/test_vlm_server_config.py
@@ -81,7 +81,7 @@ def test_all_local_profiles_select_cosmos3_reasoner_runtime() -> None:
         assert cfg["mm_encoder_tp_mode"] == "data", config_path
 
 
-def test_hardware_profiles_reserve_measured_reasoner_memory() -> None:
+def test_profiles_reserve_reasoner_memory_in_absolute_gib() -> None:
     blackwell = yaml.safe_load(
         (_MODEL_PROFILES / "96G_blackwell" / "vlm_server.yaml").read_text()
     )
@@ -89,8 +89,10 @@ def test_hardware_profiles_reserve_measured_reasoner_memory() -> None:
         (_MODEL_PROFILES / "dual_48G_ada" / "vlm_server.yaml").read_text()
     )
 
-    assert blackwell["gpu_memory_utilization"] == 0.23
-    assert dual_ada["gpu_memory_utilization"] == 0.47
+    assert blackwell["gpu_memory_reservation_gib"] == 22.0
+    assert dual_ada["gpu_memory_reservation_gib"] == 22.0
+    assert "gpu_memory_utilization" not in blackwell
+    assert "gpu_memory_utilization" not in dual_ada
 
 
 def test_cosmos3_rejects_missing_reasoner_override(monkeypatch, tmp_path) -> None:

--- a/utils/xr-ai-launcher/xr_ai_launcher/__init__.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/__init__.py
@@ -33,7 +33,7 @@ from ._cloudxr_env import (
     load_cloudxr_env,
     read_device_profile,
 )
-from ._config import read_config_scalar
+from ._config import read_config_scalar, read_service_port
 from ._credentials import (
     ensure_credentials,
     load_credentials,
@@ -49,7 +49,7 @@ __all__ = [
     "XR_RUNTIME_VAR", "load_cloudxr_env",
     "NATIVE_DEVICE_PROFILES", "is_native_profile", "read_device_profile",
     "ensure_credentials", "load_credentials", "require_credentials", "warn_if_missing",
-    "read_config_scalar",
+    "read_config_scalar", "read_service_port",
     "GPUInventoryError", "detect_gpu_config",
     "ModelDeployment", "load_deployment_profile", "load_model_deployment",
     "ManagedProcess",

--- a/utils/xr-ai-launcher/xr_ai_launcher/__init__.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/__init__.py
@@ -40,7 +40,26 @@ from ._credentials import (
     require_credentials,
     warn_if_missing,
 )
-from ._gpu import GPUInventoryError, detect_gpu_config
+from ._gpu import (
+    GPUDevice,
+    GPUInventoryError,
+    detect_gpu_config,
+    query_gpu_inventory,
+)
+from ._gpu_memory import (
+    GPU_MEMORY_UTILIZATION_ENV,
+    GPUMemoryError,
+    GPUMemoryPlan,
+    GPUPreflight,
+    ServiceGPURequirement,
+    derive_gpu_memory_utilization,
+    format_gpu_memory_preflight,
+    load_service_gpu_requirement,
+    preflight_gpu_memory,
+    require_gpu_memory_preflight,
+    resolve_gpu_memory_plan,
+    utilization_overrides,
+)
 from ._models import ModelDeployment, load_deployment_profile, load_model_deployment
 from ._processes import ManagedProcess
 from ._stack import Parallel, Process, run_stack
@@ -50,7 +69,13 @@ __all__ = [
     "NATIVE_DEVICE_PROFILES", "is_native_profile", "read_device_profile",
     "ensure_credentials", "load_credentials", "require_credentials", "warn_if_missing",
     "read_config_scalar", "read_service_port",
-    "GPUInventoryError", "detect_gpu_config",
+    "GPUDevice", "GPUInventoryError",
+    "detect_gpu_config", "query_gpu_inventory",
+    "GPU_MEMORY_UTILIZATION_ENV", "GPUMemoryError", "GPUMemoryPlan",
+    "GPUPreflight", "ServiceGPURequirement", "derive_gpu_memory_utilization",
+    "format_gpu_memory_preflight", "load_service_gpu_requirement",
+    "preflight_gpu_memory", "require_gpu_memory_preflight",
+    "resolve_gpu_memory_plan", "utilization_overrides",
     "ModelDeployment", "load_deployment_profile", "load_model_deployment",
     "ManagedProcess",
     "Parallel", "Process", "run_stack",

--- a/utils/xr-ai-launcher/xr_ai_launcher/__init__.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/__init__.py
@@ -40,7 +40,7 @@ from ._credentials import (
     require_credentials,
     warn_if_missing,
 )
-from ._gpu import detect_gpu_config
+from ._gpu import GPUInventoryError, detect_gpu_config
 from ._models import ModelDeployment, load_deployment_profile, load_model_deployment
 from ._processes import ManagedProcess
 from ._stack import Parallel, Process, run_stack
@@ -50,7 +50,7 @@ __all__ = [
     "NATIVE_DEVICE_PROFILES", "is_native_profile", "read_device_profile",
     "ensure_credentials", "load_credentials", "require_credentials", "warn_if_missing",
     "read_config_scalar",
-    "detect_gpu_config",
+    "GPUInventoryError", "detect_gpu_config",
     "ModelDeployment", "load_deployment_profile", "load_model_deployment",
     "ManagedProcess",
     "Parallel", "Process", "run_stack",

--- a/utils/xr-ai-launcher/xr_ai_launcher/_config.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/_config.py
@@ -34,3 +34,18 @@ def read_config_scalar(path: Path, key: str, default: str = "") -> str:
         comment = re.search(r"[ \t]+#", raw)
         return raw[:comment.start()].rstrip() if comment else raw
     return default
+
+
+def read_service_port(path: Path) -> int | None:
+    """Read a service's top-level HTTP port from its YAML configuration."""
+
+    raw = read_config_scalar(path, "port") or read_config_scalar(path, "http_port")
+    if not raw:
+        return None
+    try:
+        port = int(raw)
+    except ValueError as exc:
+        raise ValueError(f"{path}: port must be an integer, got {raw!r}") from exc
+    if not 1 <= port <= 65535:
+        raise ValueError(f"{path}: port must be between 1 and 65535, got {port}")
+    return port

--- a/utils/xr-ai-launcher/xr_ai_launcher/_gpu.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/_gpu.py
@@ -32,7 +32,7 @@ class _GPUProcess:
 
 
 @dataclass(frozen=True)
-class _GPUDevice:
+class GPUDevice:
     """Physical GPU capacity and current availability."""
 
     index: int
@@ -102,7 +102,7 @@ def _query_compute_processes() -> dict[str, list[_GPUProcess]]:
     return result
 
 
-def _format_compute_processes(devices: tuple[_GPUDevice, ...]) -> str:
+def _format_compute_processes(devices: tuple[GPUDevice, ...]) -> str:
     """Return best-effort process context for an unsupported topology."""
     try:
         processes = _query_compute_processes()
@@ -123,7 +123,7 @@ def _format_compute_processes(devices: tuple[_GPUDevice, ...]) -> str:
     return ", ".join(details) if details else "none"
 
 
-def _query_gpu_inventory() -> tuple[_GPUDevice, ...]:
+def query_gpu_inventory() -> tuple[GPUDevice, ...]:
     """Return exact per-device GPU facts or fail without an assumed fallback."""
     try:
         raw = subprocess.check_output(
@@ -145,13 +145,13 @@ def _query_gpu_inventory() -> tuple[_GPUDevice, ...]:
         suffix = f": {detail}" if detail else ""
         raise GPUInventoryError(f"nvidia-smi GPU inventory failed{suffix}") from exc
 
-    devices: list[_GPUDevice] = []
+    devices: list[GPUDevice] = []
     for line in raw.splitlines():
         parts = [part.strip() for part in line.split(",", maxsplit=7)]
         if len(parts) != 8:
             raise GPUInventoryError(f"unparseable nvidia-smi GPU row: {line!r}")
         try:
-            device = _GPUDevice(
+            device = GPUDevice(
                 index=int(parts[0]),
                 uuid=parts[1],
                 pci_bus_id=parts[2],
@@ -176,7 +176,7 @@ def detect_gpu_config() -> str:
     This compatibility bridge remains until capability-based service planning
     replaces named config selection. It deliberately has no fallback.
     """
-    devices = _query_gpu_inventory()
+    devices = query_gpu_inventory()
     if len(devices) == 1:
         gpu = devices[0]
         if gpu.compute_capability >= 10.0:

--- a/utils/xr-ai-launcher/xr_ai_launcher/_gpu.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/_gpu.py
@@ -1,83 +1,223 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""GPU profile auto-detection via nvidia-smi (stdlib-only)."""
+"""Strict per-device GPU inventory and existing config selection."""
 from __future__ import annotations
 
 import logging
+import re
 import subprocess
+from dataclasses import dataclass
 
 log = logging.getLogger(__name__)
 
+_MIB_PER_GIB = 1024.0
+_SPARK_NAME = re.compile(r"(?i)\b(?:GB10|B10)\b")
+_BLACKWELL_96_MIN_GIB = 90.0
+_SPARK_MIN_GIB = 120.0
 
-def detect_gpu_config() -> str:
-    """Return the GPU config profile by querying nvidia-smi.
 
-    Profiles
-    --------
-    dual_48G_ada   — 2× ADA 48 GB (default / current dev box)
-    spark          — 1× Blackwell GB10 (DGX Spark; ~96 GiB GPU-visible HBM)
-    96G_blackwell  — 1× Blackwell ~96 GB
+class GPUInventoryError(RuntimeError):
+    """Raised when visible GPUs cannot be inventoried or safely classified."""
 
-    Falls back to ``dual_48G_ada`` on any detection failure.
-    """
+
+@dataclass(frozen=True)
+class _GPUProcess:
+    """One compute process reported by ``nvidia-smi``."""
+
+    gpu_uuid: str
+    pid: int
+    name: str
+    used_memory_gib: float | None
+
+
+@dataclass(frozen=True)
+class _GPUDevice:
+    """Physical GPU capacity and current availability."""
+
+    index: int
+    uuid: str
+    pci_bus_id: str
+    name: str
+    compute_capability: float
+    total_memory_gib: float | None
+    free_memory_gib: float | None
+    used_memory_gib: float | None
+
+
+def _parse_mib(value: str) -> float | None:
+    text = value.strip()
+    if text in {"N/A", "[N/A]", "Not Supported", "[Not Supported]"}:
+        return None
+    if not text:
+        raise ValueError("empty memory field")
+    return float(text.split()[0]) / _MIB_PER_GIB
+
+
+def _format_gib(value: float | None) -> str:
+    return "N/A" if value is None else f"{value:.1f} GiB"
+
+
+def _query_compute_processes() -> dict[str, list[_GPUProcess]]:
     try:
         raw = subprocess.check_output(
-            ["nvidia-smi", "--query-gpu=name,compute_cap,memory.total",
-             "--format=csv,noheader"],
-            text=True, stderr=subprocess.DEVNULL,
-        ).strip().splitlines()
-    except Exception as exc:
-        log.warning("nvidia-smi unavailable (%s) — using dual_48G_ada", exc)
-        return "dual_48G_ada"
+            [
+                "nvidia-smi",
+                "--query-compute-apps=gpu_uuid,pid,process_name,used_gpu_memory",
+                "--format=csv,noheader,nounits",
+            ],
+            text=True,
+            stderr=subprocess.PIPE,
+        ).strip()
+    except FileNotFoundError as exc:
+        raise GPUInventoryError(
+            "nvidia-smi is unavailable while inspecting GPU compute processes"
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or "").strip()
+        suffix = f": {detail}" if detail else ""
+        raise GPUInventoryError(
+            f"nvidia-smi compute-process inventory failed{suffix}"
+        ) from exc
 
-    _SPARK_NAMES = {"gb10", "b10"}
-
-    gpus: list[tuple[str, float, float]] = []
-    for line in raw:
-        parts = [p.strip() for p in line.split(",")]
-        if len(parts) < 3:
-            continue
-        name, cap_str, mem_str = parts[0], parts[1], parts[2]
+    result: dict[str, list[_GPUProcess]] = {}
+    for line in raw.splitlines():
+        parts = [part.strip() for part in line.split(",", maxsplit=3)]
+        if len(parts) != 4:
+            raise GPUInventoryError(f"unparseable nvidia-smi process row: {line!r}")
+        uuid, pid_text, name, memory_text = parts
         try:
-            cap = float(cap_str)
-        except ValueError:
+            pid = int(pid_text)
+        except ValueError as exc:
+            raise GPUInventoryError(
+                f"unparseable nvidia-smi process row: {line!r}"
+            ) from exc
+        try:
+            used = _parse_mib(memory_text)
+        except ValueError as exc:
+            raise GPUInventoryError(
+                f"unparseable nvidia-smi process row: {line!r}"
+            ) from exc
+        result.setdefault(uuid, []).append(_GPUProcess(uuid, pid, name, used))
+    return result
+
+
+def _format_compute_processes(devices: tuple[_GPUDevice, ...]) -> str:
+    """Return best-effort process context for an unsupported topology."""
+    try:
+        processes = _query_compute_processes()
+    except GPUInventoryError as exc:
+        return f"compute-process inventory unavailable ({exc})"
+
+    by_uuid = {gpu.uuid: gpu for gpu in devices}
+    details = []
+    for uuid, entries in processes.items():
+        gpu = by_uuid.get(uuid)
+        if gpu is None:
             continue
-        mem = 0.0
-        for tok in mem_str.split():
-            try:
-                mem = float(tok)
-                break
-            except ValueError:
-                pass
-        gpus.append((name.lower(), cap, mem))
+        for process in entries:
+            used = _format_gib(process.used_memory_gib)
+            details.append(
+                f"GPU {gpu.index} PID {process.pid} {process.name} ({used})"
+            )
+    return ", ".join(details) if details else "none"
 
-    if not gpus:
-        log.warning("GPU detection returned no parseable data — using dual_48G_ada")
-        return "dual_48G_ada"
 
-    n_gpus       = len(gpus)
-    first_name   = gpus[0][0]
-    first_cap    = gpus[0][1]
-    is_blackwell = first_cap >= 10.0
-    is_spark     = any(s in first_name for s in _SPARK_NAMES)
-    known_mem    = [m for _, _, m in gpus if m > 0]
-    total_mem_gb = sum(known_mem) / 1024 if known_mem else 0.0
+def _query_gpu_inventory() -> tuple[_GPUDevice, ...]:
+    """Return exact per-device GPU facts or fail without an assumed fallback."""
+    try:
+        raw = subprocess.check_output(
+            [
+                "nvidia-smi",
+                "--query-gpu=index,uuid,pci.bus_id,name,compute_cap,memory.total,"
+                "memory.free,memory.used",
+                "--format=csv,noheader,nounits",
+            ],
+            text=True,
+            stderr=subprocess.PIPE,
+        ).strip()
+    except FileNotFoundError as exc:
+        raise GPUInventoryError(
+            "nvidia-smi is unavailable; XR-AI cannot inspect GPU capacity"
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or "").strip()
+        suffix = f": {detail}" if detail else ""
+        raise GPUInventoryError(f"nvidia-smi GPU inventory failed{suffix}") from exc
 
-    if is_blackwell and (is_spark or (not known_mem)):
-        cfg = "spark"
-    elif is_blackwell and total_mem_gb >= 120:
-        cfg = "spark"
-    elif is_blackwell:
-        cfg = "96G_blackwell"
-    elif n_gpus >= 2:
-        cfg = "dual_48G_ada"
+    devices: list[_GPUDevice] = []
+    for line in raw.splitlines():
+        parts = [part.strip() for part in line.split(",", maxsplit=7)]
+        if len(parts) != 8:
+            raise GPUInventoryError(f"unparseable nvidia-smi GPU row: {line!r}")
+        try:
+            device = _GPUDevice(
+                index=int(parts[0]),
+                uuid=parts[1],
+                pci_bus_id=parts[2],
+                name=parts[3],
+                compute_capability=float(parts[4]),
+                total_memory_gib=_parse_mib(parts[5]),
+                free_memory_gib=_parse_mib(parts[6]),
+                used_memory_gib=_parse_mib(parts[7]),
+            )
+        except ValueError as exc:
+            raise GPUInventoryError(f"unparseable nvidia-smi GPU row: {line!r}") from exc
+        devices.append(device)
+
+    if not devices:
+        raise GPUInventoryError("nvidia-smi returned no GPUs")
+    return tuple(devices)
+
+
+def detect_gpu_config() -> str:
+    """Select an existing config only when the complete topology is supported.
+
+    This compatibility bridge remains until capability-based service planning
+    replaces named config selection. It deliberately has no fallback.
+    """
+    devices = _query_gpu_inventory()
+    if len(devices) == 1:
+        gpu = devices[0]
+        if gpu.compute_capability >= 10.0:
+            if _SPARK_NAME.search(gpu.name) or (
+                gpu.total_memory_gib is not None
+                and gpu.total_memory_gib >= _SPARK_MIN_GIB
+            ):
+                config = "spark"
+            elif (
+                gpu.total_memory_gib is not None
+                and gpu.total_memory_gib >= _BLACKWELL_96_MIN_GIB
+            ):
+                config = "96G_blackwell"
+            else:
+                config = ""
+        else:
+            config = ""
+    elif (
+        len(devices) == 2
+        and all(8.9 <= gpu.compute_capability < 10.0 for gpu in devices)
+        and all(
+            gpu.total_memory_gib is not None and gpu.total_memory_gib >= 44.0
+            for gpu in devices
+        )
+    ):
+        config = "dual_48G_ada"
     else:
-        cfg = "dual_48G_ada"
+        config = ""
 
-    mem_display = f"{total_mem_gb:.0f} GiB" if known_mem else "unified memory"
-    log.info(
-        "GPU config: %s  (%dx %s, %s, SM%.1f)",
-        cfg, n_gpus, gpus[0][0].upper(), mem_display, first_cap,
+    topology = "; ".join(
+        f"GPU {gpu.index}: {gpu.name}, SM{gpu.compute_capability:.1f}, "
+        f"{_format_gib(gpu.total_memory_gib)} total, "
+        f"{_format_gib(gpu.free_memory_gib)} free"
+        for gpu in devices
     )
-    return cfg
+    if not config:
+        process_context = _format_compute_processes(tuple(devices))
+        raise GPUInventoryError(
+            "no existing XR-AI model-server configuration matches the visible "
+            f"GPU topology: {topology}; active compute processes: {process_context}"
+        )
+    log.info("GPU config: %s", config)
+    log.info("GPU inventory: %s", topology)
+    return config

--- a/utils/xr-ai-launcher/xr_ai_launcher/_gpu_memory.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/_gpu_memory.py
@@ -1,0 +1,258 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Service-YAML GPU-memory requirements, preflight, and vLLM budgets."""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from pathlib import Path
+
+from ._config import read_config_scalar
+from ._gpu import GPUDevice
+
+GPU_MEMORY_UTILIZATION_ENV = "XR_AI_GPU_MEMORY_UTILIZATION"
+
+
+class GPUMemoryError(ValueError):
+    """Raised when service GPU requirements are invalid or cannot fit."""
+
+
+def _require_memory_telemetry(
+    gpu: GPUDevice, value: float | None, field: str,
+) -> float:
+    if value is None:
+        raise GPUMemoryError(
+            f"GPU {gpu.index} ({gpu.name}): {field} GPU memory telemetry is unavailable"
+        )
+    return value
+
+
+@dataclass(frozen=True)
+class ServiceGPURequirement:
+    """GPU capacity required by one service configuration."""
+
+    service: str
+    gpu: int
+    memory_gib: float
+    vllm: bool
+    config_path: Path
+
+
+@dataclass(frozen=True)
+class GPUMemoryPlan:
+    """Resolved requirements for one selected service stack."""
+
+    stack: str
+    device_safety_reserve_gib: float
+    services: tuple[ServiceGPURequirement, ...]
+
+
+@dataclass(frozen=True)
+class GPUPreflight:
+    """Capacity result for one GPU used by a plan."""
+
+    gpu: GPUDevice
+    requirements: tuple[ServiceGPURequirement, ...]
+    active_services: frozenset[str]
+    incremental_required_gib: float
+    safety_reserve_gib: float
+    remaining_gib: float
+    passed: bool
+
+
+def load_service_gpu_requirement(
+    service: str,
+    path: str | Path,
+    inventory: tuple[GPUDevice, ...],
+    *,
+    vllm: bool,
+) -> ServiceGPURequirement:
+    """Read one service requirement, retaining utilization as a fallback."""
+    config_path = Path(path).resolve()
+    gpu_text = read_config_scalar(config_path, "cuda_visible_devices", "0")
+    if "," in gpu_text:
+        raise GPUMemoryError(
+            f"{config_path}: multi-GPU services need an explicit planning policy"
+        )
+    try:
+        gpu_index = int(gpu_text)
+    except ValueError as exc:
+        raise GPUMemoryError(
+            f"{config_path}: cuda_visible_devices must be one numeric GPU index"
+        ) from exc
+
+    by_index = {gpu.index: gpu for gpu in inventory}
+    if gpu_index not in by_index:
+        raise GPUMemoryError(
+            f"{config_path}: assigns {service!r} to unavailable GPU {gpu_index}"
+        )
+
+    memory_text = read_config_scalar(config_path, "gpu_memory_reservation_gib")
+    utilization_text = read_config_scalar(config_path, "gpu_memory_utilization")
+    if not memory_text and not utilization_text:
+        raise GPUMemoryError(
+            f"{config_path}: declare gpu_memory_reservation_gib "
+            "(or legacy gpu_memory_utilization)"
+        )
+    try:
+        if memory_text:
+            memory_gib = float(memory_text)
+        else:
+            utilization = float(utilization_text)
+            if not 0 < utilization < 1:
+                raise ValueError
+            total_memory_gib = _require_memory_telemetry(
+                by_index[gpu_index], by_index[gpu_index].total_memory_gib, "total",
+            )
+            memory_gib = utilization * total_memory_gib
+    except ValueError as exc:
+        raise GPUMemoryError(f"{config_path}: invalid GPU requirement") from exc
+    if not math.isfinite(memory_gib) or memory_gib <= 0:
+        raise GPUMemoryError(f"{config_path}: GPU requirements must be positive")
+
+    return ServiceGPURequirement(
+        service=service,
+        gpu=gpu_index,
+        memory_gib=memory_gib,
+        vllm=vllm,
+        config_path=config_path,
+    )
+
+
+def resolve_gpu_memory_plan(
+    *,
+    stack: str,
+    inventory: tuple[GPUDevice, ...],
+    service_configs: dict[str, tuple[Path, bool]],
+    device_safety_reserve_gib: float = 2.0,
+) -> GPUMemoryPlan:
+    """Build a plan directly from the selected services' existing YAML files."""
+    if not math.isfinite(device_safety_reserve_gib) or device_safety_reserve_gib < 0:
+        raise GPUMemoryError("device safety reserve cannot be negative")
+    services = tuple(
+        load_service_gpu_requirement(service, path, inventory, vllm=vllm)
+        for service, (path, vllm) in service_configs.items()
+    )
+    if not services:
+        raise GPUMemoryError(f"{stack}: selected services declare no GPU requirements")
+    return GPUMemoryPlan(stack, device_safety_reserve_gib, services)
+
+
+def preflight_gpu_memory(
+    plan: GPUMemoryPlan,
+    inventory: tuple[GPUDevice, ...],
+    *,
+    active_services: frozenset[str] = frozenset(),
+) -> tuple[GPUPreflight, ...]:
+    """Check incremental requirements against each device's current free memory."""
+    by_index = {gpu.index: gpu for gpu in inventory}
+    results: list[GPUPreflight] = []
+    for index in sorted({item.gpu for item in plan.services}):
+        gpu = by_index[index]
+        requirements = tuple(item for item in plan.services if item.gpu == index)
+        active = frozenset(
+            item.service for item in requirements if item.service in active_services
+        )
+        incremental = sum(
+            item.memory_gib for item in requirements if item.service not in active
+        )
+        free_memory_gib = _require_memory_telemetry(
+            gpu, gpu.free_memory_gib, "free",
+        )
+        remaining = free_memory_gib - incremental - plan.device_safety_reserve_gib
+        results.append(GPUPreflight(
+            gpu=gpu,
+            requirements=requirements,
+            active_services=active,
+            incremental_required_gib=incremental,
+            safety_reserve_gib=plan.device_safety_reserve_gib,
+            remaining_gib=remaining,
+            passed=remaining >= 0,
+        ))
+    return tuple(results)
+
+
+def require_gpu_memory_preflight(results: tuple[GPUPreflight, ...]) -> None:
+    """Raise an actionable capacity error when any device cannot fit its services."""
+    details = []
+    for result in results:
+        if result.passed:
+            continue
+        details.append(
+            f"GPU {result.gpu.index} ({result.gpu.name}) has "
+            f"{result.gpu.free_memory_gib:.1f} GiB free but needs "
+            f"{result.incremental_required_gib:.1f} GiB for services plus "
+            f"{result.safety_reserve_gib:.1f} GiB safety reserve "
+            f"(shortfall {-result.remaining_gib:.1f} GiB)"
+        )
+    if details:
+        raise GPUMemoryError("GPU MEMORY PREFLIGHT FAILED\n" + "\n".join(details))
+
+
+def derive_gpu_memory_utilization(memory_gib: float, total_gib: float) -> float:
+    """Convert an absolute service requirement to a physical-memory fraction."""
+    if (
+        not math.isfinite(memory_gib)
+        or not math.isfinite(total_gib)
+        or memory_gib <= 0
+        or total_gib <= 0
+    ):
+        raise GPUMemoryError("GPU memory requirement and device total must be positive")
+    utilization = memory_gib / total_gib
+    if utilization >= 1:
+        raise GPUMemoryError(
+            f"{memory_gib:.1f} GiB cannot fit a {total_gib:.1f} GiB GPU"
+        )
+    return int(utilization * 10_000 + 0.999999) / 10_000
+
+
+def utilization_overrides(
+    plan: GPUMemoryPlan, inventory: tuple[GPUDevice, ...],
+) -> dict[str, str]:
+    """Return derived vLLM utilization for services with absolute requirements."""
+    by_index = {gpu.index: gpu for gpu in inventory}
+    overrides = {}
+    for item in plan.services:
+        if not item.vllm or not read_config_scalar(
+            item.config_path, "gpu_memory_reservation_gib"
+        ):
+            continue
+        gpu = by_index[item.gpu]
+        total_memory_gib = _require_memory_telemetry(
+            gpu, gpu.total_memory_gib, "total",
+        )
+        overrides[item.service] = str(derive_gpu_memory_utilization(
+            item.memory_gib, total_memory_gib,
+        ))
+    return overrides
+
+
+def format_gpu_memory_preflight(
+    plan: GPUMemoryPlan, results: tuple[GPUPreflight, ...],
+) -> str:
+    """Render a compact per-device allocation table."""
+    lines = [f"XR-AI GPU memory preflight: {plan.stack}"]
+    for result in results:
+        total = (
+            "N/A" if result.gpu.total_memory_gib is None
+            else f"{result.gpu.total_memory_gib:.1f} GiB"
+        )
+        free = (
+            "N/A" if result.gpu.free_memory_gib is None
+            else f"{result.gpu.free_memory_gib:.1f} GiB"
+        )
+        lines.extend([
+            "",
+            f"GPU {result.gpu.index}: {result.gpu.name}, "
+            f"{total} total, {free} free",
+        ])
+        for item in result.requirements:
+            suffix = " (already active)" if item.service in result.active_services else ""
+            lines.append(f"  {item.service:<24} {item.memory_gib:>6.1f} GiB{suffix}")
+        lines.append(
+            f"  {'device safety reserve':<24} {result.safety_reserve_gib:>6.1f} GiB"
+        )
+        verdict = "PASS" if result.passed else "FAIL"
+        lines.append(f"  Result: {verdict}, {result.remaining_gib:.1f} GiB remaining")
+    return "\n".join(lines)

--- a/utils/xr-ai-launcher/xr_ai_launcher/_stack.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/_stack.py
@@ -83,6 +83,9 @@ class Process:
     gpu:                 str | None = None
     """Optional ``CUDA_VISIBLE_DEVICES`` value, such as ``"0"`` or ``"0,1"``."""
 
+    environment:         tuple[tuple[str, str], ...] = ()
+    """Additional environment entries passed only to this process."""
+
     launch_mode:         str = "own"
     """Spawn and shutdown behavior.
 
@@ -213,6 +216,7 @@ def _spawn(proc: Process, base: Path, ready_file: Path) -> subprocess.Popen:
     cmd += ["--ready-file", str(ready_file)]
 
     env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
+    env.update(proc.environment)
     if proc.gpu is not None:
         env["CUDA_VISIBLE_DEVICES"] = proc.gpu
 

--- a/utils/xr-ai-vllm/xr_ai_vllm/__init__.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/__init__.py
@@ -52,6 +52,9 @@ from ._config import (
     resolve_model_cache,
     setup_hf_env,
 )
+from ._config import (
+    gpu_memory_utilization as gpu_memory_utilization,
+)
 from ._nim import serve_nim
 
 log = logging.getLogger(__name__)

--- a/utils/xr-ai-vllm/xr_ai_vllm/_config.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/_config.py
@@ -19,6 +19,25 @@ from pathlib import Path
 
 log = logging.getLogger(__name__)
 
+_GPU_MEMORY_UTILIZATION_ENV = "XR_AI_GPU_MEMORY_UTILIZATION"
+
+
+def gpu_memory_utilization(cfg: dict, default: float) -> float:
+    """Resolve a launcher-derived utilization before the YAML/default value."""
+    raw = os.environ.get(
+        _GPU_MEMORY_UTILIZATION_ENV,
+        cfg.get("gpu_memory_utilization", default),
+    )
+    try:
+        value = float(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"invalid GPU memory utilization: {raw!r}") from exc
+    if not 0 < value < 1:
+        raise ValueError(f"GPU memory utilization must be between 0 and 1: {value}")
+    if _GPU_MEMORY_UTILIZATION_ENV in os.environ:
+        log.info("Derived vLLM GPU memory utilization: %.4f", value)
+    return value
+
 
 def resolve_model_cache(cfg: dict, yaml_dir: Path, *, default: str) -> Path:
     """Resolve ``model_cache`` (relative to the YAML dir) and ensure it exists."""

--- a/utils/xr-ai-vllm/xr_ai_vllm/_diagnostics.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/_diagnostics.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Actionable classifications for common vLLM startup failures."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def _argument_value(argv: list[str], option: str) -> str | None:
+    try:
+        return argv[argv.index(option) + 1]
+    except (ValueError, IndexError):
+        return None
+
+
+def classify_vllm_failure(log_path: str | Path, argv: list[str]) -> str | None:
+    """Return a clear diagnosis when *log_path* contains a GPU-memory failure."""
+    try:
+        body = Path(log_path).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    lowered = body.lower()
+    utilization = _argument_value(argv, "--gpu-memory-utilization")
+    budget = (
+        f" (configured gpu_memory_utilization={utilization})"
+        if utilization else ""
+    )
+
+    if (
+        "no available memory for the cache blocks" in lowered
+        or (
+            "available kv cache memory" in lowered
+            and re.search(r"available kv cache memory[^\n]*-\d", lowered)
+        )
+    ):
+        available = re.search(
+            r"available kv cache memory[^\n]*?(-?\d+(?:\.\d+)?)\s*gib",
+            lowered,
+        )
+        detail = f"; vLLM reported {available.group(1)} GiB available" if available else ""
+        return (
+            "INSUFFICIENT GPU MEMORY: model weights and runtime allocations left "
+            f"no capacity for the KV cache{detail}{budget}. Reduce the configured "
+            "model/context/concurrency, free GPU memory, or use a larger device."
+        )
+
+    if "cuda out of memory" in lowered or "torch.outofmemoryerror" in lowered:
+        return (
+            "INSUFFICIENT GPU MEMORY: CUDA allocation failed during vLLM startup"
+            f"{budget}. Free GPU memory, reduce the configured model/context/"
+            "concurrency, or use a larger device."
+        )
+
+    if "free memory on device" in lowered and "desired gpu memory utilization" in lowered:
+        return (
+            "INSUFFICIENT FREE GPU MEMORY: another process is using memory required "
+            f"by this vLLM service{budget}. Stop the conflicting process or lower "
+            "the service memory budget."
+        )
+    return None

--- a/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
@@ -32,7 +32,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
-from . import _lifecycle
+from . import _diagnostics, _lifecycle
 
 log = logging.getLogger(__name__)
 
@@ -615,6 +615,7 @@ def run(
         reuse_banner=f"vLLM already running on port {port} — reusing",
         ready_banner=f"Ready  →  http://localhost:{port}/v1  (docker: {container_name})",
         ready_file=ready_file,
+        diagnostic_argv=vllm_argv,
     )
 
 
@@ -630,6 +631,7 @@ def run_container(
     reuse_banner: str,
     ready_banner: str,
     ready_file: Path | None,
+    diagnostic_argv: list[str] | None = None,
 ) -> None:
     """Shared container lifecycle for the vLLM docker backend and NIMs.
 
@@ -812,6 +814,12 @@ def run_container(
         time.sleep(0.5)
         streamer.stop()
         _append_post_mortem(container_name, streamer.log_path)
+        diagnosis = (
+            _diagnostics.classify_vllm_failure(streamer.log_path, diagnostic_argv)
+            if diagnostic_argv is not None else None
+        )
+        if diagnosis:
+            log.error("%s", diagnosis)
         log.error("container %s failed — see %s", container_name, streamer.log_path)
         raise
 


### PR DESCRIPTION
## Summary

- keep GPU placement and absolute memory requirements in each service's existing YAML
- preflight the complete selected stack against actual free memory on every assigned GPU, including a device safety reserve
- derive vLLM `gpu_memory_utilization` from `gpu_memory_reservation_gib / detected device total`
- retain `gpu_memory_utilization` as a compatibility fallback for existing custom YAML
- apply the same preflight to standalone Simple VLM and the shared model-server stacks
- report the complete per-device allocation table and exact shortfall before loading model weights

There are no reservation JSON manifests, reservation-status fields, precision declarations, runtime variants, or unverified capability claims. This PR preflights memory only.

The existing named config-directory selection remains temporarily in place as a compatibility bridge. A later focused PR can select layouts by these service contracts instead of names.

## Initial values

The checked-in `gpu_memory_reservation_gib` values are initial estimates derived from the current configurations. They must be replaced/validated by the repeatable measurement work in the next PR; this is why the PR remains a draft.

## Stack

- based on #397
- review only commit `4aad818` for this PR's focused change
- #397 is based on #396

## Testing

- Ruff passes for every changed Python file
- affected launcher/config/orchestrator/vLLM/NIM suite: `244 passed`
- all bundled model-server YAML contracts are checked for reservation fields
- all three deployment selections are checked against clean dual-45 GiB Ada, 96 GiB Blackwell, and 120 GiB unified-memory inventories
- standalone Simple VLM is checked against one 45 GiB L40S (`27 GiB` services + `2 GiB` reserve)
