### PR TITLE
ci: make PR runner configurable

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   assemble:
     name: assembleDebug
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && vars.PR_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 20
 
     defaults:

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   assemble:
     name: assembleDebug
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ci:self-hosted') && 'Linux' || 'ubuntu-latest' }}
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ci:self-hosted') && '["self-hosted","Linux","X64"]' || '["ubuntu-latest"]') }}
     timeout-minutes: 20
 
     defaults:

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -13,6 +13,7 @@ on:
       - 'client-samples/android/**'
       - '.github/workflows/android-build.yml'
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths:
       - 'client-samples/android/**'
       - '.github/workflows/android-build.yml'
@@ -24,7 +25,7 @@ concurrency:
 jobs:
   assemble:
     name: assembleDebug
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && vars.PR_RUNNER || 'ubuntu-latest' }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ci:self-hosted') && 'Linux' || 'ubuntu-latest' }}
     timeout-minutes: 20
 
     defaults:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && vars.PR_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     permissions:
       actions: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ci:self-hosted') && 'Linux' || 'ubuntu-latest' }}
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ci:self-hosted') && '["self-hosted","Linux","X64"]' || '["ubuntu-latest"]') }}
     timeout-minutes: 30
     permissions:
       actions: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,6 +15,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   schedule:
     - cron: '0 6 * * 1'
 
@@ -25,7 +26,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && vars.PR_RUNNER || 'ubuntu-latest' }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ci:self-hosted') && 'Linux' || 'ubuntu-latest' }}
     timeout-minutes: 30
     permissions:
       actions: read

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -35,7 +35,7 @@ concurrency:
 jobs:
   dco:
     name: DCO sign-off
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ci:self-hosted') && 'Linux' || 'ubuntu-latest' }}
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ci:self-hosted') && '["self-hosted","Linux","X64"]' || '["ubuntu-latest"]') }}
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -35,7 +35,7 @@ concurrency:
 jobs:
   dco:
     name: DCO sign-off
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && vars.PR_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -22,7 +22,7 @@ on:
   push:
     branches: ["**"]
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 # Read-only token is sufficient — we only inspect commit metadata.
 permissions:
@@ -35,7 +35,7 @@ concurrency:
 jobs:
   dco:
     name: DCO sign-off
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && vars.PR_RUNNER || 'ubuntu-latest' }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ci:self-hosted') && 'Linux' || 'ubuntu-latest' }}
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -73,7 +73,7 @@ concurrency:
 jobs:
   build:
     name: Build (strict)
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ci:self-hosted') && 'Linux' || 'ubuntu-latest' }}
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ci:self-hosted') && '["self-hosted","Linux","X64"]' || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -131,7 +131,7 @@ jobs:
       && (github.event_name == 'push'
           || github.event.pull_request.head.repo.full_name == github.repository)
     needs: build
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ci:self-hosted') && 'Linux' || 'ubuntu-latest' }}
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ci:self-hosted') && '["self-hosted","Linux","X64"]' || '["ubuntu-latest"]') }}
     permissions:
       contents: write
       pages: write

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -47,7 +47,7 @@ on:
       - ".github/scripts/remove_docs_preview.sh"
       - ".github/actions/deploy-docs-site/action.yaml"
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths:
       - "docs/**"
       - "agent-sdk/*/README.md"
@@ -73,7 +73,7 @@ concurrency:
 jobs:
   build:
     name: Build (strict)
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && vars.PR_RUNNER || 'ubuntu-latest' }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ci:self-hosted') && 'Linux' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -131,7 +131,7 @@ jobs:
       && (github.event_name == 'push'
           || github.event.pull_request.head.repo.full_name == github.repository)
     needs: build
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && vars.PR_RUNNER || 'ubuntu-latest' }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ci:self-hosted') && 'Linux' || 'ubuntu-latest' }}
     permissions:
       contents: write
       pages: write

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -73,7 +73,7 @@ concurrency:
 jobs:
   build:
     name: Build (strict)
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && vars.PR_RUNNER || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -131,7 +131,7 @@ jobs:
       && (github.event_name == 'push'
           || github.event.pull_request.head.repo.full_name == github.repository)
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && vars.PR_RUNNER || 'ubuntu-latest' }}
     permissions:
       contents: write
       pages: write

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 concurrency:
   group: lint-${{ github.ref }}
@@ -21,7 +22,7 @@ concurrency:
 jobs:
   ruff:
     name: ruff check
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && vars.PR_RUNNER || 'ubuntu-latest' }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ci:self-hosted') && 'Linux' || 'ubuntu-latest' }}
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   ruff:
     name: ruff check
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && vars.PR_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   ruff:
     name: ruff check
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ci:self-hosted') && 'Linux' || 'ubuntu-latest' }}
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ci:self-hosted') && '["self-hosted","Linux","X64"]' || '["ubuntu-latest"]') }}
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/lock-check.yml
+++ b/.github/workflows/lock-check.yml
@@ -17,6 +17,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 concurrency:
   group: lock-check-${{ github.ref }}
@@ -25,7 +26,7 @@ concurrency:
 jobs:
   dependency-map:
     name: generated dependency map
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && vars.PR_RUNNER || 'ubuntu-latest' }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ci:self-hosted') && 'Linux' || 'ubuntu-latest' }}
     timeout-minutes: 5
 
     steps:
@@ -40,7 +41,7 @@ jobs:
 
   uv-lock:
     name: uv lock (every project)
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && vars.PR_RUNNER || 'ubuntu-latest' }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ci:self-hosted') && 'Linux' || 'ubuntu-latest' }}
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/lock-check.yml
+++ b/.github/workflows/lock-check.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   dependency-map:
     name: generated dependency map
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && vars.PR_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 5
 
     steps:
@@ -40,7 +40,7 @@ jobs:
 
   uv-lock:
     name: uv lock (every project)
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && vars.PR_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/lock-check.yml
+++ b/.github/workflows/lock-check.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   dependency-map:
     name: generated dependency map
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ci:self-hosted') && 'Linux' || 'ubuntu-latest' }}
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ci:self-hosted') && '["self-hosted","Linux","X64"]' || '["ubuntu-latest"]') }}
     timeout-minutes: 5
 
     steps:
@@ -41,7 +41,7 @@ jobs:
 
   uv-lock:
     name: uv lock (every project)
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ci:self-hosted') && 'Linux' || 'ubuntu-latest' }}
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ci:self-hosted') && '["self-hosted","Linux","X64"]' || '["ubuntu-latest"]') }}
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/spdx.yml
+++ b/.github/workflows/spdx.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   check:
     name: check SPDX headers
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ci:self-hosted') && 'Linux' || 'ubuntu-latest' }}
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ci:self-hosted') && '["self-hosted","Linux","X64"]' || '["ubuntu-latest"]') }}
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/spdx.yml
+++ b/.github/workflows/spdx.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   check:
     name: check SPDX headers
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && vars.PR_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/spdx.yml
+++ b/.github/workflows/spdx.yml
@@ -12,6 +12,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 concurrency:
   group: spdx-${{ github.ref }}
@@ -20,7 +21,7 @@ concurrency:
 jobs:
   check:
     name: check SPDX headers
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && vars.PR_RUNNER || 'ubuntu-latest' }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ci:self-hosted') && 'Linux' || 'ubuntu-latest' }}
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   pytest:
     name: pytest (Python ${{ matrix.python-version }})
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ci:self-hosted') && 'Linux' || 'ubuntu-latest' }}
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ci:self-hosted') && '["self-hosted","Linux","X64"]' || '["ubuntu-latest"]') }}
     timeout-minutes: 15
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   pytest:
     name: pytest (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && vars.PR_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 15
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 # Cancel in-flight runs for the same ref when a new commit arrives.
 concurrency:
@@ -22,7 +23,7 @@ concurrency:
 jobs:
   pytest:
     name: pytest (Python ${{ matrix.python-version }})
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && vars.PR_RUNNER || 'ubuntu-latest' }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ci:self-hosted') && 'Linux' || 'ubuntu-latest' }}
     timeout-minutes: 15
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

- add a `ci:self-hosted` PR label that routes trusted same-repository PR CI to self-hosted Linux x64 runners
- trigger replacement workflow runs when that label is added or removed
- use `ubuntu-latest` by default and always for fork PRs, pushes, schedules, and tags

## Why

The repository accumulated 57 queued workflow runs with no GitHub-hosted runner assignments. Maintainers can now add `ci:self-hosted` to retry a PR on NVIDIA's self-hosted runners, or remove it to return to GitHub-hosted capacity.

The self-hosted selector requires all three labels: `self-hosted`, `Linux`, and `X64`. It currently matches the CPU runners `github-dobby` and `github-potter`, plus `github-hagrid`; it excludes the ARM64 `github-ron` runner.

## Validation

- `git diff --check`
- `actionlint` across all workflows, ignoring the repository's pre-existing `queue: max` findings and its existing custom `gpu` label
- live PR run assigned to the self-hosted Linux pool after applying `ci:self-hosted`
