### PR TITLE
Pin LiveKit docker image to v1.13.5

### DIFF
--- a/services/xr-media-hub/xr_media_hub/transport/livekit/_docker.py
+++ b/services/xr-media-hub/xr_media_hub/transport/livekit/_docker.py
@@ -61,6 +61,7 @@ _OUTPUT_CAPTURE_BYTES = 4096  # how much subprocess output to retain for diagnos
 _BANNER = "━" * 56
 
 _CONTAINER_NAME = "xr-ai-livekit-server"
+_LIVEKIT_IMAGE = "livekit/livekit-server:v1.13.5"
 
 
 def _render_livekit_config(cfg: LiveKitConnectorConfig) -> str:
@@ -110,7 +111,7 @@ class LiveKitDocker:
                 "--name", _CONTAINER_NAME,
                 "--network", "host",
                 "-v", f"{cfg_path}:/etc/livekit.yaml:ro",
-                "livekit/livekit-server:latest",
+                _LIVEKIT_IMAGE,
                 "--config", "/etc/livekit.yaml",
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
@@ -310,6 +311,9 @@ def _docker_ready_timeout(timeout: float, port: int, output: str) -> StartupErro
         _BANNER,
         f"  Port    : {port}",
         f"  Timeout : {timeout:.0f}s",
+        "",
+        "  If the image is not cached yet, the pull may still be in flight;",
+        f"  run `docker pull {_LIVEKIT_IMAGE}` and retry.",
         "",
         "  docker output so far (verbatim):",
         _indent(output),

--- a/tests/test_integration_livekit.py
+++ b/tests/test_integration_livekit.py
@@ -37,7 +37,7 @@ from xr_media_hub.transport.livekit.config       import LiveKitConnectorConfig
 pytestmark = [pytest.mark.asyncio, pytest.mark.gpu]
 
 
-_LIVEKIT_IMAGE   = "livekit/livekit-server:latest"
+_LIVEKIT_IMAGE   = _docker_mod._LIVEKIT_IMAGE
 _PORT_OPEN_WAIT  = 30.0   # matches _docker._READY_TIMEOUT
 _PORT_CLOSE_WAIT = 10.0
 

--- a/tests/test_livekit_docker_config.py
+++ b/tests/test_livekit_docker_config.py
@@ -1,14 +1,20 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for the generated LiveKit server configuration."""
+"""Unit tests for the LiveKit server configuration and docker run command."""
 from __future__ import annotations
 
+import asyncio
+import re
 import stat
 from pathlib import Path
 
+import pytest
 import yaml
+from xr_media_hub._errors import StartupError
+from xr_media_hub.transport.livekit import _docker as _docker_mod
 from xr_media_hub.transport.livekit._docker import (
+    LiveKitDocker,
     _render_livekit_config,
     _write_livekit_config,
 )
@@ -43,3 +49,28 @@ def test_livekit_config_file_is_owner_only(tmp_path: Path) -> None:
     _write_livekit_config(cfg_path, LiveKitConnectorConfig())
 
     assert stat.S_IMODE(cfg_path.stat().st_mode) == 0o600
+
+
+def test_livekit_image_is_pinned() -> None:
+    assert re.fullmatch(
+        r"livekit/livekit-server:v\d+\.\d+\.\d+", _docker_mod._LIVEKIT_IMAGE
+    )
+
+
+def test_docker_run_uses_pinned_image(monkeypatch: pytest.MonkeyPatch) -> None:
+    argv: list[str] = []
+
+    async def fake_exec(*cmd: str, **_kwargs: object) -> None:
+        argv.extend(cmd)
+        raise FileNotFoundError
+
+    monkeypatch.setattr(_docker_mod.asyncio, "create_subprocess_exec", fake_exec)
+    monkeypatch.setattr(_docker_mod.subprocess, "run", lambda *a, **k: None)
+
+    with pytest.raises(StartupError):
+        asyncio.run(LiveKitDocker(LiveKitConnectorConfig()).start())
+
+    image_at = argv.index(_docker_mod._LIVEKIT_IMAGE)
+    # Everything after the image is passed to the container, not to docker.
+    assert argv[image_at + 1] == "--config"
+    assert not any(arg.endswith(":latest") for arg in argv)


### PR DESCRIPTION
Pin the LiveKit server Docker image to `v1.13.5` instead of `:latest`, so container boots are reproducible. Adds non-GPU unit tests asserting the `docker run` argv uses the pinned image (so a regression to `:latest` fails PR CI), and a first-run pull hint in the startup-timeout banner.

Fixes #27. Supersedes #347.