### PR TITLE
Adopt technical writing standards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ skills/          Skill bank that sets coding agents up
   tasks. Agents own their state, resources, lifecycle, background tasks, and
   concurrency policy.
 - Application-specific capabilities stay with their application. Shared
-  process boundaries use typed msgpack/ZMQ services, not MCP.
+  process boundaries use typed msgpack over ZMQ services, not MCP.
 - Image selection and visual inference are separate tools. Selection returns
   lightweight image references; single-image, multi-image, and timestamped
   video-frame query tools resolve them through `VLMService`. Raw media remains
@@ -128,6 +128,37 @@ Comments explain a non-obvious invariant or failure mode. Do not narrate the
 code, debugging history, rejected alternatives, or plans. Keep architectural
 docs about the current system; issue trackers and Git history hold proposals
 and past decisions.
+
+The following house style applies to customer-facing Markdown and
+reStructuredText. Match the surrounding document and keep edits scoped. If a
+task or maintainer establishes a different convention, follow it and update
+this section so the repository guidance remains authoritative.
+
+- **Cross-references:** Introduce documentation links with **Refer to** or
+  **refer to**, not “See” or “see.” Prefer MyST `{doc}` links in Markdown and
+  `:doc:` or `:ref:` roles in reStructuredText. Use a descriptive Markdown link
+  when the target is source code or an external resource, and link directly to
+  the authoritative target rather than through a thin redirect page.
+- **Slashes in prose:** Do not use `/` to mean “or” or “and.” Rewrite with the
+  conjunction or a list. Keep established technical forms such as `I/O`,
+  `iOS/visionOS`, `STUN/TURN`, `VR/AR`, `LLM/VLM`, `pub/sub`, and `and/or`.
+  Keep literal UI text, URLs, paths, endpoints, and code unchanged.
+- **Terminology:** Prefer full words over informal shortenings in paraphrased
+  prose: for example, use **certificate**, not **cert**. Preserve shortenings
+  that are part of literal UI text, logs, filenames, paths, endpoints, or code.
+- **Clarity and consistency:** Use direct word order and specific self-reference
+  nouns such as “This sample,” “This workflow,” or “This reference” instead of
+  “This page” or “This guide.” Keep article usage consistent within a
+  procedure. Hyphenate compound adjectives when they precede a noun.
+- **Requirement strength:** Use **must** for requirements, an imperative for
+  instructions, and explicit softer wording such as **can** or **recommended**
+  for guidance. Avoid ambiguous **should** wording when the intended strength
+  can be stated directly.
+- **Punctuation and headings:** Use a colon to introduce an explanation or
+  list. Use the document's established em-dash style for an aside; do not use a
+  narrative `--`. Keep code markup out of headings when it makes the table of
+  contents or navigation harder to scan. In reStructuredText, make title
+  underlines span the full title.
 
 Use these canonical references when working in their area:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,36 +129,9 @@ code, debugging history, rejected alternatives, or plans. Keep architectural
 docs about the current system; issue trackers and Git history hold proposals
 and past decisions.
 
-The following house style applies to customer-facing Markdown and
-reStructuredText. Match the surrounding document and keep edits scoped. If a
-task or maintainer establishes a different convention, follow it and update
-this section so the repository guidance remains authoritative.
-
-- **Cross-references:** Introduce documentation links with **Refer to** or
-  **refer to**, not “See” or “see.” Prefer MyST `{doc}` links in Markdown and
-  `:doc:` or `:ref:` roles in reStructuredText. Use a descriptive Markdown link
-  when the target is source code or an external resource, and link directly to
-  the authoritative target rather than through a thin redirect page.
-- **Slashes in prose:** Do not use `/` to mean “or” or “and.” Rewrite with the
-  conjunction or a list. Keep established technical forms such as `I/O`,
-  `iOS/visionOS`, `STUN/TURN`, `VR/AR`, `LLM/VLM`, `pub/sub`, and `and/or`.
-  Keep literal UI text, URLs, paths, endpoints, and code unchanged.
-- **Terminology:** Prefer full words over informal shortenings in paraphrased
-  prose: for example, use **certificate**, not **cert**. Preserve shortenings
-  that are part of literal UI text, logs, filenames, paths, endpoints, or code.
-- **Clarity and consistency:** Use direct word order and specific self-reference
-  nouns such as “This sample,” “This workflow,” or “This reference” instead of
-  “This page” or “This guide.” Keep article usage consistent within a
-  procedure. Hyphenate compound adjectives when they precede a noun.
-- **Requirement strength:** Use **must** for requirements, an imperative for
-  instructions, and explicit softer wording such as **can** or **recommended**
-  for guidance. Avoid ambiguous **should** wording when the intended strength
-  can be stated directly.
-- **Punctuation and headings:** Use a colon to introduce an explanation or
-  list. Use the document's established em-dash style for an aside; do not use a
-  narrative `--`. Keep code markup out of headings when it makes the table of
-  contents or navigation harder to scan. In reStructuredText, make title
-  underlines span the full title.
+Follow the authoritative [documentation style](docs/source/guides/documentation-style.md)
+for customer-facing Markdown and reStructuredText. Match the surrounding
+document and keep edits scoped.
 
 Use these canonical references when working in their area:
 

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -654,10 +654,10 @@ Python dependency metadata, so they remain curated here.
 | `services/nemotron3-nano-llm/` | `nemotron3-nano-llm-server` | `nemotron3_nano_llm_server` | 8107 | NVIDIA-Nemotron-3-Nano-30B-A3B (GPU-selected quantization) | vLLM (pip or docker) |
 | `services/nemotron-omni-llm/` | `nemotron-omni-llm-server` | `nemotron_omni_llm_server` | 8108 | Nemotron-3-Nano-Omni-30B-A3B-Reasoning | vLLM (pip or docker), multimodal |
 | `services/embedding-server/` | `embedding-server` | `embedding_server` | 8109 | llama-nemotron-embed-1b-v2 | vLLM (pip or docker) |
-| `services/video-memory-service/` | `xr-video-memory-service` | `video_memory_service` | 8310 | — | Typed msgpack/ZMQ |
+| `services/video-memory-service/` | `xr-video-memory-service` | `video_memory_service` | 8310 | — | Typed RPC using msgpack over ZMQ |
 | `agent-samples/xr-render-demo/scene/` | `xr-render-scene` | `xr_render_scene` | 8320 | — | Sample-local typed scene service |
-| `services/openxr-service/` | `xr-openxr-service` | `openxr_service` | 8330 | — | Typed msgpack/ZMQ |
-| `services/rag-service/` | `xr-rag-service` | `rag_service` | 8340 | — | Typed msgpack/ZMQ |
+| `services/openxr-service/` | `xr-openxr-service` | `openxr_service` | 8330 | — | Typed RPC using msgpack over ZMQ |
+| `services/rag-service/` | `xr-rag-service` | `rag_service` | 8340 | — | Typed RPC using msgpack over ZMQ |
 
 Model weights are cached under the gitignored `models/` directory at the
 repository root. Each service YAML's `model_cache` value is resolved relative to

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ endpoint and no local GPU is required for the agent or hub.
 
 | Requirement | Version | Notes |
 |---|---|---|
-| OS | Linux | Ubuntu 22.04 or 24.04 recommended; WSL2 is not officially supported (refer to [Windows (WSL2)](#windows-wsl2) below) |
+| OS | Linux | Ubuntu 22.04 or 24.04 recommended; WSL2 is not officially supported (refer to [Windows (WSL2)](docs/source/getting_started/requirements.md#windows-wsl2)) |
 | Python | 3.11 or 3.12 | 3.10 and 3.13 are not supported |
 | [uv](https://docs.astral.sh/uv/) | latest | dependency manager used by all samples |
 | NVIDIA driver | 570+ | required for local model inference |
@@ -497,7 +497,7 @@ full setup. Quick steps:
 
 Permissions (`RECORD_AUDIO`, `CAMERA`) are requested at runtime on first use.
 
-### iOS and visionOS
+### iOS / visionOS
 
 Refer to [`client-samples/ios-visionos/README.md`](client-samples/ios-visionos/README.md)
 for full Xcode setup. Quick connection settings:

--- a/README.md
+++ b/README.md
@@ -560,6 +560,7 @@ For engineers and agents working in the repo:
 | Doc | Topic |
 |---|---|
 | [`AGENTS.md`](AGENTS.md) | Working contract — hard rules every change must satisfy |
+| [`docs/source/guides/documentation-style.md`](docs/source/guides/documentation-style.md) | House style for customer-facing Markdown and reStructuredText |
 | [`DEPENDENCIES.md`](DEPENDENCIES.md) | Authoritative dependency map (update with every `pyproject.toml` change) |
 | [Versioned documentation](https://nvidia.github.io/xr-ai/) | Latest release by default, plus `main` development and release-tag documentation |
 | [`skills/README.md`](skills/README.md) | Skill bank: setup skills for coding agents |

--- a/README.md
+++ b/README.md
@@ -497,7 +497,9 @@ full setup. Quick steps:
 
 Permissions (`RECORD_AUDIO`, `CAMERA`) are requested at runtime on first use.
 
-### iOS / visionOS
+<a id="ios--visionos"></a>
+
+### iOS and visionOS
 
 Refer to [`client-samples/ios-visionos/README.md`](client-samples/ios-visionos/README.md)
 for full Xcode setup. Quick connection settings:

--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ endpoint and no local GPU is required for the agent or hub.
 | simple-vlm-example (requires model services) | Uses the model-services allocation |
 | lab-instrument-monitoring (requires model-servers) | ~55 GB (models) + Piper TTS |
 | tea-making-sample (requires model services) | Uses the model-services allocation + <1 GB sample services |
-| xr-render-demo (requires model-servers) | ~55 GB (models) + ~2 GB (hub/TTS) |
+| xr-render-demo (requires model-servers) | ~55 GB (models) + ~2 GB (hub and TTS) |
 | Hub only | none |
 
 **Software**
 
 | Requirement | Version | Notes |
 |---|---|---|
-| OS | Linux | Ubuntu 22.04 / 24.04 recommended; WSL2 is not officially supported (see **Windows (WSL2)** below) |
+| OS | Linux | Ubuntu 22.04 or 24.04 recommended; WSL2 is not officially supported (refer to [Windows (WSL2)](#windows-wsl2) below) |
 | Python | 3.11 or 3.12 | 3.10 and 3.13 are not supported |
 | [uv](https://docs.astral.sh/uv/) | latest | dependency manager used by all samples |
 | NVIDIA driver | 570+ | required for local model inference |
@@ -89,7 +89,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
 The NVIDIA Container Toolkit install is one-time per host. Follow the
-official install guide and run the CDI / runtime-configure steps from
+official install guide and run the CDI and runtime-configuration steps from
 there:
 
 > https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
@@ -114,10 +114,10 @@ stack).  Networking caveats and workarounds:
 
 (All GPU profiles default to `vllm_backend: docker`, so the vLLM
 container ships nvcc + FlashInfer. If you switch a profile to
-`vllm_backend: pip`, see [`docs/source/guides/troubleshooting.md`](docs/source/guides/troubleshooting.md)
+`vllm_backend: pip`, refer to [`docs/source/guides/troubleshooting.md`](docs/source/guides/troubleshooting.md)
 for the host CUDA toolchain prereq.)
 
-If `uv sync` or the VLM fails on first run, see
+If `uv sync` or the VLM fails on first run, refer to
 [`docs/source/guides/troubleshooting.md`](docs/source/guides/troubleshooting.md).
 
 **Network** — open the firewall ports listed in
@@ -133,7 +133,7 @@ frames are dropped if it is closed.
 | Hub service | `services/device-io-hub/` | DeviceIOHub + LiveKit internal transport |
 | Launcher | `utils/xr-ai-launcher/` | stdlib-only process manager used by samples |
 | Logging | `utils/xr-ai-logging/` | shared loguru sink + stdlib bridge for every process |
-| Hub IPC | `agent-sdk/xr-ai-hub/` | Minimal agent-facing msgpack/ZMQ client |
+| Hub IPC | `agent-sdk/xr-ai-hub/` | Minimal agent-facing msgpack over ZMQ client |
 | Agent runtime | `agent-sdk/xr-ai-runtime/` | Agent registration and typed pub/sub routing |
 | Models | `agent-sdk/xr-ai-models/` | Typed model protocols and OpenAI-compatible clients |
 | Voice | `agent-sdk/xr-ai-voice/` | Voice agent, session, transport, and pipeline |
@@ -141,7 +141,7 @@ frames are dropped if it is closed.
 | Agent tools | `agent-sdk/xr-ai-tools/` | Toolkit-independent Relay-managed native tools, including QR and ArUco marker tracking |
 | Reusable services | `services/` | Model-serving and typed capability processes |
 | Agent demos | `agent-samples/` | End-to-end agent pipelines |
-| Tests | `tests/` | Multi-client / multi-agent integration tests |
+| Tests | `tests/` | Multi-client and multi-agent integration tests |
 
 Samples split model loading from the application stack: start shared model
 services once, then run samples as many times as you like without reloading
@@ -153,14 +153,14 @@ combines a deterministic foreground workflow with file-backed transcript and
 visual background tasks, using Nemotron-3-Nano-Omni for both language and vision.
 
 Every sample worker depends on `agent-sdk/xr-ai-models` — one SDK that
-abstracts the OpenAI-compatible HTTP wire format for LLM / VLM / STT / TTS /
+abstracts the OpenAI-compatible HTTP wire format for LLM, VLM, STT, TTS, and
 embeddings behind typed service protocols. Model profiles name the logical roles
 (`llm`, `vlm`, `stt`, …) and separate adapter behavior, endpoint connectivity,
 and deployment ownership. Presets pre-fill model-specific quirks
 (reasoning-field aliasing, `chat_template_kwargs`, served-model-name strings).
-Workers call
-`make_llm(config, "llm")` / `make_vlm(config, "vlm")` / `make_stt(config,
-"stt")` / `make_tts(config, "tts")` / `make_embedding(config, "embedding")` — no hand-rolled httpx clients, no model
+Workers call `make_llm(config, "llm")`, `make_vlm(config, "vlm")`,
+`make_stt(config, "stt")`, `make_tts(config, "tts")`, or
+`make_embedding(config, "embedding")` — no hand-rolled httpx clients, no model
 quirks leaking out of the SDK.  Full quickstart and the built-in preset
 table: [`agent-sdk/xr-ai-models/README.md`](agent-sdk/xr-ai-models/README.md).
 
@@ -196,7 +196,7 @@ uv sync
 uv run model_servers
 ```
 
-Known GPU profiles are auto-detected (`dual_48G_ada` / `spark` /
+Known GPU profiles are auto-detected (`dual_48G_ada`, `spark`, or
 `96G_blackwell`). Unsupported or ambiguous topologies stop with the complete
 inventory instead of assuming a profile; use `--gpu-profile NAME` only after
 copying and reviewing a custom YAML profile for that hardware.
@@ -219,7 +219,7 @@ uv run model_servers --models vlm_llm_nim
 ```
 
 `HF_TOKEN` is required by default: without it the roughly 60 GB first-run download
-can stall indefinitely.  See [`docs/source/getting_started/credentials.md`](docs/source/getting_started/credentials.md)
+can stall indefinitely. Refer to [`docs/source/getting_started/credentials.md`](docs/source/getting_started/credentials.md)
 for how to set it, or pass `--allow-anonymous` to run without one.
 
 To stop all model servers when done:
@@ -240,11 +240,11 @@ The packaged worker uses `CurrentFrameTool` to select an image, then passes its
 lightweight reference to `StreamingImageQueryTool` inside `SimpleVlmAgent` and
 publishes the result chunks to `VoiceAgent`. The same inference path supports
 one image, ordered image collections, and timestamped frame sequences. Pipecat
-remains private to the voice runtime and no MCP client is involved. See the
+remains private to the voice runtime and no MCP client is involved. Refer to the
 [sample README](agent-samples/simple-vlm-example/README.md) for the worker
 layout and configuration boundaries.
 
-Uses the text-output Reasoner from `nvidia/Cosmos3-Nano` by default. See the
+Uses the text-output Reasoner from `nvidia/Cosmos3-Nano` by default. Refer to the
 [VLM server notes](docs/source/components/ai-services.md#per-server-notes) for
 runtime-selection details.
 
@@ -287,11 +287,11 @@ appears, but the agent answers queries only after the launcher prints its
 #### Step 2 — Connect a client
 
 Open `https://localhost:8080` in a browser.  The samples ship with HTTPS
-on by default (a self-signed cert is generated on first run at
+on by default (a self-signed certificate is generated on first run at
 `~/.local/share/xr-ai/web-server.crt`), so you'll see a "Your connection
 is not private" warning the first time — click **Advanced → Proceed**
-(Chrome/Edge) or **Accept the Risk and Continue** (Firefox).  See
-[`docs/source/getting_started/networking.md`](docs/source/getting_started/networking.md) for trusting the cert
+(Chrome/Edge) or **Accept the Risk and Continue** (Firefox). Refer to
+[`docs/source/getting_started/networking.md`](docs/source/getting_started/networking.md) for trusting the certificate
 permanently or running over plain HTTP instead.
 
 Leave **Token URL** blank — the web client fetches a token from the server
@@ -318,7 +318,7 @@ To use compatible services at different locations, edit their endpoints in
 The sample has no deployment-profile selector; every configured service stays
 operator-owned.
 
-Each sample has its own `device_io_hub.yaml` controlling the hub; see
+Each sample has its own `device_io_hub.yaml` controlling the hub. Refer to
 [`services/device-io-hub/device_io_hub.yaml`](services/device-io-hub/device_io_hub.yaml)
 for the full option list.
 
@@ -366,7 +366,7 @@ operation and the routing eval.
 Speak to the web client and a sphere in the streamed scene tracks your
 voice — radius follows loudness, colour and position follow spoken commands
 ("make it red", "put it to my left", "where I'm looking"). Runs against a
-Quest 3 / Vision Pro on the same LAN, or the IWER emulator built into the
+Quest 3 or Vision Pro on the same LAN, or the IWER emulator built into the
 web client for desktop dev.
 
 Under the hood, the orchestrator launches the hub, CloudXR runtime, typed
@@ -415,9 +415,10 @@ uv sync
 uv run xr_render_demo
 ```
 
-By default this serves the web / WebRTC client (`NV_DEVICE_PROFILE=auto-webrtc`).
+By default this serves the web-based WebRTC client
+(`NV_DEVICE_PROFILE=auto-webrtc`).
 For a native Apple Vision Pro client, start it with `NV_DEVICE_PROFILE=auto-native`
-instead — see [`docs/source/reference/xr-render-demo.md`](docs/source/reference/xr-render-demo.md#selecting-the-client-type-webrtc-vs-native).
+instead. Refer to [`docs/source/reference/xr-render-demo.md`](docs/source/reference/xr-render-demo.md#selecting-the-client-type-webrtc-vs-native).
 
 On first run the orchestrator automatically downloads the pinned LOVR version to
 `deps/lovr/` inside the repo and builds the web vendor bundle (requires npm
@@ -425,7 +426,7 @@ and network access). Both steps are skipped on subsequent runs.
 
 **DGX Spark (aarch64):** LOVR does not publish a prebuilt aarch64 Linux
 binary, so the auto-download is not available — build LOVR from source and
-export `LOVR_BIN`. See
+export `LOVR_BIN`. Refer to
 [`docs/source/guides/troubleshooting.md`](docs/source/guides/troubleshooting.md#dgx-spark--lovr-auto-download-is-not-supported).
 
 To use a custom LOVR build:
@@ -438,7 +439,7 @@ uv run xr_render_demo
 **GPU pinning** for the XR side is controlled by `gpu_index` in
 `agent-samples/xr-render-demo/yaml/cloudxr_runtime.yaml`. cloudxr-runtime
 applies the pin to its own process and writes the selectors into
-`cloudxr.env`; the scene process and LOVR inherit from that file. See
+`cloudxr.env`; the scene process and LOVR inherit from that file. Refer to
 [`docs/source/reference/xr-render-demo.md`](docs/source/reference/xr-render-demo.md#gpu-pinning-for-the-xr-side)
 for full details.
 
@@ -470,9 +471,10 @@ The hub auto-discovers `services/device-io-hub/device_io_hub.yaml`.
 ### Web
 
 Open `https://localhost:8080` in a browser.  The samples ship with HTTPS
-on by default; the first connection shows a self-signed cert warning that
-you click through (or trust permanently — see
-[`docs/source/getting_started/networking.md`](docs/source/getting_started/networking.md)).  Leave **Token URL** blank to
+on by default; the first connection shows a self-signed certificate warning
+that you click through. To trust the certificate permanently, refer to
+[`docs/source/getting_started/networking.md`](docs/source/getting_started/networking.md).
+Leave **Token URL** blank to
 use the server's built-in `/token` endpoint, or paste the printed token
 directly.
 
@@ -480,12 +482,12 @@ The page's import map loads `livekit-client` and `@nvidia/cloudxr` from
 `client-samples/web/vendor/` (same-origin, so XR headsets and offline LANs
 work).  Both bundles are gitignored build output.  The xr-render-demo
 orchestrator builds them automatically on first run (requires npm on PATH).
-For a manual rebuild after an SDK bump, see
+For a manual rebuild after an SDK bump, refer to
 [`client-samples/web-xr-build/README.md`](client-samples/web-xr-build/README.md).
 
 ### Android
 
-See [`client-samples/android/README.md`](client-samples/android/README.md) for
+Refer to [`client-samples/android/README.md`](client-samples/android/README.md) for
 full setup. Quick steps:
 
 1. Open `client-samples/android/` in Android Studio (Hedgehog or later).
@@ -495,9 +497,9 @@ full setup. Quick steps:
 
 Permissions (`RECORD_AUDIO`, `CAMERA`) are requested at runtime on first use.
 
-### iOS / visionOS
+### iOS and visionOS
 
-See [`client-samples/ios-visionos/README.md`](client-samples/ios-visionos/README.md)
+Refer to [`client-samples/ios-visionos/README.md`](client-samples/ios-visionos/README.md)
 for full Xcode setup. Quick connection settings:
 
 | Field | Value |
@@ -510,30 +512,31 @@ The token is valid for 24 hours. To get a fresh one restart the server or call
 `GET https://<host>:8080/token?identity=<name>`.
 
 > **One-time per device:** the LiveKit Swift SDK does not expose a
-> server-trust hook, so iOS rejects the hub's self-signed cert until you
+> server-trust hook, so iOS rejects the hub's self-signed certificate until you
 > install it as a trusted profile. On the device, open
 > `https://<host>:8080/cert` in Safari → bypass the warning → install →
 > enable **Settings → General → About → Certificate Trust Settings →
 > Enable Full Trust**. Full walkthrough plus recovery for the common
 > failure modes is in
 > [`client-samples/ios-visionos/README.md`](client-samples/ios-visionos/README.md)
-> under "Trusting the hub's self-signed cert".
+> under its certificate-trust section.
 
 ## Networking
 
-The hub and CloudXR runtime use a small set of TCP/UDP ports (web client +
-wss /rtc proxy on 8080, WebRTC fallbacks on 7881/TCP + 7882/UDP, CloudXR
+The hub and CloudXR runtime use a small set of TCP/UDP ports (web client and
+`/rtc` WSS proxy on 8080, WebRTC fallbacks on 7881/TCP and 7882/UDP, CloudXR
 WSS proxy on 48322). LiveKit's native 7880 stays on loopback — clients
 connect through the same-origin wss proxy, not directly. Full table and
-distro-specific `ufw` / `firewall-cmd` recipes are in
-[`docs/source/getting_started/networking.md`](docs/source/getting_started/networking.md). The same doc covers HTTPS for
-the web client and self-signed certificate trust on each browser.
+distro-specific `ufw` and `firewall-cmd` recipes are in
+[`docs/source/getting_started/networking.md`](docs/source/getting_started/networking.md).
+The networking reference also covers HTTPS for the web client and self-signed
+certificate trust on each browser.
 
 ## Tests
 
-`tests/` contains the multi-client / multi-agent integration suite. The
+`tests/` contains the multi-client and multi-agent integration suite. The
 core IPC tests run without Docker or LiveKit — they spin up real
-`HubEndpoint` / `ConnectorEndpoint` / `ProcessorEndpoint` instances over
+`HubEndpoint`, `ConnectorEndpoint`, and `ProcessorEndpoint` instances over
 `ipc://` sockets and verify routing, isolation, and the
 `ReturnAudioFlush` control path.
 
@@ -543,7 +546,7 @@ uv sync
 uv run pytest -v
 ```
 
-See [`tests/README.md`](tests/README.md) for the full breakdown. CI runs
+Refer to [`tests/README.md`](tests/README.md) for the full breakdown. CI runs
 the suite on every push and pull request via
 [`.github/workflows/tests.yml`](.github/workflows/tests.yml) on Python 3.11
 and 3.12.
@@ -559,13 +562,13 @@ For engineers and agents working in the repo:
 | [Versioned documentation](https://nvidia.github.io/xr-ai/) | Latest release by default, plus `main` development and release-tag documentation |
 | [`skills/README.md`](skills/README.md) | Skill bank: setup skills for coding agents |
 | [`docs/source/overview/architecture.md`](docs/source/overview/architecture.md) | System topology, runtime data paths, ownership, and extension boundaries |
-| [`docs/source/components/launcher-and-process-model.md`](docs/source/components/launcher-and-process-model.md) | `Process` / `run_stack` mechanics; ready-file protocol |
-| [`docs/source/components/ai-services.md`](docs/source/components/ai-services.md) | VLM / STT / TTS / LLM / embedding server reference + worker call examples |
-| [`docs/source/reference/xr-render-demo.md`](docs/source/reference/xr-render-demo.md) | xr-render-demo architecture: native functions, supervisor + subagents, XR lifecycle |
+| [`docs/source/components/launcher-and-process-model.md`](docs/source/components/launcher-and-process-model.md) | `Process` and `run_stack` mechanics; ready-file protocol |
+| [`docs/source/components/ai-services.md`](docs/source/components/ai-services.md) | VLM, STT, TTS, LLM, and embedding server reference with worker call examples |
+| [`docs/source/reference/xr-render-demo.md`](docs/source/reference/xr-render-demo.md) | xr-render-demo architecture: native functions, supervisor and subagents, XR lifecycle |
 | [`docs/source/guides/adding-a-sample.md`](docs/source/guides/adding-a-sample.md) | Boilerplate for scaffolding a new sample |
 | [`docs/source/guides/adding-cloudxr.md`](docs/source/guides/adding-cloudxr.md) | Wiring CloudXR into a sample |
-| [`docs/source/getting_started/credentials.md`](docs/source/getting_started/credentials.md) | HF / NGC token management |
-| [`docs/source/getting_started/networking.md`](docs/source/getting_started/networking.md) | Firewall ports + HTTPS for the web client |
+| [`docs/source/getting_started/credentials.md`](docs/source/getting_started/credentials.md) | HF and NGC token management |
+| [`docs/source/getting_started/networking.md`](docs/source/getting_started/networking.md) | Firewall ports and HTTPS for the web client |
 | [`docs/source/guides/troubleshooting.md`](docs/source/guides/troubleshooting.md) | Known frictions and runtime symptoms |
 | [`docs/source/guides/spdx-headers.md`](docs/source/guides/spdx-headers.md) | SPDX header style and enforcement |
 

--- a/agent-samples/tea-making-sample/README.md
+++ b/agent-samples/tea-making-sample/README.md
@@ -102,7 +102,8 @@ development network or put it behind an authenticated TLS proxy.
   `voice_gate_yaml: voice_gate.always-on.yaml` in the worker YAML to dispatch
   every finalized utterance without a wake phrase.
 - `yaml/rag_service.yaml` indexes Markdown and text files under
-  `rag-documents/` and exposes retrieval over typed msgpack/ZMQ RPC.
+  `rag-documents/` and exposes retrieval through typed RPC using msgpack over
+  ZMQ.
 
 The model configuration declares LLM, VLM, STT, embedding, and TTS as reusable.
 Their health checks must pass before voice input becomes ready. The sample owns

--- a/agent-sdk/README.md
+++ b/agent-sdk/README.md
@@ -10,7 +10,7 @@ its own environment and README.
 
 | Directory | Import | Distribution | Use it for |
 |---|---|---|---|
-| [`xr-ai-hub`](xr-ai-hub/) | `xr_ai_hub` | `xr-ai-hub-client` | Minimal msgpack/ZMQ IPC with DeviceIOHub |
+| [`xr-ai-hub`](xr-ai-hub/) | `xr_ai_hub` | `xr-ai-hub-client` | Minimal IPC with DeviceIOHub using msgpack over ZMQ |
 | [`xr-ai-models`](xr-ai-models/) | `xr_ai_models` | `xr-ai-models` | Typed model services and OpenAI-compatible clients |
 | [`xr-ai-runtime`](xr-ai-runtime/) | `xr_ai_runtime` | `xr-ai-agent-runtime` | Agent registration and typed publish/fan-out |
 | [`xr-ai-tools`](xr-ai-tools/) | `xr_ai_tools` | `xr-ai-tools` | Relay-managed tools and model tool-call helpers |

--- a/agent-sdk/xr-ai-models/README.md
+++ b/agent-sdk/xr-ai-models/README.md
@@ -151,7 +151,7 @@ profile remains the authority for credentials: callers cannot supply an
 `stream_images()`. Multi-image calls preserve caller order and place every
 image in one OpenAI-compatible user message before the question.
 
-## Remote and hosted NIM endpoints
+## Remote / hosted-NIM endpoints
 
 Cloud and remote endpoints, such as hosted [NVIDIA NIM](https://build.nvidia.com),
 are a profile change:
@@ -180,7 +180,7 @@ are a profile change:
 without that route use `readiness: none`, which makes
 `health()` return `True` without a request — otherwise a worker's readiness
 gate would block forever. Refer to
-[`AI services`](https://github.com/NVIDIA/xr-ai/blob/main/docs/source/components/ai-services.md)
+[AI services](../../docs/source/components/ai-services.md)
 for hosted endpoint operation.
 
 ## Riva gRPC speech (NIM STT/TTS)

--- a/agent-sdk/xr-ai-models/README.md
+++ b/agent-sdk/xr-ai-models/README.md
@@ -151,7 +151,9 @@ profile remains the authority for credentials: callers cannot supply an
 `stream_images()`. Multi-image calls preserve caller order and place every
 image in one OpenAI-compatible user message before the question.
 
-## Remote / hosted-NIM endpoints
+<a id="remote-hosted-nim-endpoints"></a>
+
+## Remote and hosted NIM endpoints
 
 Cloud and remote endpoints, such as hosted [NVIDIA NIM](https://build.nvidia.com),
 are a profile change:

--- a/agent-sdk/xr-ai-models/README.md
+++ b/agent-sdk/xr-ai-models/README.md
@@ -47,7 +47,7 @@ async with make_llm(config, "agent_llm") as llm:
 }
 ```
 
-Built-in presets — see `xr_ai_models/presets/`:
+Built-in presets are in `xr_ai_models/presets/`:
 
 | Preset | Service it targets | Notes |
 |---|---|---|
@@ -151,9 +151,9 @@ profile remains the authority for credentials: callers cannot supply an
 `stream_images()`. Multi-image calls preserve caller order and place every
 image in one OpenAI-compatible user message before the question.
 
-## Remote / hosted-NIM endpoints
+## Remote and hosted NIM endpoints
 
-Cloud / remote endpoints (e.g. hosted [NVIDIA NIM](https://build.nvidia.com))
+Cloud and remote endpoints, such as hosted [NVIDIA NIM](https://build.nvidia.com),
 are a profile change:
 
 ```json
@@ -179,8 +179,9 @@ are a profile change:
 `readiness: health` makes `health()` probe `base_url/health`. Remote endpoints
 without that route use `readiness: none`, which makes
 `health()` return `True` without a request — otherwise a worker's readiness
-gate would block forever. See
-`docs/source/components/ai-services.md` for hosted endpoint operation.
+gate would block forever. Refer to
+[`AI services`](https://github.com/NVIDIA/xr-ai/blob/main/docs/source/components/ai-services.md)
+for hosted endpoint operation.
 
 ## Riva gRPC speech (NIM STT/TTS)
 

--- a/agent-sdk/xr-ai-models/README.md
+++ b/agent-sdk/xr-ai-models/README.md
@@ -151,6 +151,7 @@ profile remains the authority for credentials: callers cannot supply an
 `stream_images()`. Multi-image calls preserve caller order and place every
 image in one OpenAI-compatible user message before the question.
 
+<a id="remote--hosted-nim-endpoints"></a>
 <a id="remote-hosted-nim-endpoints"></a>
 
 ## Remote and hosted NIM endpoints

--- a/agent-sdk/xr-ai-runtime/README.md
+++ b/agent-sdk/xr-ai-runtime/README.md
@@ -88,7 +88,7 @@ work is responsible for controlling them, including creating, cancelling, and
 awaiting its own tasks. The runtime neither knows nor controls whether an
 agent's internal work is running. `publish()` waits for every fan-out delivery
 to settle before propagating any subscriber failures. Subscriber callbacks
-must hand off lengthy work to agent-owned bounded queues and return promptly.
+should hand off lengthy work to agent-owned bounded queues and return promptly.
 
 Topics default to `telemetry="full"`. High-cardinality transport topics use
 `"none"` when their consumer aggregates fragments and records one semantic

--- a/agent-sdk/xr-ai-runtime/README.md
+++ b/agent-sdk/xr-ai-runtime/README.md
@@ -88,7 +88,7 @@ work is responsible for controlling them, including creating, cancelling, and
 awaiting its own tasks. The runtime neither knows nor controls whether an
 agent's internal work is running. `publish()` waits for every fan-out delivery
 to settle before propagating any subscriber failures. Subscriber callbacks
-should hand off lengthy work to agent-owned bounded queues and return promptly.
+must hand off lengthy work to agent-owned bounded queues and return promptly.
 
 Topics default to `telemetry="full"`. High-cardinality transport topics use
 `"none"` when their consumer aggregates fragments and records one semantic

--- a/agent-sdk/xr-ai-tools/README.md
+++ b/agent-sdk/xr-ai-tools/README.md
@@ -111,9 +111,9 @@ instances are consumed explicitly with `stream()`.
 
 ## Typed capability services
 
-Install `xr-ai-tools[services]` for the msgpack/ZMQ RPC client/server and the
-shared tracking, video-memory, text-memory, and spatial
-building blocks. Applications compose these finite tools into their own
+Install `xr-ai-tools[services]` for the msgpack over ZMQ RPC client, server,
+and shared tracking, video-memory, text-memory, and spatial building blocks.
+Applications compose these finite tools into their own
 `ToolSet`; service processes use the matching RPC primitives without pulling
 in an agent framework or HTTP server.
 
@@ -261,10 +261,10 @@ uv run xr_ai_tools/utilities/generate_marker.py aruco 42 \
 ```
 
 Run these commands from `agent-sdk/xr-ai-tools/`. Both commands produce square
-512-pixel PNGs by default; use `--help` to see sizing and border options.
+512-pixel PNGs by default; run them with `--help` for sizing and border options.
 
 Call `release(participant_id)` when a participant disconnects. Applications
-that expose the tool to a model should inject the active participant identity
+that expose the tool to a model must inject the active participant identity
 at their workflow boundary, as they do for other participant-scoped tools.
 
 ## Magenta polygon image editing

--- a/agent-sdk/xr-ai-voice/README.md
+++ b/agent-sdk/xr-ai-voice/README.md
@@ -166,7 +166,7 @@ Transcript publication uses one private bounded FIFO owned by `VoiceAgent`, so
 a slow runtime subscriber cannot delay STT, voice gating, or accepted queries.
 The queue preserves order and drops its oldest pending transcript when full;
 shutdown cancels the active delivery and discards pending transcripts. Runtime
-subscribers must enqueue long-running work internally and return promptly.
+subscribers should enqueue long-running work internally and return promptly.
 
 Accepted speech, typed text, participant lifecycle, and interruption remain on
 application-named topics. Pass `participant_joined_topic` and/or

--- a/agent-sdk/xr-ai-voice/README.md
+++ b/agent-sdk/xr-ai-voice/README.md
@@ -87,7 +87,7 @@ async with runtime:
         await aggregation.stop()
 ```
 
-Applications should call `await aggregation.release(participant_id)` from
+Applications must call `await aggregation.release(participant_id)` from
 their participant-left subscriber so buffered speech and stream state are
 discarded as soon as that participant departs. The application owns its
 lifecycle topic; the shared aggregator therefore exposes cleanup directly
@@ -166,7 +166,7 @@ Transcript publication uses one private bounded FIFO owned by `VoiceAgent`, so
 a slow runtime subscriber cannot delay STT, voice gating, or accepted queries.
 The queue preserves order and drops its oldest pending transcript when full;
 shutdown cancels the active delivery and discards pending transcripts. Runtime
-subscribers should enqueue long-running work internally and return promptly.
+subscribers must enqueue long-running work internally and return promptly.
 
 Accepted speech, typed text, participant lifecycle, and interruption remain on
 application-named topics. Pass `participant_joined_topic` and/or

--- a/docs/source/components/agent-sdk.md
+++ b/docs/source/components/agent-sdk.md
@@ -35,7 +35,7 @@ direct execution and model tool-call loops. Bounded turns use `ToolSet` and
 retries, participant context, cancellation, and task ownership. `AgentRuntime`
 owns only typed publication and delivery tasks; it does not own model loops,
 planning, memory, media, or agent-created work. A publication waits for its
-subscribers, so a subscriber that performs lengthy work must hand the work to
+subscribers, so a subscriber that performs lengthy work should hand the work to
 its own bounded queue.
 
 Workers construct model clients with the factories in `xr_ai_models` and depend

--- a/docs/source/components/agent-sdk.md
+++ b/docs/source/components/agent-sdk.md
@@ -11,7 +11,7 @@ installation.
 
 | Directory | Import | Responsibility |
 |---|---|---|
-| `xr-ai-hub` | `xr_ai_hub` | Minimal msgpack over ZMQ IPC with DeviceIOHub |
+| `xr-ai-hub` | `xr_ai_hub` | Minimal IPC with DeviceIOHub using msgpack over ZMQ |
 | `xr-ai-models` | `xr_ai_models` | Typed model protocols, profiles, and OpenAI-compatible clients |
 | `xr-ai-runtime` | `xr_ai_runtime` | Agent registration and typed participant-scoped fan-out |
 | `xr-ai-tools` | `xr_ai_tools` | Relay-managed tools and model tool-call helpers |

--- a/docs/source/components/agent-sdk.md
+++ b/docs/source/components/agent-sdk.md
@@ -11,7 +11,7 @@ installation.
 
 | Directory | Import | Responsibility |
 |---|---|---|
-| `xr-ai-hub` | `xr_ai_hub` | Minimal msgpack/ZMQ IPC with DeviceIOHub |
+| `xr-ai-hub` | `xr_ai_hub` | Minimal msgpack over ZMQ IPC with DeviceIOHub |
 | `xr-ai-models` | `xr_ai_models` | Typed model protocols, profiles, and OpenAI-compatible clients |
 | `xr-ai-runtime` | `xr_ai_runtime` | Agent registration and typed participant-scoped fan-out |
 | `xr-ai-tools` | `xr_ai_tools` | Relay-managed tools and model tool-call helpers |
@@ -35,13 +35,13 @@ direct execution and model tool-call loops. Bounded turns use `ToolSet` and
 retries, participant context, cancellation, and task ownership. `AgentRuntime`
 owns only typed publication and delivery tasks; it does not own model loops,
 planning, memory, media, or agent-created work. A publication waits for its
-subscribers, so a subscriber that performs lengthy work should hand it to its
-own bounded queue.
+subscribers, so a subscriber that performs lengthy work must hand the work to
+its own bounded queue.
 
 Workers construct model clients with the factories in `xr_ai_models` and depend
 on the corresponding typed service protocols. Adapter behavior, endpoint
 connectivity, deployment ownership, credentials, and model-specific wire
-details remain inside that package. See {doc}`ai-services` for deployment and
+details remain inside that package. Refer to {doc}`ai-services` for deployment and
 operational guidance.
 
 `VoiceAgent` owns readiness, hub transport, voice gating, its private media
@@ -57,7 +57,7 @@ Applications may publish selected compact payloads to `WEB_EVENT_TOPIC` for a
 `WebEventsAgent` to display. The viewer owns only a bounded live history and a
 loopback HTTP listener. It is not persistence, does not inspect every runtime
 topic, and does not enter model, voice, media, or hub authentication paths. The
-application selects which typed events to forward explicitly.
+application explicitly selects which typed events to forward.
 
 Applications with multiple speech producers may place
 `VoiceAggregationAgent` before `VoiceAgent`. Producers publish candidate
@@ -76,7 +76,7 @@ interrupts active speech. Interrupted stream IDs remain quarantined through
 their terminator or idle expiry, and the agent enforces its rewrite deadline
 independently of the model transport. This
 policy remains outside the private media pipeline so applications opt in
-explicitly and retain ownership of which events should become speech.
+explicitly and retain ownership of which events become speech.
 
 `ProcessorEndpoint` is the minimal agent-side hub boundary. It receives data,
 audio, frame signals, and participant events and sends participant-routed return

--- a/docs/source/components/ai-services.md
+++ b/docs/source/components/ai-services.md
@@ -101,7 +101,7 @@ PROCESSES = [
     Process("hub",    "../../services/device-io-hub",                    "device_io_hub"),
     Process("vlm",    "../../services/vlm-server",               "vlm_server"),   # ← add as needed
     # Pick ONE LLM backend per sample — they bind different default ports
-    # (8106 / 8107) so running more than one at once is allowed but
+    # (8106 or 8107) so running more than one at once is allowed but
     # usually unnecessary.
     Process("llm",    "../../services/llama-nemotron-llm",       "llama_nemotron_llm_server"),
     # Process("llm",  "../../services/nemotron3-nano-llm",       "nemotron3_nano_llm_server"),
@@ -508,7 +508,7 @@ cleanup.
 - **piper-tts** serves any rhasspy/piper-voices ONNX voice; ~100 ms/sentence on CPU.
   All inference runs in a thread pool so the asyncio loop is never blocked.
 - **video-memory-service** owns recorded chunk queries, NVDEC, and PNG output
-  behind typed msgpack/ZMQ on port 8310. Set `recordings_dir` in its YAML to
+  behind typed msgpack over ZMQ on port 8310. Set `recordings_dir` in its YAML to
   enable recorded-video operations; the path must match the hub's
   `video_recording.out_dir`. Latest video and sampling windows end at the
   newest recorded timestamp and require only a duration. Historical frame,

--- a/docs/source/components/ai-services.md
+++ b/docs/source/components/ai-services.md
@@ -101,7 +101,7 @@ PROCESSES = [
     Process("hub",    "../../services/device-io-hub",                    "device_io_hub"),
     Process("vlm",    "../../services/vlm-server",               "vlm_server"),   # ← add as needed
     # Pick ONE LLM backend per sample — they bind different default ports
-    # (8106 or 8107) so running more than one at once is allowed but
+    # (8106 / 8107) so running more than one at once is allowed but
     # usually unnecessary.
     Process("llm",    "../../services/llama-nemotron-llm",       "llama_nemotron_llm_server"),
     # Process("llm",  "../../services/nemotron3-nano-llm",       "nemotron3_nano_llm_server"),

--- a/docs/source/components/ai-services.md
+++ b/docs/source/components/ai-services.md
@@ -101,7 +101,7 @@ PROCESSES = [
     Process("hub",    "../../services/device-io-hub",                    "device_io_hub"),
     Process("vlm",    "../../services/vlm-server",               "vlm_server"),   # ← add as needed
     # Pick ONE LLM backend per sample — they bind different default ports
-    # (8106 / 8107) so running more than one at once is allowed but
+    # (8106 or 8107) so running more than one at once is allowed but
     # usually unnecessary.
     Process("llm",    "../../services/llama-nemotron-llm",       "llama_nemotron_llm_server"),
     # Process("llm",  "../../services/nemotron3-nano-llm",       "nemotron3_nano_llm_server"),

--- a/docs/source/components/launcher-and-process-model.md
+++ b/docs/source/components/launcher-and-process-model.md
@@ -106,8 +106,8 @@ the IPC socket connects, after the HTTP server starts listening, etc.
 
 Pass `exit_after_ready=True` to `run_stack` to return immediately once
 everything is ready instead of monitoring — useful for launchers whose
-processes are all `launch_mode="persist"` and should outlive the orchestrator
-(e.g. `model-servers`).
+processes are all `launch_mode="persist"` and are designed to outlive the
+orchestrator (e.g. `model-servers`).
 
 ### The `--ready-file` protocol
 
@@ -126,7 +126,7 @@ its IPC receive loop is active.
 - `"own"` (default) — the launcher spawns this process and kills it on
   shutdown.
 - `"persist"` — the launcher spawns this process but leaves it running on
-  shutdown. Use for heavy model servers that should survive stack restarts
+  shutdown. Use for heavy model servers that need to survive stack restarts
   (e.g. vLLM containers). Cleanup is the caller's responsibility. The optional
   `port` field is used to stop such persistent services.
 - `"reuse"` — the launcher does **not** spawn this process; it is assumed to be

--- a/docs/source/components/server-runtime.md
+++ b/docs/source/components/server-runtime.md
@@ -122,7 +122,7 @@ The hub binds two sockets (defaults shown):
 connector_A ──PUSH──┐
 connector_B ──PUSH──┤─► PULL   HubEndpoint   PUB ──SUB──► consumers (agents)
 connector_N ──PUSH──┘    ↓ dispatch
-                      on_frame / on_audio / on_data / on_participant
+                      on_frame, on_audio, on_data, on_participant
 ```
 
 Each connector owns and creates its own shared-memory ring buffer and
@@ -143,14 +143,14 @@ audio                    — all audio, all participants
 audio.alice              — all of alice's audio tracks
 audio.alice.TR_mic_001   — alice's specific mic track
 data.alice.chat          — alice's "chat" data channel only
-participant              — join/leave events
+participant              — join and leave events
 ```
 
 The message types and codec are extensible: new `MsgType` IDs can be
 registered at import time via `register_encoder` and `register_decoder`.
 
 ```{note}
-Agent code should import the IPC types and `ProcessorEndpoint` from
+Import the IPC types and `ProcessorEndpoint` in agent code from
 `xr_ai_hub` directly, **not** from `device_io_hub.ipc`. The agent SDK's only
 runtime dependencies are `pyzmq` and `msgpack` — importing from the agent SDK
 avoids pulling in the full DeviceIOHub dependency tree (LiveKit, FastAPI,
@@ -233,12 +233,12 @@ Swift SDK's `Authorization: Bearer`) reaches the server, and handles both the
 versioned (`/rtc/v1`) and legacy (`/rtc`) signaling paths.
 
 The web server's `/token` endpoint returns a signed LiveKit JWT together with
-the URL the client should use. With TLS on, that URL is the same-origin
+the client connection URL. With TLS on, that URL is the same-origin
 `wss://<host>:<web_server_port>` — so the client SDK never needs a
 per-deployment toggle. A `/cert` endpoint serves the active certificate as an
 installable iOS profile.
 
-Set `web_server_tls: false` for the two cases where the hub should not
+Set `web_server_tls: false` for the two cases where the hub does not
 terminate TLS itself: a TLS-terminating reverse proxy (nginx, Caddy,
 Cloudflare Tunnel) sits in front and speaks plain `http://` + `ws://` to the
 hub on the loopback, or localhost-only development where browsers already grant

--- a/docs/source/getting_started/clients.md
+++ b/docs/source/getting_started/clients.md
@@ -198,10 +198,10 @@ against the system + user CA store automatically.
 ### Android XR
 
 The Android client is a standard Android app (`targetSdk` 34, `minSdk` 24) with
-no XR-specific code. Android XR runs unmodified Android apps, so the sample is
-designed to install and launch on an Android XR device or emulator as a flat 2D
-windowed panel. The LiveKit audio and data paths, agent-status badge, and token
-flow use the same behavior as on a phone.
+no XR-specific code. Because Android XR runs unmodified Android apps, the sample
+is expected to install and launch on an Android XR device or emulator as a flat
+2D windowed panel. The LiveKit audio and data paths, agent-status badge, and
+token flow are expected to work the same as on a phone.
 
 ```{warning}
 Android XR support is **not yet validated**. The sample has not been tested on
@@ -235,7 +235,7 @@ Following the sample's README, create a Multiplatform SwiftUI app, then:
    Product Name `StreamKitSample`, Interface SwiftUI, Language Swift.
 2. **Add destinations** — select the project root, then **Supported
    Destinations → +**; add **visionOS**, remove **macOS** if auto-added. You
-   must leave iOS and visionOS selected.
+   should be left with iOS and visionOS.
 3. **Add the StreamKit package** — **File → Add Package Dependencies… → Add
    Local…**, navigate to `client-samples/ios-visionos/StreamKit/`, and add it,
    ticking **StreamKit** and your app target.

--- a/docs/source/getting_started/clients.md
+++ b/docs/source/getting_started/clients.md
@@ -6,9 +6,9 @@
 # Connecting Clients
 
 Every sample follows the same pattern: **start the server, then connect a
-client.** This page covers the clients that ship under `client-samples/`, how
-to set up, build, and run each one, and the shared token-on-startup connect
-flow they all use.
+client.** This client reference covers the clients that ship under
+`client-samples/`, how to set up, build, and run each one, and the shared
+token-on-startup connection flow they all use.
 
 For the server side — starting the DeviceIOHub and the agent samples — refer to
 {doc}`quickstart`.
@@ -198,10 +198,10 @@ against the system + user CA store automatically.
 ### Android XR
 
 The Android client is a standard Android app (`targetSdk` 34, `minSdk` 24) with
-no XR-specific code. Android XR runs unmodified Android apps, so the sample
-should install and launch on an Android XR device or emulator as a flat 2D
-windowed panel, and the LiveKit audio and data paths, agent-status badge, and
-token flow work the same as on a phone.
+no XR-specific code. Android XR runs unmodified Android apps, so the sample is
+designed to install and launch on an Android XR device or emulator as a flat 2D
+windowed panel. The LiveKit audio and data paths, agent-status badge, and token
+flow use the same behavior as on a phone.
 
 ```{warning}
 Android XR support is **not yet validated**. The sample has not been tested on
@@ -235,7 +235,7 @@ Following the sample's README, create a Multiplatform SwiftUI app, then:
    Product Name `StreamKitSample`, Interface SwiftUI, Language Swift.
 2. **Add destinations** — select the project root, then **Supported
    Destinations → +**; add **visionOS**, remove **macOS** if auto-added. You
-   should be left with iOS and visionOS.
+   must leave iOS and visionOS selected.
 3. **Add the StreamKit package** — **File → Add Package Dependencies… → Add
    Local…**, navigate to `client-samples/ios-visionos/StreamKit/`, and add it,
    ticking **StreamKit** and your app target.

--- a/docs/source/getting_started/credentials.md
+++ b/docs/source/getting_started/credentials.md
@@ -44,7 +44,7 @@ the stall risk). Provide the token any one of these ways; all are picked up
 automatically:
 
 ```bash
-# 1. Environment variable (highest priority; good for CI / one-off overrides)
+# 1. Environment variable (highest priority; good for CI and one-off overrides)
 export HF_TOKEN=hf_xxx
 
 # 2. huggingface-cli login (writes ~/.cache/huggingface/token)

--- a/docs/source/getting_started/networking.md
+++ b/docs/source/getting_started/networking.md
@@ -56,7 +56,7 @@ cloud firewall and host firewall allow 7881/TCP and 7882/UDP. Keep both options
 disabled for local and private-network deployments.
 
 NAT also affects the TLS certificate: clients dial the VM's public IP, which
-must be listed in the certificate's SAN via `web_server_extra_sans`; see
+must be listed in the certificate's SAN via `web_server_extra_sans`. Refer to
 [TLS for the web client](#tls-for-the-web-client) below.
 
 ## RHEL, Fedora, or CentOS (`firewall-cmd`)
@@ -171,6 +171,6 @@ bypass certificate-chain validation regardless of `NSAllowsArbitraryLoads`.
 Until the certificate is trusted at the OS level, the wss handshake fails.
 ```
 
-Production deployments on any platform should replace the auto-generated
-certificate with one from a public CA via `cert_file` and `key_file` in
+For production deployments on any platform, replace the auto-generated
+certificate with one from a public CA by setting `cert_file` and `key_file` in
 `device_io_hub.yaml`.

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -8,13 +8,13 @@
 ## Set up with a coding agent
 
 The fastest path: paste this to your agent and it does the rest, including
-walking you through the choices below. See {doc}`skills` for how it works.
+walking you through the choices below. Refer to {doc}`skills` for how it works.
 
 ```{literalinclude} /_snippets/agent-setup-prompt.txt
 :language: text
 ```
 
-The rest of this page is the manual path.
+The remainder of this quickstart is the manual path.
 
 Every sample follows the same pattern: **start the server, then connect a
 client.** Once it is ready, any supported client — web browser, Android app,

--- a/docs/source/getting_started/requirements.md
+++ b/docs/source/getting_started/requirements.md
@@ -28,7 +28,7 @@ local GPU is required for the agent or DeviceIOHub.
 
 | Requirement | Version | Notes |
 |---|---|---|
-| OS | Linux | Ubuntu 22.04 / 24.04 recommended; WSL2 is not officially supported (refer to [Windows (WSL2)](#windows-wsl2) below) |
+| OS | Linux | Ubuntu 22.04 or 24.04 recommended; WSL2 is not officially supported (refer to [Windows (WSL2)](#windows-wsl2) below) |
 | Python | 3.11 or 3.12 | 3.10 and 3.13 are not supported |
 | [uv](https://docs.astral.sh/uv/) | latest | dependency manager used by all samples |
 | NVIDIA driver | 570+ | required for local model inference |
@@ -44,7 +44,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
 The NVIDIA Container Toolkit install is one-time per host. Follow the official
-install guide and run the CDI / runtime-configure steps from there:
+install guide and run the CDI and runtime-configuration steps from there:
 
 > https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
 
@@ -95,10 +95,10 @@ setups:
   Open the web client at the WSL distribution's `eth0` address instead (note
   it can change across reboots). Microphone capture needs a secure context.
   Prefer the hub's default HTTPS web server (`https://<eth0-ip>:8080`): an HTTPS
-  origin is a secure context once you trust the hub's self-signed cert
+  origin is a secure context once you trust the hub's self-signed certificate
   (download it from `https://<eth0-ip>:8080/cert`, or copy
   `~/.local/share/xr-ai/web-server.crt` out of the WSL filesystem via
-  `\\wsl$\`, then install it into the Windows cert store) or click through
+  `\\wsl$\`, then install it into the Windows certificate store) or click through
   the browser warning. On a plain-HTTP path (the legacy token server, or
   `web_server_tls: false`), the report's verified workaround is
   whitelisting the exact origin in

--- a/docs/source/guides/adding-a-sample.md
+++ b/docs/source/guides/adding-a-sample.md
@@ -52,10 +52,10 @@ agent-samples/<name>/
 `yaml/models.local.json` names the logical models the worker needs (`llm`,
 `vlm`, `stt`, `tts`, or any sample-specific name). Each role composes an
 adapter, endpoint, and deployment spec. Worker-only profiles may remain in the
-legacy flat JSON/YAML shape; a profile shared with the stdlib-only orchestrator
+legacy flat JSON or YAML shape; a profile shared with the stdlib-only orchestrator
 uses the wrapped nested JSON shape. The worker passes either form to
-`load_models_config(...)` and constructs services via `make_llm` /
-`make_vlm` / `make_stt` / `make_tts` from `xr_ai_models`.  Schema, preset
+`load_models_config(...)` and constructs services with `make_llm`, `make_vlm`,
+`make_stt`, or `make_tts` from `xr_ai_models`. Schema, preset
 table, compatibility formats, and the profile contract are in
 {doc}`/reference/agent-sdk-models`. To reuse a customized shared stack, follow
 {doc}`Customizing model servers <customizing-model-servers>`.
@@ -69,7 +69,7 @@ Suggested split (used by `simple-vlm-example`):
 | File | Responsibility |
 |---|---|
 | `__main__.py` | Argument parsing and delegation to the application lifecycle |
-| `app.py` | Dependency construction and native function/runtime composition |
+| `app.py` | Dependency construction and native function and runtime composition |
 | `config.py` | Typed configuration loading and path resolution |
 | `prompts/` | Package-owned prompt resources |
 
@@ -159,7 +159,7 @@ if __name__ == "__main__":
 
 Use this template when the worker talks directly to `ProcessorEndpoint`. Native
 voice workers keep argument parsing in `__main__.py` and delegate composition
-to sibling `app.py` and `config.py` modules; see
+to sibling `app.py` and `config.py` modules. Refer to
 [`simple-vlm-example`](https://github.com/NVIDIA/xr-ai/tree/main/agent-samples/simple-vlm-example/worker/simple_vlm_example_worker/)
 for that shape. Fill in the sections marked `# ← FILL IN`.
 
@@ -170,7 +170,7 @@ for that shape. Fill in the sections marked `# ← FILL IN`.
 Launched as a subprocess by ``uv run <snake_name>`` (the orchestrator).
 Do not run this directly.
 
-Protocol                            # ← include only if the worker sends/receives data msgs
+Protocol                            # ← include only if the worker sends or receives data messages
 --------
 Client → agent  (topic "<in.topic>"):
     <description>

--- a/docs/source/guides/contributing-and-conventions.md
+++ b/docs/source/guides/contributing-and-conventions.md
@@ -8,8 +8,9 @@
 The root [`CONTRIBUTING.md`](https://github.com/NVIDIA/xr-ai/blob/main/CONTRIBUTING.md)
 explains setup, testing, pull requests, and DCO sign-off.
 [`AGENTS.md`](https://github.com/NVIDIA/xr-ai/blob/main/AGENTS.md) contains the
-architecture, change constraints, and documentation house style used by both
-humans and coding agents.
+architecture and change constraints used by both humans and coding agents.
+{doc}`Documentation style <documentation-style>` contains the house style for
+customer-facing Markdown and reStructuredText.
 [`DEPENDENCIES.md`](https://github.com/NVIDIA/xr-ai/blob/main/DEPENDENCIES.md)
 is the package dependency map.
 
@@ -36,8 +37,8 @@ descriptions in `help=` and do not repeat flag tables in narrative pages.
 Sample configuration examples and field-level guidance live in checked-in
 YAML and JSON, with field-level guidance in adjacent YAML comments. The
 generated catalog enrolls files under a top-level sample's `yaml/` tree and
-files beside a direct capability
-subproject, then renders them verbatim. Narrative docs cover only
+files beside a direct capability subproject, then renders them verbatim.
+Narrative docs cover only
 workflows, operational decisions, credentials, and process relationships.
 
 After a `pyproject.toml` change, run

--- a/docs/source/guides/contributing-and-conventions.md
+++ b/docs/source/guides/contributing-and-conventions.md
@@ -8,7 +8,8 @@
 The root [`CONTRIBUTING.md`](https://github.com/NVIDIA/xr-ai/blob/main/CONTRIBUTING.md)
 explains setup, testing, pull requests, and DCO sign-off.
 [`AGENTS.md`](https://github.com/NVIDIA/xr-ai/blob/main/AGENTS.md) contains the
-architecture and change constraints used by both humans and coding agents.
+architecture, change constraints, and documentation house style used by both
+humans and coding agents.
 [`DEPENDENCIES.md`](https://github.com/NVIDIA/xr-ai/blob/main/DEPENDENCIES.md)
 is the package dependency map.
 
@@ -33,9 +34,10 @@ The user-facing command catalog is generated from top-level sample
 descriptions in `help=` and do not repeat flag tables in narrative pages.
 
 Sample configuration examples and field-level guidance live in checked-in
-YAML/JSON and adjacent YAML comments. The generated catalog enrolls files under
-a top-level sample's `yaml/` tree and files beside a direct capability
-subproject, then renders them verbatim. Narrative docs should cover only
+YAML and JSON, with field-level guidance in adjacent YAML comments. The
+generated catalog enrolls files under a top-level sample's `yaml/` tree and
+files beside a direct capability
+subproject, then renders them verbatim. Narrative docs cover only
 workflows, operational decisions, credentials, and process relationships.
 
 After a `pyproject.toml` change, run
@@ -43,4 +45,4 @@ After a `pyproject.toml` change, run
 normally regenerates the Python inventory in `DEPENDENCIES.md` automatically,
 and CI rejects drift. Do not edit that generated section by hand. Regenerate the
 affected project's gitignored `uv.lock` locally. New source files require an
-SPDX header; see [SPDX headers](spdx-headers.md).
+SPDX header; refer to {doc}`SPDX headers <spdx-headers>`.

--- a/docs/source/guides/contributing-and-conventions.md
+++ b/docs/source/guides/contributing-and-conventions.md
@@ -34,8 +34,8 @@ The user-facing command catalog is generated from top-level sample
 `[project.scripts]` entries and literal `argparse` declarations. Keep option
 descriptions in `help=` and do not repeat flag tables in narrative pages.
 
-Sample configuration examples and field-level guidance live in checked-in
-YAML and JSON, with field-level guidance in adjacent YAML comments. The
+Sample configuration examples live in checked-in YAML and JSON files, with
+field-level guidance in adjacent YAML comments. The
 generated catalog enrolls files under a top-level sample's `yaml/` tree and
 files beside a direct capability subproject, then renders them verbatim.
 Narrative docs cover only

--- a/docs/source/guides/documentation-style.md
+++ b/docs/source/guides/documentation-style.md
@@ -16,7 +16,9 @@ Introduce documentation links with **Refer to** or **refer to**, not "See" or
 "see." Prefer MyST `{doc}` links in Markdown and `:doc:` or `:ref:` roles in
 reStructuredText. Use a descriptive Markdown link when the target is source
 code or an external resource, and link directly to the authoritative target
-rather than through a thin redirect page.
+rather than through a thin redirect page. Treat published URL fragments as
+stable. When rewording a heading, preserve its previous fragment with an
+explicit compatibility anchor.
 
 ## Slashes in prose
 

--- a/docs/source/guides/documentation-style.md
+++ b/docs/source/guides/documentation-style.md
@@ -1,0 +1,52 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Documentation style
+
+This reference is the authoritative house style for customer-facing Markdown
+and reStructuredText. Match the surrounding document and keep edits scoped. If
+a task or maintainer establishes a different convention, follow it and update
+this reference so the repository guidance remains accurate.
+
+## Cross-references
+
+Introduce documentation links with **Refer to** or **refer to**, not “See” or
+“see.” Prefer MyST `{doc}` links in Markdown and `:doc:` or `:ref:` roles in
+reStructuredText. Use a descriptive Markdown link when the target is source
+code or an external resource, and link directly to the authoritative target
+rather than through a thin redirect page.
+
+## Slashes in prose
+
+Do not use `/` to mean “or” or “and.” Rewrite with the conjunction or a list.
+Keep established technical forms such as `I/O`, `iOS/visionOS`, `STUN/TURN`,
+`VR/AR`, `LLM/VLM`, `pub/sub`, and `and/or`. Keep literal UI text, URLs, paths,
+endpoints, and code unchanged.
+
+## Terminology
+
+Prefer full words over informal shortenings in paraphrased prose: for example,
+use **certificate**, not **cert**. Preserve shortenings that are part of literal
+UI text, logs, filenames, paths, endpoints, or code.
+
+## Clarity and consistency
+
+Use direct word order and specific self-reference nouns such as “This sample,”
+“This workflow,” or “This reference” instead of “This page” or “This guide.”
+Keep article usage consistent within a procedure. Hyphenate compound adjectives
+when they precede a noun.
+
+## Requirement strength
+
+Use **must** for requirements, an imperative for instructions, and explicit
+softer wording such as **can** or **recommended** for guidance. Avoid ambiguous
+**should** wording when the intended strength can be stated directly.
+
+## Punctuation and headings
+
+Use a colon to introduce an explanation or list. Use the document's established
+em-dash style for an aside; do not use a narrative `--`. Keep code markup out
+of headings when it makes the table of contents or navigation harder to scan.
+In reStructuredText, make title underlines span the full title.

--- a/docs/source/guides/documentation-style.md
+++ b/docs/source/guides/documentation-style.md
@@ -12,8 +12,8 @@ this reference so the repository guidance remains accurate.
 
 ## Cross-references
 
-Introduce documentation links with **Refer to** or **refer to**, not “See” or
-“see.” Prefer MyST `{doc}` links in Markdown and `:doc:` or `:ref:` roles in
+Introduce documentation links with **Refer to** or **refer to**, not "See" or
+"see." Prefer MyST `{doc}` links in Markdown and `:doc:` or `:ref:` roles in
 reStructuredText. Use a descriptive Markdown link when the target is source
 code or an external resource, and link directly to the authoritative target
 rather than through a thin redirect page.
@@ -33,8 +33,8 @@ UI text, logs, filenames, paths, endpoints, or code.
 
 ## Clarity and consistency
 
-Use direct word order and specific self-reference nouns such as “This sample,”
-“This workflow,” or “This reference” instead of “This page” or “This guide.”
+Use direct word order and specific self-reference nouns such as "This sample,"
+"This workflow," or "This reference" instead of "This page" or "This guide."
 Keep article usage consistent within a procedure. Hyphenate compound adjectives
 when they precede a noun.
 

--- a/docs/source/guides/documentation-style.md
+++ b/docs/source/guides/documentation-style.md
@@ -22,16 +22,19 @@ explicit compatibility anchor.
 
 ## Slashes in prose
 
-Do not use `/` to mean “or” or “and.” Rewrite with the conjunction or a list.
+Do not use `/` to mean "or" or "and." Rewrite with the conjunction or a list.
 Keep established technical forms such as `I/O`, `iOS/visionOS`, `STUN/TURN`,
-`VR/AR`, `LLM/VLM`, `pub/sub`, and `and/or`. Keep literal UI text, URLs, paths,
-endpoints, and code unchanged.
+`VR/AR`, `LLM/VLM`, `pub/sub`, and `and/or`. Apply these prose rules to
+explanatory comments and diagram labels inside fenced examples. Keep executable
+code, literal commands and output, identifiers, UI text, URLs, paths, and
+endpoints unchanged.
 
 ## Terminology
 
 Prefer full words over informal shortenings in paraphrased prose: for example,
 use **certificate**, not **cert**. Preserve shortenings that are part of literal
-UI text, logs, filenames, paths, endpoints, or code.
+UI text, logs, filenames, paths, endpoints, identifiers, commands, or
+executable code.
 
 ## Clarity and consistency
 

--- a/docs/source/guides/documentation-style.md
+++ b/docs/source/guides/documentation-style.md
@@ -6,9 +6,9 @@
 # Documentation style
 
 This reference is the authoritative house style for customer-facing Markdown
-and reStructuredText. Match the surrounding document and keep edits scoped. If
-a task or maintainer establishes a different convention, follow it and update
-this reference so the repository guidance remains accurate.
+and reStructuredText. Match the surrounding document and keep edits scoped.
+When maintainers adopt a repository-wide convention, update this reference in
+the same change. Document scoped exceptions in the affected content.
 
 ## Cross-references
 

--- a/docs/source/guides/index.md
+++ b/docs/source/guides/index.md
@@ -5,7 +5,8 @@
 
 # Guides
 
-How-to guides: adding a sample, wiring CloudXR, troubleshooting, and contribution conventions.
+Guides for adding a sample, wiring CloudXR, documentation style,
+troubleshooting, and contribution conventions.
 
 ```{toctree}
 :glob:

--- a/docs/source/guides/troubleshooting.md
+++ b/docs/source/guides/troubleshooting.md
@@ -204,11 +204,15 @@ https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install
 Switch back to `vllm_backend: pip` in the service YAML if you only need the
 local install.
 
-### Hub fails immediately with `RuntimeError: missing libnvcuvid.so / libnvidia-encode.so`
+(hub-fails-immediately-with-runtimeerror-missing-libnvcuvid-so-libnvidia-encode-so)=
 
-**Cause:** NVDEC (`libnvcuvid.so`) and NVENC (`libnvidia-encode.so`) are
-required — the DeviceIOHub refuses to start without them so it never silently falls
-back to OpenH264, which is royalty-bearing.
+### Hub fails immediately because NVIDIA codec libraries are missing
+
+**Cause:** The hub raises
+`RuntimeError: missing libnvcuvid.so / libnvidia-encode.so` because NVDEC
+(`libnvcuvid.so`) and NVENC (`libnvidia-encode.so`) are required. The
+DeviceIOHub refuses to start without them so it never silently falls back to
+OpenH264, which is royalty-bearing.
 
 **Fix:**
 - **Bare metal:** install or repair the NVIDIA driver. The libraries ship with the

--- a/docs/source/guides/troubleshooting.md
+++ b/docs/source/guides/troubleshooting.md
@@ -204,7 +204,7 @@ https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install
 Switch back to `vllm_backend: pip` in the service YAML if you only need the
 local install.
 
-### Hub fails immediately because NVIDIA codec libraries are missing
+### Hub fails immediately with `RuntimeError: missing libnvcuvid.so / libnvidia-encode.so`
 
 **Cause:** NVDEC (`libnvcuvid.so`) and NVENC (`libnvidia-encode.so`) are
 required — the DeviceIOHub refuses to start without them so it never silently falls

--- a/docs/source/guides/troubleshooting.md
+++ b/docs/source/guides/troubleshooting.md
@@ -204,7 +204,7 @@ https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install
 Switch back to `vllm_backend: pip` in the service YAML if you only need the
 local install.
 
-### Hub fails immediately with `RuntimeError: missing libnvcuvid.so / libnvidia-encode.so`
+### Hub fails immediately because NVIDIA codec libraries are missing
 
 **Cause:** NVDEC (`libnvcuvid.so`) and NVENC (`libnvidia-encode.so`) are
 required — the DeviceIOHub refuses to start without them so it never silently falls
@@ -297,7 +297,7 @@ If step 4 shows no toggle, the cached certificate on the hub is from an older
 xr-ai build that wrote `BasicConstraints CA:FALSE` and iOS will not
 expose the trust toggle for it. Remove the installed profile via
 **VPN & Device Management** and restart the hub — it auto-detects the
-stale cert and regenerates as a self-signed CA (logged as `TLS: cached
+stale certificate and regenerates it as a self-signed CA (logged as `TLS: cached
 cert is not a CA cert — regenerating…`).
 
 If the toggle was enabled but the wss handshake still fails with
@@ -309,12 +309,12 @@ certificate whenever the SAN is missing one (logged as `TLS: cached cert
 SAN is missing …; regenerating…`); just restart the hub and re-install the
 profile on the device. If the dialed address is not on any of the hub's
 interfaces, add it to `web_server_extra_sans` in `device_io_hub.yaml` and
-restart (see [Networking](../getting_started/networking.md)). To force
-regen explicitly, delete `~/.local/share/xr-ai/web-server.crt` and
+restart. Refer to {doc}`Networking </getting_started/networking>` for details.
+To force regeneration, delete `~/.local/share/xr-ai/web-server.crt` and
 `web-server.key` before restarting.
 
 If the certificate is trusted (no `-1202`) but the room connection still fails
-with HTTP 401 / "no permissions to access the room", the hub's wss /rtc
+with HTTP 401 or "no permissions to access the room", the hub's `/rtc` WSS
 proxy is dropping the `Authorization: Bearer <token>` header the Swift
 SDK sends. Update to the latest DeviceIOHub and restart; the proxy
 forwards the `Authorization` header on `/rtc/validate` and the WebSocket.
@@ -363,7 +363,7 @@ GPU-visible memory. The complete original error remains in the reported log file
 **By design.** The vLLM-backed servers (`nemotron_omni_llm_server`,
 `vlm_server`, and `nemotron3_nano_llm_server`) survive stack
 restarts so model weights stay loaded across worker crashes and debug
-restarts. See {doc}`/components/ai-services` → *vLLM model
+restarts. Refer to {doc}`/components/ai-services` → *vLLM model
 persistence*.
 
 **Fix:** to fully release VRAM:
@@ -389,5 +389,5 @@ the repository root (gitignored; the Cosmos3 checkpoint alone is tens of GB).
 **Fix:** wait. Subsequent runs use the cached weights and start in
 ~30–60 s. If the download makes no progress, note that unauthenticated
 downloads (model-server runs started with `--allow-anonymous`) are rate-limited and can
-stall indefinitely; set `HF_TOKEN` and restart
-(see {doc}`/getting_started/credentials`).
+stall indefinitely; set `HF_TOKEN` and restart. Refer to
+{doc}`Credentials </getting_started/credentials>`.

--- a/docs/source/overview/architecture.md
+++ b/docs/source/overview/architecture.md
@@ -30,7 +30,7 @@ contain configuration, protocol, and operational details.
 | (web/mobile/XR)|                   | + transport    |                | + agent SDK     |
 +---------------+                    +----------------+                +-------+--------+
                                                                             |
-                                               typed model and tool calls   |
+                                                   typed model/tool calls   |
                                                 +---------------------------+--------+
                                                 |                                    |
                                                 v                                    v

--- a/docs/source/overview/architecture.md
+++ b/docs/source/overview/architecture.md
@@ -12,7 +12,8 @@ is process-oriented: the device I/O hub, workers, model servers, and optional
 capability services run independently and communicate through small, explicit
 interfaces.
 
-This page describes the system shape, runtime paths, and ownership boundaries.
+This architecture overview describes the system shape, runtime paths, and
+ownership boundaries.
 The component pages linked under [Where details live](#where-details-live)
 contain configuration, protocol, and operational details.
 
@@ -29,7 +30,7 @@ contain configuration, protocol, and operational details.
 | (web/mobile/XR)|                   | + transport    |                | + agent SDK     |
 +---------------+                    +----------------+                +-------+--------+
                                                                             |
-                                                   typed model/tool calls   |
+                                               typed model and tool calls   |
                                                 +---------------------------+--------+
                                                 |                                    |
                                                 v                                    v
@@ -62,7 +63,7 @@ services or externally hosted APIs.
 | Transport connector | Transport-specific sessions and conversion to hub events | Agent-facing APIs or application policy |
 | DeviceIOHub | Media fan-out, participant identity, return routing, and shared-media access | Agent state, model calls, or tools |
 | Agent SDK | Lightweight hub IPC, typed runtime events, model protocols, voice composition, and tool primitives | Application lifecycle and decision policy |
-| Agent worker | Application state, tasks, prompts, model/tool loops, concurrency, and cleanup | Transport internals or model-server lifecycle |
+| Agent worker | Application state, tasks, prompts, model and tool loops, concurrency, and cleanup | Transport internals or model-server lifecycle |
 | AI model services | Inference and model-specific serving behavior | Participant routing or application policy |
 | Tools and capability services | Bounded application capabilities | General agent orchestration |
 | Sample orchestrator | Process declarations, startup ordering, readiness, and shutdown | Runtime business logic |
@@ -93,8 +94,8 @@ participant -> hub -> subscribed worker -> hub -> same participant
 ```
 
 LiveKit currently provides the client transport, but it remains behind the hub
-boundary. Workers communicate only through XR AI's msgpack/ZMQ IPC and do not
-import or address LiveKit directly. See {doc}`Server runtime
+boundary. Workers communicate only through XR AI's msgpack over ZMQ IPC and do
+not import or address LiveKit directly. Refer to {doc}`Server runtime
 </components/server-runtime>` for shared-memory behavior, topics, and transport
 implementation details.
 
@@ -125,7 +126,7 @@ Workers obtain LLM, VLM, STT, TTS, and embedding clients from
 
 Tools are ordinary in-process `Tool` or `AsyncTool` objects. A tool can perform
 local work or call a typed service, but application agents retain ownership of
-tool selection, task lifetime, retries, and participant context. See
+tool selection, task lifetime, retries, and participant context. Refer to
 {doc}`Agent SDK </components/agent-sdk>` and {doc}`AI services
 </components/ai-services>` for the concrete interfaces and profiles.
 
@@ -193,7 +194,7 @@ it.
 
 | To add or replace | Extend at this boundary |
 |---|---|
-| XR client | Join through the client transport and consume participant-scoped return media/data |
+| XR client | Join through the client transport and consume participant-scoped return media and data |
 | Transport | Implement the connector side of the hub IPC contract |
 | Agent application | Add a worker that uses `xr_ai_hub` and the relevant SDK packages |
 | Model or provider | Add model configuration and an adapter behind the typed model protocols |
@@ -202,12 +203,12 @@ it.
 | Managed process | Add a launcher `Process` entry and signal readiness from the process |
 
 For the repository conventions and concrete file layout used by new samples,
-see {doc}`Adding a sample </guides/adding-a-sample>`.
+refer to {doc}`Adding a sample </guides/adding-a-sample>`.
 
 ## Where details live
 
-This page intentionally stops at system structure and contracts. Use these
-pages for implementation and operational detail:
+This architecture overview intentionally stops at system structure and
+contracts. Use these references for implementation and operational detail:
 
 | Topic | Authoritative page |
 |---|---|

--- a/docs/source/overview/architecture.md
+++ b/docs/source/overview/architecture.md
@@ -30,7 +30,7 @@ contain configuration, protocol, and operational details.
 | (web/mobile/XR)|                   | + transport    |                | + agent SDK     |
 +---------------+                    +----------------+                +-------+--------+
                                                                             |
-                                                   typed model/tool calls   |
+                                               typed model and tool calls   |
                                                 +---------------------------+--------+
                                                 |                                    |
                                                 v                                    v

--- a/docs/source/reference/agent-sdk-models.md
+++ b/docs/source/reference/agent-sdk-models.md
@@ -7,5 +7,5 @@
 
 ```{include} ../../../agent-sdk/xr-ai-models/README.md
 :start-after: "# xr-ai-models"
-:relative-docs: ../../../agent-sdk/xr-ai-models/
+:relative-docs: ../../
 ```

--- a/docs/source/reference/lab-instrument-monitoring.md
+++ b/docs/source/reference/lab-instrument-monitoring.md
@@ -336,7 +336,9 @@ problems from detector or VLM problems. Then inspect Relay events and the
 participant JSONL files to follow the tool call, reading, state update, and
 notification as distinct stages.
 
-## What should become shared
+<a id="what-should-become-shared"></a>
+
+## What belongs in shared code
 
 Reuse public SDK blocks directly when they already express the contract:
 `VoiceAgent`, `AgentRuntime`, `run_tool_loop`, `CurrentFrameTool`,

--- a/docs/source/reference/lab-instrument-monitoring.md
+++ b/docs/source/reference/lab-instrument-monitoring.md
@@ -336,7 +336,7 @@ problems from detector or VLM problems. Then inspect Relay events and the
 participant JSONL files to follow the tool call, reading, state update, and
 notification as distinct stages.
 
-## What belongs in shared code
+## What should become shared
 
 Reuse public SDK blocks directly when they already express the contract:
 `VoiceAgent`, `AgentRuntime`, `run_tool_loop`, `CurrentFrameTool`,

--- a/docs/source/reference/lab-instrument-monitoring.md
+++ b/docs/source/reference/lab-instrument-monitoring.md
@@ -8,8 +8,8 @@
 The lab instrument sample is a reference for applications that combine
 foreground questions, opt-in background work, persistent participant state,
 visual identification, and event-driven notifications. Start with the
-{doc}`quickstart </getting_started/quickstart>` to run it. This page focuses on
-how to reuse its structure for another application.
+{doc}`quickstart </getting_started/quickstart>` to run it. This architecture
+reference focuses on reusing the sample's structure for another application.
 
 The central design choice is to separate perception, interpretation, state,
 policy, and presentation. A marker scan identifies an instrument, a VLM reads
@@ -37,7 +37,7 @@ tool-loop, image-selection, visual-query, and event patterns are reusable.
 ```text
 camera frames ────────────────> ParticipantImageAgent
                                       │
-accepted speech / typed query          ├─> current frame + generic VLM query
+accepted speech or typed query         ├─> current frame + generic VLM query
               │                       └─> marker scan
               v                                │
         ForegroundAgent                        v
@@ -221,7 +221,7 @@ class InstrumentBackendAgent(Agent):
 
 Register this subscriber beside `FileOutputAgent`. Storage and voice can remain
 enabled during development and be removed independently for production. Use a
-typed msgpack/ZMQ service when the backend boundary is a separate process.
+typed msgpack over ZMQ service when the backend boundary is a separate process.
 
 ## Live event viewer
 
@@ -295,15 +295,16 @@ tracking loop.
 
 Subscribe to the same record and instrument topics from a new agent. Maintain
 participant correlation from `RuntimeContext.metadata`; do not add participant
-IDs to model-visible schemas. Decide explicitly whether delivery failure should
-block, retry, buffer, or drop—the runtime does not impose that application
+IDs to model-visible schemas. Decide whether to block, retry, buffer, or drop
+the event after a delivery failure—the runtime does not impose that application
 policy.
 
 ### Build a different background visual flow
 
-Use `MonitorAgent` as the minimal pattern: participant-bound start/stop/status
-tools, one owned task per participant, current-frame selection, a dedicated
-`ImageQueryTool`, typed output events, and cancellation on participant leave.
+Use `MonitorAgent` as the minimal pattern: participant-bound start, stop, and
+status tools, one owned task per participant, current-frame selection, a
+dedicated `ImageQueryTool`, typed output events, and cancellation on participant
+leave.
 
 ## Lifecycle invariants
 
@@ -330,12 +331,12 @@ Use three layers:
 
 For manual pipeline testing, enable `capture_marker_scans` and inspect the saved
 marker-scan image first. It is
-the exact source frame used for the marker scan and separates camera/framing
+the exact source frame used for the marker scan and separates camera and framing
 problems from detector or VLM problems. Then inspect Relay events and the
 participant JSONL files to follow the tool call, reading, state update, and
 notification as distinct stages.
 
-## What should become shared
+## What belongs in shared code
 
 Reuse public SDK blocks directly when they already express the contract:
 `VoiceAgent`, `AgentRuntime`, `run_tool_loop`, `CurrentFrameTool`,

--- a/docs/source/reference/migrations.md
+++ b/docs/source/reference/migrations.md
@@ -21,7 +21,7 @@ and command to `device_io_hub`. Rename `xr_media_hub.yaml` to
 - Boolean service settings now require YAML booleans or the strings `true`,
   `false`, `yes`, `no`, `on`, `off`, `1`, or `0` (case-insensitive). Numeric
   `1`/`0`, null values, and arbitrary strings now fail at startup instead of
-  being interpreted by Python truthiness. This applies to vLLM eager/tool/
+  being interpreted by Python truthiness. This applies to vLLM eager, tool, and
   scheduling flags, Nemotron-Omni BF16 selection, Piper CUDA, voice-gate
   `listening_chime`, lab-monitoring `capture_marker_scans`, and tea-workflow
   `complete_on_skip`.
@@ -51,7 +51,7 @@ compatibility package. Update out-of-tree code as follows:
 | `VadSttProcessor`, `VoiceGateProcessor`, and `StreamingTtsProcessor` | Configure `VoiceAgent` with `VadConfig`, `VoiceGateConfig`, and `text_topic`; pipeline processors are private implementation details. |
 | `SttClient` and `TtsClient` | Construct services through `xr_ai_models.make_stt` and `make_tts`, or use `OpenAICompatSTT` and `OpenAICompatTTS` directly. |
 | `http_probe`, `mcp_probe`, and `wait_for_services` | Pass additional readiness callables through `VoiceAgent(probes=...)`; MCP readiness is no longer part of the voice SDK. |
-| `xr_ai_pipecat.audio` conversion helpers | Let `VoiceAgent` own media conversion. Applications that truly need raw hub media should use `xr_ai_hub` types and own their format conversion. |
+| `xr_ai_pipecat.audio` conversion helpers | Let `VoiceAgent` own media conversion. If an application truly needs raw hub media, use `xr_ai_hub` types and own the format conversion. |
 | `VoiceAgent.text_transform` and `text_ignore_topics` | `VoiceAgent` treats only untopiced client data as direct text. Use `text_input=False` to disable it; transform application queries in their subscribing agent. |
 | `xr_ai_models.config`, `factory`, `openai_compat`, and `protocols` | Import public names directly from `xr_ai_models`. This includes `KIND_OPENAI_COMPAT`, `ModelKind`, `Category`, and `Spec`. |
 | `LiveVisionTool` and `StreamingVisionTool` | Select with `CurrentFrameTool`, then pass its `ImageReference` to `ImageQueryTool` or `StreamingImageQueryTool`. |

--- a/docs/source/reference/tea-making-sample.md
+++ b/docs/source/reference/tea-making-sample.md
@@ -8,9 +8,9 @@
 The tea-making sample is a reference for applications that combine a guided
 procedure, visual evidence, foreground questions, independent background
 observers, and voice output. Start with the
-{doc}`quickstart </getting_started/quickstart>` to run it. This page explains
-how to adapt its architecture to another procedure rather than merely changing
-model settings.
+{doc}`quickstart </getting_started/quickstart>` to run it. This architecture
+reference explains how to adapt the sample to another procedure rather than
+merely changing model settings.
 
 The defining pattern is a deterministic workflow around an agentic core. YAML
 declares the steps and state contract. Application code owns transitions and
@@ -81,7 +81,7 @@ is only a bounded view of the current worker process.
 ```text
 camera frames ────────────────> ParticipantImageAgent
                                       │
-accepted speech / typed query          ├─> GuidanceAgent observation loop
+accepted speech or typed query         ├─> GuidanceAgent observation loop
               │                       ├─> ChangeWatchAgent
               v                       └─> VideoLogAgent
         ForegroundAgent
@@ -145,7 +145,7 @@ locks, and participant cleanup.
 | `workflow.py` | Participant sessions and visual observation loop | Add another trigger or evidence source |
 | `foreground.py` | Root-versus-active tool routing and current-query loop | Change interactive behavior |
 | `images.py` | Shared participant image acquisition | Add another image selector |
-| `background_context.py` | Recent-fact store and query tool | Change foreground/background context policy |
+| `background_context.py` | Recent-fact store and query tool | Change foreground and background context policy |
 | `change_watch.py` | Focused visual observer | Build another event-oriented monitor |
 | `transcript.py` | Transcript recording and summarization | Forward or classify laboratory dialogue |
 | `video_log.py` | Periodic caption and delta observer | Build a visual journal |
@@ -209,7 +209,8 @@ restart controls change the participant's position.
 
 The model can propose state only through the commit tool. It cannot mutate the
 session object directly. Deterministic clock and temperature tools perform
-calculations that should not be left to language-model arithmetic.
+calculations that require deterministic arithmetic rather than language-model
+arithmetic.
 
 ## Visual observation loop
 
@@ -298,8 +299,8 @@ class JournalBackendAgent(Agent):
 
 Register the subscriber beside `FileOutputAgent`. A customer system can consume
 guidance records, background facts, transcripts, or video deltas independently.
-If it runs in another process, expose the boundary through a typed msgpack/ZMQ
-service rather than bypassing the repository's service model.
+If it runs in another process, expose the boundary through a typed msgpack over
+ZMQ service rather than bypassing the repository's service model.
 
 ## Adapting the sample
 
@@ -326,10 +327,11 @@ public `execute()` boundary so validation and Relay tracing are preserved.
 ### Add another background observer
 
 Follow the same contract as the three existing applications: an agent-owned
-task per participant, idempotent start/stop/status tools, cancellation on leave,
-a typed durable record topic, and optional compact `BackgroundFact` output.
-Decide explicitly whether the result should be spoken; do not make every
-background record a voice message.
+task per participant, idempotent start, stop, and status tools, cancellation on
+leave, a typed durable record topic, and optional compact `BackgroundFact`
+output.
+Decide explicitly whether to speak the result; do not make every background
+record a voice message.
 
 ### Replace files with production persistence
 
@@ -342,7 +344,7 @@ or voice by accident.
 
 `GuidanceVoiceAgent` is intentionally separate from `GuidanceAgent`. Add,
 suppress, batch, or redirect notices there. Background applications remain
-text/event producers unless a dedicated voice subscriber chooses otherwise.
+text and event producers unless a dedicated voice subscriber chooses otherwise.
 Foreground responses and guidance notices publish to `VoiceAggregationAgent`,
 which combines non-urgent output produced during an active utterance before it
 reaches `VoiceAgent`. The response text reaches the connection client's Agent
@@ -371,7 +373,7 @@ cleanup are one design decision, not separate implementation details.
 
 Test deterministic behavior separately from model quality:
 
-1. Validate workflow YAML, field types, readable/writable sets, and step links.
+1. Validate workflow YAML, field types, readable and writable sets, and step links.
 2. Unit-test atomic commits, evidence counts, explicit advancement, skips,
    resets, and no mutation after completion.
 3. Test root-versus-active tool visibility and the absence of conversation
@@ -384,7 +386,7 @@ When debugging, inspect the workflow, background, foreground, and Relay JSONL
 files as separate stages. This shows whether the problem came from evidence,
 tool selection, state policy, event delivery, or presentation.
 
-## What should become shared
+## What belongs in shared code
 
 Reuse public SDK blocks directly when they already express the contract:
 `VoiceAgent`, `AgentRuntime`, `run_tool_loop`, `CurrentFrameTool`,

--- a/docs/source/reference/tea-making-sample.md
+++ b/docs/source/reference/tea-making-sample.md
@@ -386,7 +386,9 @@ When debugging, inspect the workflow, background, foreground, and Relay JSONL
 files as separate stages. This shows whether the problem came from evidence,
 tool selection, state policy, event delivery, or presentation.
 
-## What should become shared
+<a id="what-should-become-shared"></a>
+
+## What belongs in shared code
 
 Reuse public SDK blocks directly when they already express the contract:
 `VoiceAgent`, `AgentRuntime`, `run_tool_loop`, `CurrentFrameTool`,

--- a/docs/source/reference/tea-making-sample.md
+++ b/docs/source/reference/tea-making-sample.md
@@ -386,7 +386,7 @@ When debugging, inspect the workflow, background, foreground, and Relay JSONL
 files as separate stages. This shows whether the problem came from evidence,
 tool selection, state policy, event delivery, or presentation.
 
-## What belongs in shared code
+## What should become shared
 
 Reuse public SDK blocks directly when they already express the contract:
 `VoiceAgent`, `AgentRuntime`, `run_tool_loop`, `CurrentFrameTool`,

--- a/docs/source/reference/xr-render-demo.md
+++ b/docs/source/reference/xr-render-demo.md
@@ -136,7 +136,7 @@ LiveKit mic (int16 PCM) → hub IPC (float32) → VoiceAgent
       pre-roll buffer    last 10 chunks (~320 ms) kept at all times;
                          prepended to the utterance buffer on speech onset
                          so the first word's attack isn't clipped
-      VAD                Silero (ONNX, 512-sample (32 ms) windows,
+      VAD                Silero (ONNX, 512-sample / 32 ms windows,
                          probability threshold) via shared xr-ai-vad util
       accumulates        audio while speaking
       finalizes when     silence ≥ 0.8s AND speech ≥ 0.15s
@@ -260,7 +260,7 @@ is worked-example heavy and opens with pronoun and reference resolution.
 The placement agent's prompt maps utterance shapes to tools with contrast
 pairs: a stated distance is a shift (`nudge`); a user-anchored destination
 uses `move_user_relative`; a destination anchored on another object uses
-`move_object_relative` (stacking is relation `above`); `into` or `inside` is
+`move_object_relative` (stacking is relation `above`); "into/inside" is
 containment (`move_inside`). Every rule has a paired worked example, and
 the highest-leakage failure modes carry explicit contrast examples.
 
@@ -330,7 +330,7 @@ the supervisor's per-participant lock, and a global scene lock serializes
 the snapshot, mutation, and verification window across participants, so scene
 turns from different participants queue rather than interleave.
 
-### Prompt and evaluation overlap audit
+### Prompt/eval overlap audit
 
 Per `AGENTS.md` "Prompt-driven samples", the harness audits every worker
 prompt against every tier's case inputs at startup and warns on overlap:

--- a/docs/source/reference/xr-render-demo.md
+++ b/docs/source/reference/xr-render-demo.md
@@ -5,9 +5,9 @@
 
 # xr-render-demo — architecture
 
-This page describes the architecture of the xr-render-demo sample. Start with
+This architecture reference describes the xr-render-demo sample. Start with
 {doc}`/getting_started/quickstart` to run it. For inference-server mechanics
-shared with other samples, see {doc}`/components/ai-services`.
+shared with other samples, refer to {doc}`/components/ai-services`.
 
 ## Process stack
 
@@ -18,7 +18,7 @@ any owned process exit terminates the application stack.
 
 | Role | Ownership | Directory | Command | Port |
 |---|---|---|---|---|
-| hub | sample | `services/device-io-hub/` | `device_io_hub` | 8080 (https + wss /rtc proxy); LiveKit 7880 stays on 127.0.0.1 |
+| hub | sample | `services/device-io-hub/` | `device_io_hub` | 8080 (HTTPS and `/rtc` WSS proxy); LiveKit 7880 stays on 127.0.0.1 |
 | cloudxr | sample | `services/cloudxr-runtime/` | `cloudxr_runtime` | 48322 (WSS proxy) |
 | stt | reused | `services/stt-server/` | `stt_server` | 8103 |
 | tts | reused | `services/piper-tts/` | `piper_tts_server` | 8105 |
@@ -136,7 +136,7 @@ LiveKit mic (int16 PCM) → hub IPC (float32) → VoiceAgent
       pre-roll buffer    last 10 chunks (~320 ms) kept at all times;
                          prepended to the utterance buffer on speech onset
                          so the first word's attack isn't clipped
-      VAD                Silero (ONNX, 512-sample / 32 ms windows,
+      VAD                Silero (ONNX, 512-sample (32 ms) windows,
                          probability threshold) via shared xr-ai-vad util
       accumulates        audio while speaking
       finalizes when     silence ≥ 0.8s AND speech ≥ 0.15s
@@ -260,7 +260,7 @@ is worked-example heavy and opens with pronoun and reference resolution.
 The placement agent's prompt maps utterance shapes to tools with contrast
 pairs: a stated distance is a shift (`nudge`); a user-anchored destination
 uses `move_user_relative`; a destination anchored on another object uses
-`move_object_relative` (stacking is relation `above`); "into/inside" is
+`move_object_relative` (stacking is relation `above`); `into` or `inside` is
 containment (`move_inside`). Every rule has a paired worked example, and
 the highest-leakage failure modes carry explicit contrast examples.
 
@@ -278,7 +278,7 @@ a streaming client connects. LOVR cannot start before then.
 5. Worker polls `get_health` every 500 ms (up to 120s)
    lovr_started: true  → send `render.ready` to client → XR session unlocked
    spawn_error: "..."  → log + abort
-6. On reconnect / refresh: `xr.session.started` arrives again
+6. On reconnect or refresh: `xr.session.started` arrives again
    → `_xr_started` is already True → skip spawn, send `render.ready`
    immediately
 ```
@@ -327,10 +327,10 @@ turn is recorded as failed in the runtime event log.
 
 **Concurrent participants.** Each participant's turns are serialized by
 the supervisor's per-participant lock, and a global scene lock serializes
-the snapshot/mutation/verification window across participants, so scene
+the snapshot, mutation, and verification window across participants, so scene
 turns from different participants queue rather than interleave.
 
-### Prompt/eval overlap audit
+### Prompt and evaluation overlap audit
 
 Per `AGENTS.md` "Prompt-driven samples", the harness audits every worker
 prompt against every tier's case inputs at startup and warns on overlap:

--- a/docs/source/reference/xr-render-demo.md
+++ b/docs/source/reference/xr-render-demo.md
@@ -136,7 +136,7 @@ LiveKit mic (int16 PCM) → hub IPC (float32) → VoiceAgent
       pre-roll buffer    last 10 chunks (~320 ms) kept at all times;
                          prepended to the utterance buffer on speech onset
                          so the first word's attack isn't clipped
-      VAD                Silero (ONNX, 512-sample / 32 ms windows,
+      VAD                Silero ONNX (512 samples per 32 ms window,
                          probability threshold) via shared xr-ai-vad util
       accumulates        audio while speaking
       finalizes when     silence ≥ 0.8s AND speech ≥ 0.15s
@@ -330,7 +330,9 @@ the supervisor's per-participant lock, and a global scene lock serializes
 the snapshot, mutation, and verification window across participants, so scene
 turns from different participants queue rather than interleave.
 
-### Prompt/eval overlap audit
+(prompt-eval-overlap-audit)=
+
+### Prompt and evaluation overlap audit
 
 Per `AGENTS.md` "Prompt-driven samples", the harness audits every worker
 prompt against every tier's case inputs at startup and warns on overlap:

--- a/services/rag-service/README.md
+++ b/services/rag-service/README.md
@@ -5,9 +5,9 @@
 
 # RAG service
 
-Indexes Markdown and text documents and exposes dense retrieval over private
-msgpack/ZMQ. Applications construct `xr_ai_tools.rag.RAGTools` with the
-private endpoint; the transport itself is not an agent-facing API.
+Indexes Markdown and text documents and exposes dense retrieval through private
+RPC using msgpack over ZMQ. Applications construct `xr_ai_tools.rag.RAGTools`
+with the private endpoint; the transport itself is not an agent-facing API.
 
 The checked-in `rag_service.yaml` is a reference configuration. Copy it into
 the consuming application's `yaml/` directory, set `documents_dir` and


### PR DESCRIPTION
## Summary
- establish XR AI technical-writing standards
- keep the authoritative style in a dedicated documentation guide
- link to the guide from AGENTS.md and contributor documentation
- revise customer-facing Sphinx pages, the root README, and included SDK READMEs
- preserve literal UI text, paths, endpoints, logs, and established technical terms

## Testing
- strict Sphinx build with warnings treated as errors
- generated public API reference check
- git diff --check