### PR TITLE
fix(native): address Sonar telemetry findings

### DIFF
--- a/client-samples/native/App/main.cpp
+++ b/client-samples/native/App/main.cpp
@@ -126,21 +126,26 @@ int main(int argc, char** argv) {
     };
 
     session.on_network_metrics = [](const streamkit::NetworkMetrics& metrics) {
-        const auto quality = [&]() -> std::string_view {
+        const auto quality = [&metrics]() -> std::string_view {
+            using enum streamkit::NetworkQuality;
             switch (metrics.quality) {
-                case streamkit::NetworkQuality::kExcellent: return "excellent";
-                case streamkit::NetworkQuality::kGood: return "good";
-                case streamkit::NetworkQuality::kPoor: return "poor";
-                case streamkit::NetworkQuality::kLost: return "lost";
-                case streamkit::NetworkQuality::kUnknown: return "unknown";
+                case kExcellent: return "excellent";
+                case kGood: return "good";
+                case kPoor: return "poor";
+                case kLost: return "lost";
+                case kUnknown: return "unknown";
             }
             return "unknown";
         }();
         std::cout << "[network] quality=" << quality << " rtt=";
-        if (metrics.round_trip_time_ms) std::cout << *metrics.round_trip_time_ms << "ms";
+        if (metrics.round_trip_time_ms.has_value()) {
+            std::cout << *metrics.round_trip_time_ms << "ms";
+        }
         else std::cout << "—";
         std::cout << " jitter=";
-        if (metrics.receive_jitter_ms) std::cout << *metrics.receive_jitter_ms << "ms";
+        if (metrics.receive_jitter_ms.has_value()) {
+            std::cout << *metrics.receive_jitter_ms << "ms";
+        }
         else std::cout << "—";
         std::cout << "\n";
     };

--- a/client-samples/native/App/main.cpp
+++ b/client-samples/native/App/main.cpp
@@ -140,13 +140,15 @@ int main(int argc, char** argv) {
         std::cout << "[network] quality=" << quality << " rtt=";
         if (metrics.round_trip_time_ms.has_value()) {
             std::cout << *metrics.round_trip_time_ms << "ms";
+        } else {
+            std::cout << "—";
         }
-        else std::cout << "—";
         std::cout << " jitter=";
         if (metrics.receive_jitter_ms.has_value()) {
             std::cout << *metrics.receive_jitter_ms << "ms";
+        } else {
+            std::cout << "—";
         }
-        else std::cout << "—";
         std::cout << "\n";
     };
 

--- a/client-samples/native/StreamKit/Tests/StreamKitTests/LiveKitBackendTests.cpp
+++ b/client-samples/native/StreamKit/Tests/StreamKitTests/LiveKitBackendTests.cpp
@@ -27,12 +27,18 @@
 #include <thread>
 #include <vector>
 
-namespace streamkit {
+namespace {
 
 class CallbackFailure : public std::runtime_error {
 public:
     CallbackFailure() : std::runtime_error("callback failure") {}
 };
+
+struct NonStandardCallbackFailure {};
+
+} // namespace
+
+namespace streamkit {
 
 struct LiveKitBackendTestAccess {
     static std::uint64_t ConnectionEpoch(const LiveKitBackend& backend) {
@@ -176,7 +182,9 @@ int main() {
     Expect(callback_started_future.wait_for(std::chrono::seconds(2)) ==
            std::future_status::ready);
 
-    std::jthread app_disconnect([&callback_backend]() {
+    // The test joins explicitly; jthread would add an unnecessary libc++
+    // requirement without exercising cooperative cancellation.
+    std::thread app_disconnect([&callback_backend]() { // NOSONAR
         callback_backend.Disconnect();
     });
     const auto teardown_deadline = std::chrono::steady_clock::now() +
@@ -227,10 +235,14 @@ int main() {
     throwing_backend.on_network_metrics =
         [&throwing_callback_count,
          &throwing_callback_repeated](const streamkit::NetworkMetrics&) {
-        if (throwing_callback_count.fetch_add(1) == 1) {
+        const int callback_index = throwing_callback_count.fetch_add(1);
+        if (callback_index == 1) {
             throwing_callback_repeated.set_value();
         }
-        throw streamkit::CallbackFailure{};
+        if (callback_index == 0) {
+            throw NonStandardCallbackFailure{}; // NOSONAR - pins catch-all behavior.
+        }
+        throw CallbackFailure{};
     };
     throwing_backend.Connect(streamkit::SessionConfig::Default());
     Expect(throwing_callback_future.wait_for(std::chrono::seconds(3)) ==

--- a/client-samples/native/StreamKit/Tests/StreamKitTests/LiveKitBackendTests.cpp
+++ b/client-samples/native/StreamKit/Tests/StreamKitTests/LiveKitBackendTests.cpp
@@ -29,9 +29,14 @@
 
 namespace streamkit {
 
+class CallbackFailure : public std::runtime_error {
+public:
+    CallbackFailure() : std::runtime_error("callback failure") {}
+};
+
 struct LiveKitBackendTestAccess {
     static std::uint64_t ConnectionEpoch(const LiveKitBackend& backend) {
-        return backend.connection_epoch_.load();
+        return backend.network_metrics_.connection_epoch.load();
     }
 
     static void StopNetworkMetricsReporting(LiveKitBackend& backend) {
@@ -39,12 +44,12 @@ struct LiveKitBackendTestAccess {
     }
 
     static void DeliverNetworkMetrics(LiveKitBackend& backend,
-                                      NetworkMetrics metrics,
+                                      const NetworkMetrics& metrics,
                                       std::uint64_t connection_epoch) {
-        backend.DeliverNetworkMetrics(std::move(metrics), connection_epoch);
+        backend.DeliverNetworkMetrics(metrics, connection_epoch);
     }
 
-    static bool TearDownInProgress(LiveKitBackend& backend) {
+    static bool TearDownInProgress(const LiveKitBackend& backend) {
         return backend.teardown_in_progress_.load();
     }
 };
@@ -137,7 +142,8 @@ int main() {
     streamkit::LiveKitBackend cancelled_connect_backend{lk};
     std::vector<ConnectionState> cancelled_connect_states;
     cancelled_connect_backend.on_connection_state_changed =
-        [&](ConnectionState state) {
+        [&cancelled_connect_backend,
+         &cancelled_connect_states](ConnectionState state) {
             cancelled_connect_states.push_back(state);
             if (state == ConnectionState::kConnecting) {
                 cancelled_connect_backend.Disconnect();
@@ -158,7 +164,9 @@ int main() {
     auto release_callback_future = release_callback.get_future();
     std::promise<void> callback_finished;
     auto callback_future = callback_finished.get_future();
-    callback_backend.on_network_metrics = [&](const streamkit::NetworkMetrics&) {
+    callback_backend.on_network_metrics =
+        [&callback_backend, &callback_finished, &callback_started,
+         &release_callback_future](const streamkit::NetworkMetrics&) {
         callback_started.set_value();
         release_callback_future.wait();
         callback_backend.Disconnect();
@@ -168,7 +176,7 @@ int main() {
     Expect(callback_started_future.wait_for(std::chrono::seconds(2)) ==
            std::future_status::ready);
 
-    std::thread app_disconnect([&callback_backend]() {
+    std::jthread app_disconnect([&callback_backend]() {
         callback_backend.Disconnect();
     });
     const auto teardown_deadline = std::chrono::steady_clock::now() +
@@ -213,14 +221,16 @@ int main() {
     // User callback exceptions are contained at the delivery boundary and do
     // not terminate the telemetry worker.
     streamkit::LiveKitBackend throwing_backend{lk};
-    std::atomic<int> throwing_callback_count{0};
+    std::atomic throwing_callback_count{0};
     std::promise<void> throwing_callback_repeated;
     auto throwing_callback_future = throwing_callback_repeated.get_future();
-    throwing_backend.on_network_metrics = [&](const streamkit::NetworkMetrics&) {
+    throwing_backend.on_network_metrics =
+        [&throwing_callback_count,
+         &throwing_callback_repeated](const streamkit::NetworkMetrics&) {
         if (throwing_callback_count.fetch_add(1) == 1) {
             throwing_callback_repeated.set_value();
         }
-        throw std::runtime_error("callback failure");
+        throw streamkit::CallbackFailure{};
     };
     throwing_backend.Connect(streamkit::SessionConfig::Default());
     Expect(throwing_callback_future.wait_for(std::chrono::seconds(3)) ==

--- a/client-samples/native/StreamKit/include/streamkit/Backends/LiveKit/LiveKitBackend.h
+++ b/client-samples/native/StreamKit/include/streamkit/Backends/LiveKit/LiveKitBackend.h
@@ -173,7 +173,7 @@ private:
     void StartNetworkMetricsReporting();
     void StopNetworkMetricsReporting();
     void PublishNetworkMetrics(std::uint64_t connection_epoch);
-    void DeliverNetworkMetrics(NetworkMetrics metrics,
+    void DeliverNetworkMetrics(const NetworkMetrics& metrics,
                                std::uint64_t connection_epoch);
 
     LiveKitConfig config_;
@@ -202,23 +202,31 @@ private:
     std::atomic<bool> camera_armed_{false};
     std::atomic<bool> audio_armed_{false};
     std::atomic<ConnectionState> last_fired_state_{ConnectionState::kDisconnected};
-    std::atomic<NetworkQuality> network_quality_{NetworkQuality::kUnknown};
-    std::atomic<std::uint64_t> connection_epoch_{0};
     std::atomic<std::uint64_t> connect_generation_{0};
+
     // Serializes liveness checks, delivery, and state transitions. Shared
     // ownership lets a callback finish unlocking if it destroys the backend.
     struct NetworkMetricsDeliveryState {
         std::recursive_mutex mutex;
         bool blocked = true;
     };
-    std::shared_ptr<NetworkMetricsDeliveryState> network_metrics_delivery_ =
-        std::make_shared<NetworkMetricsDeliveryState>();
-    // Protects ownership changes to the stop flag and std::thread. Joining is
-    // deliberately performed after releasing this mutex so a worker callback
-    // can make an overlapping Disconnect() call without deadlocking.
-    std::mutex network_metrics_mutex_;
-    std::shared_ptr<std::atomic<bool>> network_metrics_stop_;
-    std::thread network_metrics_thread_;
+    struct NetworkMetricsState {
+        std::atomic<NetworkQuality> quality{NetworkQuality::kUnknown};
+        std::atomic<std::uint64_t> connection_epoch{0};
+        std::shared_ptr<NetworkMetricsDeliveryState> delivery =
+            std::make_shared<NetworkMetricsDeliveryState>();
+        // Protects ownership changes to the stop flag and thread. Joining is
+        // deliberately performed after releasing this mutex so a worker
+        // callback can make an overlapping Disconnect() call without
+        // deadlocking.
+        std::mutex mutex;
+        std::shared_ptr<std::atomic<bool>> stop;
+        // A callback may destroy the backend on this worker, which requires a
+        // self-detach path that std::jthread cannot support safely.
+        std::thread thread; // NOSONAR
+    };
+    NetworkMetricsState network_metrics_;
+
     // Owns the complete teardown, not just the telemetry thread fields.
     std::recursive_mutex teardown_mutex_;
     std::atomic<bool> teardown_in_progress_{false};

--- a/client-samples/native/StreamKit/include/streamkit/Backends/LiveKit/LiveKitBackend.h
+++ b/client-samples/native/StreamKit/include/streamkit/Backends/LiveKit/LiveKitBackend.h
@@ -219,7 +219,8 @@ private:
         // deliberately performed after releasing this mutex so a worker
         // callback can make an overlapping Disconnect() call without
         // deadlocking.
-        std::mutex mutex;
+        // Lock order: delivery->mutex before thread_mutex; never the reverse.
+        std::mutex thread_mutex;
         std::shared_ptr<std::atomic<bool>> stop;
         // A callback may destroy the backend on this worker, which requires a
         // self-detach path that std::jthread cannot support safely.

--- a/client-samples/native/StreamKit/src/Backends/LiveKit/LiveKitBackend.cpp
+++ b/client-samples/native/StreamKit/src/Backends/LiveKit/LiveKitBackend.cpp
@@ -294,7 +294,7 @@ void LiveKitBackend::StartAudio(const AudioConfig& config) {
     // AEC / AGC / NS toggles on AudioSource — software DSP would go
     // through AudioProcessingModule, tracked as a follow-up.
     StopAudio();
-    std::lock_guard<std::mutex> lock(tracks_mutex_);
+    std::scoped_lock lock(tracks_mutex_);
     audio_source_ = std::make_shared<livekit::AudioSource>(48000, 1, 0);
     audio_track_ = room_->localParticipant()->publishAudioTrack(
         "mic", audio_source_, livekit::TrackSource::SOURCE_MICROPHONE);
@@ -307,7 +307,7 @@ void LiveKitBackend::StartAudio(const AudioConfig& config) {
 
 void LiveKitBackend::StopAudio() {
 #if STREAMKIT_HAVE_LIVEKIT
-    std::lock_guard<std::mutex> lock(tracks_mutex_);
+    std::scoped_lock lock(tracks_mutex_);
     if (audio_track_ && room_) {
         room_->localParticipant()->unpublishTrack(audio_track_->sid());
     }
@@ -339,7 +339,7 @@ void LiveKitBackend::StartCamera(const CameraConfig& config) {
 
 void LiveKitBackend::StopCamera() {
 #if STREAMKIT_HAVE_LIVEKIT
-    std::lock_guard<std::mutex> lock(tracks_mutex_);
+    std::scoped_lock lock(tracks_mutex_);
     if (video_track_ && room_) {
         room_->localParticipant()->unpublishTrack(video_track_->sid());
     }
@@ -409,7 +409,7 @@ void LiveKitBackend::InjectVideoFrame(std::vector<std::uint8_t>&& data,
 
     std::shared_ptr<livekit::VideoSource> source;
     {
-        std::lock_guard<std::mutex> lock(tracks_mutex_);
+        std::scoped_lock lock(tracks_mutex_);
         if (!video_source_) {
             video_source_ = std::make_shared<livekit::VideoSource>(width, height);
             video_track_ = livekit::LocalVideoTrack::createLocalVideoTrack(
@@ -478,7 +478,7 @@ void LiveKitBackend::InjectAudioFrame(std::span<const std::int16_t> pcm,
                               samples_per_channel);
     std::shared_ptr<livekit::AudioSource> source;
     {
-        std::lock_guard<std::mutex> lock(tracks_mutex_);
+        std::scoped_lock lock(tracks_mutex_);
         source = audio_source_;
     }
     if (source) {
@@ -646,7 +646,7 @@ void LiveKitBackend::StartNetworkMetricsReporting() {
     });
     bool installed = false;
     {
-        std::scoped_lock lock(network_metrics_.mutex);
+        std::scoped_lock lock(network_metrics_.thread_mutex);
         if (is_connected_.load()) {
             network_metrics_.stop = stop;
             network_metrics_.thread = std::move(worker);
@@ -664,7 +664,7 @@ void LiveKitBackend::StartNetworkMetricsReporting() {
 void LiveKitBackend::StopNetworkMetricsReporting() {
     std::thread worker_to_join; // NOSONAR - paired with the self-detaching worker.
     {
-        std::scoped_lock lock(network_metrics_.mutex);
+        std::scoped_lock lock(network_metrics_.thread_mutex);
         if (network_metrics_.stop) {
             network_metrics_.stop->store(true);
         }
@@ -826,7 +826,7 @@ void LiveKitBackend::TearDown() {
 
 #if STREAMKIT_HAVE_LIVEKIT
         {
-            std::lock_guard<std::mutex> lock(tracks_mutex_);
+            std::scoped_lock lock(tracks_mutex_);
             video_track_.reset();
             video_source_.reset();
             audio_track_.reset();

--- a/client-samples/native/StreamKit/src/Backends/LiveKit/LiveKitBackend.cpp
+++ b/client-samples/native/StreamKit/src/Backends/LiveKit/LiveKitBackend.cpp
@@ -58,7 +58,10 @@ namespace streamkit {
 
 namespace {
 
-thread_local LiveKitBackend* metrics_callback_backend = nullptr;
+LiveKitBackend*& MetricsCallbackBackend() noexcept {
+    static thread_local LiveKitBackend* backend = nullptr;
+    return backend;
+}
 
 #if STREAMKIT_HAVE_LIVEKIT
 // Lazy one-shot initialise of the SDK's global state. livekit::initialize()
@@ -217,7 +220,7 @@ void LiveKitBackend::Connect(const SessionConfig& session_config) {
         throw MissingTokenError{};
     }
 
-    std::unique_lock<std::recursive_mutex> connect_lock(teardown_mutex_);
+    std::unique_lock connect_lock(teardown_mutex_);
     teardown_complete_.store(false);
     const auto connect_generation = connect_generation_.fetch_add(1) + 1;
     FireStateChanged(ConnectionState::kConnecting);
@@ -536,35 +539,36 @@ void LiveKitBackend::ApplyConnectionState(ConnectionState state) {
     std::uint64_t connection_epoch;
     {
         if (teardown_in_progress_.load() || teardown_complete_.load()) return;
-        std::lock_guard<std::recursive_mutex> delivery_lock(
-            network_metrics_delivery_->mutex);
+        std::scoped_lock delivery_lock(network_metrics_.delivery->mutex);
         if (teardown_in_progress_.load() || teardown_complete_.load()) return;
-        connection_epoch = connection_epoch_.load();
+        connection_epoch = network_metrics_.connection_epoch.load();
         is_connected_.store(true);
-        network_metrics_delivery_->blocked = true;
+        network_metrics_.delivery->blocked = true;
     }
     try {
         FireStateChanged(state);
     } catch (...) {
-        std::lock_guard<std::recursive_mutex> lock(network_metrics_delivery_->mutex);
-        if (is_connected_.load() && connection_epoch_.load() == connection_epoch) {
-            network_metrics_delivery_->blocked = false;
+        std::scoped_lock lock(network_metrics_.delivery->mutex);
+        if (is_connected_.load() &&
+            network_metrics_.connection_epoch.load() == connection_epoch) {
+            network_metrics_.delivery->blocked = false;
         }
         throw;
     }
     {
-        std::lock_guard<std::recursive_mutex> lock(network_metrics_delivery_->mutex);
-        if (is_connected_.load() && connection_epoch_.load() == connection_epoch) {
-            network_metrics_delivery_->blocked = false;
+        std::scoped_lock lock(network_metrics_.delivery->mutex);
+        if (is_connected_.load() &&
+            network_metrics_.connection_epoch.load() == connection_epoch) {
+            network_metrics_.delivery->blocked = false;
         }
     }
 }
 
 void LiveKitBackend::BlockNetworkMetricsDelivery() {
-    const auto delivery = network_metrics_delivery_;
-    std::lock_guard<std::recursive_mutex> lock(delivery->mutex);
+    const auto delivery = network_metrics_.delivery;
+    std::scoped_lock lock(delivery->mutex);
     is_connected_.store(false);
-    connection_epoch_.fetch_add(1);
+    network_metrics_.connection_epoch.fetch_add(1);
     delivery->blocked = true;
 }
 
@@ -594,27 +598,28 @@ void LiveKitBackend::HandleDataReceived(std::string_view topic,
 }
 
 void LiveKitBackend::HandleNetworkQualityChange(int lk_quality) {
+    NetworkQuality quality = NetworkQuality::kUnknown;
 #if STREAMKIT_HAVE_LIVEKIT
     switch (static_cast<livekit::ConnectionQuality>(lk_quality)) {
         case livekit::ConnectionQuality::Excellent:
-            network_quality_.store(NetworkQuality::kExcellent);
+            quality = NetworkQuality::kExcellent;
             break;
         case livekit::ConnectionQuality::Good:
-            network_quality_.store(NetworkQuality::kGood);
+            quality = NetworkQuality::kGood;
             break;
         case livekit::ConnectionQuality::Poor:
-            network_quality_.store(NetworkQuality::kPoor);
+            quality = NetworkQuality::kPoor;
             break;
         case livekit::ConnectionQuality::Lost:
-            network_quality_.store(NetworkQuality::kLost);
+            quality = NetworkQuality::kLost;
             break;
         default:
-            network_quality_.store(NetworkQuality::kUnknown);
             break;
     }
 #else
     (void)lk_quality;
 #endif
+    network_metrics_.quality.store(quality);
 }
 
 void LiveKitBackend::StartNetworkMetricsReporting() {
@@ -622,13 +627,14 @@ void LiveKitBackend::StartNetworkMetricsReporting() {
     auto stop = std::make_shared<std::atomic<bool>>(false);
     std::promise<void> assigned;
     auto assigned_future = assigned.get_future();
-    std::thread worker([this, stop, assigned = std::move(assigned_future)]() mutable {
+    std::thread worker( // NOSONAR - this worker must support self-detach.
+        [this, stop, assigned = std::move(assigned_future)]() mutable {
         // The worker must not call Disconnect() before its std::thread has
-        // been moved into network_metrics_thread_.
+        // been moved into network_metrics_.thread.
         assigned.wait();
         while (!stop->load()) {
             if (is_connected_.load()) {
-                PublishNetworkMetrics(connection_epoch_.load());
+                PublishNetworkMetrics(network_metrics_.connection_epoch.load());
             }
             // PublishNetworkMetrics may invoke a callback that destroys this
             // backend. Only the separately-owned stop flag is safe to touch
@@ -640,10 +646,10 @@ void LiveKitBackend::StartNetworkMetricsReporting() {
     });
     bool installed = false;
     {
-        std::lock_guard<std::mutex> lock(network_metrics_mutex_);
+        std::scoped_lock lock(network_metrics_.mutex);
         if (is_connected_.load()) {
-            network_metrics_stop_ = stop;
-            network_metrics_thread_ = std::move(worker);
+            network_metrics_.stop = stop;
+            network_metrics_.thread = std::move(worker);
             installed = true;
         } else {
             stop->store(true);
@@ -656,20 +662,20 @@ void LiveKitBackend::StartNetworkMetricsReporting() {
 }
 
 void LiveKitBackend::StopNetworkMetricsReporting() {
-    std::thread worker_to_join;
+    std::thread worker_to_join; // NOSONAR - paired with the self-detaching worker.
     {
-        std::lock_guard<std::mutex> lock(network_metrics_mutex_);
-        if (network_metrics_stop_) {
-            network_metrics_stop_->store(true);
+        std::scoped_lock lock(network_metrics_.mutex);
+        if (network_metrics_.stop) {
+            network_metrics_.stop->store(true);
         }
-        if (network_metrics_thread_.joinable()) {
-            if (network_metrics_thread_.get_id() == std::this_thread::get_id()) {
-                network_metrics_thread_.detach();
+        if (network_metrics_.thread.joinable()) {
+            if (network_metrics_.thread.get_id() == std::this_thread::get_id()) {
+                network_metrics_.thread.detach(); // NOSONAR - joining self terminates.
             } else {
-                worker_to_join = std::move(network_metrics_thread_);
+                worker_to_join = std::move(network_metrics_.thread);
             }
         }
-        network_metrics_stop_.reset();
+        network_metrics_.stop.reset();
     }
     if (worker_to_join.joinable()) {
         worker_to_join.join();
@@ -678,7 +684,7 @@ void LiveKitBackend::StopNetworkMetricsReporting() {
 
 void LiveKitBackend::PublishNetworkMetrics(std::uint64_t connection_epoch) {
     NetworkMetrics metrics{
-        .quality = network_quality_.load(),
+        .quality = network_metrics_.quality.load(),
         .round_trip_time_ms = std::nullopt,
         .receive_jitter_ms = std::nullopt,
     };
@@ -689,7 +695,7 @@ void LiveKitBackend::PublishNetworkMetrics(std::uint64_t connection_epoch) {
     try {
         std::vector<std::shared_ptr<livekit::Track>> tracks;
         {
-            std::lock_guard<std::mutex> lock(tracks_mutex_);
+            std::scoped_lock lock(tracks_mutex_);
             if (audio_track_) tracks.push_back(audio_track_);
             if (video_track_) tracks.push_back(video_track_);
         }
@@ -764,32 +770,34 @@ void LiveKitBackend::PublishNetworkMetrics(std::uint64_t connection_epoch) {
                 }
             }
         }
-    } catch (...) {
+    } catch (...) { // NOSONAR - RTC stats are optional and SDK exceptions vary.
         // Quality remains useful while RTCStats is temporarily unavailable.
     }
 #endif
     DeliverNetworkMetrics(metrics, connection_epoch);
 }
 
-void LiveKitBackend::DeliverNetworkMetrics(NetworkMetrics metrics,
+void LiveKitBackend::DeliverNetworkMetrics(const NetworkMetrics& metrics,
                                            std::uint64_t connection_epoch) {
     std::function<void(const NetworkMetrics&)> callback;
-    const auto delivery = network_metrics_delivery_;
-    std::lock_guard<std::recursive_mutex> lock(delivery->mutex);
+    const auto delivery = network_metrics_.delivery;
+    std::scoped_lock lock(delivery->mutex);
     if (delivery->blocked || !is_connected_.load() ||
-        connection_epoch_.load() != connection_epoch || !on_network_metrics) {
+        network_metrics_.connection_epoch.load() != connection_epoch ||
+        !on_network_metrics) {
         return;
     }
     callback = on_network_metrics;
 
-    auto* previous_backend = metrics_callback_backend;
-    metrics_callback_backend = this;
+    auto*& callback_backend = MetricsCallbackBackend();
+    auto* previous_backend = callback_backend;
+    callback_backend = this;
     try {
         callback(metrics);
-    } catch (...) {
+    } catch (...) { // NOSONAR - user callbacks may throw any exception type.
         // User callback failures do not stop telemetry or escape the worker.
     }
-    metrics_callback_backend = previous_backend;
+    callback_backend = previous_backend;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -797,8 +805,8 @@ void LiveKitBackend::DeliverNetworkMetrics(NetworkMetrics metrics,
 // ─────────────────────────────────────────────────────────────────────────────
 
 void LiveKitBackend::TearDown() {
-    std::unique_lock<std::recursive_mutex> teardown_lock(teardown_mutex_, std::defer_lock);
-    if (metrics_callback_backend == this) {
+    std::unique_lock teardown_lock(teardown_mutex_, std::defer_lock);
+    if (MetricsCallbackBackend() == this) {
         // An application-thread teardown may be joining this worker. In that
         // case this call is redundant and must not wait for the owner.
         if (!teardown_lock.try_lock()) return;
@@ -812,7 +820,7 @@ void LiveKitBackend::TearDown() {
     try {
         BlockNetworkMetricsDelivery();
         StopNetworkMetricsReporting();
-        network_quality_.store(NetworkQuality::kUnknown);
+        network_metrics_.quality.store(NetworkQuality::kUnknown);
         camera_armed_.store(false);
         audio_armed_.store(false);
 


### PR DESCRIPTION
## Summary

- fix the actionable Sonar findings in native network telemetry: explicit optional checks and lambda captures, const-correct parameters, CTAD/scoped locks, and a dedicated test exception
- group the telemetry synchronization and lifecycle fields into one cohesive state object
- hide the mutable thread-local callback marker behind an accessor
- retain std::thread/self-detach and catch-all callback boundaries where they are required; annotate those exact lines because std::jthread cannot safely self-join and user callbacks can throw non-standard exceptions

## Sonar audit

This addresses the 36 C++ findings from the August 20 scan. The separate Python S2083 report in lab-instrument-monitoring is not a vulnerability: Sonar followed YAML contents into Path.write_text() as file content, while the destination is a constant filename in an internally created TemporaryDirectory. I documented that flow and resolved the issue as FALSE_POSITIVE in Sonar.

## Validation

- compiled the native sample and all six StreamKit tests directly with Apple clang 21 in C++20 stub mode
- ran all six StreamKit test binaries successfully
- git diff --check

CMake was not installed in the local environment; the direct compiler commands covered the same stub-mode sources and warning flags.