### PR TITLE
Support extra SANs in self-signed cert for NAT and proxy hosts

### DIFF
--- a/client-samples/ios-visionos/README.md
+++ b/client-samples/ios-visionos/README.md
@@ -238,18 +238,19 @@ is:
 
 If you installed the profile and toggled Full Trust on but the wss
 handshake still errors out with NSURLErrorDomain `-1202` and a message
-like *"pretending to be 10.29.90.196"*, the cert's SubjectAlternativeName
+like *"pretending to be 192.168.1.42"*, the cert's SubjectAlternativeName
 does not cover the IP you're typing into the app. This happens when the
 hub generated the cert before that interface was up, or via an
 `/etc/hosts` loopback alias (the Ubuntu default of `127.0.1.1` instead of
 the LAN IP).
 
-**Fix:** the hub now probes the kernel's outbound IPv4 addresses at cert
-load and regenerates the cert whenever its SAN is missing a current local
-IP. Restart the hub — it logs `TLS: cached cert SAN is missing local
-IP(s) [10.29.90.196] — regenerating…` — then on the device remove the
-old profile under **VPN & Device Management** and reinstall from
-`https://<host>:8080/cert` exactly as above.
+**Fix:** the hub probes the kernel's outbound IPv4 addresses at cert load
+and regenerates the cert whenever its SAN is missing a current local IP.
+Restart the hub (it logs `TLS: cached cert SAN is missing …;
+regenerating…`), then on the device remove the old profile under **VPN &
+Device Management** and reinstall from `https://<host>:8080/cert` exactly
+as above. If the address you type into the app is not on any of the hub's
+interfaces, add it to `web_server_extra_sans` in `xr_media_hub.yaml` first.
 
 ### TLS succeeds but the room rejects the token with 401
 

--- a/docs/source/components/server-runtime.md
+++ b/docs/source/components/server-runtime.md
@@ -219,7 +219,9 @@ When `web_server_tls` is enabled (the default), the web server
 (`_web_server.py`) terminates TLS on `web_server_port` (8080 by default) and
 mounts a `/rtc` route that proxies LiveKit signaling bidirectionally to the
 internal `ws://127.0.0.1:7880` (`_lk_proxy.py`). A self-signed certificate is
-auto-generated on first run; supply `cert_file` and `key_file` to use your own.
+auto-generated on first run (SAN coverage and regeneration:
+[Networking](../getting_started/networking.md)); supply `cert_file` and
+`key_file` to use your own.
 The proxy forwards end-to-end headers so SDK authentication (such as the LiveKit
 Swift SDK's `Authorization: Bearer`) reaches the server, and handles both the
 versioned (`/rtc/v1`) and legacy (`/rtc`) signaling paths.

--- a/docs/source/getting_started/networking.md
+++ b/docs/source/getting_started/networking.md
@@ -55,6 +55,10 @@ Skipping validation does not make a closed port reachable. Ensure the VM's
 cloud firewall and host firewall allow 7881/TCP and 7882/UDP. Keep both options
 disabled for local and private-network deployments.
 
+NAT also affects the TLS certificate: clients dial the VM's public IP, which
+must be listed in the certificate's SAN via `web_server_extra_sans`; see
+[TLS for the web client](#tls-for-the-web-client) below.
+
 ## RHEL, Fedora, or CentOS (`firewall-cmd`)
 
 ```bash
@@ -123,6 +127,18 @@ never reached directly by client traffic.
 On first run a self-signed certificate is generated at
 `~/.local/share/xr-ai/web-server.crt`. To use your own, set `cert_file`
 and `key_file` in `xr_media_hub.yaml`.
+
+The generated certificate covers `localhost`, the hostname, and every local
+interface IP. When clients dial an address that is not on any local
+interface (the public IP of a NAT'd cloud VM such as Brev, a forwarding
+proxy's address, or a DNS name), list it in `xr_media_hub.yaml` and the
+certificate is regenerated to include it on the next hub start:
+
+```yaml
+web_server_extra_sans:
+  - 203.0.113.7
+  - hub.example.com
+```
 
 To **disable** TLS for `localhost`-only dev where the certificate warning is
 noise, set `web_server_tls: false`. With TLS off, the same-origin proxy

--- a/docs/source/guides/troubleshooting.md
+++ b/docs/source/guides/troubleshooting.md
@@ -302,14 +302,16 @@ cert is not a CA cert — regenerating…`).
 
 If the toggle was enabled but the wss handshake still fails with
 `errSSLBadCert` or NSURLErrorDomain `-1202` and a message like *"pretending
-to be 10.29.90.196"* (that is, the IP you typed into the app), the
-certificate's SubjectAlternativeName doesn't cover that IP. The hub now detects
-local IPv4 addresses via a UDP-connect probe and auto-regenerates the certificate
-whenever the SAN is missing one (logged as `TLS: cached cert SAN is
-missing local IP(s) … — regenerating…`); just restart the hub and
-re-install the profile on the device. To force regen explicitly, delete
-`~/.local/share/xr-ai/web-server.crt` and `web-server.key` before
-restarting.
+to be 192.168.1.42"* (that is, the IP you typed into the app), the
+certificate's SubjectAlternativeName doesn't cover that IP. The hub detects
+local IPv4 addresses via a UDP-connect probe and auto-regenerates the
+certificate whenever the SAN is missing one (logged as `TLS: cached cert
+SAN is missing …; regenerating…`); just restart the hub and re-install the
+profile on the device. If the dialed address is not on any of the hub's
+interfaces, add it to `web_server_extra_sans` in `xr_media_hub.yaml` and
+restart (see [Networking](../getting_started/networking.md)). To force
+regen explicitly, delete `~/.local/share/xr-ai/web-server.crt` and
+`web-server.key` before restarting.
 
 If the certificate is trusted (no `-1202`) but the room connection still fails
 with HTTP 401 / "no permissions to access the room", the hub's wss /rtc

--- a/services/xr-media-hub/xr_media_hub.yaml
+++ b/services/xr-media-hub/xr_media_hub.yaml
@@ -44,6 +44,13 @@ web_client_dir:    ../../client-samples/web
 # cert_file / key_file:
 # cert_file: /path/to/cert.pem
 # key_file:  /path/to/key.pem
+# The auto-generated cert's SAN covers localhost, the hostname, and every
+# local interface IP. List here any address clients dial that is not on a
+# local interface (a NAT'd cloud VM's public IP, a forwarding proxy's
+# address, or a DNS name):
+# web_server_extra_sans:
+#   - 203.0.113.7
+#   - hub.example.com
 
 # ── Optional: token server (legacy plain-HTTP entry point) ────────────────────
 enable_token_server: true

--- a/services/xr-media-hub/xr_media_hub/_config_loader.py
+++ b/services/xr-media-hub/xr_media_hub/_config_loader.py
@@ -72,6 +72,16 @@ def load_config() -> LiveKitConnectorConfig:
         if data.get(key):
             data[key] = _resolve_path(data[key], base)
 
+    if "web_server_extra_sans" in data:
+        sans = data["web_server_extra_sans"]
+        if sans is None:
+            data["web_server_extra_sans"] = []
+        elif isinstance(sans, str):
+            data["web_server_extra_sans"] = [sans]
+        elif not isinstance(sans, list):
+            logger.warning("web_server_extra_sans must be a list of strings; ignoring {!r}", sans)
+            data["web_server_extra_sans"] = []
+
     # Filter to only fields that exist on the dataclass.
     valid = {f.name for f in dataclasses.fields(LiveKitConnectorConfig)}
     filtered = {k: v for k, v in data.items() if k in valid}

--- a/services/xr-media-hub/xr_media_hub/transport/livekit/_tls.py
+++ b/services/xr-media-hub/xr_media_hub/transport/livekit/_tls.py
@@ -8,6 +8,7 @@ import datetime
 import ipaddress
 import pathlib
 import socket
+from collections.abc import Sequence
 
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
@@ -42,13 +43,31 @@ def _is_ca_cert(cert: x509.Certificate) -> bool:
         return False
 
 
-def _cert_ipv4_san(cert: x509.Certificate) -> set[str]:
+def _cert_san_entries(cert: x509.Certificate) -> set[str]:
     try:
         san = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
     except x509.ExtensionNotFound:
         return set()
-    return {str(ip) for ip in san.get_values_for_type(x509.IPAddress)
-            if isinstance(ip, ipaddress.IPv4Address)}
+    return ({str(ip) for ip in san.get_values_for_type(x509.IPAddress)}
+            | set(san.get_values_for_type(x509.DNSName)))
+
+
+def _normalize_san(entry: str) -> str:
+    try:
+        return str(ipaddress.ip_address(entry))
+    except ValueError:
+        return entry
+
+
+def _san_general_name(entry: str) -> x509.GeneralName | None:
+    try:
+        return x509.IPAddress(ipaddress.ip_address(entry))
+    except ValueError:
+        pass
+    try:
+        return x509.DNSName(entry)
+    except (ValueError, TypeError):
+        return None
 
 
 def _local_ipv4_addrs() -> set[str]:
@@ -78,26 +97,49 @@ def _local_ipv4_addrs() -> set[str]:
     return ips
 
 
-def ensure_self_signed_cert() -> tuple[str, str]:
-    """Return (cert_path, key_path), generating them once and reusing thereafter."""
+def _wanted_san_entries(extra_sans: Sequence[str]) -> set[str]:
+    """Normalized, encodable SAN entries the cert must cover."""
+    candidates = {"localhost", socket.gethostname(), "127.0.0.1"} | _local_ipv4_addrs()
+    for entry in extra_sans:
+        if isinstance(entry, str) and entry.strip():
+            candidates.add(_normalize_san(entry.strip()))
+        else:
+            logger.warning("TLS: ignoring invalid web_server_extra_sans entry {!r}", entry)
+    wanted: set[str] = set()
+    for entry in candidates:
+        if _san_general_name(entry) is None:
+            logger.warning("TLS: cannot encode SAN entry {!r}, skipping", entry)
+        else:
+            wanted.add(entry)
+    return wanted
+
+
+def ensure_self_signed_cert(extra_sans: Sequence[str] = ()) -> tuple[str, str]:
+    """Return (cert_path, key_path), generating them once and reusing thereafter.
+
+    extra_sans lists hostnames or IPs clients dial that are on no local
+    interface, e.g. a NAT'd cloud VM's public IP or a forwarding proxy.
+    """
     _CERT_DIR.mkdir(parents=True, exist_ok=True)
 
-    detected_ips = _local_ipv4_addrs()
+    wanted = _wanted_san_entries(extra_sans)
+    cached_entries: set[str] = set()
     reasons: list[str] = []
 
     if _CERT_FILE.exists() and _KEY_FILE.exists():
         cached = _load_cert(_CERT_FILE)
         if cached is not None:
+            cached_entries = _cert_san_entries(cached)
             if not _is_ca_cert(cached):
                 reasons.append(
                     "cached cert is not a CA cert — regenerating so iOS Full "
                     "Trust toggle appears"
                 )
-            if missing := detected_ips - _cert_ipv4_san(cached):
+            if missing := wanted - cached_entries:
                 reasons.append(
-                    f"cached cert SAN is missing local IP(s) {sorted(missing)} "
-                    "— regenerating so clients connecting via those addresses "
-                    "can validate the host"
+                    f"cached cert SAN is missing {sorted(missing)}; "
+                    "regenerating so clients dialing those addresses can "
+                    "validate the host"
                 )
             if not reasons:
                 return str(_CERT_FILE), str(_KEY_FILE)
@@ -107,16 +149,14 @@ def ensure_self_signed_cert() -> tuple[str, str]:
 
     key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
     hostname = socket.gethostname()
-    san: list[x509.GeneralName] = [
-        x509.DNSName("localhost"),
-        x509.DNSName(hostname),
-        x509.IPAddress(ipaddress.IPv4Address("127.0.0.1")),
-    ]
-    for ip in sorted(detected_ips):
-        try:
-            san.append(x509.IPAddress(ipaddress.IPv4Address(ip)))
-        except (ipaddress.AddressValueError, ValueError):
-            continue
+    # Union in the cached entries so the SAN only grows: an interface that is
+    # down at regen time isn't dropped, which would re-trigger regeneration
+    # (and another round of device profile reinstalls) when it comes back.
+    san: list[x509.GeneralName] = []
+    for entry in sorted(wanted | cached_entries):
+        name = _san_general_name(entry)
+        if name is not None:
+            san.append(name)
 
     public_key = key.public_key()
     now  = datetime.datetime.now(datetime.timezone.utc)

--- a/services/xr-media-hub/xr_media_hub/transport/livekit/_web_server.py
+++ b/services/xr-media-hub/xr_media_hub/transport/livekit/_web_server.py
@@ -111,7 +111,10 @@ class WebServer:
             cert = self._cfg.cert_file or None
             key  = self._cfg.key_file  or None
             if not cert or not key:
-                cert, key = ensure_self_signed_cert()
+                # Off-loop: cert generation does RSA keygen and network probes.
+                cert, key = await asyncio.to_thread(
+                    ensure_self_signed_cert, self._cfg.web_server_extra_sans
+                )
                 logger.info("TLS: using auto-generated self-signed cert  {}", cert)
             ssl_kwargs = {"ssl_certfile": cert, "ssl_keyfile": key}
             scheme = "https"

--- a/services/xr-media-hub/xr_media_hub/transport/livekit/config.py
+++ b/services/xr-media-hub/xr_media_hub/transport/livekit/config.py
@@ -69,6 +69,10 @@ class LiveKitConnectorConfig:
     # loopback; (b) localhost-only dev where browsers grant camera/mic on
     # http://localhost and the cert dance adds friction with no benefit.
     web_server_tls:    bool = True
+    # Extra hostnames/IPs added to the auto-generated cert's SAN: addresses
+    # clients dial that are on no local interface (a NAT'd cloud VM's public
+    # IP, a forwarding proxy's address, or a DNS name).
+    web_server_extra_sans: list[str] = field(default_factory=list)
 
     # ── Shared-memory ring buffer ──────────────────────────────────────────────
     shm_num_slots:       int = 10

--- a/tests/test_livekit_tls_san.py
+++ b/tests/test_livekit_tls_san.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for self-signed cert SAN generation and regeneration."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from cryptography import x509
+from xr_media_hub.transport.livekit import _tls
+
+
+@pytest.fixture()
+def cert_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    monkeypatch.setattr(_tls, "_CERT_DIR", tmp_path)
+    monkeypatch.setattr(_tls, "_CERT_FILE", tmp_path / "web-server.crt")
+    monkeypatch.setattr(_tls, "_KEY_FILE", tmp_path / "web-server.key")
+    monkeypatch.setattr(_tls, "_local_ipv4_addrs", lambda: {"10.0.0.5"})
+    monkeypatch.setattr(_tls.socket, "gethostname", lambda: "testhost")
+    return tmp_path
+
+
+def _cert(path: str) -> x509.Certificate:
+    return x509.load_pem_x509_certificate(Path(path).read_bytes())
+
+
+def test_normalize_san_canonicalizes_ips() -> None:
+    assert _tls._normalize_san("203.0.113.7") == "203.0.113.7"
+    assert _tls._normalize_san("2001:DB8::0:1") == "2001:db8::1"
+    assert _tls._normalize_san("hub.example.com") == "hub.example.com"
+
+
+def test_san_general_name_types() -> None:
+    assert isinstance(_tls._san_general_name("203.0.113.7"), x509.IPAddress)
+    assert isinstance(_tls._san_general_name("2001:db8::1"), x509.IPAddress)
+    assert isinstance(_tls._san_general_name("hub.example.com"), x509.DNSName)
+    assert _tls._san_general_name("hüb.example.com") is None
+
+
+def test_fresh_cert_covers_locals_and_extras(cert_env: Path) -> None:
+    cert_path, key_path = _tls.ensure_self_signed_cert(["203.0.113.7", "proxy.example.com"])
+
+    entries = _tls._cert_san_entries(_cert(cert_path))
+    assert {"localhost", "testhost", "127.0.0.1", "10.0.0.5",
+            "203.0.113.7", "proxy.example.com"} <= entries
+    assert Path(key_path).exists()
+
+
+def test_same_inputs_reuse_cached_cert(cert_env: Path) -> None:
+    cert_path, _ = _tls.ensure_self_signed_cert(["203.0.113.7"])
+    serial = _cert(cert_path).serial_number
+
+    cert_path, _ = _tls.ensure_self_signed_cert(["203.0.113.7"])
+
+    assert _cert(cert_path).serial_number == serial
+
+
+def test_removed_extra_does_not_regenerate(cert_env: Path) -> None:
+    cert_path, _ = _tls.ensure_self_signed_cert(["203.0.113.7"])
+    serial = _cert(cert_path).serial_number
+
+    cert_path, _ = _tls.ensure_self_signed_cert([])
+
+    assert _cert(cert_path).serial_number == serial
+
+
+def test_new_extra_regenerates_and_keeps_old_entries(cert_env: Path) -> None:
+    cert_path, _ = _tls.ensure_self_signed_cert(["203.0.113.7"])
+    serial = _cert(cert_path).serial_number
+
+    cert_path, _ = _tls.ensure_self_signed_cert(["198.51.100.9"])
+
+    cert = _cert(cert_path)
+    assert cert.serial_number != serial
+    assert {"198.51.100.9", "203.0.113.7"} <= _tls._cert_san_entries(cert)
+
+
+def test_missing_local_ip_regenerates(cert_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cert_path, _ = _tls.ensure_self_signed_cert()
+    serial = _cert(cert_path).serial_number
+
+    monkeypatch.setattr(_tls, "_local_ipv4_addrs", lambda: {"10.0.0.5", "192.0.2.33"})
+    cert_path, _ = _tls.ensure_self_signed_cert()
+
+    cert = _cert(cert_path)
+    assert cert.serial_number != serial
+    assert {"192.0.2.33", "10.0.0.5"} <= _tls._cert_san_entries(cert)
+
+
+def test_invalid_extras_are_skipped_not_fatal(cert_env: Path) -> None:
+    cert_path, _ = _tls.ensure_self_signed_cert(
+        [None, 10.0, "  ", "hüb.example.com", " 203.0.113.7 "]  # type: ignore[list-item]
+    )
+
+    entries = _tls._cert_san_entries(_cert(cert_path))
+    assert "203.0.113.7" in entries
+    assert "hüb.example.com" not in entries
+    # A prior bug class: a scalar iterated per character.
+    assert "2" not in entries
+
+
+def test_unencodable_entries_do_not_regen_loop(cert_env: Path) -> None:
+    cert_path, _ = _tls.ensure_self_signed_cert(["hüb.example.com"])
+    serial = _cert(cert_path).serial_number
+
+    cert_path, _ = _tls.ensure_self_signed_cert(["hüb.example.com"])
+
+    assert _cert(cert_path).serial_number == serial
+
+
+@pytest.mark.parametrize(
+    ("yaml_value", "expected"),
+    [
+        ("web_server_extra_sans: hub.example.com", ["hub.example.com"]),
+        ("web_server_extra_sans:", []),
+        ("web_server_extra_sans: true", []),
+        ("web_server_extra_sans:\n  - 203.0.113.7", ["203.0.113.7"]),
+    ],
+)
+def test_loader_coerces_extra_sans(
+    yaml_value: str, expected: list[str], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from xr_media_hub._config_loader import load_config
+
+    cfg_file = tmp_path / "xr_media_hub.yaml"
+    cfg_file.write_text(yaml_value + "\n")
+    monkeypatch.setattr("sys.argv", ["prog", "--config", str(cfg_file)])
+
+    assert load_config().web_server_extra_sans == expected


### PR DESCRIPTION
Behind NAT, clients dial a public IP that is on no local interface, so the auto-generated cert's SAN never covers it and iOS/Android reject the connection even with the profile installed.

- Add `web_server_extra_sans` to `xr_media_hub.yaml` for addresses clients dial that the hub can't detect (public IP, forwarding proxy, DNS name)
- Regenerate the cached cert when a configured entry is missing from its SAN; regeneration is additive so entries are never dropped
- Validate config input: scalar/empty/invalid yaml values and unencodable entries are warned about and skipped instead of crashing startup
- Run cert generation in a worker thread
- Documentation and tests

Tested on LAN with iOS end to end; NAT validation pending.
