### PR TITLE
docs: dedupe sample READMEs against published reference pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,8 +354,10 @@ uv run lab_instrument_monitoring
 
 Connect an existing glasses or platform client with the authenticated URL and
 token printed by the hub. See the
-[sample README](agent-samples/lab-instrument-monitoring/README.md) for the
-agent topology, output records, transcription semantics, and routing eval.
+[reference guide](docs/source/reference/lab-instrument-monitoring.md) for the
+agent topology, output-record contract, and transcription semantics. The
+[sample README](agent-samples/lab-instrument-monitoring/README.md) covers
+operation and the routing eval.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 Agentic AI for XR — an open-source foundation for multi-modal, real-time
 conversational AI within the CloudXR ecosystem.
 
+Docs: <https://nvidia.github.io/xr-ai/>
+
 **Using a coding agent?** Paste this to it:
 
 ```text

--- a/agent-samples/lab-instrument-monitoring/README.md
+++ b/agent-samples/lab-instrument-monitoring/README.md
@@ -10,8 +10,9 @@ For an adaptation-oriented architecture guide, see
 
 This sample writes durable monitoring output to files and serves a bounded live
 event viewer while a separate foreground agent answers voice or typed queries.
-See the docs page above for architecture, agent responsibilities, and how to
-adapt the sample.
+There is no domain-specific monitoring UI, MCP adapter, NAT compatibility
+layer, or separate activity-viewer process. See the docs page above for
+architecture, agent responsibilities, and how to adapt the sample.
 
 ## Run
 

--- a/agent-samples/lab-instrument-monitoring/README.md
+++ b/agent-samples/lab-instrument-monitoring/README.md
@@ -11,7 +11,7 @@ For an adaptation-oriented architecture guide, see
 This sample writes durable monitoring output to files and serves a bounded live
 event viewer while a separate foreground agent answers voice or typed queries.
 There is no domain-specific monitoring UI, MCP adapter, NAT compatibility
-layer, or separate activity-viewer process. See the docs page above for
+layer, or separate activity-viewer process. See the linked guide above for
 architecture, agent responsibilities, and how to adapt the sample.
 
 ## Run
@@ -69,7 +69,7 @@ chime, and allows one follow-up utterance for five seconds.
 **Every finalized STT result, including speech rejected by the wake-word
 gate, is written to `transcript.jsonl`.** Wake-word rejection controls
 whether the foreground responds, not whether the utterance is stored. See the
-docs page above for the full persistence and redaction contract.
+linked guide above for the full persistence and redaction contract.
 
 Each connection writes to a new participant-scoped directory:
 

--- a/agent-samples/lab-instrument-monitoring/README.md
+++ b/agent-samples/lab-instrument-monitoring/README.md
@@ -10,86 +10,8 @@ For an adaptation-oriented architecture guide, see
 
 This sample writes durable monitoring output to files and serves a bounded live
 event viewer while a separate foreground agent answers voice or typed queries.
-Monitoring stays dormant until the foreground model calls the matching
-participant-scoped start tool. The model can also inspect the current frame or
-read recent monitor observations. The shared connection web client is served,
-but there is no domain-specific monitoring UI, MCP adapter, NAT compatibility
-layer, or separate activity-viewer process.
-
-The worker composes peer agents through typed runtime topics:
-
-```text
-hub participant join ──────────────────────────────────> file session
-final voice STT ─────────> FileOutputAgent ─────────────> transcript.jsonl
-accepted STT / typed text ─> ForegroundAgent ─┬> direct answer
-                                           ├> current frame → image query
-                                           ├> FileOutputAgent history tool
-                                           ├> MonitorAgent start/stop/status tools
-                                           ├> one-shot marker-labelled reads → VLM
-                                           ├> InstrumentMonitorAgent controls
-                                           ├> VoiceAggregationAgent → Piper TTS
-                                           └> foreground.jsonl
-MonitorAgent while active ──> current frame → image query ──> monitor.jsonl
-InstrumentMonitorAgent ──> LabInstrumentAgent ──> change/lost/state topics
- change/lost topics ──> InstrumentAlertAgent ──> VoiceAggregationAgent
- change/lost/state topics ──> FileOutputAgent ──> instrument-monitoring.jsonl
- selected typed topics ──> WebEventsAdapterAgent ──> browser event viewer
-```
-
-`ParticipantImageAgent` owns the shared image registry, `CurrentFrameTool`, and
-participant image cleanup. The monitor and foreground agents own their respective
-`ImageQueryTool` instances and acquire frames through that image agent. The monitor
-periodically queries a frame only while its participant-scoped task is active.
-It also owns idempotent `start_monitoring`, `stop_monitoring`, and
-`monitoring_status` tools. The foreground agent exposes its own composed
-current-view tool and calls the monitor's control tools directly, binding the
-participant before every operation.
-
-`FileOutputAgent` owns structured durable outputs and the bounded recent-history
-tool. `LabInstrumentAgent` performs reusable one-frame marker-associated reads.
-It can optionally write source-frame snapshots used to debug marker extraction.
-The shared
-image agent uses `MarkerTrackingTool` for QR and ArUco markers. `device_map.yaml`
-maps each marker family and raw ID to the device name used in readings, state,
-logs, and voice alerts. Ready-to-print PNGs for every configured device and a
-mapping table are available in [`sample-markers/`](sample-markers/).
-Detections absent from the device map are logged and ignored; they never become
-invented device names or voice alerts. The reader overlays every detected marker
-with a temporary label and asks the VLM for one joint label-to-reading JSON map.
-For each mapped marker, the VLM must visibly establish that the labelled marker
-and display share one continuous instrument housing. A nearby or lone readable
-display is not sufficient; the reader returns `UNKNOWN` whenever ownership
-cannot be proved from the image. The temporary labels are mapped back to the
-CV-decoded identities after inference, so marker payloads are not placed in the
-VLM prompt.
-
-`InstrumentMonitorAgent` owns all participant-scoped instrument state. It
-normalizes numeric readings, retains a known unit when a later VLM result omits
-it, and emits an event only when a device is first discovered or its normalized
-value or unit changes. Mapped marker sightings refresh last-seen state even when
-glare or obstruction makes the display unreadable. A device can leave and
-re-enter view without another alert when its reading is unchanged. Once its
-marker has not been seen for the configured loss timeout, the agent emits one
-lost-device event. It also emits the full tracked state every 10 seconds.
-`InstrumentAlertAgent` converts change and lost-device
-topics into voice notes; state snapshots are persisted without being spoken.
-Foreground replies and alert notes first pass through `VoiceAggregationAgent`,
-which keeps one participant response active and combines non-urgent updates
-that arrive while it is being spoken. Interrupting safety messages retain the
-existing immediate interruption behavior.
-
-Each foreground turn starts with only the system prompt and current request.
-Its native `run_tool_loop` integration uses a namespaced route catalog and
-four-iteration limit. The model selects from one fixed tool catalog; the worker
-does not apply a second lexical router or corrective prompt. It carries no
-conversation across requests.
-Return-direct monitor controls end the turn immediately.
-When the model selects `current_view`, the sample follows the
-`simple-vlm-example` path: it acquires one frame and publishes
-`StreamingImageQueryTool` chunks directly to voice. The visual answer is not
-sent back through the foreground LLM for rewriting. A dedicated current-view
-prompt applies visible-evidence, plain-speech, and response-length rules on this
-direct path.
+See the docs page above for architecture, agent responsibilities, and how to
+adapt the sample.
 
 ## Run
 
@@ -127,15 +49,10 @@ uv run --project agent-samples/lab-instrument-monitoring \
 Connect a glasses or platform client using the authenticated LiveKit URL,
 room, and token printed by the hub. Port 8080 serves the shared connection web
 client together with the authenticated token and signaling routes. The separate
-read-only event viewer defaults to `http://127.0.0.1:8092`. Pass
-`--expose-web-events` to listen on all IPv4 interfaces, then open
-`http://<xr-host>:8092` to group live output by participant and topic. JSONL
-files remain the durable output. Allow TCP port 8092 through the host firewall
-only from a trusted network when connecting remotely.
-
-The event viewer does not reuse DeviceIOHub authentication and serves plain HTTP.
-Use `--expose-web-events` only on a trusted network; put an authenticated TLS
-reverse proxy in front of it before broader exposure.
+read-only event viewer defaults to `http://127.0.0.1:8092`. Its listener has no
+authentication or TLS. Pass `--expose-web-events` to listen on all IPv4
+interfaces, then open `http://<xr-host>:8092` only from a trusted network, or
+put an authenticated TLS reverse proxy in front of it.
 
 Ask the foreground assistant to start a background task with an optional focus,
 for example “watch for packages near the doorway.” It can report status or stop
@@ -143,15 +60,15 @@ the task on later turns without capturing the foreground. Current-view
 questions and ordinary nonvisual questions work whether monitoring is active
 or stopped.
 
-Every non-empty final STT result is written to `transcript.jsonl` before voice
-gating, including ambient speech rejected by a configured wake phrase. The
-default gate accepts `agent` and `hey agent`, plays a listening chime, and
-allows one follow-up utterance for five seconds. Accepted speech reaches the
-foreground as a `UserQuery`. Typed text reaches the foreground but is not an
-STT transcript. Spoken agent text is also published to the client
-`agent.response` topic for captions and other accessibility presentation.
+The default voice gate accepts `agent` and `hey agent`, plays a listening
+chime, and allows one follow-up utterance for five seconds.
 
 ## File outputs
+
+**Every finalized STT result, including speech rejected by the wake-word
+gate, is written to `transcript.jsonl`.** Wake-word rejection controls
+whether the foreground responds, not whether the utterance is stored. See the
+docs page above for the full persistence and redaction contract.
 
 Each connection writes to a new participant-scoped directory:
 
@@ -165,34 +82,20 @@ artifacts/
     └── foreground.jsonl
 ```
 
-Every per-session file begins with a `session` record and receives a
-`session_end` record on participant departure once that output type has been
-written. Monitor records contain a baseline, observations, unavailable-frame
-notices, or errors. Foreground records include the query, response, and
-model-selected tool names. Relay events contain prompts, responses, participant
-metadata, and tool lifecycles;
-live camera bytes are redacted by the shared vision tool. When
-`capture_marker_scans` is enabled, every lab-instrument invocation saves the
-exact source JPEG under `marker-scans/`; the worker log records that path and
-marker-family counts for debugging. Unmapped marker payloads are represented by
-a bounded hash rather than logged verbatim. Instrument monitoring
-records contain discrete changes, one-time tracking-loss events, and complete
-state snapshots.
-
-The visual and instrument monitoring cadences, 10-second instrument-state
-interval, device-loss timeout, history bound, frame timeouts, prompts, VAD
-settings, device-map path, output path, and event-viewer listener live in
+Sample markers to print are in [`sample-markers/`](sample-markers/). The
+visual and instrument monitoring cadences, device-loss timeout, history bound,
+prompts, VAD settings, device-map path, and event-viewer listener live in
 `yaml/lab_instrument_monitoring_worker.yaml`. Marker-to-device mappings live in
-`yaml/device_map.yaml`. Model
-adapters, endpoints, readiness, and deployment ownership live in
+`yaml/device_map.yaml`. Model adapters and endpoints live in
 `yaml/models.json`.
 
 ## Foreground routing eval
 
 The eval checks whether the LLM selects current vision, monitoring history,
 background controls, or no tool, and validates every tool call against its
-runtime request model. It requires the configured `llm` role to be running; the
-fixed model configuration provides it through `model-servers`.
+runtime request model. It requires the configured `llm` role — and, for the
+visual evals, the relevant VLM — to already be running; the fixed model
+configuration provides both through `model-servers`.
 
 ```bash
 cd agent-samples/lab-instrument-monitoring

--- a/agent-samples/simple-vlm-example/README.md
+++ b/agent-samples/simple-vlm-example/README.md
@@ -20,6 +20,21 @@ The worker is a package under `worker/simple_vlm_example_worker/`:
 - `app.py` composes the native runtime (`VoiceAgent` + `SimpleVlmAgent`).
 - `prompts/system.txt` owns the VLM system prompt.
 
+`VoiceAgent` privately owns STT/TTS/VLM readiness, the hub voice transport,
+voice-gate processing, streaming TTS, signals, and cleanup. It publishes every
+final pre-gate STT result on `voice.transcript`, including speech without the
+wake phrase, and publishes accepted speech and typed text as `UserQuery` on
+this sample's topic. `SimpleVlmAgent` subscribes to that topic, selects the participant's
+current image with `CurrentFrameTool`, passes its opaque reference to the
+transport-independent `StreamingImageQueryTool`, and publishes chunks to
+`voice.output`. The query tool has no voice dependency and sends its provider
+stream through Relay's managed LLM path. Camera bytes stay out of tool results
+and image locations are redacted from VLM telemetry. `VoiceAgent` publishes
+participant departure and interruption on sample-named topics;
+`SimpleVlmAgent` subscribes and releases its own cached frames and tasks. A
+newer turn cancels and interrupts a superseded response. `app.py` only composes
+the two agents and their dependencies.
+
 No MCP client or MCP tool invocation is part of this sample.
 
 ## Run

--- a/agent-samples/simple-vlm-example/README.md
+++ b/agent-samples/simple-vlm-example/README.md
@@ -5,6 +5,9 @@
 
 # Simple VLM example
 
+For a walkthrough of running this sample, see
+[`docs/source/getting_started/quickstart.md`](../../docs/source/getting_started/quickstart.md).
+
 This sample answers voice and text questions against each participant's latest
 camera frame. Responses stream to both Piper TTS and the `vlm.response` data
 topic.
@@ -14,23 +17,8 @@ The worker is a package under `worker/simple_vlm_example_worker/`:
 - `__main__.py` parses launcher arguments.
 - `agent.py` owns participant-scoped vision turns and cancellation.
 - `config.py` resolves worker, model, voice-gate, and prompt settings.
-- `app.py` composes the native runtime.
+- `app.py` composes the native runtime (`VoiceAgent` + `SimpleVlmAgent`).
 - `prompts/system.txt` owns the VLM system prompt.
-
-`VoiceAgent` privately owns STT/TTS/VLM readiness, the hub voice transport,
-voice-gate processing, streaming TTS, signals, and cleanup. It publishes every
-final pre-gate STT result on `voice.transcript`, including speech without the
-wake phrase, and publishes accepted speech and typed text as `UserQuery` on
-this sample's topic. `SimpleVlmAgent` subscribes to that topic, selects the participant's
-current image with `CurrentFrameTool`, passes its opaque reference to the
-transport-independent `StreamingImageQueryTool`, and publishes chunks to
-`voice.output`. The query tool has no voice dependency and sends its provider
-stream through Relay's managed LLM path. Camera bytes stay out of tool results
-and image locations are redacted from VLM telemetry. `VoiceAgent` publishes
-participant departure and interruption on sample-named topics;
-`SimpleVlmAgent` subscribes and releases its own cached frames and tasks. A
-newer turn cancels and interrupts a superseded response. `app.py` only composes
-the two agents and their dependencies.
 
 No MCP client or MCP tool invocation is part of this sample.
 

--- a/agent-samples/tea-making-sample/README.md
+++ b/agent-samples/tea-making-sample/README.md
@@ -9,22 +9,9 @@ For an adaptation-oriented architecture guide, see
 [`docs/source/reference/tea-making-sample.md`](../../docs/source/reference/tea-making-sample.md).
 
 This sample combines a foreground tea guide with independent background
-observers. The foreground guide identifies tea, retrieves brewing guidance,
-watches visible preparation steps, and maintains one deterministic workflow per
-participant. Background tasks can record transcripts, watch for requested visual
-changes, and write periodic video observations without replacing the active tea
-guide.
-
-Foreground replies and workflow notices publish candidate speech through
-`VoiceAggregationAgent`. It preserves one participant's active response,
-combines non-urgent updates that arrive while that response is being spoken,
-and forwards interrupting output immediately.
-
-The sample uses native `xr_ai_runtime` agents and `xr_ai_tools`; it does not use
-NAT, PydanticAI, or MCP. Nemotron-3-Nano-Omni on port 8108 supplies both language
-reasoning and visual inference. STT, embedding, and RAG remain separate typed
-services. Selected runtime events appear in a generic live browser viewer while
-durable operational records remain JSON Lines files under `artifacts/`.
+observers (transcripts, visual-change watching, periodic video observations).
+See the docs page above for architecture, agent responsibilities, and how to
+adapt the sample.
 
 ## Run it
 
@@ -75,22 +62,7 @@ finalized when its rewrite completes; playback pacing does not delay the Agent
 panel. An urgent interruption may stop audio after the complete intended text
 has already appeared.
 
-## Behavior
-
-The foreground agent sees only the current user query and compact workflow
-state. Its native tool loop can answer directly, inspect the current image,
-retrieve tea references, control the tea workflow, or start and stop background
-tasks. Participant identity is injected by the application and is never exposed
-as a model-selected argument.
-
-When that loop selects `current_view`, the sample uses the same direct streaming
-path as `simple-vlm-example`: one current frame goes to
-`StreamingImageQueryTool`, whose chunks go straight to participant voice. Omni's
-visual response is not passed back through the foreground LLM for rewriting.
-
-The tea workflow advances only after explicit user commands. Visual observations
-may update evidence-backed state, but they do not silently move to the next step.
-Participant joins create fresh state; leaving cancels participant-owned work.
+## File outputs
 
 Background task output is retained under the sample's `artifacts/` directory:
 

--- a/agent-samples/tea-making-sample/README.md
+++ b/agent-samples/tea-making-sample/README.md
@@ -11,7 +11,7 @@ For an adaptation-oriented architecture guide, see
 This sample combines a foreground tea guide with independent background
 observers (transcripts, visual-change watching, periodic video observations).
 It uses native `xr_ai_runtime` agents and `xr_ai_tools`; it does not use NAT,
-PydanticAI, or MCP. See the docs page above for architecture, agent
+PydanticAI, or MCP. See the linked guide above for architecture, agent
 responsibilities, and how to adapt the sample.
 
 ## Run it

--- a/agent-samples/tea-making-sample/README.md
+++ b/agent-samples/tea-making-sample/README.md
@@ -10,8 +10,9 @@ For an adaptation-oriented architecture guide, see
 
 This sample combines a foreground tea guide with independent background
 observers (transcripts, visual-change watching, periodic video observations).
-See the docs page above for architecture, agent responsibilities, and how to
-adapt the sample.
+It uses native `xr_ai_runtime` agents and `xr_ai_tools`; it does not use NAT,
+PydanticAI, or MCP. See the docs page above for architecture, agent
+responsibilities, and how to adapt the sample.
 
 ## Run it
 

--- a/agent-samples/xr-render-demo/README.md
+++ b/agent-samples/xr-render-demo/README.md
@@ -5,6 +5,9 @@
 
 # xr-render-demo
 
+For process-stack, agentic-loop, and tracing/debugging details, see
+[`docs/source/reference/xr-render-demo.md`](../../docs/source/reference/xr-render-demo.md).
+
 Voice-driven XR scene manipulation sample. A supervisor routes natural-language
 commands to five focused subagents; each subagent calls typed function groups
 from `xr-ai-tools` to read and mutate the live XR scene.
@@ -120,27 +123,5 @@ uv run --project agent-samples/xr-render-demo/eval xr_render_demo_eval
 uv run --project agent-samples/xr-render-demo/eval xr_render_demo_live_manip
 ```
 
-## Tracing and debugging
-
-Each voice turn carries a `trace_id` equal to `ctx.metadata.message_id` from
-the xr-ai-runtime `RuntimeContext`. Filter logs by it:
-
-```
-grep "trace=<id>" <log-file>
-```
-
-Key log events (all at `DEBUG` level in `supervisor.py`):
-
-| Event | Message pattern |
-|-------|----------------|
-| Turn received | `supervisor turn participant=... trace=... transcript=...` |
-| Subagent delegated | emitted by the subagent's `run_tool_loop` |
-| Tool rejected (ValueError) | `tool <name> rejected input: ...` |
-| Tool failed (unexpected) | `tool <name> failed unexpectedly` (with traceback) |
-| Turn failed | `xr-render turn failed for <participant>: ...` |
-
-Expected degradation (tool error converted to model scratch, turn continues):
-`ValueError` from a tool call (bad arguments, object not found).
-
-Unexpected failures (traceback logged, turn aborted): any other exception
-propagating out of `SceneSupervisor.handle()`.
+Tracing and debugging (trace IDs, key log events, error policy) are covered in
+the docs page linked above.

--- a/docs/source/reference/lab-instrument-monitoring.md
+++ b/docs/source/reference/lab-instrument-monitoring.md
@@ -239,6 +239,41 @@ no participant authentication or TLS. Use the externally reachable sample mode
 only on a trusted development network, or put an authenticated TLS reverse
 proxy in front of it.
 
+## File outputs and persistence
+
+Every non-empty final STT result is written to `transcript.jsonl` before voice
+gating, including ambient speech rejected by a configured wake phrase. Wake-word
+gating controls dispatch to the foreground, not storage: rejected speech is
+still transcribed and persisted. The default gate accepts `agent` and
+`hey agent`, plays a listening chime, and allows one follow-up utterance for
+five seconds. Accepted speech reaches the foreground as a `UserQuery`. Typed
+text reaches the foreground but is not an STT transcript.
+
+Each connection writes to a new participant-scoped directory:
+
+```text
+artifacts/
+├── relay-events.jsonl
+└── <participant>-<utc-session-stamp>/
+    ├── monitor.jsonl
+    ├── instrument-monitoring.jsonl
+    ├── transcript.jsonl
+    └── foreground.jsonl
+```
+
+Every per-session file begins with a `session` record and receives a
+`session_end` record on participant departure once that output type has been
+written. Monitor records contain a baseline, observations, unavailable-frame
+notices, or errors. Foreground records include the query, response, and
+model-selected tool names. Relay events contain prompts, responses, participant
+metadata, and tool lifecycles; live camera bytes are redacted by the shared
+vision tool. When `capture_marker_scans` is enabled, every lab-instrument
+invocation saves the exact source JPEG under `marker-scans/`; the worker log
+records that path and marker-family counts for debugging. Unmapped marker
+payloads are represented by a bounded hash rather than logged verbatim.
+Instrument monitoring records contain discrete changes, one-time
+tracking-loss events, and complete state snapshots.
+
 ## Adapting the sample
 
 ### Track another measured object


### PR DESCRIPTION
## Summary
- Sample READMEs (`lab-instrument-monitoring`, `tea-making-sample`, `xr-render-demo`, `simple-vlm-example`) re-explained architecture, agent-ownership tables, and adaptation guidance that's already maintained in `docs/source/reference/*.md`, and had drifted out of sync with it. Each now links to that page (or, for `simple-vlm-example`, the quickstart) with a same-revision relative link, and drops the narrative content that duplicated it.
- Content with no home in docs — running/connection instructions, file-output layout, config-file pointers, `xr-render-demo`'s file map and extension guide, `simple-vlm-example`'s Relay-visibility internals — is kept as-is; this PR does not claim a strict "running instructions only" policy, only removal of duplicated narrative.
- The lab sample's persistence/privacy contract (wake-word-rejected speech is still transcribed and stored, session/record shapes, Relay redaction, marker-payload hashing) moved into the docs reference page, with a concise warning retained beside the README's File outputs section.
- The main `README.md` links to the docs site root near the top (unversioned — resolves to the latest release per the docs deploy workflow, so it's safe from a release-tag checkout).

Rebased (via reset + reapply) onto main's model-server reuse refactor (#414), which landed independently while this was in review and touched the same READMEs (removed `--tts-mode`/`--vlm-mode`, renamed `models.local.json` → `models.json` for the affected samples). Those behavioral changes are preserved as-is; only the dedup edits were reapplied on top.

## Test plan
- [x] Reviewed diffs for each README to confirm running instructions and privacy-relevant warnings were preserved.
- [x] Manually checked the new docs section's Markdown (heading levels, code-fence balance).
- [ ] Docs strict build (`make -C docs strict-versions`) — not run locally (no local Sphinx env); CI docs workflow covers `docs/**` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)