### PR TITLE
Apple client keyboard fix

### DIFF
--- a/client-samples/ios-visionos/App/ContentView.swift
+++ b/client-samples/ios-visionos/App/ContentView.swift
@@ -101,12 +101,12 @@ struct ContentView: View {
                 TextField("Host / IP", text: $m.host)
                     .autocorrectionDisabled()
                     .textInputAutocapitalization(.never)
-                    #if os(iOS)
-                    .keyboardType(.decimalPad)
+                    #if os(iOS) || os(visionOS)
+                    .keyboardType(.numbersAndPunctuation)
                     #endif
 
                 TextField("Port", text: $m.port)
-                    #if os(iOS)
+                    #if os(iOS) || os(visionOS)
                     .keyboardType(.numberPad)
                     #endif
 
@@ -118,7 +118,7 @@ struct ContentView: View {
                     .autocorrectionDisabled()
                     .textInputAutocapitalization(.never)
                     .onSubmit {}
-                    #if os(iOS)
+                    #if os(iOS) || os(visionOS)
                     .keyboardType(.URL)
                     #endif
 


### PR DESCRIPTION
Apple clients used numpad keyboard for IP address fields, which prevents users from entering an IP address on devices with a regional format that doesn't use a period as a decimal point (e.g. France).