### PR TITLE
XR render demo perception improvements

### DIFF
--- a/agent-samples/xr-render-demo/README.md
+++ b/agent-samples/xr-render-demo/README.md
@@ -54,9 +54,9 @@ voice query
        └─ SceneSupervisor.handle()           one turn, per-participant lock
             └─ run_tool_loop (LLM + subagent tools)
                  ├─ make_placement_agent()   SceneTools + TrackingTools
-                 ├─ make_appearance_agent()  SceneTools + physical-color camera tool
+                 ├─ make_appearance_agent()  SceneTools + camera-backed color resolver
                  ├─ make_object_agent()      SceneTools + TrackingTools
-                 │                           + physical-color camera tool
+                 │                           + camera-backed color resolver
                  ├─ make_vision_agent()      CurrentFrameTool + ImageQueryTool
                  │                           + VideoMemoryTools (optional)
                  └─ make_memory_agent()      TextMemoryTools

--- a/agent-samples/xr-render-demo/README.md
+++ b/agent-samples/xr-render-demo/README.md
@@ -54,8 +54,9 @@ voice query
        └─ SceneSupervisor.handle()           one turn, per-participant lock
             └─ run_tool_loop (LLM + subagent tools)
                  ├─ make_placement_agent()   SceneTools + TrackingTools
-                 ├─ make_appearance_agent()  SceneTools
+                 ├─ make_appearance_agent()  SceneTools + physical-color camera tool
                  ├─ make_object_agent()      SceneTools + TrackingTools
+                 │                           + physical-color camera tool
                  ├─ make_vision_agent()      CurrentFrameTool + ImageQueryTool
                  │                           + VideoMemoryTools (optional)
                  └─ make_memory_agent()      TextMemoryTools

--- a/agent-samples/xr-render-demo/eval/README.md
+++ b/agent-samples/xr-render-demo/eval/README.md
@@ -91,7 +91,7 @@ fast gate manually after each edit:
 uv run xr_render_demo_eval utterances
 ```
 
-25 cases, ~3 minutes. The `scenarios` and `precision` tiers catch
+34 cases, a few minutes. The `scenarios` and `precision` tiers catch
 regressions but take longer; run them before calling a tuning round done.
 
 ## Writing a case
@@ -105,8 +105,9 @@ exemplified). Precision and utterances cases are `Case` dataclasses in
 ## Don't train on the test set
 
 Prompt worked examples and case fixtures share the same model, so the
-harness audits every worker prompt at startup (all three offline tiers run
-it) and warns on:
+harness audits every worker prompt plus the model-visible tool text in
+`spatial_ops.py`, `_physical_color.py`, and the agent modules at startup
+(all three offline tiers run it) and warns on:
 
 1. A case utterance from any tier appearing verbatim in a prompt.
 2. A case fixture id appearing in a prompt.
@@ -124,4 +125,5 @@ while the prompt contains its vocabulary is scoring recall, not skill.
 - The live worker pipeline (VAD, STT, TTS, history bookkeeping); the live
   tier covers it.
 - Real scene-service / LOVR effects (fixture-succeeded).
-- Real visual queries (`look_at_current_frame`, `look_at_past_frame`): stubbed.
+- Real visual queries (`look_at_current_frame`, `look_at_past_frame`,
+  `resolve_physical_color`): stubbed.

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/cases.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/cases.py
@@ -1265,8 +1265,8 @@ CASES = [
     },
 
     # ── perception gating: real-world colour must come from the camera ───────
-    # The colour word is never in the utterance; the model must call
-    # look_at_current_frame FIRST and read the colour out of the answer.
+    # The colour word is never in the utterance; a perception tool (either of
+    # PERCEPTION_TOOL) must observe the camera before any mutation.
     # `vlm_answer` is what the mocked camera sees; `must_call_first` fails
     # the case if the model mutates before (or without) looking.
     {

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/cases.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/cases.py
@@ -78,7 +78,7 @@ def _stacked_vertically(mutations: list[tuple[str, dict]]) -> tuple[bool, str]:
     return True, f"stacked at y={ys}"
 
 
-PERCEPTION_TOOL = "look_at_current_frame"
+PERCEPTION_TOOL = ("look_at_current_frame", "resolve_physical_color")
 
 CASES = [
     # ── direct render ops ─────────────────────────────────────────────────────

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/cases.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/cases.py
@@ -78,7 +78,7 @@ def _stacked_vertically(mutations: list[tuple[str, dict]]) -> tuple[bool, str]:
     return True, f"stacked at y={ys}"
 
 
-PERCEPTION_TOOL = ("look_at_current_frame", "resolve_physical_color")
+PERCEPTION_TOOLS = ("look_at_current_frame", "resolve_physical_color")
 
 CASES = [
     # ── direct render ops ─────────────────────────────────────────────────────
@@ -1266,7 +1266,7 @@ CASES = [
 
     # ── perception gating: real-world colour must come from the camera ───────
     # The colour word is never in the utterance; a perception tool (either of
-    # PERCEPTION_TOOL) must observe the camera before any mutation.
+    # PERCEPTION_TOOLS) must observe the camera before any mutation.
     # `vlm_answer` is what the mocked camera sees; `must_call_first` fails
     # the case if the model mutates before (or without) looking.
     {
@@ -1274,7 +1274,7 @@ CASES = [
         "scene": [],
         "user":  "Make a sphere the same color as the thing I'm holding.",
         "vlm_answer": "The user is holding a bright red apple.",
-        "must_call_first": PERCEPTION_TOOL,
+        "must_call_first": PERCEPTION_TOOLS,
         "result": [
             {"tool": "add_primitive",
              "args": {"prim_type": "sphere",
@@ -1287,7 +1287,7 @@ CASES = [
                    "pos": [0.0, 1.6, -1.5], "color": [1, 1, 1], "size": 0.1}],
         "user":  "Make the sphere the same color as my shirt.",
         "vlm_answer": "The user's shirt is blue.",
-        "must_call_first": PERCEPTION_TOOL,
+        "must_call_first": PERCEPTION_TOOLS,
         "result": [
             {"tool": "update_primitive",
              "args": {"obj_id": "sphere-0",
@@ -1299,7 +1299,7 @@ CASES = [
         "scene": [],
         "user":  "Add a cube that matches the color of the wall I'm looking at.",
         "vlm_answer": "The wall is green.",
-        "must_call_first": PERCEPTION_TOOL,
+        "must_call_first": PERCEPTION_TOOLS,
         "result": [
             {"tool": "add_primitive",
              "args": {"prim_type": "box",

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/harness.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/harness.py
@@ -125,7 +125,7 @@ class _FakePhysicalColorQuery:
 
     async def execute(self, request: Any) -> Any:
         from xr_ai_tools.vision import ImageQueryResult
-        from xr_render_demo_worker.spatial_ops import COLOR_WORDS
+        from xr_render_demo_worker.spatial_ops import _COLOR_WORDS
         self._fake.calls.append(("resolve_physical_color", {"question": request.query}))
         if self._fake.vision_error:
             return ImageQueryResult(text=self._fake.vision_error, available=False)
@@ -141,8 +141,8 @@ class _FakePhysicalColorQuery:
         import re as _re
         observed = None
         for word in _re.findall(r"[a-z]+", (self._fake.vision_answer or "").lower()):
-            if word in COLOR_WORDS:
-                observed = COLOR_WORDS[word]
+            if word in _COLOR_WORDS:
+                observed = _COLOR_WORDS[word]
         if observed is None:
             return ImageQueryResult(text="UNKNOWN", available=True)
         r, g, b = observed
@@ -824,6 +824,20 @@ UTTERANCES = (
         ),
         required_tools=frozenset({"add_primitive"}),
         expected_colors=(("sphere-0", (0.0, 0.4, 1.0)),),
+    ),
+    Case(
+        name="basics_repeat_identical_create",
+        # A verbatim repeat of a completed creation is a NEW creation; the
+        # existing object never satisfies it.
+        request="Make a red cube.",
+        scene=(
+            {"id": "box-0", "type": "box",
+             "position": {"x": 0.0, "y": 1.6, "z": -1.5},
+             "color": {"r": 1, "g": 0, "b": 0}, "size": 0.1},
+        ),
+        history=(("Make a red cube.", "Created a red cube in front of you."),),
+        required_tools=frozenset({"add_primitive"}),
+        expected_colors=(("box-1", (1.0, 0.0, 0.0)),),
     ),
     Case(
         name="basics_create_despite_similar_existing",

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/harness.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/harness.py
@@ -115,13 +115,17 @@ class _FakeCurrentFrameTool:
 
 
 class _FakePhysicalColorQuery:
-    """Records the resolver's VLM query distinctly from the vision agent's."""
+    """Records the resolver's VLM query distinctly from the vision agent's.
+
+    Simulates a grammar-obedient VLM: prose fixture answers are translated
+    to "VISIBLE r g b" from their last color word, or "UNKNOWN"."""
 
     def __init__(self, fake: "FakeScene") -> None:
         self._fake = fake
 
     async def execute(self, request: Any) -> Any:
         from xr_ai_tools.vision import ImageQueryResult
+        from xr_render_demo_worker.spatial_ops import COLOR_WORDS
         self._fake.calls.append(("resolve_physical_color", {"question": request.query}))
         if self._fake.vision_error:
             return ImageQueryResult(text=self._fake.vision_error, available=False)
@@ -132,8 +136,17 @@ class _FakePhysicalColorQuery:
             and self._fake.physical_expect_source.lower() not in request.query.lower()
         ):
             return ImageQueryResult(text="UNKNOWN", available=True)
-        answer = self._fake.physical_answer or self._fake.vision_answer
-        return ImageQueryResult(text=answer or "Nothing notable is visible.", available=True)
+        if self._fake.physical_answer:
+            return ImageQueryResult(text=self._fake.physical_answer, available=True)
+        import re as _re
+        observed = None
+        for word in _re.findall(r"[a-z]+", (self._fake.vision_answer or "").lower()):
+            if word in COLOR_WORDS:
+                observed = COLOR_WORDS[word]
+        if observed is None:
+            return ImageQueryResult(text="UNKNOWN", available=True)
+        r, g, b = observed
+        return ImageQueryResult(text=f"VISIBLE {r} {g} {b}", available=True)
 
 
 def make_fake_video(fake: "FakeScene", video_error: str = ""):
@@ -157,9 +170,7 @@ def make_fake_video(fake: "FakeScene", video_error: str = ""):
 
 def make_fake_physical_color(fake: "FakeScene"):
     from xr_render_demo_worker._physical_color import make_physical_color_tool
-    from xr_render_demo_worker.spatial_ops import COLOR_WORDS
-    return make_physical_color_tool(
-        _FakeCurrentFrameTool(fake), _FakePhysicalColorQuery(fake), COLOR_WORDS)
+    return make_physical_color_tool(_FakeCurrentFrameTool(fake), _FakePhysicalColorQuery(fake))
 
 
 class _FakeImageQueryTool:
@@ -197,6 +208,7 @@ class Case:
     history: tuple[tuple[str, str], ...] = ()
     reply_contains: str = ""
     camera_error: str = ""
+    physical_expect_source: str = ""
 
 
 CASES = (
@@ -248,7 +260,7 @@ CASES = (
             },
         ),
         vision="The wall is orange: normalized RGB (1.0, 0.5, 0.0).",
-        required_tools=frozenset({"update_primitive"}),
+        required_tools=frozenset({"resolve_physical_color", "update_primitive"}),
         expected_colors=(("cone-0", (1.0, 0.5, 0.0)),),
     ),
     Case(
@@ -455,6 +467,7 @@ class FakeScene:
             case.memory,
             case.history,
             camera_error=case.camera_error,
+            physical_expect_source=case.physical_expect_source,
         )
 
     @classmethod
@@ -726,14 +739,16 @@ UTTERANCES = (
              "color": {"r": 1, "g": 1, "b": 1}, "size": 0.1},
         ),
         vision="The ceiling is purple.",
-        required_tools=frozenset({"update_primitive"}),
+        physical_expect_source="ceiling",
+        required_tools=frozenset({"resolve_physical_color", "update_primitive"}),
         expected_colors=(("cylinder-0", (0.6, 0.0, 1.0)),),
     ),
     Case(
         name="basics_holding_color_creates",
         request="Make a sphere the color of what I'm holding.",
         vision="A hand holding a blue lid.",
-        required_tools=frozenset({"add_primitive"}),
+        physical_expect_source="holding",
+        required_tools=frozenset({"resolve_physical_color", "add_primitive"}),
         expected_colors=(("sphere-0", (0.0, 0.4, 1.0)),),
     ),
     Case(
@@ -1160,7 +1175,9 @@ def audit_prompts() -> None:
     worker = (Path(__file__).resolve().parent / "../../worker/xr_render_demo_worker").resolve()
     # Model-visible text lives in the prompt files and in the tool field
     # descriptions of spatial_ops.py; both shape the model's templates.
-    prompts = sorted(worker.rglob("*prompt*.txt")) + [worker / "spatial_ops.py"]
+    prompts = (sorted(worker.rglob("*prompt*.txt"))
+               + [worker / "spatial_ops.py", worker / "_physical_color.py"]
+               + sorted(worker.glob("agents/*/agent.py")))
     utterances = [case["user"] for case in CORPUS_CASES if case.get("user")]
     utterances += [case.request for case in (*CASES, *UTTERANCES)]
     # History turns and fixture answers reach the model verbatim too; a
@@ -1203,7 +1220,7 @@ def audit_prompts() -> None:
         eval_texts += [
             text
             for case in eval_supervisor.CASES
-            for turn in getattr(case, "history", ())
+            for turn in case.history
             for text in turn
         ]
         fixture_ids |= {item["id"] for case in eval_supervisor.CASES for item in case.scene}

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/harness.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/harness.py
@@ -584,10 +584,17 @@ def _make_supervisor(llm, fake_scene, fake_tracking, fake_text_memory,
     )
     from xr_render_demo_worker.scene import SceneContext
     context = SceneContext(fake_scene, fake_tracking)
+
+    async def physical_color(color_words: str) -> str:
+        from types import SimpleNamespace
+        result = await fake_image_query.execute(
+            SimpleNamespace(query=f"What color is {color_words}?"))
+        return result.text
+
     subagent_tools = [
         make_placement_agent(llm, fake_scene, fake_tracking, context),
-        make_appearance_agent(llm, fake_scene, context),
-        make_object_agent(llm, fake_scene, fake_tracking, context),
+        make_appearance_agent(llm, fake_scene, context, physical_color),
+        make_object_agent(llm, fake_scene, fake_tracking, context, physical_color),
         make_vision_agent(llm, fake_current_frame, fake_image_query, context),
         make_memory_agent(llm, fake_text_memory),
     ]
@@ -651,6 +658,87 @@ _BASICS_HISTORY = (
 _FORBID_MUTATIONS = _MUTATING
 
 UTTERANCES = (
+    Case(
+        name="basics_physical_color_source",
+        request="Make the cylinder the same color as the ceiling.",
+        scene=(
+            {"id": "cylinder-0", "type": "cylinder",
+             "position": {"x": 0.0, "y": 1.5, "z": -1.3},
+             "color": {"r": 1, "g": 1, "b": 1}, "size": 0.1},
+        ),
+        vision="The ceiling is purple.",
+        required_tools=frozenset({"look_at_current_frame", "update_primitive"}),
+        required_order=("look_at_current_frame", "update_primitive"),
+    ),
+    Case(
+        name="basics_holding_color_creates",
+        request="Make a sphere the color of what I'm holding.",
+        vision="A hand holding a blue lid.",
+        required_tools=frozenset({"look_at_current_frame", "add_primitive"}),
+        required_order=("look_at_current_frame", "add_primitive"),
+        expected_colors=(("sphere-0", (0.0, 0.4, 1.0)),),
+    ),
+    Case(
+        name="basics_preposition_final_question",
+        request="What am I looking at right now?",
+        vision="A hand holding a blue lid.",
+        required_tools=frozenset({"look_at_current_frame"}),
+        forbidden_tools=_FORBID_MUTATIONS,
+    ),
+    Case(
+        name="basics_holding_after_camera_chatter",
+        request="What am I holding?",
+        vision="A hand holding a blue lid.",
+        scene=(
+            {"id": "sphere-0", "type": "sphere",
+             "position": {"x": 0.0, "y": 1.6, "z": -1.5},
+             "color": {"r": 0, "g": 0.8, "b": 0}, "size": 0.1},
+            {"id": "box-0", "type": "box",
+             "position": {"x": 0.5, "y": 1.4, "z": -1.2},
+             "color": {"r": 1, "g": 0.5, "b": 0}, "size": 0.1},
+        ),
+        history=(
+            ("No cameras cannot see the scene.",
+             "The scene is empty, so there are no objects for the camera to see."),
+            ("The camera doesn't look at the scene.",
+             "The camera is not currently viewing any objects in the scene."),
+            ("Okay.", "What would you like me to do?"),
+            ("What am I looking at?", "You are looking at the camera."),
+            ("True.", "What would you like me to do?"),
+            ("Make a spear the color of the thing I am holding.",
+             "What are you holding?"),
+            ("Look for yourself.",
+             "I see a green sphere and an orange box in the scene."),
+        ),
+        required_tools=frozenset({"look_at_current_frame"}),
+        forbidden_tools=_FORBID_MUTATIONS,
+    ),
+    Case(
+        name="basics_holding_color_with_history",
+        request="Make a spear the color of the thing I am holding.",
+        vision="A hand holding a blue lid.",
+        history=(
+            ("The camera doesn't look at the scene.",
+             "I'm sorry, but I can't help with that."),
+            ("What am I looking at?", "You are looking at a blue plastic lid."),
+        ),
+        required_tools=frozenset({"look_at_current_frame", "add_primitive"}),
+        required_order=("look_at_current_frame", "add_primitive"),
+        expected_colors=(("sphere-0", (0.0, 0.4, 1.0)),),
+    ),
+    Case(
+        name="basics_recall_beyond_window",
+        request="What color was the very first thing I created?",
+        history=(
+            ("Add a green capsule.", "Created a green capsule."),
+            ("Move it to my left.", "Moved the capsule to your left."),
+            ("Add a white cylinder behind it.", "Created a white cylinder."),
+            ("Make the cylinder bigger.", "Enlarged the cylinder."),
+            ("Swap the capsule and the cylinder.", "Swapped them."),
+        ),
+        expected_call_counts=(("recall_conversation", 2),),
+        forbidden_tools=_FORBID_MUTATIONS,
+    ),
     Case(
         name="basics_create_cube",
         request="Make a red cube.",

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/harness.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/harness.py
@@ -52,6 +52,7 @@ _DEFAULT_POSE = {
 
 class _FakeSceneTools:
     def __init__(self, fake: "FakeScene") -> None:
+        self._fake = fake
         self.get_scene_state = Tool("get_scene_state", "Return scene.", EmptyRequest, SceneState, fake.get_scene_state)
         self.update_primitive = Tool(
             "update_primitive", "Update.", UpdatePrimitiveRequest, MutationResult, fake.update_primitive)
@@ -98,6 +99,8 @@ class _FakeCurrentFrameTool:
         self._fake = fake
 
     async def execute(self, request: Any) -> Any:
+        if self._fake.camera_error:
+            raise RuntimeError(self._fake.camera_error)
         from xr_ai_tools.current_frame import ImageFrame
         from xr_ai_tools.image import ImageReference
         return ImageFrame(
@@ -108,6 +111,48 @@ class _FakeCurrentFrameTool:
 
     def release(self, participant_id: str) -> None:
         pass
+
+
+class _FakePhysicalColorQuery:
+    """Records the resolver's VLM query distinctly from the vision agent's."""
+
+    def __init__(self, fake: "FakeScene") -> None:
+        self._fake = fake
+
+    async def execute(self, request: Any) -> Any:
+        from xr_ai_tools.vision import ImageQueryResult
+        self._fake.calls.append(("resolve_physical_color", {"question": request.query}))
+        if self._fake.vision_error:
+            return ImageQueryResult(text=self._fake.vision_error, available=False)
+        return ImageQueryResult(
+            text=self._fake.vision_answer or "Nothing notable is visible.", available=True
+        )
+
+
+def make_fake_video(fake: "FakeScene", video_error: str = ""):
+    from types import SimpleNamespace
+
+    from xr_ai_tools.image import ImageReference
+    from xr_ai_tools.video_memory import HistoricalFrameRequest, HistoricalFrameResult
+
+    async def historical(req: HistoricalFrameRequest) -> HistoricalFrameResult:
+        fake.calls.append(("look_at_past_frame", {"start_us": req.start_us}))
+        if video_error:
+            raise RuntimeError(video_error)
+        return HistoricalFrameResult(
+            image=ImageReference(uri="fake://past"), timestamp_us=req.start_us,
+            width=640, height=480)
+
+    return SimpleNamespace(get_historical_frame=Tool(
+        "get_historical_frame", "Recorded frame nearest a timestamp.",
+        HistoricalFrameRequest, HistoricalFrameResult, historical))
+
+
+def make_fake_physical_color(fake: "FakeScene"):
+    from xr_render_demo_worker._physical_color import make_physical_color_tool
+    from xr_render_demo_worker.spatial_ops import _COLOR_WORDS
+    return make_physical_color_tool(
+        _FakeCurrentFrameTool(fake), _FakePhysicalColorQuery(fake), _COLOR_WORDS)
 
 
 class _FakeImageQueryTool:
@@ -143,6 +188,7 @@ class Case:
     expected_positions: tuple[tuple[str, tuple[float, float, float]], ...] = ()
     memory: str = ""
     history: tuple[tuple[str, str], ...] = ()
+    reply_contains: str = ""
 
 
 CASES = (
@@ -194,7 +240,8 @@ CASES = (
             },
         ),
         vision="The wall is orange: normalized RGB (1.0, 0.5, 0.0).",
-        required_tools=frozenset({"look_at_current_frame", "update_primitive"}),
+        required_tools=frozenset({"update_primitive"}),
+        expected_colors=(("cone-0", (1.0, 0.5, 0.0)),),
     ),
     Case(
         name="compound_object_and_placement",
@@ -380,6 +427,7 @@ class FakeScene:
     vision_error: str
     memory_answer: str
     history: tuple[tuple[str, str], ...] = ()
+    camera_error: str = ""
     calls: list[tuple[str, dict[str, Any]]] = field(default_factory=list)
     counters: dict[str, int] = field(default_factory=dict)
 
@@ -538,11 +586,13 @@ def check_corpus(calls: list[tuple[str, dict[str, Any]]], case: dict[str, Any]) 
     names = [name for name, _args in calls]
     mutations = [(name, args) for name, args in calls if name in _MUTATING]
     if first_tool := case.get("must_call_first"):
-        if first_tool not in names:
-            return False, f"{first_tool} was never called"
+        first_tools = (first_tool,) if isinstance(first_tool, str) else tuple(first_tool)
+        called = [name for name in first_tools if name in names]
+        if not called:
+            return False, f"none of {first_tools} was called"
         first_mutation = next((index for index, name in enumerate(names) if name in _MUTATING), None)
-        if first_mutation is not None and names.index(first_tool) > first_mutation:
-            return False, f"{first_tool} called after the first mutation"
+        if first_mutation is not None and min(names.index(name) for name in called) > first_mutation:
+            return False, f"{called} called after the first mutation"
     wanted = list(case.get("result") or ())
     if not wanted and not mutations:
         return False, f"no mutating calls: {names}"
@@ -584,18 +634,13 @@ def _make_supervisor(llm, fake_scene, fake_tracking, fake_text_memory,
     )
     from xr_render_demo_worker.scene import SceneContext
     context = SceneContext(fake_scene, fake_tracking)
-
-    async def physical_color(color_words: str) -> str:
-        from types import SimpleNamespace
-        result = await fake_image_query.execute(
-            SimpleNamespace(query=f"What color is {color_words}?"))
-        return result.text
-
+    physical_color = make_fake_physical_color(fake_scene._fake)
     subagent_tools = [
         make_placement_agent(llm, fake_scene, fake_tracking, context),
         make_appearance_agent(llm, fake_scene, context, physical_color),
         make_object_agent(llm, fake_scene, fake_tracking, context, physical_color),
-        make_vision_agent(llm, fake_current_frame, fake_image_query, context),
+        make_vision_agent(llm, fake_current_frame, fake_image_query, context,
+                          make_fake_video(fake_scene._fake)),
         make_memory_agent(llm, fake_text_memory),
     ]
     return SceneSupervisor(
@@ -621,7 +666,7 @@ async def run_corpus_case(case: dict[str, Any]) -> bool:
                 SceneRequest(
                     transcript=case["user"],
                     participant_id=_PARTICIPANT,
-                    timestamp_us=10_000_000,
+                    timestamp_us=1_700_000_000_000_000,
                 )
             )
             response = reply.response
@@ -667,20 +712,19 @@ UTTERANCES = (
              "color": {"r": 1, "g": 1, "b": 1}, "size": 0.1},
         ),
         vision="The ceiling is purple.",
-        required_tools=frozenset({"look_at_current_frame", "update_primitive"}),
-        required_order=("look_at_current_frame", "update_primitive"),
+        required_tools=frozenset({"update_primitive"}),
+        expected_colors=(("cylinder-0", (0.6, 0.0, 1.0)),),
     ),
     Case(
         name="basics_holding_color_creates",
         request="Make a sphere the color of what I'm holding.",
         vision="A hand holding a blue lid.",
-        required_tools=frozenset({"look_at_current_frame", "add_primitive"}),
-        required_order=("look_at_current_frame", "add_primitive"),
+        required_tools=frozenset({"add_primitive"}),
         expected_colors=(("sphere-0", (0.0, 0.4, 1.0)),),
     ),
     Case(
         name="basics_preposition_final_question",
-        request="What am I looking at right now?",
+        request="What is this thing I'm staring at?",
         vision="A hand holding a blue lid.",
         required_tools=frozenset({"look_at_current_frame"}),
         forbidden_tools=_FORBID_MUTATIONS,
@@ -703,7 +747,7 @@ UTTERANCES = (
             ("The camera doesn't look at the scene.",
              "The camera is not currently viewing any objects in the scene."),
             ("Okay.", "What would you like me to do?"),
-            ("What am I looking at?", "You are looking at the camera."),
+            ("Tell me what the camera sees.", "You are looking at the camera."),
             ("True.", "What would you like me to do?"),
             ("Make a spear the color of the thing I am holding.",
              "What are you holding?"),
@@ -720,23 +764,40 @@ UTTERANCES = (
         history=(
             ("The camera doesn't look at the scene.",
              "I'm sorry, but I can't help with that."),
-            ("What am I looking at?", "You are looking at a blue plastic lid."),
+            ("Tell me what the camera sees.", "You are looking at a blue plastic lid."),
         ),
-        required_tools=frozenset({"look_at_current_frame", "add_primitive"}),
-        required_order=("look_at_current_frame", "add_primitive"),
+        required_tools=frozenset({"add_primitive"}),
         expected_colors=(("sphere-0", (0.0, 0.4, 1.0)),),
+    ),
+    Case(
+        name="basics_create_despite_similar_existing",
+        request="Make a cube the color of what I'm holding.",
+        scene=(
+            {"id": "box-0", "type": "box",
+             "position": {"x": 0.4, "y": 1.5, "z": -1.2},
+             "color": {"r": 1, "g": 1, "b": 1}, "size": 0.1},
+        ),
+        vision="A hand holding a blue lid.",
+        history=(
+            ("Make a green ball.", "Created a green ball."),
+            ("Add a white cube.", "The white cube has been created."),
+            ("Put a red ring above the cube.", "The red ring has been placed above the cube."),
+            ("Make a cube.", "Created a white cube in front of you."),
+        ),
+        required_tools=frozenset({"add_primitive"}),
+        expected_colors=(("box-1", (0.0, 0.4, 1.0)),),
     ),
     Case(
         name="basics_recall_beyond_window",
         request="What color was the very first thing I created?",
         history=(
-            ("Add a green capsule.", "Created a green capsule."),
-            ("Move it to my left.", "Moved the capsule to your left."),
-            ("Add a white cylinder behind it.", "Created a white cylinder."),
-            ("Make the cylinder bigger.", "Enlarged the cylinder."),
-            ("Swap the capsule and the cylinder.", "Swapped them."),
+            ("Add a green ball.", "Created a green ball."),
+            ("Move it to my left.", "Moved the ball to your left."),
+            ("Add a white box behind it.", "Created a white box."),
+            ("Make the box bigger.", "Enlarged the box."),
+            ("Swap the ball and the box.", "Swapped them."),
         ),
-        expected_call_counts=(("recall_conversation", 2),),
+        reply_contains="green",
         forbidden_tools=_FORBID_MUTATIONS,
     ),
     Case(
@@ -968,7 +1029,7 @@ async def run_case(case: Case) -> bool:
                 SceneRequest(
                     transcript=case.request,
                     participant_id=_PARTICIPANT,
-                    timestamp_us=10_000_000,
+                    timestamp_us=1_700_000_000_000_000,
                 )
             )
             response = reply.response
@@ -1013,8 +1074,12 @@ async def run_case(case: Case) -> bool:
         if object_id not in scene.objects
         or tuple(scene.objects[object_id].position.model_dump().values()) != expected
     }
+    wrong_reply = bool(
+        case.reply_contains and case.reply_contains.lower() not in response.lower()
+    )
     passed = (
         not errored
+        and not wrong_reply
         and not missing
         and not forbidden
         and not out_of_order
@@ -1027,7 +1092,8 @@ async def run_case(case: Case) -> bool:
         "PASS"
         if passed
         else (
-            f"FAIL missing={sorted(missing)} forbidden={sorted(forbidden)} order={call_order} "
+            f"FAIL missing={sorted(missing)} forbidden={sorted(forbidden)} wrong_reply={wrong_reply} "
+            f"order={call_order} "
             f"counts={wrong_call_counts} sizes={wrong_sizes} colors={wrong_colors} "
             f"positions={wrong_positions}"
         )

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/harness.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/harness.py
@@ -99,6 +99,7 @@ class _FakeCurrentFrameTool:
         self._fake = fake
 
     async def execute(self, request: Any) -> Any:
+        self._fake.calls.append(("current_frame", {}))
         if self._fake.camera_error:
             raise RuntimeError(self._fake.camera_error)
         from xr_ai_tools.current_frame import ImageFrame
@@ -124,9 +125,15 @@ class _FakePhysicalColorQuery:
         self._fake.calls.append(("resolve_physical_color", {"question": request.query}))
         if self._fake.vision_error:
             return ImageQueryResult(text=self._fake.vision_error, available=False)
-        return ImageQueryResult(
-            text=self._fake.vision_answer or "Nothing notable is visible.", available=True
-        )
+        # A truncated or wrong source in the resolver's query must fail the
+        # case, not silently receive the configured color.
+        if (
+            self._fake.physical_expect_source
+            and self._fake.physical_expect_source.lower() not in request.query.lower()
+        ):
+            return ImageQueryResult(text="UNKNOWN", available=True)
+        answer = self._fake.physical_answer or self._fake.vision_answer
+        return ImageQueryResult(text=answer or "Nothing notable is visible.", available=True)
 
 
 def make_fake_video(fake: "FakeScene", video_error: str = ""):
@@ -150,9 +157,9 @@ def make_fake_video(fake: "FakeScene", video_error: str = ""):
 
 def make_fake_physical_color(fake: "FakeScene"):
     from xr_render_demo_worker._physical_color import make_physical_color_tool
-    from xr_render_demo_worker.spatial_ops import _COLOR_WORDS
+    from xr_render_demo_worker.spatial_ops import COLOR_WORDS
     return make_physical_color_tool(
-        _FakeCurrentFrameTool(fake), _FakePhysicalColorQuery(fake), _COLOR_WORDS)
+        _FakeCurrentFrameTool(fake), _FakePhysicalColorQuery(fake), COLOR_WORDS)
 
 
 class _FakeImageQueryTool:
@@ -189,6 +196,7 @@ class Case:
     memory: str = ""
     history: tuple[tuple[str, str], ...] = ()
     reply_contains: str = ""
+    camera_error: str = ""
 
 
 CASES = (
@@ -285,6 +293,9 @@ CASES = (
         request="What color was the object I held ten seconds ago?",
         vision="The previously held object was purple.",
         required_tools=frozenset({"look_at_past_frame"}),
+        # The supervisor's own conversation recall is the single expected
+        # call; the camera's past is video, never the transcript.
+        expected_call_counts=(("recall_conversation", 1),),
     ),
     Case(
         name="durable_memory",
@@ -428,6 +439,8 @@ class FakeScene:
     memory_answer: str
     history: tuple[tuple[str, str], ...] = ()
     camera_error: str = ""
+    physical_answer: str = ""
+    physical_expect_source: str = ""
     calls: list[tuple[str, dict[str, Any]]] = field(default_factory=list)
     counters: dict[str, int] = field(default_factory=dict)
 
@@ -441,6 +454,7 @@ class FakeScene:
             case.vision_error,
             case.memory,
             case.history,
+            camera_error=case.camera_error,
         )
 
     @classmethod
@@ -758,6 +772,33 @@ UTTERANCES = (
         forbidden_tools=_FORBID_MUTATIONS,
     ),
     Case(
+        name="basics_look_for_yourself",
+        # Answering a clarifying question with "go observe" must re-enter
+        # the pending request through the camera, never echo those words.
+        request="Look for yourself.",
+        vision="A hand holding a blue lid.",
+        history=(
+            ("Make a spear the color of the thing I am holding.",
+             "What are you holding?"),
+        ),
+        required_tools=frozenset({"add_primitive"}),
+        expected_colors=(("sphere-0", (0.0, 0.4, 1.0)),),
+    ),
+    Case(
+        name="basics_physical_source_camera_down",
+        # The camera outage must degrade to an honest no-change reply: the
+        # resolver was attempted, nothing mutated, no invented color.
+        request="Make the box the color of my shirt.",
+        scene=(
+            {"id": "box-0", "type": "box",
+             "position": {"x": 0.3, "y": 1.4, "z": -1.2},
+             "color": {"r": 1, "g": 1, "b": 1}, "size": 0.1},
+        ),
+        camera_error="RPCError: camera feed unavailable",
+        required_tools=frozenset({"current_frame"}),
+        forbidden_tools=_FORBID_MUTATIONS,
+    ),
+    Case(
         name="basics_holding_color_with_history",
         request="Make a spear the color of the thing I am holding.",
         vision="A hand holding a blue lid.",
@@ -799,6 +840,10 @@ UTTERANCES = (
         ),
         reply_contains="green",
         forbidden_tools=_FORBID_MUTATIONS,
+        # One recall from the supervisor plus one from memory_agent: the
+        # answer must come from the transcript store, not a lucky guess off
+        # the recent-conversation block.
+        expected_call_counts=(("recall_conversation", 2),),
     ),
     Case(
         name="basics_create_cube",
@@ -928,10 +973,9 @@ UTTERANCES = (
     ),
     Case(
         name="basics_anchored_create_keeps_words",
-        # Live flail: the supervisor misroutes an anchored create to
-        # placement, gets it bounced, then re-delegates WITHOUT the user's
-        # spatial words and patches with a move. One add, no update, and the
-        # cube must land on the user's left of the anchor.
+        # An anchored create must keep the user's spatial words in a single
+        # object_agent delegation: exactly one add, no patch-up move, and
+        # the cube lands on the user's left of the anchor.
         request="Put a yellow cube to the left of the blue cube.",
         scene=(
             {"id": "box-0", "type": "box", "position": {"x": 0.5, "y": 1.4, "z": -1.2},
@@ -1103,9 +1147,8 @@ async def run_case(case: Case) -> bool:
 
 
 # Train/test separation audit. Prompt worked examples are what the model
-# memorizes as templates; any overlap with case inputs means the eval scores
-# recall, not behavior (proven live: a blue/green prompt example made the
-# anchored-create case pass while the same request failed on other colors).
+# memorizes as templates; any overlap with case inputs, history turns, or
+# fixture text means the eval scores recall, not behavior.
 _EVAL_VOCAB_COLORS = ("red", "green", "blue", "yellow", "cyan", "orange", "purple", "white", "black")
 _EVAL_VOCAB_SHAPES = ("sphere", "cube", "box", "ball")
 
@@ -1115,9 +1158,27 @@ def audit_prompts() -> None:
     from pathlib import Path
 
     worker = (Path(__file__).resolve().parent / "../../worker/xr_render_demo_worker").resolve()
-    prompts = sorted(worker.rglob("*prompt*.txt"))
+    # Model-visible text lives in the prompt files and in the tool field
+    # descriptions of spatial_ops.py; both shape the model's templates.
+    prompts = sorted(worker.rglob("*prompt*.txt")) + [worker / "spatial_ops.py"]
     utterances = [case["user"] for case in CORPUS_CASES if case.get("user")]
     utterances += [case.request for case in (*CASES, *UTTERANCES)]
+    # History turns and fixture answers reach the model verbatim too; a
+    # prompt example copied from them scores recall, not behavior.
+    eval_texts = [
+        text
+        for case in (*CASES, *UTTERANCES)
+        for turn in case.history
+        for text in turn
+    ]
+    eval_texts += [case.vision for case in (*CASES, *UTTERANCES) if case.vision]
+    eval_texts += [case["vlm_answer"] for case in CORPUS_CASES if case.get("vlm_answer")]
+    eval_texts += [
+        text
+        for case in CORPUS_CASES
+        for turn in case.get("history", ())
+        for text in turn
+    ]
     fixture_ids = {
         item["id"]
         for case in CORPUS_CASES
@@ -1131,6 +1192,7 @@ def audit_prompts() -> None:
         pass
     else:
         utterances += [case.instruction for case in eval_subagents.CASES]
+        eval_texts += [case.vision_answer for case in eval_subagents.CASES if case.vision_answer]
         fixture_ids |= {item["id"] for case in eval_subagents.CASES for item in case.scene}
     try:
         from . import supervisor as eval_supervisor
@@ -1138,12 +1200,18 @@ def audit_prompts() -> None:
         pass
     else:
         utterances += [case.request for case in eval_supervisor.CASES]
+        eval_texts += [
+            text
+            for case in eval_supervisor.CASES
+            for turn in getattr(case, "history", ())
+            for text in turn
+        ]
         fixture_ids |= {item["id"] for case in eval_supervisor.CASES for item in case.scene}
     for prompt_path in prompts:
         label = str(prompt_path.relative_to(worker))
         text = prompt_path.read_text(encoding="utf-8")
         lowered = text.lower()
-        for utterance in utterances:
+        for utterance in (*utterances, *eval_texts):
             needle = utterance.lower().strip(".?! ")
             # Short fragments ("the box") appear in ordinary prose; only
             # utterances long enough to be templates count as overlap.

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/subagents.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/subagents.py
@@ -35,6 +35,7 @@ from xr_render_demo_worker.scene import SceneContext
 from xr_render_scene import SceneObject
 
 from . import harness
+from .harness import make_fake_physical_color, make_fake_video
 
 _PARTICIPANT = "eval-user"
 _MUTATING = harness._MUTATING
@@ -79,6 +80,7 @@ class SubagentCase:
     forbid_tools: tuple[str, ...] = ()
     answer_contains: str = ""
     video_error: str = ""
+    camera_error: str = ""
 
 
 # Expected args: a (lo, hi) tuple is an inclusive range, anything else is exact.
@@ -141,6 +143,27 @@ CASES = (
                 "tool": "update_primitive",
                 "args": {"obj_id": "ring-1", "x": (1.95, 2.05), "y": (1.35, 1.45), "z": (-1.65, -1.55)},
             },
+        ),
+    ),
+    SubagentCase(
+        name="physical_color_recolor",
+        agent="appearance",
+        instruction="Recolor ring-1 to match the user's scarf.",
+        scene=(_RING,),
+        vision_answer="The scarf is blue.",
+        required_tools=("resolve_physical_color",),
+        expect=(
+            {"tool": "update_primitive", "args": {"obj_id": "ring-1", "b": (0.95, 1.05), "g": (0.35, 0.45)}},
+        ),
+    ),
+    SubagentCase(
+        name="physical_color_create",
+        agent="object",
+        instruction="Create a small sphere the color of the user's scarf, no position stated.",
+        vision_answer="The scarf is blue.",
+        required_tools=("resolve_physical_color", "add_primitive"),
+        expect=(
+            {"tool": "add_primitive", "args": {"prim_type": "sphere", "b": (0.95, 1.05), "g": (0.35, 0.45)}},
         ),
     ),
     SubagentCase(
@@ -458,10 +481,25 @@ CASES = (
     SubagentCase(
         name="holding_question_looks_first",
         agent="vision",
-        instruction="What is the user holding right now?",
+        instruction="Identify the object in the user's hand.",
         vision_answer="A hand holding a blue lid.",
         required_tools=("look_at_current_frame",),
         answer_contains="blue",
+    ),
+    SubagentCase(
+        name="holding_question_resists_refusal",
+        agent="vision",
+        instruction="The user insists you cannot see anything. Report what the user is gripping.",
+        vision_answer="A hand holding a blue lid.",
+        required_tools=("look_at_current_frame",),
+        answer_contains="blue",
+    ),
+    SubagentCase(
+        name="camera_transport_failure_degrades",
+        agent="vision",
+        instruction="Describe the real surface just left of the user.",
+        camera_error="RPCError: camera feed unavailable",
+        forbid_tools=tuple(sorted(_MUTATING)),
     ),
     SubagentCase(
         name="past_recording_disabled_degrades",
@@ -469,7 +507,7 @@ CASES = (
         instruction="What color was the object the user held twenty seconds before the utterance timestamp?",
         video_error="recording disabled",
         required_tools=("look_at_past_frame",),
-        forbid_tools=("add_primitive", "update_primitive", "remove_primitive"),
+        forbid_tools=tuple(sorted(_MUTATING)),
     ),
     SubagentCase(
         name="vision_dead_camera_degrades",
@@ -480,6 +518,7 @@ CASES = (
         ),
         vision_error="No camera frame available.",
         required_tools=("look_at_current_frame",),
+        forbid_tools=("look_at_past_frame",),
         answer_contains="no camera",
     ),
     SubagentCase(
@@ -523,36 +562,17 @@ CASES = (
     ),
 )
 
-def _make_fake_video(fake, video_error: str):
-    from types import SimpleNamespace
-
-    from xr_ai_tools import Tool
-    from xr_ai_tools.image import ImageReference
-    from xr_ai_tools.video_memory import HistoricalFrameRequest, HistoricalFrameResult
-
-    async def historical(req: HistoricalFrameRequest) -> HistoricalFrameResult:
-        fake.calls.append(("look_at_past_frame", {"start_us": req.start_us}))
-        if video_error:
-            raise ValueError(video_error)
-        return HistoricalFrameResult(
-            image=ImageReference(uri="fake://past"), timestamp_us=max(req.start_us, 0),
-            width=640, height=480)
-
-    return SimpleNamespace(get_historical_frame=Tool(
-        "get_historical_frame", "Recorded frame nearest a timestamp.",
-        HistoricalFrameRequest, HistoricalFrameResult, historical))
-
 
 def _make_agent(
     case_agent, llm, fake_scene, fake_tracking, fake_text_memory,
-    fake_current_frame, fake_image_query, context, video=None,
+    fake_current_frame, fake_image_query, context, video=None, physical_color=None,
 ):
     if case_agent == "placement":
         return make_placement_agent(llm, fake_scene, fake_tracking, context)
     if case_agent == "appearance":
-        return make_appearance_agent(llm, fake_scene, context)
+        return make_appearance_agent(llm, fake_scene, context, physical_color)
     if case_agent == "object":
-        return make_object_agent(llm, fake_scene, fake_tracking, context)
+        return make_object_agent(llm, fake_scene, fake_tracking, context, physical_color)
     if case_agent == "vision":
         return make_vision_agent(llm, fake_current_frame, fake_image_query, context, video)
     if case_agent == "memory":
@@ -624,6 +644,7 @@ async def run_case(case: SubagentCase) -> bool:
         case.vision_answer,
         case.vision_error,
         case.memory,
+        camera_error=case.camera_error,
     )
     llm = make_llm(load_models_config(harness._CONFIG.models_config), "agent_llm")
     try:
@@ -633,7 +654,8 @@ async def run_case(case: SubagentCase) -> bool:
         agent = _make_agent(
             case.agent, llm, fake_scene, fake_tracking, fake_text_memory,
             fake_current_frame, fake_image_query, context,
-            video=_make_fake_video(scene, case.video_error),
+            video=make_fake_video(scene, case.video_error),
+            physical_color=make_fake_physical_color(scene),
         )
         current_participant_id.set(_PARTICIPANT)
         current_reference_time_us.set(1_700_000_000_000_000)

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/subagents.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/subagents.py
@@ -78,6 +78,7 @@ class SubagentCase:
     required_tools: tuple[str, ...] = ()
     forbid_tools: tuple[str, ...] = ()
     answer_contains: str = ""
+    video_error: str = ""
 
 
 # Expected args: a (lo, hi) tuple is an inclusive range, anything else is exact.
@@ -455,6 +456,22 @@ CASES = (
         answer_contains="purple",
     ),
     SubagentCase(
+        name="holding_question_looks_first",
+        agent="vision",
+        instruction="What is the user holding right now?",
+        vision_answer="A hand holding a blue lid.",
+        required_tools=("look_at_current_frame",),
+        answer_contains="blue",
+    ),
+    SubagentCase(
+        name="past_recording_disabled_degrades",
+        agent="vision",
+        instruction="What color was the object the user held twenty seconds before the utterance timestamp?",
+        video_error="recording disabled",
+        required_tools=("look_at_past_frame",),
+        forbid_tools=("add_primitive", "update_primitive", "remove_primitive"),
+    ),
+    SubagentCase(
         name="vision_dead_camera_degrades",
         agent="vision",
         instruction=(
@@ -506,9 +523,29 @@ CASES = (
     ),
 )
 
+def _make_fake_video(fake, video_error: str):
+    from types import SimpleNamespace
+
+    from xr_ai_tools import Tool
+    from xr_ai_tools.image import ImageReference
+    from xr_ai_tools.video_memory import HistoricalFrameRequest, HistoricalFrameResult
+
+    async def historical(req: HistoricalFrameRequest) -> HistoricalFrameResult:
+        fake.calls.append(("look_at_past_frame", {"start_us": req.start_us}))
+        if video_error:
+            raise ValueError(video_error)
+        return HistoricalFrameResult(
+            image=ImageReference(uri="fake://past"), timestamp_us=max(req.start_us, 0),
+            width=640, height=480)
+
+    return SimpleNamespace(get_historical_frame=Tool(
+        "get_historical_frame", "Recorded frame nearest a timestamp.",
+        HistoricalFrameRequest, HistoricalFrameResult, historical))
+
+
 def _make_agent(
     case_agent, llm, fake_scene, fake_tracking, fake_text_memory,
-    fake_current_frame, fake_image_query, context,
+    fake_current_frame, fake_image_query, context, video=None,
 ):
     if case_agent == "placement":
         return make_placement_agent(llm, fake_scene, fake_tracking, context)
@@ -517,7 +554,7 @@ def _make_agent(
     if case_agent == "object":
         return make_object_agent(llm, fake_scene, fake_tracking, context)
     if case_agent == "vision":
-        return make_vision_agent(llm, fake_current_frame, fake_image_query, context)
+        return make_vision_agent(llm, fake_current_frame, fake_image_query, context, video)
     if case_agent == "memory":
         return make_memory_agent(llm, fake_text_memory)
     raise ValueError(f"unknown agent: {case_agent!r}")
@@ -596,9 +633,10 @@ async def run_case(case: SubagentCase) -> bool:
         agent = _make_agent(
             case.agent, llm, fake_scene, fake_tracking, fake_text_memory,
             fake_current_frame, fake_image_query, context,
+            video=_make_fake_video(scene, case.video_error),
         )
         current_participant_id.set(_PARTICIPANT)
-        current_reference_time_us.set(10_000_000)
+        current_reference_time_us.set(1_700_000_000_000_000)
         errored = False
         try:
             reply = await agent.execute(SubagentTask(instruction=case.instruction))

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/subagents.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/subagents.py
@@ -81,6 +81,8 @@ class SubagentCase:
     answer_contains: str = ""
     video_error: str = ""
     camera_error: str = ""
+    physical_answer: str = ""
+    physical_expect_source: str = ""
 
 
 # Expected args: a (lo, hi) tuple is an inclusive range, anything else is exact.
@@ -151,9 +153,56 @@ CASES = (
         instruction="Recolor ring-1 to match the user's scarf.",
         scene=(_RING,),
         vision_answer="The scarf is blue.",
+        physical_expect_source="scarf",
         required_tools=("resolve_physical_color",),
         expect=(
             {"tool": "update_primitive", "args": {"obj_id": "ring-1", "b": (0.95, 1.05), "g": (0.35, 0.45)}},
+        ),
+    ),
+    SubagentCase(
+        name="physical_color_numeric_answer",
+        agent="appearance",
+        instruction="Recolor ring-1 to match the user's headband.",
+        scene=(_RING,),
+        physical_answer="0.1 0.6 0.4",
+        physical_expect_source="headband",
+        required_tools=("resolve_physical_color",),
+        expect=(
+            {"tool": "update_primitive",
+             "args": {"obj_id": "ring-1", "r": (0.05, 0.15), "g": (0.55, 0.65), "b": (0.35, 0.45)}},
+        ),
+    ),
+    SubagentCase(
+        name="physical_color_not_visible",
+        agent="appearance",
+        instruction="Recolor ring-1 to match the user's bracelet.",
+        scene=(_RING,),
+        physical_answer="UNKNOWN",
+        required_tools=("resolve_physical_color",),
+        forbid_tools=tuple(sorted(_MUTATING)),
+    ),
+    SubagentCase(
+        name="physical_color_beats_scene_shape",
+        # A physical phrase that names a shape which also exists in the XR
+        # scene must be observed by the camera, never copied from the scene.
+        agent="appearance",
+        instruction="Recolor ring-1 to match the cone the user is holding.",
+        scene=(_RING, _CONE),
+        vision_answer="The cone in the user's hand is blue.",
+        required_tools=("resolve_physical_color",),
+        expect=(
+            {"tool": "update_primitive", "args": {"obj_id": "ring-1", "b": (0.95, 1.05), "g": (0.35, 0.45)}},
+        ),
+    ),
+    SubagentCase(
+        name="misspelled_color_recolor",
+        agent="appearance",
+        instruction="Make cone-0 teel.",
+        scene=(_CONE,),
+        forbid_tools=("resolve_physical_color",),
+        expect=(
+            {"tool": "update_primitive",
+             "args": {"obj_id": "cone-0", "r": (0.0, 0.1), "g": (0.75, 0.85), "b": (0.75, 0.85)}},
         ),
     ),
     SubagentCase(
@@ -499,15 +548,26 @@ CASES = (
         agent="vision",
         instruction="Describe the real surface just left of the user.",
         camera_error="RPCError: camera feed unavailable",
-        forbid_tools=tuple(sorted(_MUTATING)),
+        required_tools=("current_frame",),
+        answer_contains="camera",
     ),
     SubagentCase(
         name="past_recording_disabled_degrades",
         agent="vision",
         instruction="What color was the object the user held twenty seconds before the utterance timestamp?",
-        video_error="recording disabled",
+        video_error="RPCError: recording disabled",
         required_tools=("look_at_past_frame",),
-        forbid_tools=tuple(sorted(_MUTATING)),
+        answer_contains="record",
+    ),
+    SubagentCase(
+        name="placement_phrased_physical_view",
+        # XR-placement phrasing about the real surroundings is still a
+        # physical-view question.
+        agent="vision",
+        instruction="Is there open physical space two meters ahead of the user for hanging a banner?",
+        vision_answer="An empty hallway stretches ahead of the user.",
+        required_tools=("look_at_current_frame",),
+        answer_contains="hallway",
     ),
     SubagentCase(
         name="vision_dead_camera_degrades",
@@ -645,6 +705,8 @@ async def run_case(case: SubagentCase) -> bool:
         case.vision_error,
         case.memory,
         camera_error=case.camera_error,
+        physical_answer=case.physical_answer,
+        physical_expect_source=case.physical_expect_source,
     )
     llm = make_llm(load_models_config(harness._CONFIG.models_config), "agent_llm")
     try:

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/subagents.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/subagents.py
@@ -164,7 +164,7 @@ CASES = (
         agent="appearance",
         instruction="Recolor ring-1 to match the user's headband.",
         scene=(_RING,),
-        physical_answer="0.1 0.6 0.4",
+        physical_answer="VISIBLE 0.1 0.6 0.4",
         physical_expect_source="headband",
         required_tools=("resolve_physical_color",),
         expect=(
@@ -186,7 +186,7 @@ CASES = (
         # A physical phrase that names a shape which also exists in the XR
         # scene must be observed by the camera, never copied from the scene.
         agent="appearance",
-        instruction="Recolor ring-1 to match the cone the user is holding.",
+        instruction="Recolor ring-1 to match the cone the user is gripping.",
         scene=(_RING, _CONE),
         vision_answer="The cone in the user's hand is blue.",
         required_tools=("resolve_physical_color",),
@@ -203,6 +203,16 @@ CASES = (
         expect=(
             {"tool": "update_primitive",
              "args": {"obj_id": "cone-0", "r": (0.0, 0.1), "g": (0.75, 0.85), "b": (0.75, 0.85)}},
+        ),
+    ),
+    SubagentCase(
+        name="misspelled_color_create",
+        agent="object",
+        instruction="Create a teel capsule, no position stated.",
+        forbid_tools=("resolve_physical_color",),
+        expect=(
+            {"tool": "add_primitive",
+             "args": {"prim_type": "capsule", "r": (0.0, 0.1), "g": (0.75, 0.85), "b": (0.75, 0.85)}},
         ),
     ),
     SubagentCase(

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/supervisor.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/supervisor.py
@@ -119,12 +119,13 @@ CASES = (
         expect_agent="vision_agent",
     ),
     RoutingCase(
-        name="physical_color_source_routes_to_vision",
+        name="physical_color_stays_with_mutating_agent",
         request="Turn the box the color of my carpet.",
         scene=(
             {"id": "box-0", "type": "box", "pos": [0.0, 1.5, -1.3], "color": [1, 1, 1], "size": 0.1},
         ),
-        expect_agent="vision_agent",
+        expect_agent="appearance_agent",
+        instruction_contains=("carpet",),
     ),
     RoutingCase(
         name="memory_question_routes_to_memory",
@@ -283,7 +284,7 @@ async def run_case(case: RoutingCase) -> bool:
                 SceneRequest(
                     transcript=case.request,
                     participant_id="eval-user",
-                    timestamp_us=10_000_000,
+                    timestamp_us=1_700_000_000_000_000,
                 )
             )
         except Exception as exc:

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/supervisor.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/supervisor.py
@@ -119,6 +119,14 @@ CASES = (
         expect_agent="vision_agent",
     ),
     RoutingCase(
+        name="physical_color_source_routes_to_vision",
+        request="Turn the box the color of my carpet.",
+        scene=(
+            {"id": "box-0", "type": "box", "pos": [0.0, 1.5, -1.3], "color": [1, 1, 1], "size": 0.1},
+        ),
+        expect_agent="vision_agent",
+    ),
+    RoutingCase(
         name="memory_question_routes_to_memory",
         request="What did I ask you to make earlier?",
         history=(

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/_physical_color.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/_physical_color.py
@@ -3,10 +3,10 @@
 
 """Camera-backed resolution of physical color references.
 
-The subagent LLM copies the user's phrase; it does not observe. This tool
-owns the observation: one strict VLM query over the participant's current
-frame, parsed into RGB, with an explicit not-visible answer so the VLM is
-never forced to invent a color.
+The subagent LLM names the source; it does not observe. This tool owns the
+observation: one VLM query over the participant's current frame with a
+closed response grammar, full-matching ``VISIBLE r g b`` or ``UNKNOWN``.
+Any other reply fails closed; no color is ever inferred from prose.
 """
 
 from __future__ import annotations
@@ -20,30 +20,19 @@ from xr_ai_tools import Tool
 from xr_ai_tools.current_frame import CurrentFrameRequest, CurrentFrameTool
 from xr_ai_tools.vision import ImageQueryRequest, ImageQueryResult
 
-from ._tolerant import as_unavailable
-from ._trace import current_participant_id, current_reference_time_us
+from ._tolerant import reraise_unavailable
+from ._trace import current_participant_id, current_trace_id
 
 IMAGE_QUERY_SYSTEM_PROMPT = (
-    "Reply with exactly three numbers r, g, b between 0 and 1, separated by spaces, "
-    "describing the color actually visible. If the thing asked about is not visible "
-    "or you cannot tell, reply exactly UNKNOWN. Never answer with a typical or "
-    "assumed color."
+    'Reply with exactly "VISIBLE r g b", where r, g, b are numbers between 0 '
+    "and 1 for the color you actually see, or exactly \"UNKNOWN\" when the "
+    "asked-about thing is not clearly visible. Reply with nothing else; never "
+    "answer with a typical or assumed color."
 )
 
 _NUMBER = r"(?:\d+(?:\.\d+)?|\.\d+)"
-_TRIPLE = re.compile(rf"(?<![\d.])({_NUMBER})[,;\s]+({_NUMBER})[,;\s]+({_NUMBER})(?!\d)")
-_CHANNEL_TAGS = re.compile(r"\b(?:rgb|[rgb])\s*[=:]")
-_WRAPPERS = re.compile(r"[*()\[\]]")
-
-# Refusals AND hedges fail closed: an answer that qualifies its observation
-# ("may be occluded; likely RGB 1 0 0", "outside the frame; the couch is
-# blue") is not an observation of the requested thing.
-_REFUSAL = re.compile(
-    r"\b(unknown|not[_\s]?visible|cannot|can't|unable|unclear|"
-    r"don'?t\s+(?:see|know)|not\s+(?:sure|certain|able)|"
-    r"occluded|obscured|hidden|blocked|likely|probably|possibly|might|"
-    r"may\s+be|guess\w*|assum\w*|typical\w*|usually|"
-    r"outside|out\s+of\s+(?:frame|view|sight))\b",
+_VISIBLE = re.compile(
+    rf"^\W*visible[\s:,]+({_NUMBER})[,\s]+({_NUMBER})[,\s]+({_NUMBER})\W*$",
     re.IGNORECASE,
 )
 
@@ -62,80 +51,72 @@ class ResolvedColor(BaseModel):
     b: float = Field(ge=0, le=1)
 
 
-def parse_color_answer(
-    answer: str, color_words: dict[str, tuple[float, float, float]]
-) -> tuple[float, float, float] | None:
-    if _REFUSAL.search(answer):
-        return None
-    numeric = _WRAPPERS.sub(" ", _CHANNEL_TAGS.sub(" ", answer.lower()))
-    for match in _TRIPLE.finditer(numeric):
+def parse_color_answer(answer: str) -> tuple[float, float, float] | None:
+    """Full-match the closed grammar; UNKNOWN, malformed, and out-of-range
+    replies all yield None (no observation)."""
+    match = _VISIBLE.match(answer)
+    if match:
         values = tuple(float(v) for v in match.groups())
         if all(0.0 <= v <= 1.0 for v in values):
             return values
-    resolved = None
-    # Last color word wins: replies name the answer after any echoed context
-    # ("the wall behind the red couch is white").
-    for word in re.findall(r"[a-z]+", answer.lower()):
-        if word in color_words:
-            resolved = color_words[word]
-    return resolved
+    return None
 
 
 def make_physical_color_tool(
     current_frame: CurrentFrameTool,
     image_query: _ImageQuery,
-    color_words: dict[str, tuple[float, float, float]],
 ) -> Tool:
     # One observation per phrase per turn: repeated resolutions inside a turn
     # ("make three cones the color of my shirt") must not return three
-    # different colors or defeat the creation ledger's retry dedupe.
-    cache: dict[tuple[str, int, str], tuple[float, float, float]] = {}
+    # different colors or defeat the creation ledger's retry dedupe. Keyed
+    # on the runtime-bound trace id; client timestamps can repeat.
+    cache: dict[tuple[str, str, str], tuple[float, float, float]] = {}
 
     async def resolve(req: ResolvePhysicalColorRequest) -> ResolvedColor:
-        source = req.source_words.strip()
+        source = req.source_words.strip().replace('"', "'")
+        # "the color of my apron" and "my apron" name the same observation.
+        source = re.sub(r"^(?:the\s+)?colou?r\s+of\s+", "", source, flags=re.IGNORECASE) or source
         if len(source) > 80:
-            source = source[:80].rsplit(" ", 1)[0]
+            head = source[:80]
+            clipped = head.rsplit(" ", 1)[0]
+            source = clipped if len(clipped) >= 40 else head
             logger.debug("physical color source truncated to {!r}", source)
-        key = (current_participant_id.get(), current_reference_time_us.get(), source.lower())
-        if cache and next(iter(cache))[:2] != key[:2]:
-            cache.clear()
-        if (cached := cache.get(key)) is not None:
-            return ResolvedColor(r=cached[0], g=cached[1], b=cached[2])
+        # An empty trace id cannot distinguish turns; skip caching entirely.
+        trace = current_trace_id.get()
+        key = (current_participant_id.get(), trace, source.lower())
+        if trace:
+            if cache and next(iter(cache))[:2] != key[:2]:
+                cache.clear()
+            if (cached := cache.get(key)) is not None:
+                return ResolvedColor(r=cached[0], g=cached[1], b=cached[2])
         try:
             frame = await current_frame.execute(
                 CurrentFrameRequest(participant_id=current_participant_id.get())
             )
         except Exception as error:
-            degraded = as_unavailable(error, "the current camera view")
-            if degraded is None:
-                raise
-            logger.debug("physical color frame fetch degraded: {}", degraded)
-            raise degraded from error
+            reraise_unavailable(error, "the current camera view")
         try:
             result = await image_query.execute(ImageQueryRequest(
                 image=frame.image,
                 query=(
-                    f'What color is "{source}"? Answer with three numbers r, g, b, each '
-                    "between 0 and 1, or exactly UNKNOWN if you cannot see it."
+                    f'What color is "{source}"? Reply with exactly "VISIBLE r g b" '
+                    '(each number between 0 and 1) or exactly "UNKNOWN".'
                 ),
             ))
         except Exception as error:
-            degraded = as_unavailable(error, "the vision model")
-            if degraded is None:
-                raise
-            logger.debug("physical color VLM query degraded: {}", degraded)
-            raise degraded from error
+            reraise_unavailable(error, "the vision model")
         if not result.available:
             logger.debug("physical color {!r} unavailable: {!r}", source, result.text[:120])
             raise ValueError(f"the camera cannot currently see {source!r}: {result.text[:120]}")
-        resolved = parse_color_answer(result.text, color_words)
+        resolved = parse_color_answer(result.text)
         if resolved is None:
-            logger.debug("physical color {!r} unresolved: {!r}", source, result.text[:120])
+            logger.debug("physical color {!r} not observed: {!r}", source, result.text[:120])
             raise ValueError(
-                f"the camera view did not yield a color for {source!r}: {result.text[:120]}"
+                f"the camera view did not yield an observation of {source!r}: {result.text[:120]}"
             )
         logger.debug("physical color {!r} -> {}", source, resolved)
-        cache[key] = resolved
+        if trace:
+            cache[key] = resolved
         return ResolvedColor(r=resolved[0], g=resolved[1], b=resolved[2])
 
     return Tool(

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/_physical_color.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/_physical_color.py
@@ -35,9 +35,15 @@ _TRIPLE = re.compile(rf"(?<![\d.])({_NUMBER})[,;\s]+({_NUMBER})[,;\s]+({_NUMBER}
 _CHANNEL_TAGS = re.compile(r"\b(?:rgb|[rgb])\s*[=:]")
 _WRAPPERS = re.compile(r"[*()\[\]]")
 
+# Refusals AND hedges fail closed: an answer that qualifies its observation
+# ("may be occluded; likely RGB 1 0 0", "outside the frame; the couch is
+# blue") is not an observation of the requested thing.
 _REFUSAL = re.compile(
     r"\b(unknown|not[_\s]?visible|cannot|can't|unable|unclear|"
-    r"don'?t\s+(?:see|know)|not\s+(?:sure|certain|able))\b",
+    r"don'?t\s+(?:see|know)|not\s+(?:sure|certain|able)|"
+    r"occluded|obscured|hidden|blocked|likely|probably|possibly|might|"
+    r"may\s+be|guess\w*|assum\w*|typical\w*|usually|"
+    r"outside|out\s+of\s+(?:frame|view|sight))\b",
     re.IGNORECASE,
 )
 

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/_physical_color.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/_physical_color.py
@@ -3,29 +3,47 @@
 
 """Camera-backed resolution of physical color references.
 
-The subagent LLM reliably classifies a color source and copies the user's
-phrase; it does not reliably observe. This tool owns the observation: one
-strict VLM query over the participant's current frame, parsed into RGB.
+The subagent LLM copies the user's phrase; it does not observe. This tool
+owns the observation: one strict VLM query over the participant's current
+frame, parsed into RGB, with an explicit not-visible answer so the VLM is
+never forced to invent a color.
 """
 
 from __future__ import annotations
 
 import re
+from typing import Protocol
 
 from loguru import logger
 from pydantic import BaseModel, Field
 from xr_ai_tools import Tool
 from xr_ai_tools.current_frame import CurrentFrameRequest, CurrentFrameTool
-from xr_ai_tools.vision import ImageQueryRequest
+from xr_ai_tools.vision import ImageQueryRequest, ImageQueryResult
 
 from ._tolerant import as_unavailable
-from ._trace import current_participant_id
+from ._trace import current_participant_id, current_reference_time_us
 
 IMAGE_QUERY_SYSTEM_PROMPT = (
-    "Reply with exactly three numbers r, g, b between 0 and 1, separated by spaces."
+    "Reply with exactly three numbers r, g, b between 0 and 1, separated by spaces, "
+    "describing the color actually visible. If the thing asked about is not visible "
+    "or you cannot tell, reply exactly UNKNOWN. Never answer with a typical or "
+    "assumed color."
 )
 
-_TRIPLE = re.compile(r"^\s*(\d(?:\.\d+)?)[,\s]+(\d(?:\.\d+)?)[,\s]+(\d(?:\.\d+)?)\s*\.?\s*$")
+_NUMBER = r"(?:\d+(?:\.\d+)?|\.\d+)"
+_TRIPLE = re.compile(rf"(?<![\d.])({_NUMBER})[,;\s]+({_NUMBER})[,;\s]+({_NUMBER})(?!\d)")
+_CHANNEL_TAGS = re.compile(r"\b(?:rgb|[rgb])\s*[=:]")
+_WRAPPERS = re.compile(r"[*()\[\]]")
+
+_REFUSAL = re.compile(
+    r"\b(unknown|not[_\s]?visible|cannot|can't|unable|unclear|"
+    r"don'?t\s+(?:see|know)|not\s+(?:sure|certain|able))\b",
+    re.IGNORECASE,
+)
+
+
+class _ImageQuery(Protocol):
+    async def execute(self, request: ImageQueryRequest) -> ImageQueryResult: ...
 
 
 class ResolvePhysicalColorRequest(BaseModel):
@@ -33,16 +51,18 @@ class ResolvePhysicalColorRequest(BaseModel):
 
 
 class ResolvedColor(BaseModel):
-    r: float
-    g: float
-    b: float
+    r: float = Field(ge=0, le=1)
+    g: float = Field(ge=0, le=1)
+    b: float = Field(ge=0, le=1)
 
 
 def parse_color_answer(
     answer: str, color_words: dict[str, tuple[float, float, float]]
 ) -> tuple[float, float, float] | None:
-    match = _TRIPLE.match(answer)
-    if match:
+    if _REFUSAL.search(answer):
+        return None
+    numeric = _WRAPPERS.sub(" ", _CHANNEL_TAGS.sub(" ", answer.lower()))
+    for match in _TRIPLE.finditer(numeric):
         values = tuple(float(v) for v in match.groups())
         if all(0.0 <= v <= 1.0 for v in values):
             return values
@@ -57,11 +77,24 @@ def parse_color_answer(
 
 def make_physical_color_tool(
     current_frame: CurrentFrameTool,
-    image_query,
+    image_query: _ImageQuery,
     color_words: dict[str, tuple[float, float, float]],
 ) -> Tool:
+    # One observation per phrase per turn: repeated resolutions inside a turn
+    # ("make three cones the color of my shirt") must not return three
+    # different colors or defeat the creation ledger's retry dedupe.
+    cache: dict[tuple[str, int, str], tuple[float, float, float]] = {}
+
     async def resolve(req: ResolvePhysicalColorRequest) -> ResolvedColor:
-        source = req.source_words[:80]
+        source = req.source_words.strip()
+        if len(source) > 80:
+            source = source[:80].rsplit(" ", 1)[0]
+            logger.debug("physical color source truncated to {!r}", source)
+        key = (current_participant_id.get(), current_reference_time_us.get(), source.lower())
+        if cache and next(iter(cache))[:2] != key[:2]:
+            cache.clear()
+        if (cached := cache.get(key)) is not None:
+            return ResolvedColor(r=cached[0], g=cached[1], b=cached[2])
         try:
             frame = await current_frame.execute(
                 CurrentFrameRequest(participant_id=current_participant_id.get())
@@ -70,19 +103,33 @@ def make_physical_color_tool(
             degraded = as_unavailable(error, "the current camera view")
             if degraded is None:
                 raise
+            logger.debug("physical color frame fetch degraded: {}", degraded)
             raise degraded from error
-        result = await image_query.execute(ImageQueryRequest(
-            image=frame.image,
-            query=f'What color is "{source}"? Answer with three numbers r, g, b, each between 0 and 1.',
-        ))
+        try:
+            result = await image_query.execute(ImageQueryRequest(
+                image=frame.image,
+                query=(
+                    f'What color is "{source}"? Answer with three numbers r, g, b, each '
+                    "between 0 and 1, or exactly UNKNOWN if you cannot see it."
+                ),
+            ))
+        except Exception as error:
+            degraded = as_unavailable(error, "the vision model")
+            if degraded is None:
+                raise
+            logger.debug("physical color VLM query degraded: {}", degraded)
+            raise degraded from error
         if not result.available:
-            raise ValueError(f"the camera cannot currently see {source!r}: {result.text}")
+            logger.debug("physical color {!r} unavailable: {!r}", source, result.text[:120])
+            raise ValueError(f"the camera cannot currently see {source!r}: {result.text[:120]}")
         resolved = parse_color_answer(result.text, color_words)
         if resolved is None:
+            logger.debug("physical color {!r} unresolved: {!r}", source, result.text[:120])
             raise ValueError(
                 f"the camera view did not yield a color for {source!r}: {result.text[:120]}"
             )
         logger.debug("physical color {!r} -> {}", source, resolved)
+        cache[key] = resolved
         return ResolvedColor(r=resolved[0], g=resolved[1], b=resolved[2])
 
     return Tool(

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/_physical_color.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/_physical_color.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Camera-backed resolution of physical color references.
+
+The subagent LLM reliably classifies a color source and copies the user's
+phrase; it does not reliably observe. This tool owns the observation: one
+strict VLM query over the participant's current frame, parsed into RGB.
+"""
+
+from __future__ import annotations
+
+import re
+
+from loguru import logger
+from pydantic import BaseModel, Field
+from xr_ai_tools import Tool
+from xr_ai_tools.current_frame import CurrentFrameRequest, CurrentFrameTool
+from xr_ai_tools.vision import ImageQueryRequest
+
+from ._tolerant import as_unavailable
+from ._trace import current_participant_id
+
+IMAGE_QUERY_SYSTEM_PROMPT = (
+    "Reply with exactly three numbers r, g, b between 0 and 1, separated by spaces."
+)
+
+_TRIPLE = re.compile(r"^\s*(\d(?:\.\d+)?)[,\s]+(\d(?:\.\d+)?)[,\s]+(\d(?:\.\d+)?)\s*\.?\s*$")
+
+
+class ResolvePhysicalColorRequest(BaseModel):
+    source_words: str = Field(description="The user's words for the physical color source.")
+
+
+class ResolvedColor(BaseModel):
+    r: float
+    g: float
+    b: float
+
+
+def parse_color_answer(
+    answer: str, color_words: dict[str, tuple[float, float, float]]
+) -> tuple[float, float, float] | None:
+    match = _TRIPLE.match(answer)
+    if match:
+        values = tuple(float(v) for v in match.groups())
+        if all(0.0 <= v <= 1.0 for v in values):
+            return values
+    resolved = None
+    # Last color word wins: replies name the answer after any echoed context
+    # ("the wall behind the red couch is white").
+    for word in re.findall(r"[a-z]+", answer.lower()):
+        if word in color_words:
+            resolved = color_words[word]
+    return resolved
+
+
+def make_physical_color_tool(
+    current_frame: CurrentFrameTool,
+    image_query,
+    color_words: dict[str, tuple[float, float, float]],
+) -> Tool:
+    async def resolve(req: ResolvePhysicalColorRequest) -> ResolvedColor:
+        source = req.source_words[:80]
+        try:
+            frame = await current_frame.execute(
+                CurrentFrameRequest(participant_id=current_participant_id.get())
+            )
+        except Exception as error:
+            degraded = as_unavailable(error, "the current camera view")
+            if degraded is None:
+                raise
+            raise degraded from error
+        result = await image_query.execute(ImageQueryRequest(
+            image=frame.image,
+            query=f'What color is "{source}"? Answer with three numbers r, g, b, each between 0 and 1.',
+        ))
+        if not result.available:
+            raise ValueError(f"the camera cannot currently see {source!r}: {result.text}")
+        resolved = parse_color_answer(result.text, color_words)
+        if resolved is None:
+            raise ValueError(
+                f"the camera view did not yield a color for {source!r}: {result.text[:120]}"
+            )
+        logger.debug("physical color {!r} -> {}", source, resolved)
+        return ResolvedColor(r=resolved[0], g=resolved[1], b=resolved[2])
+
+    return Tool(
+        "resolve_physical_color",
+        "Resolve a physical-world color reference against the participant's current camera view.",
+        ResolvePhysicalColorRequest,
+        ResolvedColor,
+        resolve,
+    )
+
+
+__all__ = [
+    "IMAGE_QUERY_SYSTEM_PROMPT",
+    "ResolvePhysicalColorRequest",
+    "ResolvedColor",
+    "make_physical_color_tool",
+    "parse_color_answer",
+]

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/_tolerant.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/_tolerant.py
@@ -15,6 +15,27 @@ from loguru import logger
 from xr_ai_tools import Tool, ToolSet
 from xr_ai_tools.tools import ToolInvocationResult
 
+_TRANSPORT_MARKERS = ("RPCError", "Timeout", "Connection", "unavailable", "not started", "disabled")
+
+
+def as_unavailable(error: BaseException, what: str) -> ValueError | None:
+    """Classify transport/availability failures as expected degradation.
+
+    Returns a model-readable ValueError for outages of an external feed,
+    None for anything else so genuine bugs keep propagating.
+    """
+    seen: set[int] = set()
+    node: BaseException | None = error
+    while node is not None and id(node) not in seen:
+        seen.add(id(node))
+        if isinstance(node, (TimeoutError, ConnectionError, OSError)):
+            return ValueError(f"{what} is unavailable ({type(node).__name__}: {node})")
+        node = node.__cause__ or node.__context__
+    text = str(error)
+    if any(marker in text for marker in _TRANSPORT_MARKERS):
+        return ValueError(f"{what} is unavailable ({type(error).__name__}: {text})")
+    return None
+
 
 def _rejection(exc: BaseException) -> str | None:
     seen: set[int] = set()
@@ -58,4 +79,4 @@ def tolerant_toolset(tools: Iterable[Tool]) -> ToolSet:
     ])
 
 
-__all__ = ["tolerant_toolset"]
+__all__ = ["as_unavailable", "tolerant_toolset"]

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/_tolerant.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/_tolerant.py
@@ -9,13 +9,24 @@ and the turn continues. Any other failure propagates and aborts the turn.
 """
 
 import json
+import re
 from collections.abc import Iterable
 
 from loguru import logger
 from xr_ai_tools import Tool, ToolSet
 from xr_ai_tools.tools import ToolInvocationResult
 
-_TRANSPORT_MARKERS = ("RPCError", "Timeout", "Connection", "unavailable", "not started", "disabled")
+_TRANSPORT_TYPE_NAMES = frozenset({"RPCError", "FrameUnavailable"})
+
+# Relay layers re-raise with the original exception's class name embedded in
+# the message and the cause chain erased, so the wrapped text is the only
+# place the real type survives. Match class-name tokens, never ordinary
+# English words ("unavailable", "disabled") that self-match error prose.
+_TRANSPORT_TOKENS = re.compile(
+    r"\b(?:RPCError|FrameUnavailable|TimeoutError|ConnectionError|"
+    r"connection refused|StatusCode\.UNAVAILABLE)\b",
+    re.IGNORECASE,
+)
 
 
 def as_unavailable(error: BaseException, what: str) -> ValueError | None:
@@ -28,12 +39,14 @@ def as_unavailable(error: BaseException, what: str) -> ValueError | None:
     node: BaseException | None = error
     while node is not None and id(node) not in seen:
         seen.add(id(node))
-        if isinstance(node, (TimeoutError, ConnectionError, OSError)):
+        if (
+            isinstance(node, (TimeoutError, ConnectionError))
+            or type(node).__name__ in _TRANSPORT_TYPE_NAMES
+        ):
             return ValueError(f"{what} is unavailable ({type(node).__name__}: {node})")
         node = node.__cause__ or node.__context__
-    text = str(error)
-    if any(marker in text for marker in _TRANSPORT_MARKERS):
-        return ValueError(f"{what} is unavailable ({type(error).__name__}: {text})")
+    if _TRANSPORT_TOKENS.search(str(error)):
+        return ValueError(f"{what} is unavailable ({type(error).__name__}: {error})")
     return None
 
 

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/_tolerant.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/_tolerant.py
@@ -5,12 +5,15 @@
 
 Rejected input (a ValueError anywhere in the failure chain, e.g. an
 unresolvable object description) becomes an error payload the model reads,
-and the turn continues. Any other failure propagates and aborts the turn.
+and the turn continues. Transport and availability failures are converted
+to such rejections by ``as_unavailable``; anything else propagates and
+aborts the turn.
 """
 
 import json
 import re
 from collections.abc import Iterable
+from typing import NoReturn
 
 from loguru import logger
 from xr_ai_tools import Tool, ToolSet
@@ -50,6 +53,16 @@ def as_unavailable(error: BaseException, what: str) -> ValueError | None:
     return None
 
 
+def reraise_unavailable(error: BaseException, what: str) -> NoReturn:
+    """Re-raise *error* as expected degradation when it is a transport
+    failure of *what*, unchanged otherwise."""
+    degraded = as_unavailable(error, what)
+    if degraded is None:
+        raise error
+    logger.debug("{} degraded: {}", what, degraded)
+    raise degraded from error
+
+
 def _rejection(exc: BaseException) -> str | None:
     seen: set[int] = set()
     node: BaseException | None = exc
@@ -58,8 +71,7 @@ def _rejection(exc: BaseException) -> str | None:
         if isinstance(node, ValueError):
             return str(node)
         node = node.__cause__ or node.__context__
-    # Relay layers re-raise with the original message embedded rather than
-    # chained; fall back to the message text.
+    # Same Relay rewrap as _TRANSPORT_TOKENS handles above.
     detail = str(exc)
     if "ValueError: " in detail:
         return detail.split("ValueError: ", 1)[1]
@@ -92,4 +104,4 @@ def tolerant_toolset(tools: Iterable[Tool]) -> ToolSet:
     ])
 
 
-__all__ = ["as_unavailable", "tolerant_toolset"]
+__all__ = ["as_unavailable", "reraise_unavailable", "tolerant_toolset"]

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/_trace.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/_trace.py
@@ -14,3 +14,4 @@ from contextvars import ContextVar
 current_trace_id: ContextVar[str] = ContextVar("current_trace_id", default="")
 current_participant_id: ContextVar[str] = ContextVar("current_participant_id", default="")
 current_reference_time_us: ContextVar[int] = ContextVar("current_reference_time_us", default=0)
+current_instruction: ContextVar[str] = ContextVar("current_instruction", default="")

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/_trace.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/_trace.py
@@ -1,7 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Turn-scoped identity shared between the supervisor and its subagents.
+"""Turn-scoped identity and evidence shared between the supervisor and its
+subagents.
 
 Context variables, not SubagentTask fields: the task schema is filled by the
 supervisor LLM, which must never be trusted to copy participant identity or
@@ -14,4 +15,18 @@ from contextvars import ContextVar
 current_trace_id: ContextVar[str] = ContextVar("current_trace_id", default="")
 current_participant_id: ContextVar[str] = ContextVar("current_participant_id", default="")
 current_reference_time_us: ContextVar[int] = ContextVar("current_reference_time_us", default=0)
-current_instruction: ContextVar[str] = ContextVar("current_instruction", default="")
+
+
+class MutationEvidence:
+    """Count of scene writes actually applied (or found already satisfied)
+    this turn; the supervisor's success gate reads it instead of trusting
+    the model's wording."""
+
+    def __init__(self) -> None:
+        self.applied = 0
+        self.satisfied = 0
+
+
+current_mutation_evidence: ContextVar[MutationEvidence | None] = ContextVar(
+    "current_mutation_evidence", default=None
+)

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/appearance/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/appearance/agent.py
@@ -4,7 +4,6 @@
 """Appearance subagent: change the color of existing XR objects."""
 
 import asyncio
-from collections.abc import Awaitable, Callable
 from pathlib import Path
 
 from loguru import logger
@@ -29,7 +28,7 @@ def make_appearance_agent(
     llm: LLMService,
     scene: SceneTools,
     context: SceneContext,
-    physical_color: Callable[[str], Awaitable[str]] | None = None,
+    physical_color: Tool | None = None,
 ) -> Tool:
     delegation_lock = asyncio.Lock()
 

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/appearance/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/appearance/agent.py
@@ -13,7 +13,12 @@ from xr_ai_tools.tool_calling import ToolLoopError, run_tool_loop
 from xr_render_scene import EmptyRequest, SceneState, SceneTools
 
 from ..._tolerant import tolerant_toolset
-from ..._trace import current_participant_id, current_reference_time_us, current_trace_id
+from ..._trace import (
+    current_instruction,
+    current_participant_id,
+    current_reference_time_us,
+    current_trace_id,
+)
 from ...models import SubagentResult, SubagentTask
 from ...scene import SceneContext
 from ...spatial_ops import TurnGuard, make_appearance_tools
@@ -34,6 +39,7 @@ def make_appearance_agent(
 
     async def handle(request: SubagentTask) -> SubagentResult:
         logger.debug("appearance agent instruction={!r} trace={}", request.instruction[:200], current_trace_id.get())
+        current_instruction.set(request.instruction)
         async with delegation_lock:
             guard = TurnGuard()
             tools = make_appearance_tools(scene, guard=guard, physical_color=physical_color)

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/appearance/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/appearance/agent.py
@@ -4,6 +4,7 @@
 """Appearance subagent: change the color of existing XR objects."""
 
 import asyncio
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 
 from loguru import logger
@@ -28,6 +29,7 @@ def make_appearance_agent(
     llm: LLMService,
     scene: SceneTools,
     context: SceneContext,
+    physical_color: Callable[[str], Awaitable[str]] | None = None,
 ) -> Tool:
     delegation_lock = asyncio.Lock()
 
@@ -35,7 +37,7 @@ def make_appearance_agent(
         logger.debug("appearance agent instruction={!r} trace={}", request.instruction[:200], current_trace_id.get())
         async with delegation_lock:
             guard = TurnGuard()
-            tools = make_appearance_tools(scene, guard=guard)
+            tools = make_appearance_tools(scene, guard=guard, physical_color=physical_color)
             tools.append(Tool(
                 "get_scene_state",
                 "Return every current XR object with its ID, type, world position, color, and size.",

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/appearance/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/appearance/agent.py
@@ -13,12 +13,7 @@ from xr_ai_tools.tool_calling import ToolLoopError, run_tool_loop
 from xr_render_scene import EmptyRequest, SceneState, SceneTools
 
 from ..._tolerant import tolerant_toolset
-from ..._trace import (
-    current_instruction,
-    current_participant_id,
-    current_reference_time_us,
-    current_trace_id,
-)
+from ..._trace import current_participant_id, current_reference_time_us, current_trace_id
 from ...models import SubagentResult, SubagentTask
 from ...scene import SceneContext
 from ...spatial_ops import TurnGuard, make_appearance_tools
@@ -39,7 +34,6 @@ def make_appearance_agent(
 
     async def handle(request: SubagentTask) -> SubagentResult:
         logger.debug("appearance agent instruction={!r} trace={}", request.instruction[:200], current_trace_id.get())
-        current_instruction.set(request.instruction)
         async with delegation_lock:
             guard = TurnGuard()
             tools = make_appearance_tools(scene, guard=guard, physical_color=physical_color)

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/appearance/prompt.txt
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/appearance/prompt.txt
@@ -12,7 +12,13 @@ and color_words is the instruction's color word, mangled spellings
 included; the tool resolves both against the scene itself and reports back
 when nothing or several objects match — relay that answer instead of
 guessing. An explicit color used to identify an object is a reference, not
-a request to recolor it.
+a request to recolor it. A physical color source (clothing, a held object,
+a wall, the ceiling, any real-world thing) is one recolor call, never a
+guess or a question back: "Make the torus match my apron" is
+recolor(object_words="torus", color_words="my apron"), and "match the
+ceiling" is recolor(object_words="torus", color_words="the ceiling"). The
+tool reads the camera and picks the color itself, so never ask the user
+for it.
 
 Execute only the focused task, then report a concise result with stable ids
 and resolved values the supervisor may need. Never expose JSON, tool

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/appearance/prompt.txt
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/appearance/prompt.txt
@@ -13,12 +13,19 @@ included; the tool resolves both against the scene itself and reports back
 when nothing or several objects match — relay that answer instead of
 guessing. An explicit color used to identify an object is a reference, not
 a request to recolor it. A physical color source (clothing, a held object,
-a wall, the ceiling, any real-world thing) is one recolor call, never a
-guess or a question back: "Make the torus match my apron" is
+any real-world surface or thing) is one recolor call, never a guess or a
+question back: "Make the torus match my apron" is
 recolor(object_words="torus", color_words="my apron"), and "match the
-ceiling" is recolor(object_words="torus", color_words="the ceiling"). The
-tool reads the camera and picks the color itself, so never ask the user
-for it.
+countertop" is recolor(object_words="torus", color_words="the countertop").
+A held, worn, or otherwise physical thing is never in SCENE OBJECTS, even
+when it shares a shape name with an XR object there: "Recolor the torus to
+match the crate the user is holding" with crate-2 listed in SCENE OBJECTS
+is recolor(object_words="the torus", color_words="the crate the user is
+holding"), which observes the held crate through the camera;
+color_words="crate-2" instead wrongly copies the XR crate's color. Keep the
+whole physical phrase and let the tool decide between scene and camera. The
+tool reads the camera and picks the color itself, so never ask the user for
+it.
 
 Execute only the focused task, then report a concise result with stable ids
 and resolved values the supervisor may need. Never expose JSON, tool

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/appearance/prompt.txt
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/appearance/prompt.txt
@@ -5,27 +5,27 @@ The SCENE OBJECTS context is authoritative for ids, types, positions, RGB
 colors, and sizes. Pronouns refer to the object named in the latest
 assistant reply; plural pronouns require acting on every resolved object.
 
-Handle color changes only, with one recolor call per object. Quote both
-arguments from the instruction verbatim: object_words is the instruction's
-words for the target ("the teal capsule", or an id the instruction states),
-and color_words is the instruction's color word, mangled spellings
-included; the tool resolves both against the scene itself and reports back
-when nothing or several objects match — relay that answer instead of
-guessing. An explicit color used to identify an object is a reference, not
-a request to recolor it. A physical color source (clothing, a held object,
-any real-world surface or thing) is one recolor call, never a guess or a
-question back: "Make the torus match my apron" is
-recolor(object_words="torus", color_words="my apron"), and "match the
-countertop" is recolor(object_words="torus", color_words="the countertop").
-A held, worn, or otherwise physical thing is never in SCENE OBJECTS, even
-when it shares a shape name with an XR object there: "Recolor the torus to
-match the crate the user is holding" with crate-2 listed in SCENE OBJECTS
-is recolor(object_words="the torus", color_words="the crate the user is
-holding"), which observes the held crate through the camera;
-color_words="crate-2" instead wrongly copies the XR crate's color. Keep the
-whole physical phrase and let the tool decide between scene and camera. The
-tool reads the camera and picks the color itself, so never ask the user for
-it.
+Handle color changes only, with one recolor call per object. object_words
+quotes the instruction's words for the target verbatim ("the teal capsule",
+or an id the instruction states); the tool resolves it against the scene
+and reports back when nothing or several objects match — relay that answer
+instead of guessing. An explicit color used to identify an object is a
+reference, not a request to recolor it.
+
+color_kind picks the source and color_value carries the instruction's
+exact words for it:
+- literal: a stated color word or numbers, copied verbatim, mangled
+  spellings included (color_value "lavendar"); the tool repairs them.
+- scene_object: copy an existing XR object's color; color_value is the
+  instruction's words or id for it ("capsule-8").
+- physical: any real-world thing observed through the camera (clothing, a
+  held object, a room surface), with the phrase kept whole: "match my
+  apron" is physical "my apron", "match the countertop" is physical "the
+  countertop". A held or worn thing is physical even when an XR object has
+  the same shape: "match the crate the user is holding" with crate-2 in
+  SCENE OBJECTS is physical "the crate the user is holding", never
+  scene_object "crate-2". The tool reads the camera and picks the color
+  itself, so never ask the user for a physical color, and never guess one.
 
 Execute only the focused task, then report a concise result with stable ids
 and resolved values the supervisor may need. Never expose JSON, tool

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/memory/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/memory/agent.py
@@ -22,7 +22,8 @@ from ...models import SubagentResult, SubagentTask
 
 _PROMPT = Path(__file__).with_name("prompt.txt")
 DESCRIPTION = ("Recall what was said in earlier conversation turns, including objects and "
-               "colors mentioned there; knows nothing about the physical world or the camera.")
+               "colors mentioned there; never a source for present-day or physical-world "
+               "facts like the color of a real surface.")
 
 _MAX_END_US = RecallConversationRequest.model_fields["end_us"].default
 

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/memory/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/memory/agent.py
@@ -21,7 +21,8 @@ from ..._trace import current_participant_id, current_reference_time_us, current
 from ...models import SubagentResult, SubagentTask
 
 _PROMPT = Path(__file__).with_name("prompt.txt")
-DESCRIPTION = "Recall earlier conversation turns; never mutates the XR scene."
+DESCRIPTION = ("Recall what was said in earlier conversation turns; knows nothing about "
+               "the physical world, the camera, or any object's color.")
 
 _MAX_END_US = RecallConversationRequest.model_fields["end_us"].default
 

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/memory/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/memory/agent.py
@@ -21,8 +21,8 @@ from ..._trace import current_participant_id, current_reference_time_us, current
 from ...models import SubagentResult, SubagentTask
 
 _PROMPT = Path(__file__).with_name("prompt.txt")
-DESCRIPTION = ("Recall what was said in earlier conversation turns; knows nothing about "
-               "the physical world, the camera, or any object's color.")
+DESCRIPTION = ("Recall what was said in earlier conversation turns, including objects and "
+               "colors mentioned there; knows nothing about the physical world or the camera.")
 
 _MAX_END_US = RecallConversationRequest.model_fields["end_us"].default
 

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/object/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/object/agent.py
@@ -14,7 +14,12 @@ from xr_ai_tools.tracking import TrackingTools
 from xr_render_scene import EmptyRequest, SceneState, SceneTools
 
 from ..._tolerant import tolerant_toolset
-from ..._trace import current_participant_id, current_reference_time_us, current_trace_id
+from ..._trace import (
+    current_instruction,
+    current_participant_id,
+    current_reference_time_us,
+    current_trace_id,
+)
 from ...models import SubagentResult, SubagentTask
 from ...scene import SceneContext
 from ...spatial_ops import CreationLedger, TurnGuard, make_object_tools
@@ -39,6 +44,7 @@ def make_object_agent(
 
     async def handle(request: SubagentTask) -> SubagentResult:
         logger.debug("object agent instruction={!r} trace={}", request.instruction[:200], current_trace_id.get())
+        current_instruction.set(request.instruction)
         async with delegation_lock:
             guard = TurnGuard()
             ledger = CreationLedger()

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/object/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/object/agent.py
@@ -14,12 +14,7 @@ from xr_ai_tools.tracking import TrackingTools
 from xr_render_scene import EmptyRequest, SceneState, SceneTools
 
 from ..._tolerant import tolerant_toolset
-from ..._trace import (
-    current_instruction,
-    current_participant_id,
-    current_reference_time_us,
-    current_trace_id,
-)
+from ..._trace import current_participant_id, current_reference_time_us, current_trace_id
 from ...models import SubagentResult, SubagentTask
 from ...scene import SceneContext
 from ...spatial_ops import CreationLedger, TurnGuard, make_object_tools
@@ -44,7 +39,6 @@ def make_object_agent(
 
     async def handle(request: SubagentTask) -> SubagentResult:
         logger.debug("object agent instruction={!r} trace={}", request.instruction[:200], current_trace_id.get())
-        current_instruction.set(request.instruction)
         async with delegation_lock:
             guard = TurnGuard()
             ledger = CreationLedger()

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/object/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/object/agent.py
@@ -4,7 +4,6 @@
 """Object subagent: create, remove, resize, and reshape XR objects."""
 
 import asyncio
-from collections.abc import Awaitable, Callable
 from pathlib import Path
 
 from loguru import logger
@@ -34,7 +33,7 @@ def make_object_agent(
     scene: SceneTools,
     tracking: TrackingTools,
     context: SceneContext,
-    physical_color: Callable[[str], Awaitable[str]] | None = None,
+    physical_color: Tool | None = None,
 ) -> Tool:
     delegation_lock = asyncio.Lock()
 

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/object/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/object/agent.py
@@ -4,6 +4,7 @@
 """Object subagent: create, remove, resize, and reshape XR objects."""
 
 import asyncio
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 
 from loguru import logger
@@ -33,6 +34,7 @@ def make_object_agent(
     scene: SceneTools,
     tracking: TrackingTools,
     context: SceneContext,
+    physical_color: Callable[[str], Awaitable[str]] | None = None,
 ) -> Tool:
     delegation_lock = asyncio.Lock()
 
@@ -41,7 +43,8 @@ def make_object_agent(
         async with delegation_lock:
             guard = TurnGuard()
             ledger = CreationLedger()
-            tools = make_object_tools(scene, tracking, ledger=ledger, guard=guard)
+            tools = make_object_tools(scene, tracking, ledger=ledger, guard=guard,
+                                      physical_color=physical_color)
             tools.append(Tool(
                 "get_scene_state",
                 "Return every current XR object with its ID, type, world position, color, and size.",

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/object/prompt.txt
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/object/prompt.txt
@@ -53,7 +53,7 @@ default distance.
   object's description. The tool computes the midpoint. Never use create_at
   for this. Example: "Create a teal cone between the ivory capsule and the
   lavender cylinder" → create_object_relative(prim_type="cone",
-  color_words="teal", anchor_words="ivory capsule",
+  color_kind="literal", color_value="teal", anchor_words="ivory capsule",
   second_anchor_words="lavender cylinder").
 - create_at is only for coordinates stated numerically in the instruction;
   with no numbers present, never call it. With no
@@ -61,18 +61,22 @@ default distance.
   direction front and the default distance, so the object appears in front
   of the user; never direction above unless the request says above.
 
-The creation tools take color_words: quote the instruction's color word
-exactly as written, mangled spellings included, and the tool resolves the
-RGB itself. "Create a teal capsule" passes color_words "teal"; "a teel
-capsule" passes color_words "teel" (the tool repairs mangled spellings;
-never drop an unrecognized color word or leave color_words empty for it);
-an identical copy of capsule-8 passes color_words "same as capsule-8". A physical color
-source is one tool call, never a guess, a default, or a report-back:
-"Create a cone the color of my apron, no position stated" is
-create_user_relative(prim_type="cone", color_words="the color of my apron",
-direction="front"); the tool reads the camera and picks the color itself. When the
-instruction states no color, leave color_words empty and the standard
-default applies. Never translate a color to numbers yourself.
+The creation tools take color_kind and color_value; color_value carries
+the instruction's exact words for the source:
+- literal: a stated color word, copied verbatim, mangled spellings
+  included: "a teal capsule" is literal "teal", and "a graye sphere" is
+  literal "graye" (the tool repairs mangled spellings; never drop an
+  unrecognized color word).
+- scene_object: copy an existing XR object's color; an identical copy of
+  capsule-8 is scene_object "capsule-8".
+- physical: any real-world thing observed through the camera, with the
+  phrase kept whole: "Create a cone the color of my apron, no
+  position stated" is create_user_relative(prim_type="cone",
+  direction="front") with color_kind physical and color_value "the color
+  of my apron"; the tool reads the camera and picks the color itself,
+  never a guess, a default, or a report-back.
+When the instruction states no color, leave color_value empty and the
+standard default applies. Never translate a color to numbers yourself.
 
 Never create first and move the new object afterward, and never substitute
 renderer defaults for requested placement.

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/object/prompt.txt
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/object/prompt.txt
@@ -63,8 +63,14 @@ default distance.
 
 The creation tools take color_words: quote the instruction's color word
 exactly as written, mangled spellings included, and the tool resolves the
-RGB itself. "Create a teal capsule" passes color_words "teal"; an identical
-copy of capsule-8 passes color_words "same as capsule-8"; when the
+RGB itself. "Create a teal capsule" passes color_words "teal"; "a teel
+capsule" passes color_words "teel" (the tool repairs mangled spellings;
+never drop an unrecognized color word or leave color_words empty for it);
+an identical copy of capsule-8 passes color_words "same as capsule-8". A physical color
+source is one tool call, never a guess, a default, or a report-back:
+"Create a cone the color of my apron, no position stated" is
+create_user_relative(prim_type="cone", color_words="the color of my apron",
+direction="front"); the tool reads the camera and picks the color itself. When the
 instruction states no color, leave color_words empty and the standard
 default applies. Never translate a color to numbers yourself.
 

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/vision/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/vision/agent.py
@@ -14,7 +14,7 @@ from xr_ai_tools.tool_calling import ToolLoopError, run_tool_loop
 from xr_ai_tools.video_memory import HistoricalFrameRequest, VideoMemoryTools
 from xr_ai_tools.vision import ImageQueryRequest, ImageQueryResult, ImageQueryTool
 
-from ..._tolerant import as_unavailable, tolerant_toolset
+from ..._tolerant import reraise_unavailable, tolerant_toolset
 from ..._trace import current_participant_id, current_reference_time_us, current_trace_id
 from ...models import SubagentResult, SubagentTask
 from ...scene import SceneContext
@@ -51,10 +51,7 @@ def make_vision_agent(
             try:
                 frame = await current_frame.execute(CurrentFrameRequest(participant_id=participant_id))
             except Exception as error:
-                degraded = as_unavailable(error, "the current camera view")
-                if degraded is None:
-                    raise
-                raise degraded from error
+                reraise_unavailable(error, "the current camera view")
             return await image_query.execute(ImageQueryRequest(image=frame.image, query=req.question))
 
         tools = [
@@ -77,10 +74,7 @@ def make_vision_agent(
                         HistoricalFrameRequest(participant_id=participant_id, start_us=start_us)
                     )
                 except Exception as error:
-                    degraded = as_unavailable(error, "recorded video")
-                    if degraded is None:
-                        raise
-                    raise degraded from error
+                    reraise_unavailable(error, "recorded video")
                 return await image_query.execute(ImageQueryRequest(image=frame.image, query=req.question))
 
             tools.append(Tool(

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/vision/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/vision/agent.py
@@ -14,7 +14,7 @@ from xr_ai_tools.tool_calling import ToolLoopError, run_tool_loop
 from xr_ai_tools.video_memory import HistoricalFrameRequest, VideoMemoryTools
 from xr_ai_tools.vision import ImageQueryRequest, ImageQueryResult, ImageQueryTool
 
-from ..._tolerant import tolerant_toolset
+from ..._tolerant import as_unavailable, tolerant_toolset
 from ..._trace import current_participant_id, current_reference_time_us, current_trace_id
 from ...models import SubagentResult, SubagentTask
 from ...scene import SceneContext
@@ -51,8 +51,10 @@ def make_vision_agent(
             try:
                 frame = await current_frame.execute(CurrentFrameRequest(participant_id=participant_id))
             except Exception as error:
-                # Camera unavailability is expected degradation, not a crash.
-                raise ValueError(f"the current camera view is unavailable ({error})") from None
+                degraded = as_unavailable(error, "the current camera view")
+                if degraded is None:
+                    raise
+                raise degraded from error
             return await image_query.execute(ImageQueryRequest(image=frame.image, query=req.question))
 
         tools = [
@@ -75,9 +77,10 @@ def make_vision_agent(
                         HistoricalFrameRequest(participant_id=participant_id, start_us=start_us)
                     )
                 except Exception as error:
-                    # Recording may be disabled or hold no frame for this
-                    # window; expected degradation, not a crash.
-                    raise ValueError(f"recorded video is unavailable ({error})") from None
+                    degraded = as_unavailable(error, "recorded video")
+                    if degraded is None:
+                        raise
+                    raise degraded from error
                 return await image_query.execute(ImageQueryRequest(image=frame.image, query=req.question))
 
             tools.append(Tool(

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/vision/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/vision/agent.py
@@ -48,7 +48,11 @@ def make_vision_agent(
 
         async def look(req: _LiveQuestion) -> ImageQueryResult:
             from xr_ai_tools.current_frame import CurrentFrameRequest
-            frame = await current_frame.execute(CurrentFrameRequest(participant_id=participant_id))
+            try:
+                frame = await current_frame.execute(CurrentFrameRequest(participant_id=participant_id))
+            except Exception as error:
+                # Camera unavailability is expected degradation, not a crash.
+                raise ValueError(f"the current camera view is unavailable ({error})") from None
             return await image_query.execute(ImageQueryRequest(image=frame.image, query=req.question))
 
         tools = [
@@ -66,9 +70,14 @@ def make_vision_agent(
 
             async def look_past(req: _PastQuestion) -> ImageQueryResult:
                 start_us = reference_time_us - req.seconds_ago * 1_000_000
-                frame = await video.get_historical_frame.execute(
-                    HistoricalFrameRequest(participant_id=participant_id, start_us=start_us)
-                )
+                try:
+                    frame = await video.get_historical_frame.execute(
+                        HistoricalFrameRequest(participant_id=participant_id, start_us=start_us)
+                    )
+                except Exception as error:
+                    # Recording may be disabled or hold no frame for this
+                    # window; expected degradation, not a crash.
+                    raise ValueError(f"recorded video is unavailable ({error})") from None
                 return await image_query.execute(ImageQueryRequest(image=frame.image, query=req.question))
 
             tools.append(Tool(

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/vision/prompt.txt
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/vision/prompt.txt
@@ -7,12 +7,18 @@ supervisor. When SCENE OBJECTS is present, it lists every XR object;
 contrast: "Is there a magenta cone currently in the scene?": answer directly from
 SCENE OBJECTS with the ids and positions it shows, no tool call. "What color
 is the mug the user is holding?": a physical-world fact, call
-vision__look_at_current_frame with that question. Call vision__look_at_current_frame with a specific question only
+look_at_current_frame with that question. Call look_at_current_frame with a specific question only
 for the present physical view. Never guess a real-world object, color, shape,
-or text. If the current frame is unavailable, report that failure immediately;
-never substitute a recorded frame or repeat the failed call.
+or text, and never reply that you cannot see something without calling
+look_at_current_frame first: only the tool's own result can establish that
+the view is unavailable. A question that mentions XR placement is still a
+physical-view question when it asks about the real surroundings; "What is
+directly in front of the user for mounting a torus?" calls
+look_at_current_frame about what is in front of the user. If the tool reports the current frame is
+unavailable, report that failure immediately; never substitute a recorded
+frame or repeat the failed call.
 
-Call vision__look_at_past_frame only when the supervisor explicitly asks about
+Call look_at_past_frame only when the supervisor explicitly asks about
 a past moment. Pass a positive seconds_ago offset; never reinterpret a present
 question as historical. Only call this tool when it is present in the toolset.
 

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/vision/prompt.txt
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/vision/prompt.txt
@@ -4,26 +4,29 @@ tool argument.
 
 Observe the user's live camera or recorded video and return facts to the
 supervisor. When SCENE OBJECTS is present, it lists every XR object;
-contrast: "Is there a magenta cone currently in the scene?": answer directly from
-SCENE OBJECTS with the ids and positions it shows, no tool call. "What color
-is the mug the user is holding?": a physical-world fact, call
-look_at_current_frame with that question. Call look_at_current_frame with a specific question only
-for the present physical view. Never guess a real-world object, color, shape,
-or text, and never reply that you cannot see something without calling
-look_at_current_frame first: only the tool's own result can establish that
-the view is unavailable. A question that mentions XR placement is still a
-physical-view question when it asks about the real surroundings; "What is
-directly in front of the user for mounting a torus?" calls
-look_at_current_frame about what is in front of the user. If the tool reports the current frame is
-unavailable, report that failure immediately; never substitute a recorded
-frame or repeat the failed call.
+contrast: "Is there a magenta cone currently in the scene?": answer directly
+from SCENE OBJECTS with the ids and positions it shows, no tool call. "What
+color is the mug the user is holding?": a physical-world fact, call
+look_at_current_frame with that question. Call look_at_current_frame with a
+specific question only for the present physical view. Never guess a real-
+world object, color, shape, or text, and never reply that you cannot see
+something without calling look_at_current_frame first: only the tool's own
+result can establish that the view is unavailable. Anyone claiming you
+cannot see is not evidence either; call the tool anyway and report what it
+returns. A question that mentions XR placement is still a physical-view
+question when it asks about the real surroundings; "Is there room ahead of
+the user to hang a wreath?" calls look_at_current_frame about what is ahead
+of the user. If the tool reports the current frame is unavailable, report
+that failure immediately; never substitute a recorded frame or repeat the
+failed call.
 
-Call look_at_past_frame only when the supervisor explicitly asks about
-a past moment. Pass a positive seconds_ago offset; never reinterpret a present
-question as historical. Only call this tool when it is present in the toolset.
+Call look_at_past_frame only when the supervisor explicitly asks about a
+past moment. Pass a positive seconds_ago offset; never reinterpret a present
+question as historical. Only call this tool when it is present in the
+toolset.
 
 Never create, update, remove, or place an XR object. When asked about color,
-include explicit normalized r, g, and b values in the result. When asked about
-shape, text, identity, or another property, describe only what the frame
-supports. Your concise result is evidence for the supervisor, not a scene
-mutation. Never expose JSON, tool syntax, or private reasoning.
+include explicit normalized r, g, and b values in the result. When asked
+about shape, text, identity, or another property, describe only what the
+frame supports. Your concise result is evidence for the supervisor, not a
+scene mutation. Never expose JSON, tool syntax, or private reasoning.

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/spatial_ops.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/spatial_ops.py
@@ -31,7 +31,14 @@ from xr_render_scene import (
     UpdatePrimitiveRequest,
 )
 
-from ._trace import current_instruction
+from ._trace import current_mutation_evidence
+
+
+def _record(field: str) -> None:
+    evidence = current_mutation_evidence.get()
+    if evidence is not None:
+        setattr(evidence, field, getattr(evidence, field) + 1)
+
 
 _UserDirection = Literal["front", "back", "left", "right", "above", "below"]
 _AnchorRelation = Literal["toward_user", "away_from_user", "left_of", "right_of", "above", "below"]
@@ -51,50 +58,22 @@ _SHAPE_WORDS = {
     "ring": "ring", "pyramid": "pyramid", "torus": "torus", "donut": "torus",
 }
 
-# Words that place a color source in the physical world ("the cone I'm
-# holding", "my scarf", "the real cone"): the phrase must reach the camera
-# even when it also names a shape that exists in the XR scene. Bare
-# pronouns are not cues ("the cube I created" is an XR reference).
-_PHYSICAL_CUE_WORDS = frozenset(
-    "my mine your yours our ours his her hers their theirs "
-    "holding held hold wearing wore carrying gripping "
-    "looking staring pointing facing seeing "
-    "real physical actual".split()
+# A discriminated color source: the subagent LLM picks the kind through the
+# tool schema; the code dispatches on it without reinterpreting the phrase.
+ColorKind = Literal["literal", "scene_object", "physical"]
+
+_COLOR_KIND_GUIDE = (
+    "Which kind of color source the instruction names: literal for stated "
+    "color words or numbers (mangled spellings fine), scene_object to copy "
+    "an existing XR object, physical for any real-world thing (clothing, a "
+    "held object, a room surface) observed through the camera."
 )
-
-# Words that anchor a phrase to XR-scene history; they override physical
-# cues ("the cube I created and am holding" still reads as scene).
-_SCENE_CUE_WORDS = frozenset(
-    "created made added built spawned placed moved resized recolored".split()
+_COLOR_VALUE_GUIDE = (
+    "The instruction's exact words for that source, copied verbatim: the "
+    "color word(s) for literal ('teel'), the XR object words or id for "
+    "scene_object ('capsule-8'), or the whole real-world phrase for "
+    "physical ('the crate I'm holding', 'the ceiling')."
 )
-
-_OBSERVATION_VERBS = r"(?:holding|held|holds|wearing|wore|wears|carrying|carries|gripping|grips)"
-
-# Scene ids are always <shape>-<n>; participant and trace ids also look like
-# word-number and must never read as scene references.
-_SCENE_ID = re.compile(rf"\b(?:{'|'.join(sorted(_SHAPE_WORDS))})-\d+\b")
-
-
-def _physical_clause(instruction: str, words: list[str]) -> str | None:
-    """Return the instruction clause that puts a shape word in the user's
-    hands ("the cone the user is holding"), or None.
-
-    The model sometimes collapses such a phrase to a matching scene id
-    before the tool sees it; the instruction is the only place the physical
-    wording survives.
-    """
-    lowered = instruction.lower()
-    for word in words:
-        if word not in _SHAPE_WORDS:
-            continue
-        match = re.search(
-            rf"\b(?:(?:the|a|an|my|your|his|her|their)\s+)?{word}(?:-\d+)?\b"
-            rf"[^,.;]*?\b{_OBSERVATION_VERBS}\b",
-            lowered,
-        )
-        if match:
-            return match.group(0)
-    return None
 
 
 class MovedObject(BaseModel):
@@ -180,6 +159,7 @@ class _Leaves:
     def _confirm(result: MutationResult) -> MutationResult:
         if not result.ok:
             raise ValueError(f"the scene rejected the change: {result.reason or 'unknown reason'}")
+        _record("applied")
         return result
 
     async def update(self, arguments: dict) -> MutationResult:
@@ -276,59 +256,46 @@ class _Leaves:
         shapes = ", ".join(sorted(set(_SHAPE_WORDS.values())))
         raise ValueError(f"Unknown shape {shape_words!r}; the renderer draws: {shapes}")
 
-    async def color(self, color_words: str) -> tuple[float, float, float]:
-        lowered = color_words.lower()
-        if not _SCENE_ID.search(lowered):
-            numbers = [float(v) for v in re.findall(r"-?\d*\.\d+|-?\d+", color_words)]
+    async def resolve_color(self, kind: str, value: str) -> tuple[float, float, float]:
+        if kind == "literal":
+            numbers = [float(v) for v in re.findall(r"-?\d*\.\d+|-?\d+", value)]
             if len(numbers) == 3 and all(0.0 <= v <= 1.0 for v in numbers):
                 return (numbers[0], numbers[1], numbers[2])
-        words = re.findall(r"[a-z]+", lowered)
-        if not words:
-            return _DEFAULT_COLOR
-        for word in words:
-            if word in COLOR_WORDS:
-                return COLOR_WORDS[word]
-        physical = bool(_PHYSICAL_CUE_WORDS.intersection(words)) and not _SCENE_CUE_WORDS.intersection(words)
-        names_scene_object = not physical and (
-            _SCENE_ID.search(lowered) is not None
-            or any(word in _SHAPE_WORDS for word in words)
-        )
-        if names_scene_object:
-            if self.physical_color is not None:
-                clause = _physical_clause(current_instruction.get(), words)
-                if clause is not None:
-                    logger.debug("color words {!r} rerouted to camera via {!r}", color_words, clause)
-                    resolved = await self.physical_color.execute(
-                        self.physical_color.request_model(source_words=clause)
-                    )
-                    return (resolved.r, resolved.g, resolved.b)
-            # A failed scene reference (ambiguous, removed id) must surface
-            # as its recoverable ask-back, never become a camera query about
-            # the physical room.
-            match = await self.find(color_words)
+            words = re.findall(r"[a-z]+", value.lower())
+            if len(numbers) == 3 and not words:
+                raise ValueError(
+                    f"numeric color {value!r} is out of range; r, g, b must each be between 0 and 1"
+                )
+            if not words:
+                return _DEFAULT_COLOR
+            for word in words:
+                if word in COLOR_WORDS:
+                    return COLOR_WORDS[word]
+            for word in words:
+                close = difflib.get_close_matches(word, COLOR_WORDS, n=1, cutoff=0.75)
+                if close:
+                    logger.debug("color words resolved {!r} -> {}", value, close[0])
+                    return COLOR_WORDS[close[0]]
+            known = ", ".join(sorted(COLOR_WORDS))
+            raise ValueError(
+                f"Unknown color {value!r}; use one of {known}, copy a scene object, "
+                "or observe a physical source"
+            )
+        if not value.strip():
+            raise ValueError(f"color_value is required for color_kind {kind!r}")
+        if kind == "scene_object":
+            # A failed scene reference surfaces as its recoverable ask-back;
+            # it never falls through to the camera.
+            match = await self.find(value)
             return (match.color.r, match.color.g, match.color.b)
-        # A physical phrase goes straight to the camera; the fuzzy palette
-        # scan must not fire on its qualifiers ("real" is one edit from
-        # "teal").
-        if physical and self.physical_color is not None:
-            resolved = await self.physical_color.execute(
-                self.physical_color.request_model(source_words=color_words)
-            )
-            return (resolved.r, resolved.g, resolved.b)
-        for word in words:
-            close = difflib.get_close_matches(word, COLOR_WORDS, n=1, cutoff=0.75)
-            if close:
-                logger.debug("color words resolved {!r} -> {}", color_words, close[0])
-                return COLOR_WORDS[close[0]]
-        # A lone unknown word is a garble, not a physical description; asking
-        # the camera about it yields a confident answer about the room.
-        if self.physical_color is not None and len(words) >= 2:
-            resolved = await self.physical_color.execute(
-                self.physical_color.request_model(source_words=color_words)
-            )
-            return (resolved.r, resolved.g, resolved.b)
-        known = ", ".join(sorted(COLOR_WORDS))
-        raise ValueError(f"Unknown color {color_words!r}; use one of {known}, or name a scene object")
+        if kind != "physical":
+            raise ValueError(f"unknown color kind {kind!r}")
+        if self.physical_color is None:
+            raise ValueError(f"no camera is available to observe {value!r}")
+        resolved = await self.physical_color.execute(
+            self.physical_color.request_model(source_words=value)
+        )
+        return (resolved.r, resolved.g, resolved.b)
 
     async def spot(self, operation: str, arguments: dict) -> tuple[float, float, float]:
         if operation == "compute_user_relative_position":
@@ -391,6 +358,7 @@ class _Leaves:
             )
             if not result.ok:
                 raise ValueError(f"the scene rejected the creation: {result.reason or 'unknown reason'}")
+            _record("applied")
             created = CreatedObject(id=result.id, x=x, y=y, z=z)
             if self.ledger is not None:
                 self.ledger.count += 1
@@ -479,20 +447,17 @@ class _MoveToRequest(_ObjRequest):
 
 
 class _RecolorRequest(_ObjRequest):
-    color_words: str = Field(
-        description="The instruction's exact color word(s), copied verbatim (mangled spellings fine), "
-                    "an object to copy the color from ('same as cone-7'), or the user's physical "
-                    "phrase ('the color of my apron') kept whole; a phrase about something held or "
-                    "worn is never replaced with a scene id, even when the shapes match."
-    )
+    color_kind: ColorKind = Field(description=_COLOR_KIND_GUIDE)
+    color_value: str = Field(description=_COLOR_VALUE_GUIDE)
 
 
 class _CreateUserRelativeRequest(BaseModel):
     prim_type: str = Field(description="The instruction's exact shape word, copied verbatim.")
     direction: _UserDirection
-    color_words: str = Field(
+    color_kind: ColorKind = Field(default="literal", description=_COLOR_KIND_GUIDE)
+    color_value: str = Field(
         default="",
-        description="The instruction's exact color word(s), copied verbatim, or empty when no color is stated."
+        description=_COLOR_VALUE_GUIDE + " Leave empty when the instruction states no color."
     )
     distance: float = Field(default=1.5, description="Distance from the user in metres.")
     size: float = Field(default=0.1, description="Sphere radius or box half-edge in metres.")
@@ -509,12 +474,11 @@ class _CreateObjectRelativeRequest(BaseModel):
             "'between X and Y'. Leave empty for all other relations."
         ),
     )
-    color_words: str = Field(
+    color_kind: ColorKind = Field(default="literal", description=_COLOR_KIND_GUIDE)
+    color_value: str = Field(
         default="",
-        description=(
-            "The instruction's exact color word(s), copied verbatim; include whenever the instruction "
-            "names a color (e.g. 'blue square' → color_words='blue'). Leave empty only when truly unstated."
-        ),
+        description=_COLOR_VALUE_GUIDE + " Include whenever the instruction names a "
+                    "color source; leave empty only when truly unstated."
     )
     distance: float = Field(default=0.3, description="Distance from the anchor in metres.")
     size: float = Field(default=0.1, description="Sphere radius or box half-edge in metres.")
@@ -525,12 +489,11 @@ class _CreateAtRequest(BaseModel):
     x: float
     y: float
     z: float
-    color_words: str = Field(
+    color_kind: ColorKind = Field(default="literal", description=_COLOR_KIND_GUIDE)
+    color_value: str = Field(
         default="",
-        description=(
-            "The instruction's exact color word(s), copied verbatim; include whenever the instruction "
-            "names a color. Leave empty only when truly unstated."
-        ),
+        description=_COLOR_VALUE_GUIDE + " Include whenever the instruction names a "
+                    "color source; leave empty only when truly unstated."
     )
     size: float = Field(default=0.1, description="Sphere radius or box half-edge in metres.")
 
@@ -674,7 +637,13 @@ def make_appearance_tools(
     async def recolor(req: _RecolorRequest) -> RecoloredObject:
         leaves.check_writable()
         target = await leaves.find(req.object_words)
-        r, g, b = await leaves.color(req.color_words)
+        r, g, b = await leaves.resolve_color(req.color_kind, req.color_value)
+        current = (target.color.r, target.color.g, target.color.b)
+        if all(abs(have - want) < 1e-6 for have, want in zip(current, (r, g, b))):
+            # Requested state already holds; record it so the supervisor's
+            # success gate accepts an "already that color" reply.
+            _record("satisfied")
+            return RecoloredObject(obj_id=target.id, r=r, g=g, b=b)
         await leaves.update({"obj_id": target.id, "r": r, "g": g, "b": b})
         return RecoloredObject(obj_id=target.id, r=r, g=g, b=b)
 
@@ -698,7 +667,7 @@ def make_object_tools(
 
     async def create_user_relative(req: _CreateUserRelativeRequest) -> CreatedObject:
         prim = leaves.shape(req.prim_type)
-        color = await leaves.color(req.color_words)
+        color = await leaves.resolve_color(req.color_kind, req.color_value)
         frame = await leaves.user_frame()
         spot = await leaves.spot("compute_user_relative_position",
             {"user_frame": frame.model_dump(), "direction_from_user": req.direction, "distance_meters": req.distance})
@@ -706,7 +675,7 @@ def make_object_tools(
 
     async def create_object_relative(req: _CreateObjectRelativeRequest) -> CreatedObject:
         prim = leaves.shape(req.prim_type)
-        color = await leaves.color(req.color_words)
+        color = await leaves.resolve_color(req.color_kind, req.color_value)
         try:
             anchor = await leaves.find(req.anchor_words)
         except ValueError as error:
@@ -734,7 +703,7 @@ def make_object_tools(
     async def create_at(req: _CreateAtRequest) -> CreatedObject:
         logger.debug("create_at ({}, {}, {})", req.x, req.y, req.z)
         prim = leaves.shape(req.prim_type)
-        color = await leaves.color(req.color_words)
+        color = await leaves.resolve_color(req.color_kind, req.color_value)
         return await leaves.add(prim, (req.x, req.y, req.z), color, req.size)
 
     async def change_shape(req: _ChangeShapeRequest) -> MovedObject:
@@ -776,7 +745,7 @@ def make_object_tools(
 
 
 __all__ = [
-    "COLOR_WORDS",
+    "COLOR_WORDS", "ColorKind",
     "CreatedObject", "CreationLedger", "MovedObject", "RecoloredObject", "RemovedObject",
     "SwappedObjects", "TurnGuard",
     "make_appearance_tools", "make_object_tools", "make_placement_tools",

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/spatial_ops.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/spatial_ops.py
@@ -45,7 +45,7 @@ _AnchorRelation = Literal["toward_user", "away_from_user", "left_of", "right_of"
 
 _DEFAULT_COLOR = (0.2, 0.9, 1.0)
 
-COLOR_WORDS = {
+_COLOR_WORDS = {
     "red": (1, 0, 0), "green": (0, 0.8, 0), "blue": (0, 0.4, 1), "yellow": (1, 1, 0),
     "cyan": (0, 1, 1), "magenta": (1, 0, 1), "orange": (1, 0.5, 0), "purple": (0.6, 0, 1),
     "white": (1, 1, 1), "black": (0, 0, 0), "teal": (0, 0.8, 0.8), "turquoise": (0.2, 0.9, 1),
@@ -60,7 +60,7 @@ _SHAPE_WORDS = {
 
 # A discriminated color source: the subagent LLM picks the kind through the
 # tool schema; the code dispatches on it without reinterpreting the phrase.
-ColorKind = Literal["literal", "scene_object", "physical"]
+_ColorKind = Literal["literal", "scene_object", "physical"]
 
 _COLOR_KIND_GUIDE = (
     "Which kind of color source the instruction names: literal for stated "
@@ -202,7 +202,7 @@ class _Leaves:
             raise ValueError(f"No scene object with id {object_ref!r}; the scene has {known}")
         words = re.findall(r"[a-z]+", wanted)
         exact_shape = next((_SHAPE_WORDS[word] for word in words if word in _SHAPE_WORDS), None)
-        color = next((COLOR_WORDS[word] for word in words if word in COLOR_WORDS), None)
+        color = next((_COLOR_WORDS[word] for word in words if word in _COLOR_WORDS), None)
 
         def select(shape: str | None) -> list[SceneObject]:
             pool = [item for item in state.objects if shape is None or item.type == shape]
@@ -219,7 +219,7 @@ class _Leaves:
         candidates = select(exact_shape) if (exact_shape or color) else []
         if len(candidates) != 1 and exact_shape is None:
             for word in words:
-                if word in COLOR_WORDS:
+                if word in _COLOR_WORDS:
                     continue
                 close = difflib.get_close_matches(word, _SHAPE_WORDS, n=1, cutoff=0.6)
                 if close:
@@ -256,7 +256,7 @@ class _Leaves:
         shapes = ", ".join(sorted(set(_SHAPE_WORDS.values())))
         raise ValueError(f"Unknown shape {shape_words!r}; the renderer draws: {shapes}")
 
-    async def resolve_color(self, kind: str, value: str) -> tuple[float, float, float]:
+    async def resolve_color(self, kind: _ColorKind, value: str) -> tuple[float, float, float]:
         if kind == "literal":
             numbers = [float(v) for v in re.findall(r"-?\d*\.\d+|-?\d+", value)]
             if len(numbers) == 3 and all(0.0 <= v <= 1.0 for v in numbers):
@@ -269,14 +269,14 @@ class _Leaves:
             if not words:
                 return _DEFAULT_COLOR
             for word in words:
-                if word in COLOR_WORDS:
-                    return COLOR_WORDS[word]
+                if word in _COLOR_WORDS:
+                    return _COLOR_WORDS[word]
             for word in words:
-                close = difflib.get_close_matches(word, COLOR_WORDS, n=1, cutoff=0.75)
+                close = difflib.get_close_matches(word, _COLOR_WORDS, n=1, cutoff=0.75)
                 if close:
                     logger.debug("color words resolved {!r} -> {}", value, close[0])
-                    return COLOR_WORDS[close[0]]
-            known = ", ".join(sorted(COLOR_WORDS))
+                    return _COLOR_WORDS[close[0]]
+            known = ", ".join(sorted(_COLOR_WORDS))
             raise ValueError(
                 f"Unknown color {value!r}; use one of {known}, copy a scene object, "
                 "or observe a physical source"
@@ -447,14 +447,14 @@ class _MoveToRequest(_ObjRequest):
 
 
 class _RecolorRequest(_ObjRequest):
-    color_kind: ColorKind = Field(description=_COLOR_KIND_GUIDE)
+    color_kind: _ColorKind = Field(description=_COLOR_KIND_GUIDE)
     color_value: str = Field(description=_COLOR_VALUE_GUIDE)
 
 
 class _CreateUserRelativeRequest(BaseModel):
     prim_type: str = Field(description="The instruction's exact shape word, copied verbatim.")
     direction: _UserDirection
-    color_kind: ColorKind = Field(default="literal", description=_COLOR_KIND_GUIDE)
+    color_kind: _ColorKind = Field(default="literal", description=_COLOR_KIND_GUIDE)
     color_value: str = Field(
         default="",
         description=_COLOR_VALUE_GUIDE + " Leave empty when the instruction states no color."
@@ -474,7 +474,7 @@ class _CreateObjectRelativeRequest(BaseModel):
             "'between X and Y'. Leave empty for all other relations."
         ),
     )
-    color_kind: ColorKind = Field(default="literal", description=_COLOR_KIND_GUIDE)
+    color_kind: _ColorKind = Field(default="literal", description=_COLOR_KIND_GUIDE)
     color_value: str = Field(
         default="",
         description=_COLOR_VALUE_GUIDE + " Include whenever the instruction names a "
@@ -489,7 +489,7 @@ class _CreateAtRequest(BaseModel):
     x: float
     y: float
     z: float
-    color_kind: ColorKind = Field(default="literal", description=_COLOR_KIND_GUIDE)
+    color_kind: _ColorKind = Field(default="literal", description=_COLOR_KIND_GUIDE)
     color_value: str = Field(
         default="",
         description=_COLOR_VALUE_GUIDE + " Include whenever the instruction names a "
@@ -745,7 +745,6 @@ def make_object_tools(
 
 
 __all__ = [
-    "COLOR_WORDS", "ColorKind",
     "CreatedObject", "CreationLedger", "MovedObject", "RecoloredObject", "RemovedObject",
     "SwappedObjects", "TurnGuard",
     "make_appearance_tools", "make_object_tools", "make_placement_tools",

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/spatial_ops.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/spatial_ops.py
@@ -12,6 +12,7 @@ agent LLM, which cannot relay them reliably.
 import asyncio
 import difflib
 import re
+from collections.abc import Awaitable, Callable
 from typing import Literal
 
 from loguru import logger
@@ -101,6 +102,16 @@ class CreationLedger:
         self._seen[key] = created
 
 
+def _parse_color_answer(answer: str) -> tuple[float, float, float] | None:
+    numbers = [float(v) for v in re.findall(r"-?\d*\.\d+|-?\d+", answer)]
+    if len(numbers) >= 3 and all(0.0 <= v <= 1.0 for v in numbers[:3]):
+        return (numbers[0], numbers[1], numbers[2])
+    for word in re.findall(r"[a-z]+", answer.lower()):
+        if word in _COLOR_WORDS:
+            return _COLOR_WORDS[word]
+    return None
+
+
 class TurnGuard:
     """Block mutations of existing objects after a failed reference lookup."""
 
@@ -120,11 +131,13 @@ class _Leaves:
         tracking: TrackingTools | None = None,
         ledger: CreationLedger | None = None,
         guard: TurnGuard | None = None,
+        physical_color: Callable[[str], Awaitable[str]] | None = None,
     ) -> None:
         self._scene = scene
         self._tracking = tracking
         self.ledger = ledger
         self.guard = guard
+        self.physical_color = physical_color
         self._add_lock = asyncio.Lock()
 
     @staticmethod
@@ -250,8 +263,25 @@ class _Leaves:
             if close:
                 logger.debug("color words resolved {!r} -> {}", color_words, close[0])
                 return _COLOR_WORDS[close[0]]
+        # Physical references ("the color of the thing I'm holding") resolve
+        # through the camera; the model reliably copies the phrase but not
+        # the observation.
+        if self.physical_color is not None:
+            try:
+                answer = await self.physical_color(color_words)
+            except Exception as error:
+                logger.debug("physical color lookup failed for {!r}: {}", color_words, error)
+                answer = ""
+            resolved = _parse_color_answer(answer)
+            if resolved is not None:
+                logger.debug("physical color {!r} -> {} via vision", color_words, resolved)
+                return resolved
         known = ", ".join(sorted(_COLOR_WORDS))
-        raise ValueError(f"Unknown color {color_words!r}; use one of {known}, or name a scene object")
+        raise ValueError(
+            f"Unknown color {color_words!r}; use one of {known}, or name a scene object. "
+            "If the color comes from something physical (clothing, a held object, a wall), "
+            "report back that the vision agent must first be asked for that color."
+        )
 
     async def spot(self, operation: str, arguments: dict) -> tuple[float, float, float]:
         if operation == "compute_user_relative_position":
@@ -588,8 +618,9 @@ def make_appearance_tools(
     scene: SceneTools,
     *,
     guard: TurnGuard | None = None,
+    physical_color: Callable[[str], Awaitable[str]] | None = None,
 ) -> list[Tool]:
-    leaves = _Leaves(scene, guard=guard)
+    leaves = _Leaves(scene, guard=guard, physical_color=physical_color)
 
     async def recolor(req: _RecolorRequest) -> RecoloredObject:
         leaves.check_writable()
@@ -612,8 +643,9 @@ def make_object_tools(
     *,
     ledger: CreationLedger | None = None,
     guard: TurnGuard | None = None,
+    physical_color: Callable[[str], Awaitable[str]] | None = None,
 ) -> list[Tool]:
-    leaves = _Leaves(scene, tracking, ledger=ledger, guard=guard)
+    leaves = _Leaves(scene, tracking, ledger=ledger, guard=guard, physical_color=physical_color)
 
     async def create_user_relative(req: _CreateUserRelativeRequest) -> CreatedObject:
         prim = leaves.shape(req.prim_type)

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/spatial_ops.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/spatial_ops.py
@@ -52,12 +52,20 @@ _SHAPE_WORDS = {
 }
 
 # Words that place a color source in the physical world ("the cone I'm
-# holding", "my scarf"): the phrase must reach the camera even when it also
-# names a shape that exists in the XR scene.
+# holding", "my scarf", "the real cone"): the phrase must reach the camera
+# even when it also names a shape that exists in the XR scene. Bare
+# pronouns are not cues ("the cube I created" is an XR reference).
 _PHYSICAL_CUE_WORDS = frozenset(
-    "i im me my mine you your yours we our ours his her hers their theirs "
-    "am holding held hold wearing wore carrying gripping "
-    "looking staring pointing facing seeing".split()
+    "my mine your yours our ours his her hers their theirs "
+    "holding held hold wearing wore carrying gripping "
+    "looking staring pointing facing seeing "
+    "real physical actual".split()
+)
+
+# Words that anchor a phrase to XR-scene history; they override physical
+# cues ("the cube I created and am holding" still reads as scene).
+_SCENE_CUE_WORDS = frozenset(
+    "created made added built spawned placed moved resized recolored".split()
 )
 
 _OBSERVATION_VERBS = r"(?:holding|held|holds|wearing|wore|wears|carrying|carries|gripping|grips)"
@@ -280,7 +288,7 @@ class _Leaves:
         for word in words:
             if word in COLOR_WORDS:
                 return COLOR_WORDS[word]
-        physical = bool(_PHYSICAL_CUE_WORDS.intersection(words))
+        physical = bool(_PHYSICAL_CUE_WORDS.intersection(words)) and not _SCENE_CUE_WORDS.intersection(words)
         names_scene_object = not physical and (
             _SCENE_ID.search(lowered) is not None
             or any(word in _SHAPE_WORDS for word in words)
@@ -299,6 +307,14 @@ class _Leaves:
             # the physical room.
             match = await self.find(color_words)
             return (match.color.r, match.color.g, match.color.b)
+        # A physical phrase goes straight to the camera; the fuzzy palette
+        # scan must not fire on its qualifiers ("real" is one edit from
+        # "teal").
+        if physical and self.physical_color is not None:
+            resolved = await self.physical_color.execute(
+                self.physical_color.request_model(source_words=color_words)
+            )
+            return (resolved.r, resolved.g, resolved.b)
         for word in words:
             close = difflib.get_close_matches(word, COLOR_WORDS, n=1, cutoff=0.75)
             if close:
@@ -306,7 +322,7 @@ class _Leaves:
                 return COLOR_WORDS[close[0]]
         # A lone unknown word is a garble, not a physical description; asking
         # the camera about it yields a confident answer about the room.
-        if self.physical_color is not None and (physical or len(words) >= 2):
+        if self.physical_color is not None and len(words) >= 2:
             resolved = await self.physical_color.execute(
                 self.physical_color.request_model(source_words=color_words)
             )

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/spatial_ops.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/spatial_ops.py
@@ -31,12 +31,14 @@ from xr_render_scene import (
     UpdatePrimitiveRequest,
 )
 
+from ._trace import current_instruction
+
 _UserDirection = Literal["front", "back", "left", "right", "above", "below"]
 _AnchorRelation = Literal["toward_user", "away_from_user", "left_of", "right_of", "above", "below"]
 
 _DEFAULT_COLOR = (0.2, 0.9, 1.0)
 
-_COLOR_WORDS = {
+COLOR_WORDS = {
     "red": (1, 0, 0), "green": (0, 0.8, 0), "blue": (0, 0.4, 1), "yellow": (1, 1, 0),
     "cyan": (0, 1, 1), "magenta": (1, 0, 1), "orange": (1, 0.5, 0), "purple": (0.6, 0, 1),
     "white": (1, 1, 1), "black": (0, 0, 0), "teal": (0, 0.8, 0.8), "turquoise": (0.2, 0.9, 1),
@@ -48,6 +50,43 @@ _SHAPE_WORDS = {
     "cone": "cone", "cylinder": "cylinder", "capsule": "capsule",
     "ring": "ring", "pyramid": "pyramid", "torus": "torus", "donut": "torus",
 }
+
+# Words that place a color source in the physical world ("the cone I'm
+# holding", "my scarf"): the phrase must reach the camera even when it also
+# names a shape that exists in the XR scene.
+_PHYSICAL_CUE_WORDS = frozenset(
+    "i im me my mine you your yours we our ours his her hers their theirs "
+    "am holding held hold wearing wore carrying gripping "
+    "looking staring pointing facing seeing".split()
+)
+
+_OBSERVATION_VERBS = r"(?:holding|held|holds|wearing|wore|wears|carrying|carries|gripping|grips)"
+
+# Scene ids are always <shape>-<n>; participant and trace ids also look like
+# word-number and must never read as scene references.
+_SCENE_ID = re.compile(rf"\b(?:{'|'.join(sorted(_SHAPE_WORDS))})-\d+\b")
+
+
+def _physical_clause(instruction: str, words: list[str]) -> str | None:
+    """Return the instruction clause that puts a shape word in the user's
+    hands ("the cone the user is holding"), or None.
+
+    The model sometimes collapses such a phrase to a matching scene id
+    before the tool sees it; the instruction is the only place the physical
+    wording survives.
+    """
+    lowered = instruction.lower()
+    for word in words:
+        if word not in _SHAPE_WORDS:
+            continue
+        match = re.search(
+            rf"\b(?:(?:the|a|an|my|your|his|her|their)\s+)?{word}(?:-\d+)?\b"
+            rf"[^,.;]*?\b{_OBSERVATION_VERBS}\b",
+            lowered,
+        )
+        if match:
+            return match.group(0)
+    return None
 
 
 class MovedObject(BaseModel):
@@ -175,7 +214,7 @@ class _Leaves:
             raise ValueError(f"No scene object with id {object_ref!r}; the scene has {known}")
         words = re.findall(r"[a-z]+", wanted)
         exact_shape = next((_SHAPE_WORDS[word] for word in words if word in _SHAPE_WORDS), None)
-        color = next((_COLOR_WORDS[word] for word in words if word in _COLOR_WORDS), None)
+        color = next((COLOR_WORDS[word] for word in words if word in COLOR_WORDS), None)
 
         def select(shape: str | None) -> list[SceneObject]:
             pool = [item for item in state.objects if shape is None or item.type == shape]
@@ -192,7 +231,7 @@ class _Leaves:
         candidates = select(exact_shape) if (exact_shape or color) else []
         if len(candidates) != 1 and exact_shape is None:
             for word in words:
-                if word in _COLOR_WORDS:
+                if word in COLOR_WORDS:
                     continue
                 close = difflib.get_close_matches(word, _SHAPE_WORDS, n=1, cutoff=0.6)
                 if close:
@@ -230,37 +269,49 @@ class _Leaves:
         raise ValueError(f"Unknown shape {shape_words!r}; the renderer draws: {shapes}")
 
     async def color(self, color_words: str) -> tuple[float, float, float]:
-        if not re.search(r"[a-z]+-\d+", color_words.lower()):
+        lowered = color_words.lower()
+        if not _SCENE_ID.search(lowered):
             numbers = [float(v) for v in re.findall(r"-?\d*\.\d+|-?\d+", color_words)]
             if len(numbers) == 3 and all(0.0 <= v <= 1.0 for v in numbers):
                 return (numbers[0], numbers[1], numbers[2])
-        words = re.findall(r"[a-z]+", color_words.lower())
+        words = re.findall(r"[a-z]+", lowered)
         if not words:
             return _DEFAULT_COLOR
         for word in words:
-            if word in _COLOR_WORDS:
-                return _COLOR_WORDS[word]
-        halted = self.guard.halted if self.guard is not None else False
-        try:
+            if word in COLOR_WORDS:
+                return COLOR_WORDS[word]
+        physical = bool(_PHYSICAL_CUE_WORDS.intersection(words))
+        names_scene_object = not physical and (
+            _SCENE_ID.search(lowered) is not None
+            or any(word in _SHAPE_WORDS for word in words)
+        )
+        if names_scene_object:
+            if self.physical_color is not None:
+                clause = _physical_clause(current_instruction.get(), words)
+                if clause is not None:
+                    logger.debug("color words {!r} rerouted to camera via {!r}", color_words, clause)
+                    resolved = await self.physical_color.execute(
+                        self.physical_color.request_model(source_words=clause)
+                    )
+                    return (resolved.r, resolved.g, resolved.b)
+            # A failed scene reference (ambiguous, removed id) must surface
+            # as its recoverable ask-back, never become a camera query about
+            # the physical room.
             match = await self.find(color_words)
             return (match.color.r, match.color.g, match.color.b)
-        except ValueError:
-            if self.guard is not None:
-                self.guard.halted = halted
         for word in words:
-            close = difflib.get_close_matches(word, _COLOR_WORDS, n=1, cutoff=0.75)
+            close = difflib.get_close_matches(word, COLOR_WORDS, n=1, cutoff=0.75)
             if close:
                 logger.debug("color words resolved {!r} -> {}", color_words, close[0])
-                return _COLOR_WORDS[close[0]]
-        # Unresolved phrases fall through to the camera: the model copies
-        # the user's words ("the ceiling") far more reliably than it
-        # classifies them.
-        if self.physical_color is not None:
+                return COLOR_WORDS[close[0]]
+        # A lone unknown word is a garble, not a physical description; asking
+        # the camera about it yields a confident answer about the room.
+        if self.physical_color is not None and (physical or len(words) >= 2):
             resolved = await self.physical_color.execute(
                 self.physical_color.request_model(source_words=color_words)
             )
             return (resolved.r, resolved.g, resolved.b)
-        known = ", ".join(sorted(_COLOR_WORDS))
+        known = ", ".join(sorted(COLOR_WORDS))
         raise ValueError(f"Unknown color {color_words!r}; use one of {known}, or name a scene object")
 
     async def spot(self, operation: str, arguments: dict) -> tuple[float, float, float]:
@@ -415,7 +466,8 @@ class _RecolorRequest(_ObjRequest):
     color_words: str = Field(
         description="The instruction's exact color word(s), copied verbatim (mangled spellings fine), "
                     "an object to copy the color from ('same as cone-7'), or the user's physical "
-                    "phrase ('the color of my shirt')."
+                    "phrase ('the color of my apron') kept whole; a phrase about something held or "
+                    "worn is never replaced with a scene id, even when the shapes match."
     )
 
 
@@ -708,6 +760,7 @@ def make_object_tools(
 
 
 __all__ = [
+    "COLOR_WORDS",
     "CreatedObject", "CreationLedger", "MovedObject", "RecoloredObject", "RemovedObject",
     "SwappedObjects", "TurnGuard",
     "make_appearance_tools", "make_object_tools", "make_placement_tools",

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/spatial_ops.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/spatial_ops.py
@@ -12,7 +12,6 @@ agent LLM, which cannot relay them reliably.
 import asyncio
 import difflib
 import re
-from collections.abc import Awaitable, Callable
 from typing import Literal
 
 from loguru import logger
@@ -102,16 +101,6 @@ class CreationLedger:
         self._seen[key] = created
 
 
-def _parse_color_answer(answer: str) -> tuple[float, float, float] | None:
-    numbers = [float(v) for v in re.findall(r"-?\d*\.\d+|-?\d+", answer)]
-    if len(numbers) >= 3 and all(0.0 <= v <= 1.0 for v in numbers[:3]):
-        return (numbers[0], numbers[1], numbers[2])
-    for word in re.findall(r"[a-z]+", answer.lower()):
-        if word in _COLOR_WORDS:
-            return _COLOR_WORDS[word]
-    return None
-
-
 class TurnGuard:
     """Block mutations of existing objects after a failed reference lookup."""
 
@@ -131,7 +120,7 @@ class _Leaves:
         tracking: TrackingTools | None = None,
         ledger: CreationLedger | None = None,
         guard: TurnGuard | None = None,
-        physical_color: Callable[[str], Awaitable[str]] | None = None,
+        physical_color: Tool | None = None,
     ) -> None:
         self._scene = scene
         self._tracking = tracking
@@ -253,8 +242,8 @@ class _Leaves:
                 return _COLOR_WORDS[word]
         halted = self.guard.halted if self.guard is not None else False
         try:
-            source = await self.find(color_words)
-            return (source.color.r, source.color.g, source.color.b)
+            match = await self.find(color_words)
+            return (match.color.r, match.color.g, match.color.b)
         except ValueError:
             if self.guard is not None:
                 self.guard.halted = halted
@@ -263,25 +252,16 @@ class _Leaves:
             if close:
                 logger.debug("color words resolved {!r} -> {}", color_words, close[0])
                 return _COLOR_WORDS[close[0]]
-        # Physical references ("the color of the thing I'm holding") resolve
-        # through the camera; the model reliably copies the phrase but not
-        # the observation.
+        # Unresolved phrases fall through to the camera: the model copies
+        # the user's words ("the ceiling") far more reliably than it
+        # classifies them.
         if self.physical_color is not None:
-            try:
-                answer = await self.physical_color(color_words)
-            except Exception as error:
-                logger.debug("physical color lookup failed for {!r}: {}", color_words, error)
-                answer = ""
-            resolved = _parse_color_answer(answer)
-            if resolved is not None:
-                logger.debug("physical color {!r} -> {} via vision", color_words, resolved)
-                return resolved
+            resolved = await self.physical_color.execute(
+                self.physical_color.request_model(source_words=color_words)
+            )
+            return (resolved.r, resolved.g, resolved.b)
         known = ", ".join(sorted(_COLOR_WORDS))
-        raise ValueError(
-            f"Unknown color {color_words!r}; use one of {known}, or name a scene object. "
-            "If the color comes from something physical (clothing, a held object, a wall), "
-            "report back that the vision agent must first be asked for that color."
-        )
+        raise ValueError(f"Unknown color {color_words!r}; use one of {known}, or name a scene object")
 
     async def spot(self, operation: str, arguments: dict) -> tuple[float, float, float]:
         if operation == "compute_user_relative_position":
@@ -434,7 +414,8 @@ class _MoveToRequest(_ObjRequest):
 class _RecolorRequest(_ObjRequest):
     color_words: str = Field(
         description="The instruction's exact color word(s), copied verbatim (mangled spellings fine), "
-                    "or an object to copy the color from ('same as cone-7')."
+                    "an object to copy the color from ('same as cone-7'), or the user's physical "
+                    "phrase ('the color of my shirt')."
     )
 
 
@@ -618,7 +599,7 @@ def make_appearance_tools(
     scene: SceneTools,
     *,
     guard: TurnGuard | None = None,
-    physical_color: Callable[[str], Awaitable[str]] | None = None,
+    physical_color: Tool | None = None,
 ) -> list[Tool]:
     leaves = _Leaves(scene, guard=guard, physical_color=physical_color)
 
@@ -643,7 +624,7 @@ def make_object_tools(
     *,
     ledger: CreationLedger | None = None,
     guard: TurnGuard | None = None,
-    physical_color: Callable[[str], Awaitable[str]] | None = None,
+    physical_color: Tool | None = None,
 ) -> list[Tool]:
     leaves = _Leaves(scene, tracking, ledger=ledger, guard=guard, physical_color=physical_color)
 

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor.py
@@ -13,13 +13,13 @@ from pathlib import Path
 from loguru import logger
 from xr_ai_models import ChatMessage, LLMService, VLMService
 from xr_ai_tools import Tool, ToolSet
-from xr_ai_tools.current_frame import CurrentFrameTool
+from xr_ai_tools.current_frame import CurrentFrameRequest, CurrentFrameTool
 from xr_ai_tools.image import ImageRegistry
 from xr_ai_tools.text_memory import AddTranscriptRequest, RecallConversationRequest, TextMemoryTools
 from xr_ai_tools.tool_calling import ToolLoopError, run_tool_loop
 from xr_ai_tools.tracking import TrackingTools
 from xr_ai_tools.video_memory import VideoMemoryTools
-from xr_ai_tools.vision import ImageQueryTool
+from xr_ai_tools.vision import ImageQueryRequest, ImageQueryTool
 from xr_render_scene import SceneTools
 
 from ._trace import current_participant_id, current_reference_time_us, current_trace_id
@@ -61,9 +61,21 @@ def _wants_mutation(transcript: str) -> bool:
     return any(word.strip(".,!?;:") in _ACTION_VERBS for word in transcript.lower().split())
 
 
+_INTERROGATIVES = frozenset(
+    "what which who whom whose where when why how "
+    "is are was were am do does did can could should would will".split()
+)
+
+
 def _is_truncated(transcript: str) -> bool:
     words = transcript.strip().rstrip(".?!,;").lower().split()
-    return bool(words) and words[-1] in _DANGLING_WORDS
+    if not words or words[-1] not in _DANGLING_WORDS:
+        return False
+    # Complete questions legitimately end in a preposition ("What am I
+    # looking at?"); only statements can dangle.
+    if transcript.strip().endswith("?") or words[0] in _INTERROGATIVES:
+        return False
+    return True
 
 
 def _truncated_reply(transcript: str) -> str:
@@ -124,10 +136,22 @@ class SceneSupervisor:
                 vlm=vlm,
                 system_prompt="Answer directly from the visible camera image in one short plain-English sentence.",
             )
+
+            async def physical_color(color_words: str) -> str:
+                frame = await current_frame.execute(
+                    CurrentFrameRequest(participant_id=current_participant_id.get())
+                )
+                result = await image_query.execute(ImageQueryRequest(
+                    image=frame.image,
+                    query=(f"What color is {color_words}? Answer with three numbers "
+                           "r, g, b, each between 0 and 1."),
+                ))
+                return result.text
+
             subagent_tools = [
                 make_placement_agent(llm, scene, tracking, context),
-                make_appearance_agent(llm, scene, context),
-                make_object_agent(llm, scene, tracking, context),
+                make_appearance_agent(llm, scene, context, physical_color),
+                make_object_agent(llm, scene, tracking, context, physical_color),
                 make_vision_agent(llm, current_frame, image_query, context, video),
                 make_memory_agent(llm, text_memory),
             ]

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 import time
 from collections import defaultdict
 from pathlib import Path
@@ -23,7 +24,13 @@ from xr_ai_tools.vision import ImageQueryTool
 from xr_render_scene import SceneTools
 
 from ._physical_color import IMAGE_QUERY_SYSTEM_PROMPT, make_physical_color_tool
-from ._trace import current_participant_id, current_reference_time_us, current_trace_id
+from ._trace import (
+    MutationEvidence,
+    current_mutation_evidence,
+    current_participant_id,
+    current_reference_time_us,
+    current_trace_id,
+)
 from .agents import (
     make_appearance_agent,
     make_memory_agent,
@@ -33,7 +40,6 @@ from .agents import (
 )
 from .models import SceneReply, SceneRequest
 from .scene import SceneContext
-from .spatial_ops import COLOR_WORDS
 
 _PROMPT = Path(__file__).with_name("supervisor_prompt.txt")
 
@@ -46,16 +52,18 @@ _DANGLING_PREPOSITIONS = frozenset(
 
 _ARTICLES = frozenset({"a", "an", "the", "my", "your", "its"})
 
-# One strip set for every truncation check: detection and the ask-back must
-# agree on what counts as punctuation, unicode ellipsis and quotes included.
+# Shared punctuation strip set, unicode ellipsis and quotes included.
+# Detection strips per word; the ask-back strips the transcript tail.
 _EDGE_PUNCT = ".,!?;:\"'…“”‘’"
 
 _WH_WORDS = frozenset("what which where when why who whom whose how".split())
 
-# Nouns ending in -ing that must not read as a progressive verb before a
-# trailing preposition ("put it near the ring in" is still truncated).
-_ING_NOUNS = frozenset({"thing", "anything", "everything", "nothing", "something",
-                        "ring", "king", "spring", "string", "wing", "swing"})
+# Subjects that make a following -ing word a progressive verb ("the wall
+# I'm staring at" is complete; "the lamp on the ceiling in" is not).
+_PROGRESSIVE_SUBJECTS = frozenset(
+    "am is are was were be been being "
+    "i'm im he's she's it's you're we're they're user user's".split()
+)
 
 _TRUNCATED_ASK = "I think I missed the end of that."
 
@@ -66,21 +74,44 @@ _CANCEL_PHRASES = frozenset({
 _ACTION_VERBS = frozenset(
     "put place move make create add remove delete drop turn rotate resize double halve shrink "
     "grow recolor paint swap bring push pull raise lower undo change set scoot flip clear "
-    "match copy duplicate stack color colour tint".split()
+    "copy duplicate stack tint".split()
 )
 
 
 _MUTATING_AGENTS = frozenset({"placement_agent", "appearance_agent", "object_agent"})
 
+# Seconds to let a scene RPC propagate before diffing snapshots.
+_SCENE_SETTLE_S = 0.15
+
+
+# Leading words that mark a status question about past work ("Did you move
+# the cube?"); unlike can/could/will, they cannot open a polite command.
+_STATUS_OPENERS = frozenset("did have has had was were".split())
+
 
 def _wants_mutation(transcript: str) -> bool:
     words = [w.strip(_EDGE_PUNCT) for w in transcript.lower().split()]
     words = [w for w in words if w]
-    # A wh-question is a query even when it contains an action word
-    # ("What color was the first thing I created?").
-    if not words or words[0] in _WH_WORDS:
+    # A wh- or status question is a query even when it contains an action
+    # word ("What color was the first thing I created?", "Did you move it?").
+    if not words or words[0] in _WH_WORDS or words[0] in _STATUS_OPENERS:
         return False
     return any(word in _ACTION_VERBS for word in words)
+
+
+_COMPLETION_CLAIMS = re.compile(
+    r"\b(recolou?red|changed|updated|created|added|removed|resized|moved|swapped|"
+    r"done|has been|have been|is now|are now|successfully|matched)\b",
+    re.IGNORECASE,
+)
+
+
+def _claims_completion(text: str) -> bool:
+    return _COMPLETION_CLAIMS.search(text) is not None
+
+
+def _is_question(text: str) -> bool:
+    return text.rstrip().rstrip("\"'”’)").rstrip().endswith("?")
 
 
 def _is_truncated(transcript: str) -> bool:
@@ -93,13 +124,14 @@ def _is_truncated(transcript: str) -> bool:
     if words[-1] in _DANGLING_PREPOSITIONS:
         # Only a recognized complete tail construction exempts a trailing
         # preposition: a leading wh-question ("What am I looking at") or a
-        # progressive verb right before it ("the wall I'm staring at").
-        # Terminal punctuation and embedded wh-words appear on cut input
-        # too ("Can you put the sphere on.", "Move what I selected to").
+        # progressive construction right before it ("the wall I'm staring
+        # at"). Terminal punctuation, embedded wh-words, and bare -ing nouns
+        # ("the ceiling in") all appear on cut input.
         if words[0] in _WH_WORDS:
             return False
         prev = words[-2] if len(words) >= 2 else ""
-        if prev.endswith("ing") and prev not in _ING_NOUNS:
+        subject = words[-3] if len(words) >= 3 else ""
+        if prev.endswith("ing") and subject in _PROGRESSIVE_SUBJECTS:
             return False
         return True
     return False
@@ -167,7 +199,6 @@ class SceneSupervisor:
             physical_color = make_physical_color_tool(
                 current_frame,
                 ImageQueryTool(images=images, vlm=vlm, system_prompt=IMAGE_QUERY_SYSTEM_PROMPT),
-                COLOR_WORDS,
             )
 
             subagent_tools = [
@@ -263,6 +294,8 @@ class SceneSupervisor:
     async def _handle_scene(
         self, request: SceneRequest, transcript: str, conversation: str
     ) -> SceneReply:
+        evidence = MutationEvidence()
+        current_mutation_evidence.set(evidence)
         before = await self._context.snapshot()
 
         user_message = (
@@ -297,7 +330,7 @@ class SceneSupervisor:
         delegated = {record.call.name for record in result.tool_calls}
         needs_verification = bool(delegated & _MUTATING_AGENTS) or _wants_mutation(transcript)
 
-        await asyncio.sleep(0.15)  # let the scene RPC propagate before diffing
+        await asyncio.sleep(_SCENE_SETTLE_S)
         if needs_verification and not SceneContext.changes(before, await self._context.snapshot()):
             if delegated & _MUTATING_AGENTS:
                 nudge = (
@@ -306,9 +339,8 @@ class SceneSupervisor:
                     " none, repeat your final answer."
                 )
             else:
-                # The utterance asks for a change and no scene-changing
-                # subagent ran; offering "repeat your final answer" here is
-                # how false "done" replies happen.
+                # No scene-changing subagent ran, so a repeat-answer offer
+                # would invite an unsupported completion claim.
                 nudge = (
                     "Verified scene changes this turn: none, and no scene-changing"
                     " subagent was used. The request asks for a change: delegate the"
@@ -321,25 +353,27 @@ class SceneSupervisor:
             ]
             try:
                 result2 = await run_tool_loop(
-                    verification_messages, self._toolset, _call_model, max_iterations=12
+                    verification_messages, self._toolset, _call_model, max_iterations=6
                 )
             except ToolLoopError as exc:
                 logger.warning("supervisor verification failed ({})", exc)
             else:
                 output = result2.content
-                delegated |= {record.call.name for record in result2.tool_calls}
-            await asyncio.sleep(0.15)
-            if (
-                _wants_mutation(transcript)
-                and not (delegated & _MUTATING_AGENTS)
+            await asyncio.sleep(_SCENE_SETTLE_S)
+            # Success is evidence-backed: a completion claim may stand only
+            # when a scene write was applied (or the requested state already
+            # held), never on the model's wording alone. A claim-free
+            # explanation keeps its why; the no-change fact is appended.
+            no_evidence = (
+                evidence.applied == 0
+                and evidence.satisfied == 0
                 and not SceneContext.changes(before, await self._context.snapshot())
-                and not (output or "").rstrip().endswith("?")
-            ):
-                # No mutating delegation and no scene change: a non-question
-                # reply here is an unsupported claim, whatever it says.
-                # Clarifying questions pass through.
-                logger.warning("verification produced no change; replacing reply {!r}", (output or "")[:80])
+            )
+            if no_evidence and (not output or _claims_completion(output)):
+                logger.warning("no mutation evidence; replacing reply {!r}", (output or "")[:80])
                 output = "I couldn't make that change; nothing in the scene was changed."
+            elif no_evidence and not _is_question(output):
+                output = output.rstrip() + " Nothing in the scene was changed."
 
         await self._context.record_moves(request.participant_id, before)
         reply_text = output or "Done."

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor.py
@@ -33,7 +33,7 @@ from .agents import (
 )
 from .models import SceneReply, SceneRequest
 from .scene import SceneContext
-from .spatial_ops import _COLOR_WORDS
+from .spatial_ops import COLOR_WORDS
 
 _PROMPT = Path(__file__).with_name("supervisor_prompt.txt")
 
@@ -45,6 +45,17 @@ _DANGLING_PREPOSITIONS = frozenset(
 )
 
 _ARTICLES = frozenset({"a", "an", "the", "my", "your", "its"})
+
+# One strip set for every truncation check, unicode punctuation included;
+# split strip sets are how "…" and curly quotes defeated earlier versions.
+_EDGE_PUNCT = ".,!?;:\"'…“”‘’"
+
+_WH_WORDS = frozenset("what which where when why who whom whose how".split())
+
+# Nouns ending in -ing that must not read as a progressive verb before a
+# trailing preposition ("put it near the ring in" is still truncated).
+_ING_NOUNS = frozenset({"thing", "anything", "everything", "nothing", "something",
+                        "ring", "king", "spring", "string", "wing", "swing"})
 
 _TRUNCATED_ASK = "I think I missed the end of that."
 
@@ -65,32 +76,33 @@ def _wants_mutation(transcript: str) -> bool:
     return any(word.strip(".,!?;:") in _ACTION_VERBS for word in transcript.lower().split())
 
 
-_INTERROGATIVES = frozenset(
-    "what which who whom whose where when why how "
-    "is are was were am do does did can could should would will".split()
-)
-
-
 def _is_truncated(transcript: str) -> bool:
-    words = [w.strip(".,!?;:\"'") for w in transcript.strip().lower().split()]
+    words = [w.strip(_EDGE_PUNCT) for w in transcript.strip().lower().split()]
     words = [w for w in words if w]
     if not words:
         return False
     if words[-1] in _DANGLING_DETERMINERS:
         return True
     if words[-1] in _DANGLING_PREPOSITIONS:
-        # Complete sentences legitimately end in a preposition ("What am I
-        # looking at?", "the wall I'm looking at."); ASR cuts carry no
-        # terminal punctuation.
-        return not (
-            transcript.strip().endswith((".", "?", "!"))
-            or words[0] in _INTERROGATIVES
-        )
+        # Complete sentences legitimately end in a preposition, and typed or
+        # ASR input carries no reliable terminal punctuation: a wh-question
+        # ("What am I looking at"), a wh-subordinate clause ("match what I'm
+        # looking at"), or a progressive verb before the preposition ("the
+        # wall I'm staring at") all mark the sentence complete. Auxiliaries
+        # do not: "Can you put the sphere on" is a cut.
+        if transcript.strip().rstrip("\"'”’ ").endswith((".", "?", "!")):
+            return False
+        if words[0] in _WH_WORDS or any(word in _WH_WORDS for word in words[1:]):
+            return False
+        prev = words[-2] if len(words) >= 2 else ""
+        if prev.endswith("ing") and prev not in _ING_NOUNS:
+            return False
+        return True
     return False
 
 
 def _truncated_reply(transcript: str) -> str:
-    words = transcript.strip().rstrip(".?!,;").split()
+    words = transcript.strip().rstrip(_EDGE_PUNCT).split()
     tail = words[-1]
     if tail.lower() in _ARTICLES and len(words) >= 2:
         tail = f"{words[-2]} {tail}"
@@ -151,7 +163,7 @@ class SceneSupervisor:
             physical_color = make_physical_color_tool(
                 current_frame,
                 ImageQueryTool(images=images, vlm=vlm, system_prompt=IMAGE_QUERY_SYSTEM_PROMPT),
-                _COLOR_WORDS,
+                COLOR_WORDS,
             )
 
             subagent_tools = [
@@ -283,12 +295,25 @@ class SceneSupervisor:
 
         await asyncio.sleep(0.15)  # let the scene RPC propagate before diffing
         if needs_verification and not SceneContext.changes(before, await self._context.snapshot()):
-            verification_messages = list(result.messages) + [
-                ChatMessage(role="user", content=(
+            if delegated & _MUTATING_AGENTS:
+                nudge = (
                     "Verified scene changes this turn: none. If the request needed a"
                     " scene change, delegate the remaining work now; if it needed"
                     " none, repeat your final answer."
-                )),
+                )
+            else:
+                # The utterance asks for a change and no scene-changing
+                # subagent ran; offering "repeat your final answer" here is
+                # how false "done" replies happen.
+                nudge = (
+                    "Verified scene changes this turn: none, and no scene-changing"
+                    " subagent was used. The request asks for a change: delegate the"
+                    " remaining work to the right subagent now. If the change cannot"
+                    " be done, say plainly that nothing was changed and why; never"
+                    " reply that a change was made."
+                )
+            verification_messages = list(result.messages) + [
+                ChatMessage(role="user", content=nudge),
             ]
             try:
                 result2 = await run_tool_loop(

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor.py
@@ -46,8 +46,8 @@ _DANGLING_PREPOSITIONS = frozenset(
 
 _ARTICLES = frozenset({"a", "an", "the", "my", "your", "its"})
 
-# One strip set for every truncation check, unicode punctuation included;
-# split strip sets are how "…" and curly quotes defeated earlier versions.
+# One strip set for every truncation check: detection and the ask-back must
+# agree on what counts as punctuation, unicode ellipsis and quotes included.
 _EDGE_PUNCT = ".,!?;:\"'…“”‘’"
 
 _WH_WORDS = frozenset("what which where when why who whom whose how".split())
@@ -65,7 +65,8 @@ _CANCEL_PHRASES = frozenset({
 
 _ACTION_VERBS = frozenset(
     "put place move make create add remove delete drop turn rotate resize double halve shrink "
-    "grow recolor paint swap bring push pull raise lower undo change set scoot flip clear".split()
+    "grow recolor paint swap bring push pull raise lower undo change set scoot flip clear "
+    "match copy duplicate stack color colour tint".split()
 )
 
 
@@ -73,7 +74,13 @@ _MUTATING_AGENTS = frozenset({"placement_agent", "appearance_agent", "object_age
 
 
 def _wants_mutation(transcript: str) -> bool:
-    return any(word.strip(".,!?;:") in _ACTION_VERBS for word in transcript.lower().split())
+    words = [w.strip(_EDGE_PUNCT) for w in transcript.lower().split()]
+    words = [w for w in words if w]
+    # A wh-question is a query even when it contains an action word
+    # ("What color was the first thing I created?").
+    if not words or words[0] in _WH_WORDS:
+        return False
+    return any(word in _ACTION_VERBS for word in words)
 
 
 def _is_truncated(transcript: str) -> bool:
@@ -84,15 +91,12 @@ def _is_truncated(transcript: str) -> bool:
     if words[-1] in _DANGLING_DETERMINERS:
         return True
     if words[-1] in _DANGLING_PREPOSITIONS:
-        # Complete sentences legitimately end in a preposition, and typed or
-        # ASR input carries no reliable terminal punctuation: a wh-question
-        # ("What am I looking at"), a wh-subordinate clause ("match what I'm
-        # looking at"), or a progressive verb before the preposition ("the
-        # wall I'm staring at") all mark the sentence complete. Auxiliaries
-        # do not: "Can you put the sphere on" is a cut.
-        if transcript.strip().rstrip("\"'”’ ").endswith((".", "?", "!")):
-            return False
-        if words[0] in _WH_WORDS or any(word in _WH_WORDS for word in words[1:]):
+        # Only a recognized complete tail construction exempts a trailing
+        # preposition: a leading wh-question ("What am I looking at") or a
+        # progressive verb right before it ("the wall I'm staring at").
+        # Terminal punctuation and embedded wh-words appear on cut input
+        # too ("Can you put the sphere on.", "Move what I selected to").
+        if words[0] in _WH_WORDS:
             return False
         prev = words[-2] if len(words) >= 2 else ""
         if prev.endswith("ing") and prev not in _ING_NOUNS:
@@ -323,6 +327,19 @@ class SceneSupervisor:
                 logger.warning("supervisor verification failed ({})", exc)
             else:
                 output = result2.content
+                delegated |= {record.call.name for record in result2.tool_calls}
+            await asyncio.sleep(0.15)
+            if (
+                _wants_mutation(transcript)
+                and not (delegated & _MUTATING_AGENTS)
+                and not SceneContext.changes(before, await self._context.snapshot())
+                and not (output or "").rstrip().endswith("?")
+            ):
+                # No mutating delegation and no scene change: a non-question
+                # reply here is an unsupported claim, whatever it says.
+                # Clarifying questions pass through.
+                logger.warning("verification produced no change; replacing reply {!r}", (output or "")[:80])
+                output = "I couldn't make that change; nothing in the scene was changed."
 
         await self._context.record_moves(request.participant_id, before)
         reply_text = output or "Done."

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor.py
@@ -13,15 +13,16 @@ from pathlib import Path
 from loguru import logger
 from xr_ai_models import ChatMessage, LLMService, VLMService
 from xr_ai_tools import Tool, ToolSet
-from xr_ai_tools.current_frame import CurrentFrameRequest, CurrentFrameTool
+from xr_ai_tools.current_frame import CurrentFrameTool
 from xr_ai_tools.image import ImageRegistry
 from xr_ai_tools.text_memory import AddTranscriptRequest, RecallConversationRequest, TextMemoryTools
 from xr_ai_tools.tool_calling import ToolLoopError, run_tool_loop
 from xr_ai_tools.tracking import TrackingTools
 from xr_ai_tools.video_memory import VideoMemoryTools
-from xr_ai_tools.vision import ImageQueryRequest, ImageQueryTool
+from xr_ai_tools.vision import ImageQueryTool
 from xr_render_scene import SceneTools
 
+from ._physical_color import IMAGE_QUERY_SYSTEM_PROMPT, make_physical_color_tool
 from ._trace import current_participant_id, current_reference_time_us, current_trace_id
 from .agents import (
     make_appearance_agent,
@@ -32,11 +33,14 @@ from .agents import (
 )
 from .models import SceneReply, SceneRequest
 from .scene import SceneContext
+from .spatial_ops import _COLOR_WORDS
 
 _PROMPT = Path(__file__).with_name("supervisor_prompt.txt")
 
-_DANGLING_WORDS = frozenset(
-    "a an the my your its of to on in at by and or with near under over "
+_DANGLING_DETERMINERS = frozenset("a an the my your its".split())
+
+_DANGLING_PREPOSITIONS = frozenset(
+    "of to on in at by and or with near under over "
     "onto into between behind above below beside toward towards from".split()
 )
 
@@ -68,14 +72,21 @@ _INTERROGATIVES = frozenset(
 
 
 def _is_truncated(transcript: str) -> bool:
-    words = transcript.strip().rstrip(".?!,;").lower().split()
-    if not words or words[-1] not in _DANGLING_WORDS:
+    words = [w.strip(".,!?;:\"'") for w in transcript.strip().lower().split()]
+    words = [w for w in words if w]
+    if not words:
         return False
-    # Complete questions legitimately end in a preposition ("What am I
-    # looking at?"); only statements can dangle.
-    if transcript.strip().endswith("?") or words[0] in _INTERROGATIVES:
-        return False
-    return True
+    if words[-1] in _DANGLING_DETERMINERS:
+        return True
+    if words[-1] in _DANGLING_PREPOSITIONS:
+        # Complete sentences legitimately end in a preposition ("What am I
+        # looking at?", "the wall I'm looking at."); ASR cuts carry no
+        # terminal punctuation.
+        return not (
+            transcript.strip().endswith((".", "?", "!"))
+            or words[0] in _INTERROGATIVES
+        )
+    return False
 
 
 def _truncated_reply(transcript: str) -> str:
@@ -137,16 +148,11 @@ class SceneSupervisor:
                 system_prompt="Answer directly from the visible camera image in one short plain-English sentence.",
             )
 
-            async def physical_color(color_words: str) -> str:
-                frame = await current_frame.execute(
-                    CurrentFrameRequest(participant_id=current_participant_id.get())
-                )
-                result = await image_query.execute(ImageQueryRequest(
-                    image=frame.image,
-                    query=(f"What color is {color_words}? Answer with three numbers "
-                           "r, g, b, each between 0 and 1."),
-                ))
-                return result.text
+            physical_color = make_physical_color_tool(
+                current_frame,
+                ImageQueryTool(images=images, vlm=vlm, system_prompt=IMAGE_QUERY_SYSTEM_PROMPT),
+                _COLOR_WORDS,
+            )
 
             subagent_tools = [
                 make_placement_agent(llm, scene, tracking, context),

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor_prompt.txt
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor_prompt.txt
@@ -13,14 +13,18 @@ vision_agent answers questions about the PHYSICAL world only: what the user
 holds, wears, points at, or what a real wall or room looks like. Every fact
 about XR objects, positions, and empty space is already in SCENE OBJECTS, and
 the subagents resolve user-relative placement ("ahead of me", "at my feet",
-"on the left") through tracking. So for any create, move, recolor, resize, or
-remove request, call vision_agent only when the request names a physical-world
-fact the mutation depends on ("the color of my shirt"). Ask one precise
-question, then pass the returned fact in the next subagent instruction. If
-present-time vision is unavailable, never retry or substitute historical
-video; when the request truly depends on the missing visual fact, tell the
-user, and otherwise continue satisfying the request without vision. A mention
-of a camera or an earlier perception attempt is not a perception request.
+"on the left") through tracking. A mutation whose color comes from the
+physical world does not need vision_agent: pass the user's phrase to the
+mutating agent, whose tools read the camera themselves. If present-time
+vision is unavailable, never retry or substitute historical video; when the
+request truly depends on the missing visual fact, tell the user, and
+otherwise continue satisfying the request without vision. A user statement
+about the camera itself is not a perception request, but a new question
+about what the user holds, wears, or sees always is, no matter what [Recent
+conversation] says about cameras or earlier looks: delegate vision_agent
+again fresh each time. When the user answers a clarifying question of yours
+with "look for yourself" or similar, delegate vision_agent with the original
+pending question, never those literal words.
 Never call vision_agent to look up, confirm, or verify the color, shape,
 position, or existence of any object already listed in SCENE OBJECTS; that
 data is always current and complete. Read those values directly from SCENE
@@ -32,11 +36,16 @@ re-execute a request from [Recent conversation] that the current utterance
 does not restate.
 
 memory_agent answers questions about the conversation itself. Route every
-question about what was said, asked, or done earlier ("what color was the
-first cone I asked for?", "what did I ask you to build?") to memory_agent
+question about what was said, asked, or done earlier ("which shape did I
+request first?", "what did I ask you to build?") to memory_agent
 once, even when [Recent conversation] seems to contain the answer; that
 block exists to resolve references, never to answer history questions from,
-and guessing a history answer is always wrong.
+and guessing a history answer is always wrong. But questions about what the
+camera saw earlier ("what color was the thing in my hand a while ago?") are
+vision_agent with the past-time question, never memory_agent: the camera's
+past lives in recorded video, the conversation's past in the transcript.
+Present-day facts about the user's clothing, body, or surroundings are
+never memory either; they are perception.
 
 appearance_agent changes only color. placement_agent moves objects that
 already exist, including swaps, containment, stacking, and undo; those are
@@ -56,9 +65,10 @@ Routing examples:
 - "Put/place the X in/on/inside the Y", X already in SCENE OBJECTS: a move,
   placement_agent, never object_agent.
 - "Add/create an X inside the Y": a creation, object_agent.
-- "Put a lavender cone above the teal capsule" and SCENE OBJECTS in this
-  message lists no lavender cone: a creation with an anchor, object_agent
-  in one call. SCENE OBJECTS already states what exists and where;
+- "Put/place a lavender cone above the teal capsule" and SCENE OBJECTS in
+  this message lists no lavender cone: a creation with an anchor,
+  object_agent in one call, never placement_agent; only an X that already
+  exists can move. SCENE OBJECTS already states what exists and where;
   vision_agent never answers either question.
 - "Put an ivory pyramid above the teal capsule" and the capsule appears in
   SCENE OBJECTS: one object_agent call with the anchor name. Never call
@@ -75,30 +85,21 @@ Routing examples:
   to the user's body): object_agent directly in one call; never
   vision_agent first, and never a vision check afterwards — tracking
   already knows where the user stands and faces, camera or no camera.
-- "Create a cone matching my jacket": the jacket is physical, so one
-  vision_agent question about the jacket's color, then object_agent with
-  the returned color. But an anchor that names an XR object, whatever its
-  color or shape: object_agent alone, never vision.
-- "Create a torus the color of whatever I'm holding": vision_agent with
-  "What color is the object the user is holding?" (ask for the color, not
-  what the object is), and when it returns, say, lavender: object_agent
-  "Create a lavender torus, no position stated". Never write "the color of
-  the <object>" into an instruction; that phrase is not a color.
-- Knowing WHAT the user holds never supplies its color. [Recent
-  conversation] says the user is holding a soda can and the user asks for
-  "a torus the color of this can": brands and typical looks are not
-  observations, so never color it from what such objects usually look
-  like; ask vision_agent "What color is the can the user is holding?" and
-  pass only the color it returns. When an earlier assistant turn already
-  stated the observed color ("a turquoise soda can"), pass turquoise
-  directly.
-- "Make the capsule the same color as the wall" (or my desk, my shirt,
-  any physical color source): one vision_agent question ("What color is
-  the wall?"), then appearance_agent with the returned color. Never reply
-  that the color was changed without both calls having succeeded.
+- "Create a cone matching my jacket" / "Make the capsule the same color
+  as the wall" / "Recolor the torus to match my sweater": a physical color
+  source (a real-world thing, including the user's clothing) may go
+  straight to the mutating agent with the user's own words ("Create a cone the color of my jacket,
+  no position stated"); its tools read the camera themselves. Asking
+  vision_agent one color question first and passing the returned color
+  word is equally fine. What is never fine is guessing: brands and
+  typical looks are not observations. An anchor that names an XR object,
+  whatever its color or shape: object_agent alone, never vision.
 - "What am I looking at?" / "Describe what you can see": the user means
   their physical view; one vision_agent question about what is in front
   of the user.
+- "What color is the mug on my table?": the mug is physical (not in SCENE
+  OBJECTS), so vision_agent once with that question; never answer from the
+  XR scene that no such object exists.
 - "What's in my hand?", even right after turns discussing the camera or a
   clarifying question you asked: one vision_agent question ("What is the
   user holding?"). Nothing in [Recent conversation] makes a fresh
@@ -106,8 +107,8 @@ Routing examples:
 - "What was I holding a moment ago?" or any question about what the camera
   saw at an earlier time: vision_agent once with the past-time question; it
   consults the recorded video.
-- "What color was the first capsule I asked for?" / "What did I ask you to
-  build earlier?": memory_agent once with the question. The transcript
+- "What was the first thing I asked you to create?" / "What did I ask you
+  to build earlier?": memory_agent once with the question. The transcript
   store is the only reliable history; answering from [Recent conversation]
   or from your own impression invents facts.
 - "Remove/delete the X on the left": removal, object_agent; the side words
@@ -117,10 +118,10 @@ Routing examples:
   conversation]: "Resize capsule-8 to half its current size".
 
 Phrase every creation instruction as: Create <count, when more than one>
-<color> <shape>(s) <the user's own spatial words>. The color slot always
-carries an actual color word, never "the color of X" or an object's name:
-read the color from SCENE OBJECTS for an XR source, or ask vision_agent for
-a physical one, and pass the color it returns. If the user named no
+<color> <shape>(s) <the user's own spatial words>. The color slot carries
+the user's color words verbatim: a color word, an XR object to copy
+("same as capsule-8"), or the user's physical phrase ("the color of my
+shirt"); the mutating agent resolves them. If the user named no
 position at all, end with "no position stated" in place of spatial words;
 never add "no position stated" when spatial words are present. Use that
 exact phrasing whatever verb the user chose (add, make, spawn, put up), and
@@ -135,7 +136,9 @@ exists must move.
 Do not repeat a completed mutation, and never report a change you did not
 delegate this turn: a request like "triple its size" always requires a
 subagent call now, even when [Recent conversation] shows related earlier
-work. When all required work is complete, respond
+work. An existing object never satisfies a new creation request: "make a
+cone" with a cone already in SCENE OBJECTS still creates another one;
+never answer that the user already has one. When all required work is complete, respond
 with one short plain-English sentence. That sentence is spoken aloud through
 text-to-speech: never include numeric coordinates, object ids, or unit
 symbols; describe positions in everyday words, like "just below the teal

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor_prompt.txt
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor_prompt.txt
@@ -25,8 +25,7 @@ conversation] says about cameras or earlier looks: delegate vision_agent
 again fresh each time. When the user answers a clarifying question of yours
 by telling you to observe instead of answering ("check the camera", "use
 your eyes", or similar), delegate vision_agent with the original pending
-question, never those literal words, then finish the pending request using
-what vision reports; never ask the user that question again.
+question, never those literal words.
 Never call vision_agent to look up, confirm, or verify the color, shape,
 position, or existence of any object already listed in SCENE OBJECTS; that
 data is always current and complete. Read those values directly from SCENE

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor_prompt.txt
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor_prompt.txt
@@ -25,7 +25,8 @@ conversation] says about cameras or earlier looks: delegate vision_agent
 again fresh each time. When the user answers a clarifying question of yours
 by telling you to observe instead of answering ("check the camera", "use
 your eyes", or similar), delegate vision_agent with the original pending
-question, never those literal words.
+question, never those literal words, then finish the pending request using
+what vision reports; never ask the user that question again.
 Never call vision_agent to look up, confirm, or verify the color, shape,
 position, or existence of any object already listed in SCENE OBJECTS; that
 data is always current and complete. Read those values directly from SCENE

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor_prompt.txt
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor_prompt.txt
@@ -23,8 +23,9 @@ about the camera itself is not a perception request, but a new question
 about what the user holds, wears, or sees always is, no matter what [Recent
 conversation] says about cameras or earlier looks: delegate vision_agent
 again fresh each time. When the user answers a clarifying question of yours
-with "look for yourself" or similar, delegate vision_agent with the original
-pending question, never those literal words.
+by telling you to observe instead of answering ("check the camera", "use
+your eyes", or similar), delegate vision_agent with the original pending
+question, never those literal words.
 Never call vision_agent to look up, confirm, or verify the color, shape,
 position, or existence of any object already listed in SCENE OBJECTS; that
 data is always current and complete. Read those values directly from SCENE
@@ -86,14 +87,13 @@ Routing examples:
   vision_agent first, and never a vision check afterwards — tracking
   already knows where the user stands and faces, camera or no camera.
 - "Create a cone matching my jacket" / "Make the capsule the same color
-  as the wall" / "Recolor the torus to match my sweater": a physical color
-  source (a real-world thing, including the user's clothing) may go
+  as the curtains" / "Recolor the torus to match my sweater": a physical
+  color source (a real-world thing, including the user's clothing) goes
   straight to the mutating agent with the user's own words ("Create a cone the color of my jacket,
-  no position stated"); its tools read the camera themselves. Asking
-  vision_agent one color question first and passing the returned color
-  word is equally fine. What is never fine is guessing: brands and
-  typical looks are not observations. An anchor that names an XR object,
-  whatever its color or shape: object_agent alone, never vision.
+  no position stated"); its tools read the camera themselves. What is
+  never fine is guessing: brands and typical looks are not observations.
+  An anchor that names an XR object, whatever its color or shape:
+  object_agent alone, never vision.
 - "What am I looking at?" / "Describe what you can see": the user means
   their physical view; one vision_agent question about what is in front
   of the user.
@@ -121,7 +121,7 @@ Phrase every creation instruction as: Create <count, when more than one>
 <color> <shape>(s) <the user's own spatial words>. The color slot carries
 the user's color words verbatim: a color word, an XR object to copy
 ("same as capsule-8"), or the user's physical phrase ("the color of my
-shirt"); the mutating agent resolves them. If the user named no
+apron"); the mutating agent resolves them. If the user named no
 position at all, end with "no position stated" in place of spatial words;
 never add "no position stated" when spatial words are present. Use that
 exact phrasing whatever verb the user chose (add, make, spawn, put up), and

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor_prompt.txt
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor_prompt.txt
@@ -31,9 +31,12 @@ conversationally or ask one short question; never call a subagent, and never
 re-execute a request from [Recent conversation] that the current utterance
 does not restate.
 
-memory_agent recalls conversation older than the [Recent conversation] block.
-Use it when the request depends on a conversational fact absent from both the
-current request and that block.
+memory_agent answers questions about the conversation itself. Route every
+question about what was said, asked, or done earlier ("what color was the
+first cone I asked for?", "what did I ask you to build?") to memory_agent
+once, even when [Recent conversation] seems to contain the answer; that
+block exists to resolve references, never to answer history questions from,
+and guessing a history answer is always wrong.
 
 appearance_agent changes only color. placement_agent moves objects that
 already exist, including swaps, containment, stacking, and undo; those are
@@ -76,9 +79,37 @@ Routing examples:
   vision_agent question about the jacket's color, then object_agent with
   the returned color. But an anchor that names an XR object, whatever its
   color or shape: object_agent alone, never vision.
+- "Create a torus the color of whatever I'm holding": vision_agent with
+  "What color is the object the user is holding?" (ask for the color, not
+  what the object is), and when it returns, say, lavender: object_agent
+  "Create a lavender torus, no position stated". Never write "the color of
+  the <object>" into an instruction; that phrase is not a color.
+- Knowing WHAT the user holds never supplies its color. [Recent
+  conversation] says the user is holding a soda can and the user asks for
+  "a torus the color of this can": brands and typical looks are not
+  observations, so never color it from what such objects usually look
+  like; ask vision_agent "What color is the can the user is holding?" and
+  pass only the color it returns. When an earlier assistant turn already
+  stated the observed color ("a turquoise soda can"), pass turquoise
+  directly.
+- "Make the capsule the same color as the wall" (or my desk, my shirt,
+  any physical color source): one vision_agent question ("What color is
+  the wall?"), then appearance_agent with the returned color. Never reply
+  that the color was changed without both calls having succeeded.
+- "What am I looking at?" / "Describe what you can see": the user means
+  their physical view; one vision_agent question about what is in front
+  of the user.
+- "What's in my hand?", even right after turns discussing the camera or a
+  clarifying question you asked: one vision_agent question ("What is the
+  user holding?"). Nothing in [Recent conversation] makes a fresh
+  perception question rhetorical.
 - "What was I holding a moment ago?" or any question about what the camera
   saw at an earlier time: vision_agent once with the past-time question; it
   consults the recorded video.
+- "What color was the first capsule I asked for?" / "What did I ask you to
+  build earlier?": memory_agent once with the question. The transcript
+  store is the only reliable history; answering from [Recent conversation]
+  or from your own impression invents facts.
 - "Remove/delete the X on the left": removal, object_agent; the side words
   only select which X, never a move.
 - "Double it / make the X half the size": resize, object_agent, and the
@@ -86,7 +117,10 @@ Routing examples:
   conversation]: "Resize capsule-8 to half its current size".
 
 Phrase every creation instruction as: Create <count, when more than one>
-<color> <shape>(s) <the user's own spatial words>. If the user named no
+<color> <shape>(s) <the user's own spatial words>. The color slot always
+carries an actual color word, never "the color of X" or an object's name:
+read the color from SCENE OBJECTS for an XR source, or ask vision_agent for
+a physical one, and pass the color it returns. If the user named no
 position at all, end with "no position stated" in place of spatial words;
 never add "no position stated" when spatial words are present. Use that
 exact phrasing whatever verb the user chose (add, make, spawn, put up), and

--- a/docs/source/reference/xr-render-demo.md
+++ b/docs/source/reference/xr-render-demo.md
@@ -244,7 +244,9 @@ in one place:
   scene, performs the move itself, and returns the final position; the LLM
   never applies signs to user-frame axes or copies coordinates.
 - **Appearance tool**: `recolor` resolves color words, RGB triples, and
-  copy-the-color-of-an-object references deterministically.
+  copy-the-color-of-an-object references deterministically. A color phrase
+  naming something physical ("the color of the thing I'm holding") falls
+  back to one camera query; the model copies the phrase, the code observes.
 - **Object tools** create and retire objects: `create_user_relative`,
   `create_object_relative` (one anchor, or the midpoint of two),
   `create_at`, `change_shape` (the scene replaces the object and returns

--- a/docs/source/reference/xr-render-demo.md
+++ b/docs/source/reference/xr-render-demo.md
@@ -244,9 +244,11 @@ in one place:
   scene, performs the move itself, and returns the final position; the LLM
   never applies signs to user-frame axes or copies coordinates.
 - **Appearance tool**: `recolor` resolves color words, RGB triples, and
-  copy-the-color-of-an-object references deterministically. A color phrase
-  naming something physical ("the color of the thing I'm holding") falls
-  back to one camera query; the model copies the phrase, the code observes.
+  copy-the-color-of-an-object references deterministically. Color-word
+  resolution is shared by the appearance and object tools: when the model
+  marks the source as physical ("the color of my shirt"), a typed
+  `resolve_physical_color` tool runs one strict camera query; the model
+  copies the phrase, the code observes.
 - **Object tools** create and retire objects: `create_user_relative`,
   `create_object_relative` (one anchor, or the midpoint of two),
   `create_at`, `change_shape` (the scene replaces the object and returns

--- a/docs/source/reference/xr-render-demo.md
+++ b/docs/source/reference/xr-render-demo.md
@@ -245,10 +245,10 @@ in one place:
   never applies signs to user-frame axes or copies coordinates.
 - **Appearance tool**: `recolor` resolves color words, RGB triples, and
   copy-the-color-of-an-object references deterministically. Color-word
-  resolution is shared by the appearance and object tools: when the model
-  marks the source as physical ("the color of my shirt"), a typed
-  `resolve_physical_color` tool runs one strict camera query; the model
-  copies the phrase, the code observes.
+  resolution is shared by the appearance and object tools: a phrase that
+  describes the physical world ("the color of my shirt") is detected in
+  code and resolved by a typed `resolve_physical_color` helper that runs
+  one strict camera query; the model copies the phrase, the code observes.
 - **Object tools** create and retire objects: `create_user_relative`,
   `create_object_relative` (one anchor, or the midpoint of two),
   `create_at`, `change_shape` (the scene replaces the object and returns

--- a/docs/source/reference/xr-render-demo.md
+++ b/docs/source/reference/xr-render-demo.md
@@ -199,10 +199,15 @@ services. On each accepted `xr-render.user-query` event:
    runs its own inner `run_tool_loop` (up to 4 iterations) against the
    scene, XR-tracking, and vision services.
 3. **Verification pass** — only for turns with mutation intent (a
-   mutating subagent was delegated, or the utterance contains a
+   mutating subagent was delegated, or a non-question utterance contains a
    change-requesting verb): if no scene change is observed within 150 ms
    of the loop completing, a second `run_tool_loop` call is made so the
-   supervisor can delegate remaining work or confirm a no-op turn.
+   supervisor can delegate remaining work or confirm a no-op turn. Success
+   is then evidence-backed: unless a scene write was applied somewhere in
+   the turn (or a recolor found the requested color already in place), a
+   completion claim is replaced with a fixed honest no-change sentence and
+   any other non-question reply gets the no-change fact appended. Evidence
+   is counted per turn, not per delegated task.
 4. **Conversation history persisted** — the user utterance and agent reply
    are written to `TextMemoryTools` under `{participant_id}:user` and
    `{participant_id}:agent` source keys.
@@ -243,12 +248,14 @@ in one place:
   the instruction's exact words for each object, resolves them against the
   scene, performs the move itself, and returns the final position; the LLM
   never applies signs to user-frame axes or copies coordinates.
-- **Appearance tool**: `recolor` resolves color words, RGB triples, and
-  copy-the-color-of-an-object references deterministically. Color-word
-  resolution is shared by the appearance and object tools: a phrase that
-  describes the physical world ("the color of my shirt") is detected in
-  code and resolved by a typed `resolve_physical_color` helper that runs
-  one strict camera query; the model copies the phrase, the code observes.
+- **Appearance tool**: `recolor` takes a discriminated color source the
+  model selects through the tool schema — `literal` (stated color words or
+  numbers, garbles repaired), `scene_object` (copy an XR object), or
+  `physical` (observe a real-world thing). The code dispatches on the
+  variant without reinterpreting the phrase; the `physical` variant runs
+  one camera query through `resolve_physical_color`, whose VLM answers in
+  a closed grammar (`VISIBLE r g b` or `UNKNOWN`) and fails closed on
+  anything else. The same source type drives the object tools' creations.
 - **Object tools** create and retire objects: `create_user_relative`,
   `create_object_relative` (one anchor, or the midpoint of two),
   `create_at`, `change_shape` (the scene replaces the object and returns

--- a/tests/test_render_physical_color.py
+++ b/tests/test_render_physical_color.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for camera-backed physical color resolution."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from xr_ai_tools.image import ImageReference
+from xr_render_demo_worker._physical_color import (
+    ResolvePhysicalColorRequest,
+    make_physical_color_tool,
+    parse_color_answer,
+)
+from xr_render_demo_worker._trace import current_participant_id
+from xr_render_demo_worker.spatial_ops import _COLOR_WORDS
+
+
+def test_parse_strict_triple() -> None:
+    assert parse_color_answer("0.0 0.4 1.0", _COLOR_WORDS) == (0.0, 0.4, 1.0)
+    assert parse_color_answer("0, 0.4, 1", _COLOR_WORDS) == (0.0, 0.4, 1.0)
+
+
+def test_parse_rejects_255_scale_and_stray_numbers() -> None:
+    assert parse_color_answer("255, 0, 0", _COLOR_WORDS) is None
+    assert parse_color_answer("0.5 meters, 0 lights, 1 fan", _COLOR_WORDS) is None
+
+
+def test_parse_color_word_last_mention_wins() -> None:
+    assert parse_color_answer("The lid is blue.", _COLOR_WORDS) == _COLOR_WORDS["blue"]
+    assert (
+        parse_color_answer("The wall behind the red couch is white.", _COLOR_WORDS)
+        == _COLOR_WORDS["white"]
+    )
+
+
+def test_parse_garbage_is_none() -> None:
+    assert parse_color_answer("", _COLOR_WORDS) is None
+    assert parse_color_answer("I cannot tell from this image.", _COLOR_WORDS) is None
+
+
+@pytest.fixture(autouse=True)
+def _bind_participant():
+    token = current_participant_id.set("test-user")
+    yield
+    current_participant_id.reset(token)
+
+
+def _frame_tool(error: Exception | None = None):
+    async def execute(request):
+        if error is not None:
+            raise error
+        return SimpleNamespace(image=ImageReference(uri="fake://frame"))
+    return SimpleNamespace(execute=execute)
+
+
+def _query_tool(text: str, available: bool = True):
+    async def execute(request):
+        return SimpleNamespace(text=text, available=available)
+    return SimpleNamespace(execute=execute)
+
+
+async def test_resolver_returns_typed_color() -> None:
+    tool = make_physical_color_tool(_frame_tool(), _query_tool("0.0 0.4 1.0"), _COLOR_WORDS)
+    resolved = await tool.execute(ResolvePhysicalColorRequest(source_words="the lid"))
+    assert (resolved.r, resolved.g, resolved.b) == (0.0, 0.4, 1.0)
+
+
+async def test_resolver_unavailable_view_is_value_error() -> None:
+    tool = make_physical_color_tool(
+        _frame_tool(), _query_tool("no signal", available=False), _COLOR_WORDS)
+    with pytest.raises(Exception) as excinfo:
+        await tool.execute(ResolvePhysicalColorRequest(source_words="the lid"))
+    assert "cannot currently see" in str(excinfo.value)
+
+
+async def test_resolver_unparseable_answer_is_value_error() -> None:
+    tool = make_physical_color_tool(
+        _frame_tool(), _query_tool("hard to say from here"), _COLOR_WORDS)
+    with pytest.raises(Exception) as excinfo:
+        await tool.execute(ResolvePhysicalColorRequest(source_words="the lid"))
+    assert "did not yield a color" in str(excinfo.value)
+
+
+async def test_resolver_transport_failure_degrades() -> None:
+    tool = make_physical_color_tool(
+        _frame_tool(error=RuntimeError("RPCError: no feed")), _query_tool("x"), _COLOR_WORDS)
+    with pytest.raises(Exception) as excinfo:
+        await tool.execute(ResolvePhysicalColorRequest(source_words="the lid"))
+    assert "unavailable" in str(excinfo.value)
+
+
+async def test_resolver_genuine_bug_propagates() -> None:
+    tool = make_physical_color_tool(
+        _frame_tool(error=TypeError("wiring bug")), _query_tool("x"), _COLOR_WORDS)
+    with pytest.raises(Exception) as excinfo:
+        await tool.execute(ResolvePhysicalColorRequest(source_words="the lid"))
+    assert "TypeError" in str(excinfo.value) or "wiring bug" in str(excinfo.value)
+    assert "unavailable" not in str(excinfo.value)

--- a/tests/test_render_physical_color.py
+++ b/tests/test_render_physical_color.py
@@ -13,88 +13,171 @@ from xr_render_demo_worker._physical_color import (
     make_physical_color_tool,
     parse_color_answer,
 )
-from xr_render_demo_worker._trace import current_participant_id
-from xr_render_demo_worker.spatial_ops import _COLOR_WORDS
+from xr_render_demo_worker._trace import current_participant_id, current_reference_time_us
+from xr_render_demo_worker.spatial_ops import COLOR_WORDS
 
 
-def test_parse_strict_triple() -> None:
-    assert parse_color_answer("0.0 0.4 1.0", _COLOR_WORDS) == (0.0, 0.4, 1.0)
-    assert parse_color_answer("0, 0.4, 1", _COLOR_WORDS) == (0.0, 0.4, 1.0)
+def test_parse_bare_triples() -> None:
+    assert parse_color_answer("0.0 0.4 1.0", COLOR_WORDS) == (0.0, 0.4, 1.0)
+    assert parse_color_answer("0, 0.4, 1", COLOR_WORDS) == (0.0, 0.4, 1.0)
+    assert parse_color_answer("1 0 0", COLOR_WORDS) == (1.0, 0.0, 0.0)
+    assert parse_color_answer(".5 .5 .5", COLOR_WORDS) == (0.5, 0.5, 0.5)
 
 
-def test_parse_rejects_255_scale_and_stray_numbers() -> None:
-    assert parse_color_answer("255, 0, 0", _COLOR_WORDS) is None
-    assert parse_color_answer("0.5 meters, 0 lights, 1 fan", _COLOR_WORDS) is None
+def test_parse_decorated_triples() -> None:
+    assert parse_color_answer("The color is 0.1 0.2 0.3", COLOR_WORDS) == (0.1, 0.2, 0.3)
+    assert parse_color_answer("0.1 0.2 0.3.", COLOR_WORDS) == (0.1, 0.2, 0.3)
+    assert parse_color_answer("rgb(0.1, 0.2, 0.3)", COLOR_WORDS) == (0.1, 0.2, 0.3)
+    assert parse_color_answer("r=0.0 g=0.4 b=1.0", COLOR_WORDS) == (0.0, 0.4, 1.0)
+    assert parse_color_answer("**0.1 0.2 0.3**", COLOR_WORDS) == (0.1, 0.2, 0.3)
+    assert parse_color_answer("(0.0, 0.4, 1.0)", COLOR_WORDS) == (0.0, 0.4, 1.0)
+
+
+def test_parse_rejects_out_of_range_triples() -> None:
+    # "255, 0, 0" matches the triple shape and must die at the range guard.
+    assert parse_color_answer("255, 0, 0", COLOR_WORDS) is None
+    assert parse_color_answer("2 0 0", COLOR_WORDS) is None
+    assert parse_color_answer("1.5 0.2 0.9", COLOR_WORDS) is None
+    assert parse_color_answer("0.5 meters, 0 lights, 1 fan", COLOR_WORDS) is None
+    assert parse_color_answer("0.5 0.5", COLOR_WORDS) is None
 
 
 def test_parse_color_word_last_mention_wins() -> None:
-    assert parse_color_answer("The lid is blue.", _COLOR_WORDS) == _COLOR_WORDS["blue"]
+    assert parse_color_answer("The lid is blue.", COLOR_WORDS) == COLOR_WORDS["blue"]
     assert (
-        parse_color_answer("The wall behind the red couch is white.", _COLOR_WORDS)
-        == _COLOR_WORDS["white"]
+        parse_color_answer("The wall behind the red couch is white.", COLOR_WORDS)
+        == COLOR_WORDS["white"]
     )
 
 
+def test_parse_refusals_never_become_colors() -> None:
+    assert parse_color_answer("UNKNOWN", COLOR_WORDS) is None
+    assert parse_color_answer("I cannot determine whether the wall is white.", COLOR_WORDS) is None
+    assert parse_color_answer("I am unable to see; the frame is black.", COLOR_WORDS) is None
+    assert parse_color_answer("Not visible: 0.1 0.2 0.3", COLOR_WORDS) is None
+
+
 def test_parse_garbage_is_none() -> None:
-    assert parse_color_answer("", _COLOR_WORDS) is None
-    assert parse_color_answer("I cannot tell from this image.", _COLOR_WORDS) is None
+    assert parse_color_answer("", COLOR_WORDS) is None
+    assert parse_color_answer("I cannot tell from this image.", COLOR_WORDS) is None
+    assert parse_color_answer("hard to say from here", COLOR_WORDS) is None
 
 
 @pytest.fixture(autouse=True)
 def _bind_participant():
     token = current_participant_id.set("test-user")
+    time_token = current_reference_time_us.set(1_700_000_000_000_000)
     yield
     current_participant_id.reset(token)
+    current_reference_time_us.reset(time_token)
 
 
 def _frame_tool(error: Exception | None = None):
+    calls = []
+
     async def execute(request):
+        calls.append(request)
         if error is not None:
             raise error
         return SimpleNamespace(image=ImageReference(uri="fake://frame"))
-    return SimpleNamespace(execute=execute)
+    return SimpleNamespace(execute=execute, calls=calls)
 
 
-def _query_tool(text: str, available: bool = True):
+def _query_tool(text: str, available: bool = True, error: Exception | None = None):
+    calls = []
+
     async def execute(request):
+        calls.append(request)
+        if error is not None:
+            raise error
         return SimpleNamespace(text=text, available=available)
-    return SimpleNamespace(execute=execute)
+    return SimpleNamespace(execute=execute, calls=calls)
 
 
 async def test_resolver_returns_typed_color() -> None:
-    tool = make_physical_color_tool(_frame_tool(), _query_tool("0.0 0.4 1.0"), _COLOR_WORDS)
+    tool = make_physical_color_tool(_frame_tool(), _query_tool("0.0 0.4 1.0"), COLOR_WORDS)
     resolved = await tool.execute(ResolvePhysicalColorRequest(source_words="the lid"))
     assert (resolved.r, resolved.g, resolved.b) == (0.0, 0.4, 1.0)
 
 
+async def test_resolver_caches_within_turn() -> None:
+    query = _query_tool("0.0 0.4 1.0")
+    tool = make_physical_color_tool(_frame_tool(), query, COLOR_WORDS)
+    first = await tool.execute(ResolvePhysicalColorRequest(source_words="the lid"))
+    second = await tool.execute(ResolvePhysicalColorRequest(source_words="The lid"))
+    assert (first.r, first.g, first.b) == (second.r, second.g, second.b)
+    assert len(query.calls) == 1
+    token = current_reference_time_us.set(1_700_000_001_000_000)
+    try:
+        await tool.execute(ResolvePhysicalColorRequest(source_words="the lid"))
+    finally:
+        current_reference_time_us.reset(token)
+    assert len(query.calls) == 2
+
+
+async def _expect_rejection(tool, source: str, needle: str) -> None:
+    # The Relay Tool boundary re-raises handler errors as RuntimeError with
+    # the original class name in the text; the tolerant toolset recovers the
+    # rejection from exactly that shape.
+    with pytest.raises(RuntimeError) as excinfo:
+        await tool.execute(ResolvePhysicalColorRequest(source_words=source))
+    assert "ValueError: " in str(excinfo.value)
+    assert needle in str(excinfo.value)
+
+
 async def test_resolver_unavailable_view_is_value_error() -> None:
     tool = make_physical_color_tool(
-        _frame_tool(), _query_tool("no signal", available=False), _COLOR_WORDS)
-    with pytest.raises(Exception) as excinfo:
-        await tool.execute(ResolvePhysicalColorRequest(source_words="the lid"))
-    assert "cannot currently see" in str(excinfo.value)
+        _frame_tool(), _query_tool("no signal", available=False), COLOR_WORDS)
+    await _expect_rejection(tool, "the lid", "cannot currently see")
 
 
 async def test_resolver_unparseable_answer_is_value_error() -> None:
     tool = make_physical_color_tool(
-        _frame_tool(), _query_tool("hard to say from here"), _COLOR_WORDS)
-    with pytest.raises(Exception) as excinfo:
-        await tool.execute(ResolvePhysicalColorRequest(source_words="the lid"))
-    assert "did not yield a color" in str(excinfo.value)
+        _frame_tool(), _query_tool("hard to say from here"), COLOR_WORDS)
+    await _expect_rejection(tool, "the lid", "did not yield a color")
 
 
-async def test_resolver_transport_failure_degrades() -> None:
+async def test_resolver_not_visible_is_value_error_without_mutation_value() -> None:
+    tool = make_physical_color_tool(_frame_tool(), _query_tool("UNKNOWN"), COLOR_WORDS)
+    await _expect_rejection(tool, "my shirt", "did not yield a color")
+
+
+async def test_resolver_frame_transport_failure_degrades() -> None:
     tool = make_physical_color_tool(
-        _frame_tool(error=RuntimeError("RPCError: no feed")), _query_tool("x"), _COLOR_WORDS)
-    with pytest.raises(Exception) as excinfo:
-        await tool.execute(ResolvePhysicalColorRequest(source_words="the lid"))
-    assert "unavailable" in str(excinfo.value)
+        _frame_tool(error=RuntimeError("RPCError: no feed")), _query_tool("x"), COLOR_WORDS)
+    await _expect_rejection(tool, "the lid", "unavailable")
+
+
+async def test_resolver_query_transport_failure_degrades() -> None:
+    tool = make_physical_color_tool(
+        _frame_tool(), _query_tool("x", error=TimeoutError("vlm timed out")), COLOR_WORDS)
+    await _expect_rejection(tool, "the lid", "unavailable")
 
 
 async def test_resolver_genuine_bug_propagates() -> None:
     tool = make_physical_color_tool(
-        _frame_tool(error=TypeError("wiring bug")), _query_tool("x"), _COLOR_WORDS)
-    with pytest.raises(Exception) as excinfo:
+        _frame_tool(error=TypeError("wiring bug")), _query_tool("x"), COLOR_WORDS)
+    with pytest.raises(RuntimeError) as excinfo:
         await tool.execute(ResolvePhysicalColorRequest(source_words="the lid"))
-    assert "TypeError" in str(excinfo.value) or "wiring bug" in str(excinfo.value)
+    assert "TypeError: wiring bug" in str(excinfo.value)
+    assert "ValueError" not in str(excinfo.value)
     assert "unavailable" not in str(excinfo.value)
+
+
+async def test_resolver_query_genuine_bug_propagates() -> None:
+    tool = make_physical_color_tool(
+        _frame_tool(), _query_tool("x", error=TypeError("bad request model")), COLOR_WORDS)
+    with pytest.raises(RuntimeError) as excinfo:
+        await tool.execute(ResolvePhysicalColorRequest(source_words="the lid"))
+    assert "TypeError: bad request model" in str(excinfo.value)
+    assert "ValueError" not in str(excinfo.value)
+    assert "unavailable" not in str(excinfo.value)
+
+
+async def test_resolver_truncates_long_source_at_word_boundary() -> None:
+    query = _query_tool("0.0 0.4 1.0")
+    tool = make_physical_color_tool(_frame_tool(), query, COLOR_WORDS)
+    await tool.execute(ResolvePhysicalColorRequest(source_words="the thing " * 20))
+    quoted = query.calls[0].query.split('"')[1]
+    assert len(quoted) <= 80
+    assert not quoted.endswith("thin")

--- a/tests/test_render_physical_color.py
+++ b/tests/test_render_physical_color.py
@@ -181,3 +181,10 @@ async def test_resolver_truncates_long_source_at_word_boundary() -> None:
     quoted = query.calls[0].query.split('"')[1]
     assert len(quoted) <= 80
     assert not quoted.endswith("thin")
+
+
+def test_parse_hedged_observations_fail_closed() -> None:
+    assert parse_color_answer("The object may be occluded; likely RGB 1 0 0", COLOR_WORDS) is None
+    assert parse_color_answer("The requested item is outside the frame; the couch is blue", COLOR_WORDS) is None
+    assert parse_color_answer("Probably red, hard to tell", COLOR_WORDS) is None
+    assert parse_color_answer("It is hidden behind the monitor but typically white", COLOR_WORDS) is None

--- a/tests/test_render_physical_color.py
+++ b/tests/test_render_physical_color.py
@@ -13,63 +13,38 @@ from xr_render_demo_worker._physical_color import (
     make_physical_color_tool,
     parse_color_answer,
 )
-from xr_render_demo_worker._trace import current_participant_id, current_reference_time_us
-from xr_render_demo_worker.spatial_ops import COLOR_WORDS
+from xr_render_demo_worker._trace import current_participant_id, current_trace_id
 
 
-def test_parse_bare_triples() -> None:
-    assert parse_color_answer("0.0 0.4 1.0", COLOR_WORDS) == (0.0, 0.4, 1.0)
-    assert parse_color_answer("0, 0.4, 1", COLOR_WORDS) == (0.0, 0.4, 1.0)
-    assert parse_color_answer("1 0 0", COLOR_WORDS) == (1.0, 0.0, 0.0)
-    assert parse_color_answer(".5 .5 .5", COLOR_WORDS) == (0.5, 0.5, 0.5)
+def test_parse_accepts_only_the_closed_grammar() -> None:
+    assert parse_color_answer("VISIBLE 0.0 0.4 1.0") == (0.0, 0.4, 1.0)
+    assert parse_color_answer("visible 1, 0, 0") == (1.0, 0.0, 0.0)
+    assert parse_color_answer("VISIBLE: .5 .5 .5") == (0.5, 0.5, 0.5)
+    assert parse_color_answer("**VISIBLE 0.1 0.2 0.3**") == (0.1, 0.2, 0.3)
+    assert parse_color_answer("UNKNOWN") is None
+    assert parse_color_answer("unknown.") is None
 
 
-def test_parse_decorated_triples() -> None:
-    assert parse_color_answer("The color is 0.1 0.2 0.3", COLOR_WORDS) == (0.1, 0.2, 0.3)
-    assert parse_color_answer("0.1 0.2 0.3.", COLOR_WORDS) == (0.1, 0.2, 0.3)
-    assert parse_color_answer("rgb(0.1, 0.2, 0.3)", COLOR_WORDS) == (0.1, 0.2, 0.3)
-    assert parse_color_answer("r=0.0 g=0.4 b=1.0", COLOR_WORDS) == (0.0, 0.4, 1.0)
-    assert parse_color_answer("**0.1 0.2 0.3**", COLOR_WORDS) == (0.1, 0.2, 0.3)
-    assert parse_color_answer("(0.0, 0.4, 1.0)", COLOR_WORDS) == (0.0, 0.4, 1.0)
-
-
-def test_parse_rejects_out_of_range_triples() -> None:
-    # "255, 0, 0" matches the triple shape and must die at the range guard.
-    assert parse_color_answer("255, 0, 0", COLOR_WORDS) is None
-    assert parse_color_answer("2 0 0", COLOR_WORDS) is None
-    assert parse_color_answer("1.5 0.2 0.9", COLOR_WORDS) is None
-    assert parse_color_answer("0.5 meters, 0 lights, 1 fan", COLOR_WORDS) is None
-    assert parse_color_answer("0.5 0.5", COLOR_WORDS) is None
-
-
-def test_parse_color_word_last_mention_wins() -> None:
-    assert parse_color_answer("The lid is blue.", COLOR_WORDS) == COLOR_WORDS["blue"]
-    assert (
-        parse_color_answer("The wall behind the red couch is white.", COLOR_WORDS)
-        == COLOR_WORDS["white"]
-    )
-
-
-def test_parse_refusals_never_become_colors() -> None:
-    assert parse_color_answer("UNKNOWN", COLOR_WORDS) is None
-    assert parse_color_answer("I cannot determine whether the wall is white.", COLOR_WORDS) is None
-    assert parse_color_answer("I am unable to see; the frame is black.", COLOR_WORDS) is None
-    assert parse_color_answer("Not visible: 0.1 0.2 0.3", COLOR_WORDS) is None
-
-
-def test_parse_garbage_is_none() -> None:
-    assert parse_color_answer("", COLOR_WORDS) is None
-    assert parse_color_answer("I cannot tell from this image.", COLOR_WORDS) is None
-    assert parse_color_answer("hard to say from here", COLOR_WORDS) is None
+def test_parse_rejects_everything_else() -> None:
+    # Out-of-range, prose, hedges, and bare triples all fail closed.
+    assert parse_color_answer("VISIBLE 255 0 0") is None
+    assert parse_color_answer("VISIBLE 2 0 0") is None
+    assert parse_color_answer("0.0 0.4 1.0") is None
+    assert parse_color_answer("The lid is blue.") is None
+    assert parse_color_answer("The wall behind the red couch is white.") is None
+    assert parse_color_answer("The object may be occluded; likely VISIBLE 1 0 0") is None
+    assert parse_color_answer("The requested item is outside the frame; the couch is blue") is None
+    assert parse_color_answer("I cannot tell from this image.") is None
+    assert parse_color_answer("") is None
 
 
 @pytest.fixture(autouse=True)
 def _bind_participant():
     token = current_participant_id.set("test-user")
-    time_token = current_reference_time_us.set(1_700_000_000_000_000)
+    trace_token = current_trace_id.set("trace-1")
     yield
     current_participant_id.reset(token)
-    current_reference_time_us.reset(time_token)
+    current_trace_id.reset(trace_token)
 
 
 def _frame_tool(error: Exception | None = None):
@@ -94,27 +69,6 @@ def _query_tool(text: str, available: bool = True, error: Exception | None = Non
     return SimpleNamespace(execute=execute, calls=calls)
 
 
-async def test_resolver_returns_typed_color() -> None:
-    tool = make_physical_color_tool(_frame_tool(), _query_tool("0.0 0.4 1.0"), COLOR_WORDS)
-    resolved = await tool.execute(ResolvePhysicalColorRequest(source_words="the lid"))
-    assert (resolved.r, resolved.g, resolved.b) == (0.0, 0.4, 1.0)
-
-
-async def test_resolver_caches_within_turn() -> None:
-    query = _query_tool("0.0 0.4 1.0")
-    tool = make_physical_color_tool(_frame_tool(), query, COLOR_WORDS)
-    first = await tool.execute(ResolvePhysicalColorRequest(source_words="the lid"))
-    second = await tool.execute(ResolvePhysicalColorRequest(source_words="The lid"))
-    assert (first.r, first.g, first.b) == (second.r, second.g, second.b)
-    assert len(query.calls) == 1
-    token = current_reference_time_us.set(1_700_000_001_000_000)
-    try:
-        await tool.execute(ResolvePhysicalColorRequest(source_words="the lid"))
-    finally:
-        current_reference_time_us.reset(token)
-    assert len(query.calls) == 2
-
-
 async def _expect_rejection(tool, source: str, needle: str) -> None:
     # The Relay Tool boundary re-raises handler errors as RuntimeError with
     # the original class name in the text; the tolerant toolset recovers the
@@ -125,38 +79,52 @@ async def _expect_rejection(tool, source: str, needle: str) -> None:
     assert needle in str(excinfo.value)
 
 
+async def test_resolver_returns_typed_color() -> None:
+    tool = make_physical_color_tool(_frame_tool(), _query_tool("VISIBLE 0.0 0.4 1.0"))
+    resolved = await tool.execute(ResolvePhysicalColorRequest(source_words="the lid"))
+    assert (resolved.r, resolved.g, resolved.b) == (0.0, 0.4, 1.0)
+
+
+async def test_resolver_caches_within_turn() -> None:
+    query = _query_tool("VISIBLE 0.0 0.4 1.0")
+    tool = make_physical_color_tool(_frame_tool(), query)
+    first = await tool.execute(ResolvePhysicalColorRequest(source_words="the lid"))
+    second = await tool.execute(ResolvePhysicalColorRequest(source_words="The lid"))
+    assert (first.r, first.g, first.b) == (second.r, second.g, second.b)
+    assert len(query.calls) == 1
+    token = current_trace_id.set("trace-2")
+    try:
+        await tool.execute(ResolvePhysicalColorRequest(source_words="the lid"))
+    finally:
+        current_trace_id.reset(token)
+    assert len(query.calls) == 2
+
+
 async def test_resolver_unavailable_view_is_value_error() -> None:
-    tool = make_physical_color_tool(
-        _frame_tool(), _query_tool("no signal", available=False), COLOR_WORDS)
+    tool = make_physical_color_tool(_frame_tool(), _query_tool("no signal", available=False))
     await _expect_rejection(tool, "the lid", "cannot currently see")
 
 
-async def test_resolver_unparseable_answer_is_value_error() -> None:
-    tool = make_physical_color_tool(
-        _frame_tool(), _query_tool("hard to say from here"), COLOR_WORDS)
-    await _expect_rejection(tool, "the lid", "did not yield a color")
-
-
-async def test_resolver_not_visible_is_value_error_without_mutation_value() -> None:
-    tool = make_physical_color_tool(_frame_tool(), _query_tool("UNKNOWN"), COLOR_WORDS)
-    await _expect_rejection(tool, "my shirt", "did not yield a color")
+async def test_resolver_unknown_and_malformed_cannot_mutate() -> None:
+    for answer in ("UNKNOWN", "The shirt is blue.", "VISIBLE 300 0 0", "likely VISIBLE 1 0 0"):
+        tool = make_physical_color_tool(_frame_tool(), _query_tool(answer))
+        await _expect_rejection(tool, "my shirt", "did not yield an observation")
 
 
 async def test_resolver_frame_transport_failure_degrades() -> None:
     tool = make_physical_color_tool(
-        _frame_tool(error=RuntimeError("RPCError: no feed")), _query_tool("x"), COLOR_WORDS)
+        _frame_tool(error=RuntimeError("RPCError: no feed")), _query_tool("x"))
     await _expect_rejection(tool, "the lid", "unavailable")
 
 
 async def test_resolver_query_transport_failure_degrades() -> None:
     tool = make_physical_color_tool(
-        _frame_tool(), _query_tool("x", error=TimeoutError("vlm timed out")), COLOR_WORDS)
+        _frame_tool(), _query_tool("x", error=TimeoutError("vlm timed out")))
     await _expect_rejection(tool, "the lid", "unavailable")
 
 
 async def test_resolver_genuine_bug_propagates() -> None:
-    tool = make_physical_color_tool(
-        _frame_tool(error=TypeError("wiring bug")), _query_tool("x"), COLOR_WORDS)
+    tool = make_physical_color_tool(_frame_tool(error=TypeError("wiring bug")), _query_tool("x"))
     with pytest.raises(RuntimeError) as excinfo:
         await tool.execute(ResolvePhysicalColorRequest(source_words="the lid"))
     assert "TypeError: wiring bug" in str(excinfo.value)
@@ -164,27 +132,29 @@ async def test_resolver_genuine_bug_propagates() -> None:
     assert "unavailable" not in str(excinfo.value)
 
 
-async def test_resolver_query_genuine_bug_propagates() -> None:
-    tool = make_physical_color_tool(
-        _frame_tool(), _query_tool("x", error=TypeError("bad request model")), COLOR_WORDS)
-    with pytest.raises(RuntimeError) as excinfo:
-        await tool.execute(ResolvePhysicalColorRequest(source_words="the lid"))
-    assert "TypeError: bad request model" in str(excinfo.value)
-    assert "ValueError" not in str(excinfo.value)
-    assert "unavailable" not in str(excinfo.value)
-
-
 async def test_resolver_truncates_long_source_at_word_boundary() -> None:
-    query = _query_tool("0.0 0.4 1.0")
-    tool = make_physical_color_tool(_frame_tool(), query, COLOR_WORDS)
+    query = _query_tool("VISIBLE 0.0 0.4 1.0")
+    tool = make_physical_color_tool(_frame_tool(), query)
     await tool.execute(ResolvePhysicalColorRequest(source_words="the thing " * 20))
     quoted = query.calls[0].query.split('"')[1]
     assert len(quoted) <= 80
     assert not quoted.endswith("thin")
 
 
-def test_parse_hedged_observations_fail_closed() -> None:
-    assert parse_color_answer("The object may be occluded; likely RGB 1 0 0", COLOR_WORDS) is None
-    assert parse_color_answer("The requested item is outside the frame; the couch is blue", COLOR_WORDS) is None
-    assert parse_color_answer("Probably red, hard to tell", COLOR_WORDS) is None
-    assert parse_color_answer("It is hidden behind the monitor but typically white", COLOR_WORDS) is None
+async def test_color_of_prefix_is_stripped_from_query() -> None:
+    query = _query_tool("VISIBLE 0.0 0.4 1.0")
+    tool = make_physical_color_tool(_frame_tool(), query)
+    await tool.execute(ResolvePhysicalColorRequest(source_words="the color of my apron"))
+    assert query.calls[0].query.split('"')[1] == "my apron"
+
+
+async def test_no_caching_without_a_trace_id() -> None:
+    query = _query_tool("VISIBLE 0.0 0.4 1.0")
+    tool = make_physical_color_tool(_frame_tool(), query)
+    token = current_trace_id.set("")
+    try:
+        await tool.execute(ResolvePhysicalColorRequest(source_words="the lid"))
+        await tool.execute(ResolvePhysicalColorRequest(source_words="the lid"))
+    finally:
+        current_trace_id.reset(token)
+    assert len(query.calls) == 2

--- a/tests/test_render_spatial_ops.py
+++ b/tests/test_render_spatial_ops.py
@@ -307,8 +307,8 @@ async def test_phrase_without_camera_still_errors():
 
 
 async def test_wall_never_fuzzy_matches_ball():
-    # The live false-success bug: "the wall" fuzzy-matched a scene ball and
-    # recolored the sphere to its own color, so nothing visibly changed.
+    # "the wall" must reach the camera; a fuzzy shape match ("wall"→"ball")
+    # would recolor the sphere to its own color, a silent no-op success.
     leaves, physical = _leaves_with_camera([_obj("sphere-0", "sphere", (0, 0.8, 0))])
     assert await leaves.color("the wall") == (0.1, 0.2, 0.3)
     assert physical.calls == ["the wall"]
@@ -345,3 +345,17 @@ async def test_participant_id_in_color_words_is_not_a_scene_reference():
     leaves, physical = _leaves_with_camera([_obj("sphere-0", "sphere", (0, 0.8, 0))])
     assert await leaves.color("wall-probe-1787356834-0") == (0.1, 0.2, 0.3)
     assert physical.calls == ["wall-probe-1787356834-0"]
+
+
+async def test_scene_history_phrase_stays_scene_copy():
+    # A first-person pronoun alone is not a physical cue: "the cube I
+    # created" names XR history and must copy from the scene.
+    leaves, physical = _leaves_with_camera([_obj("box-0", "box", (1, 0, 0))])
+    assert await leaves.color("the cube I created") == (1, 0, 0)
+    assert physical.calls == []
+
+
+async def test_real_qualifier_routes_to_camera():
+    leaves, physical = _leaves_with_camera([_obj("cone-0", "cone", (1, 1, 1))])
+    assert await leaves.color("the real cone") == (0.1, 0.2, 0.3)
+    assert physical.calls == ["the real cone"]

--- a/tests/test_render_spatial_ops.py
+++ b/tests/test_render_spatial_ops.py
@@ -245,3 +245,103 @@ async def test_ledger_dedupes_identical_creates():
     ledger.reset()
     third = await leaves.add("box", (0.001, 1.0, 0.0), (1, 0, 0), 0.1)
     assert third.id == "box-1"
+
+
+class _FakePhysicalColor:
+    def __init__(self, color=(0.1, 0.2, 0.3)):
+        from xr_render_demo_worker._physical_color import ResolvePhysicalColorRequest
+        self.request_model = ResolvePhysicalColorRequest
+        self.calls = []
+        self._color = color
+
+    async def execute(self, req):
+        from xr_render_demo_worker._physical_color import ResolvedColor
+        self.calls.append(req.source_words)
+        r, g, b = self._color
+        return ResolvedColor(r=r, g=g, b=b)
+
+
+def _leaves_with_camera(objects, color=(0.1, 0.2, 0.3), guard=None):
+    fake = _FakeScene(objects)
+    physical = _FakePhysicalColor(color)
+    leaves = _Leaves(_FakeSceneTools(fake), _FakeTrackingTools(), guard=guard,
+                     physical_color=physical)
+    return leaves, physical
+
+
+async def test_lone_garble_never_reaches_camera():
+    leaves, physical = _leaves_with_camera([])
+    with pytest.raises(ValueError, match="Unknown color"):
+        await leaves.color("blerg")
+    with pytest.raises(ValueError, match="Unknown color"):
+        await leaves.color("beige")
+    assert physical.calls == []
+
+
+async def test_unresolved_phrase_reaches_camera():
+    leaves, physical = _leaves_with_camera([])
+    assert await leaves.color("the ceiling") == (0.1, 0.2, 0.3)
+    assert physical.calls == ["the ceiling"]
+
+
+async def test_physical_cue_beats_scene_shape():
+    leaves, physical = _leaves_with_camera([_obj("cone-0", "cone", (1, 1, 1))])
+    assert await leaves.color("the cone I'm holding") == (0.1, 0.2, 0.3)
+    assert physical.calls == ["the cone I'm holding"]
+
+
+async def test_failed_scene_reference_stays_recoverable():
+    guard = TurnGuard()
+    leaves, physical = _leaves_with_camera(
+        [_obj("cone-0", "cone", (1, 1, 1)), _obj("cone-1", "cone", (1, 1, 1))], guard=guard)
+    with pytest.raises(ValueError, match="ambiguous"):
+        await leaves.color("same as the cone")
+    assert physical.calls == []
+    assert guard.halted
+
+
+async def test_phrase_without_camera_still_errors():
+    leaves, _ = _leaves([])
+    with pytest.raises(ValueError, match="Unknown color"):
+        await leaves.color("the ceiling")
+
+
+async def test_wall_never_fuzzy_matches_ball():
+    # The live false-success bug: "the wall" fuzzy-matched a scene ball and
+    # recolored the sphere to its own color, so nothing visibly changed.
+    leaves, physical = _leaves_with_camera([_obj("sphere-0", "sphere", (0, 0.8, 0))])
+    assert await leaves.color("the wall") == (0.1, 0.2, 0.3)
+    assert physical.calls == ["the wall"]
+
+
+async def test_collapsed_physical_phrase_rescued_from_instruction():
+    from xr_render_demo_worker._trace import current_instruction
+    # The model collapsed "the cone the user is holding" to the scene id;
+    # the instruction is where the physical wording survives.
+    leaves, physical = _leaves_with_camera([_obj("cone-0", "cone", (1, 1, 1))])
+    token = current_instruction.set("Recolor ring-1 to match the cone the user is holding.")
+    try:
+        assert await leaves.color("cone-0") == (0.1, 0.2, 0.3)
+        assert physical.calls == ["the cone the user is holding"]
+    finally:
+        current_instruction.reset(token)
+
+
+async def test_scene_copy_not_rerouted_by_unrelated_held_object():
+    from xr_render_demo_worker._trace import current_instruction
+    leaves, physical = _leaves_with_camera([_obj("ring-1", "ring", (0.25, 0.5, 0.75))])
+    token = current_instruction.set("Recolor the cone I'm holding to match ring-1.")
+    try:
+        assert await leaves.color("ring-1") == (0.25, 0.5, 0.75)
+        assert physical.calls == []
+    finally:
+        current_instruction.reset(token)
+
+
+async def test_participant_id_in_color_words_is_not_a_scene_reference():
+    # A participant id ("wall-probe-1787356834-0") is word-number shaped and
+    # contains a fuzzy shape homophone; it must reach the camera path, never
+    # resolve to a scene object.
+    leaves, physical = _leaves_with_camera([_obj("sphere-0", "sphere", (0, 0.8, 0))])
+    assert await leaves.color("wall-probe-1787356834-0") == (0.1, 0.2, 0.3)
+    assert physical.calls == ["wall-probe-1787356834-0"]

--- a/tests/test_render_spatial_ops.py
+++ b/tests/test_render_spatial_ops.py
@@ -178,15 +178,6 @@ async def test_capitalized_id_still_hits_id_branch():
         await leaves.find("Box-9")
 
 
-async def test_numeric_rgb_ignores_id_bearing_strings():
-    leaves, _ = _leaves([_obj("capsule-0", "capsule", (0.25, 0.5, 0.75))])
-    assert await leaves.color("same as capsule-0") == (0.25, 0.5, 0.75)
-    assert await leaves.color("RGB (1.0, 0.5, 0.0)") == (1.0, 0.5, 0.0)
-    # A sign-invalid triple has no letters either; it falls through to the
-    # standard default rather than a wrong saturated color.
-    assert await leaves.color("-0.5 0.2 0.3") == (0.2, 0.9, 1.0)
-
-
 async def test_synonym_prefixed_id_resolves():
     leaves, _ = _leaves([_obj("box-39", "box", (1, 1, 0))])
     assert (await leaves.find("cube-39")).id == "box-39"
@@ -220,17 +211,6 @@ def test_shape_words_resolve_and_reject():
     assert leaves.shape("cone") == "cone"
     with pytest.raises(ValueError, match="Unknown shape"):
         leaves.shape("xylophone")
-
-
-async def test_color_words_resolve_fuzzy_default_and_copy():
-    leaves, _ = _leaves([_obj("cone-3", "cone", (0.25, 0.5, 0.75))])
-    assert await leaves.color("teal") == (0, 0.8, 0.8)
-    assert await leaves.color("blew") == (0, 0.4, 1)
-    assert await leaves.color("") == (0.2, 0.9, 1.0)
-    assert await leaves.color("same as cone-3") == (0.25, 0.5, 0.75)
-    assert await leaves.color("normalized RGB (1.0, 0.5, 0.0)") == (1.0, 0.5, 0.0)
-    with pytest.raises(ValueError, match="Unknown color"):
-        await leaves.color("wibble")
 
 
 async def test_ledger_dedupes_identical_creates():
@@ -269,93 +249,95 @@ def _leaves_with_camera(objects, color=(0.1, 0.2, 0.3), guard=None):
     return leaves, physical
 
 
-async def test_lone_garble_never_reaches_camera():
-    leaves, physical = _leaves_with_camera([])
-    with pytest.raises(ValueError, match="Unknown color"):
-        await leaves.color("blerg")
-    with pytest.raises(ValueError, match="Unknown color"):
-        await leaves.color("beige")
+# ── typed color-source dispatch: each variant touches only its dependency ────
+
+async def test_literal_variant_never_touches_scene_or_camera():
+    leaves, physical = _leaves_with_camera([_obj("cone-3", "cone", (0.25, 0.5, 0.75))])
+    assert await leaves.resolve_color("literal", "teal") == (0, 0.8, 0.8)
+    assert await leaves.resolve_color("literal", "blew") == (0, 0.4, 1)
+    assert await leaves.resolve_color("literal", "teel") == (0, 0.8, 0.8)
+    assert await leaves.resolve_color("literal", "1.0, 0.5, 0.0") == (1.0, 0.5, 0.0)
+    assert await leaves.resolve_color("literal", "") == (0.2, 0.9, 1.0)
+    assert await leaves.resolve_color("literal", " ") == (0.2, 0.9, 1.0)
     assert physical.calls == []
 
 
-async def test_unresolved_phrase_reaches_camera():
+async def test_literal_garble_fails_closed():
     leaves, physical = _leaves_with_camera([])
-    assert await leaves.color("the ceiling") == (0.1, 0.2, 0.3)
-    assert physical.calls == ["the ceiling"]
+    with pytest.raises(ValueError, match="Unknown color"):
+        await leaves.resolve_color("literal", "blerg")
+    with pytest.raises(ValueError, match="Unknown color"):
+        await leaves.resolve_color("literal", "burnt sienna")
+    assert physical.calls == []
 
 
-async def test_physical_cue_beats_scene_shape():
-    leaves, physical = _leaves_with_camera([_obj("cone-0", "cone", (1, 1, 1))])
-    assert await leaves.color("the cone I'm holding") == (0.1, 0.2, 0.3)
-    assert physical.calls == ["the cone I'm holding"]
-
-
-async def test_failed_scene_reference_stays_recoverable():
+async def test_scene_variant_copies_and_never_falls_to_camera():
     guard = TurnGuard()
     leaves, physical = _leaves_with_camera(
-        [_obj("cone-0", "cone", (1, 1, 1)), _obj("cone-1", "cone", (1, 1, 1))], guard=guard)
-    with pytest.raises(ValueError, match="ambiguous"):
-        await leaves.color("same as the cone")
+        [_obj("cone-0", "cone", (0.25, 0.5, 0.75)), _obj("ring-1", "ring", (1, 0, 0))],
+        guard=guard)
+    copied = await leaves.resolve_color("scene_object", "cone-0")
+    assert copied == (0.25, 0.5, 0.75)
+    with pytest.raises(ValueError, match="No scene object matches"):
+        await leaves.resolve_color("scene_object", "the wall")
     assert physical.calls == []
     assert guard.halted
 
 
-async def test_phrase_without_camera_still_errors():
-    leaves, _ = _leaves([])
-    with pytest.raises(ValueError, match="Unknown color"):
-        await leaves.color("the ceiling")
+async def test_scene_variant_ambiguity_surfaces_ask_back():
+    guard = TurnGuard()
+    leaves, physical = _leaves_with_camera(
+        [_obj("cone-0", "cone", (1, 1, 1)), _obj("cone-1", "cone", (1, 1, 1))], guard=guard)
+    with pytest.raises(ValueError, match="ambiguous"):
+        await leaves.resolve_color("scene_object", "the cone")
+    assert physical.calls == []
+    assert guard.halted
 
 
-async def test_wall_never_fuzzy_matches_ball():
-    # "the wall" must reach the camera; a fuzzy shape match ("wall"→"ball")
-    # would recolor the sphere to its own color, a silent no-op success.
-    leaves, physical = _leaves_with_camera([_obj("sphere-0", "sphere", (0, 0.8, 0))])
-    assert await leaves.color("the wall") == (0.1, 0.2, 0.3)
-    assert physical.calls == ["the wall"]
-
-
-async def test_collapsed_physical_phrase_rescued_from_instruction():
-    from xr_render_demo_worker._trace import current_instruction
-    # The model collapsed "the cone the user is holding" to the scene id;
-    # the instruction is where the physical wording survives.
+async def test_physical_variant_observes_exact_words():
     leaves, physical = _leaves_with_camera([_obj("cone-0", "cone", (1, 1, 1))])
-    token = current_instruction.set("Recolor ring-1 to match the cone the user is holding.")
-    try:
-        assert await leaves.color("cone-0") == (0.1, 0.2, 0.3)
-        assert physical.calls == ["the cone the user is holding"]
-    finally:
-        current_instruction.reset(token)
+    assert await leaves.resolve_color("physical", "the cone I'm holding") == (0.1, 0.2, 0.3)
+    assert await leaves.resolve_color("physical", "the ceiling") == (0.1, 0.2, 0.3)
+    assert physical.calls == ["the cone I'm holding", "the ceiling"]
 
 
-async def test_scene_copy_not_rerouted_by_unrelated_held_object():
-    from xr_render_demo_worker._trace import current_instruction
-    leaves, physical = _leaves_with_camera([_obj("ring-1", "ring", (0.25, 0.5, 0.75))])
-    token = current_instruction.set("Recolor the cone I'm holding to match ring-1.")
-    try:
-        assert await leaves.color("ring-1") == (0.25, 0.5, 0.75)
-        assert physical.calls == []
-    finally:
-        current_instruction.reset(token)
+async def test_physical_variant_without_camera_fails_closed():
+    leaves, _ = _leaves([])
+    with pytest.raises(ValueError, match="no camera"):
+        await leaves.resolve_color("physical", "my scarf")
 
 
-async def test_participant_id_in_color_words_is_not_a_scene_reference():
-    # A participant id ("wall-probe-1787356834-0") is word-number shaped and
-    # contains a fuzzy shape homophone; it must reach the camera path, never
-    # resolve to a scene object.
-    leaves, physical = _leaves_with_camera([_obj("sphere-0", "sphere", (0, 0.8, 0))])
-    assert await leaves.color("wall-probe-1787356834-0") == (0.1, 0.2, 0.3)
-    assert physical.calls == ["wall-probe-1787356834-0"]
-
-
-async def test_scene_history_phrase_stays_scene_copy():
-    # A first-person pronoun alone is not a physical cue: "the cube I
-    # created" names XR history and must copy from the scene.
-    leaves, physical = _leaves_with_camera([_obj("box-0", "box", (1, 0, 0))])
-    assert await leaves.color("the cube I created") == (1, 0, 0)
+async def test_out_of_range_numeric_literal_fails_closed():
+    leaves, physical = _leaves_with_camera([])
+    with pytest.raises(ValueError, match="out of range"):
+        await leaves.resolve_color("literal", "255 0 0")
     assert physical.calls == []
 
 
-async def test_real_qualifier_routes_to_camera():
-    leaves, physical = _leaves_with_camera([_obj("cone-0", "cone", (1, 1, 1))])
-    assert await leaves.color("the real cone") == (0.1, 0.2, 0.3)
-    assert physical.calls == ["the real cone"]
+async def test_empty_value_required_for_non_literal_kinds():
+    leaves, physical = _leaves_with_camera([])
+    with pytest.raises(ValueError, match="color_value is required"):
+        await leaves.resolve_color("scene_object", "")
+    with pytest.raises(ValueError, match="color_value is required"):
+        await leaves.resolve_color("physical", "  ")
+    assert physical.calls == []
+
+
+async def test_recolor_records_applied_and_satisfied_evidence():
+    from xr_render_demo_worker._trace import MutationEvidence, current_mutation_evidence
+    from xr_render_demo_worker.spatial_ops import _RecolorRequest, make_appearance_tools
+
+    fake = _FakeScene([_obj("cone-0", "cone", (0, 0.8, 0))])
+    tools = {tool.name: tool for tool in make_appearance_tools(_FakeSceneTools(fake))}
+    evidence = MutationEvidence()
+    token = current_mutation_evidence.set(evidence)
+    try:
+        await tools["recolor"].execute(_RecolorRequest(
+            object_words="cone-0", color_kind="literal", color_value="green"))
+        assert (evidence.applied, evidence.satisfied) == (0, 1)
+        assert not any(name == "update_primitive" for name, _ in fake.calls)
+        await tools["recolor"].execute(_RecolorRequest(
+            object_words="cone-0", color_kind="literal", color_value="red"))
+        assert (evidence.applied, evidence.satisfied) == (1, 1)
+    finally:
+        current_mutation_evidence.reset(token)

--- a/tests/test_render_tolerant.py
+++ b/tests/test_render_tolerant.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the expected-degradation classifier and tolerant toolset."""
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import BaseModel
+from xr_ai_hub import FrameUnavailable
+from xr_ai_tools import Tool
+from xr_render_demo_worker._tolerant import as_unavailable, tolerant_toolset
+
+
+def test_direct_transport_types_classify() -> None:
+    assert as_unavailable(TimeoutError("slow"), "the feed") is not None
+    assert as_unavailable(ConnectionError("refused"), "the feed") is not None
+    assert as_unavailable(FrameUnavailable("No camera frame available"), "the feed") is not None
+
+
+def test_nested_cause_walk_classifies() -> None:
+    outer = RuntimeError("wrapper")
+    outer.__cause__ = TimeoutError("slow")
+    assert as_unavailable(outer, "the feed") is not None
+    contextual = RuntimeError("wrapper")
+    contextual.__context__ = ConnectionError("refused")
+    assert as_unavailable(contextual, "the feed") is not None
+
+
+def test_cause_cycle_terminates() -> None:
+    first = RuntimeError("a")
+    second = RuntimeError("b")
+    first.__cause__ = second
+    second.__context__ = first
+    assert as_unavailable(first, "the feed") is None
+
+
+def test_relay_wrapped_type_name_classifies_from_text() -> None:
+    # Relay re-raises with the cause chain erased; only the message keeps
+    # the original class name.
+    wrapped = RuntimeError(
+        "internal error: FrameUnavailable: No camera frame available — please try again."
+    )
+    assert as_unavailable(wrapped, "the camera") is not None
+    assert as_unavailable(RuntimeError("RPCError: no feed"), "the camera") is not None
+    assert as_unavailable(RuntimeError("connection refused by peer"), "the camera") is not None
+    assert as_unavailable(RuntimeError("StatusCode.UNAVAILABLE"), "the camera") is not None
+
+
+def test_ordinary_english_does_not_classify() -> None:
+    assert as_unavailable(RuntimeError("boom"), "the feed") is None
+    assert as_unavailable(RuntimeError("the operator is unavailable today"), "the feed") is None
+    assert as_unavailable(RuntimeError("feature disabled by config"), "the feed") is None
+    assert as_unavailable(FileNotFoundError("missing.yaml"), "the feed") is None
+    assert as_unavailable(PermissionError("denied"), "the feed") is None
+
+
+def test_classified_message_names_the_feed() -> None:
+    degraded = as_unavailable(TimeoutError("slow"), "the current camera view")
+    assert isinstance(degraded, ValueError)
+    assert "the current camera view is unavailable" in str(degraded)
+
+
+class _Empty(BaseModel):
+    pass
+
+
+async def test_tolerant_tool_converts_value_error_and_propagates_bugs() -> None:
+    async def reject(req: _Empty) -> None:
+        raise ValueError("no such object")
+
+    async def explode(req: _Empty) -> None:
+        raise TypeError("wiring bug")
+
+    toolset = tolerant_toolset([
+        Tool("reject", "Reject.", _Empty, None, reject),
+        Tool("explode", "Explode.", _Empty, None, explode),
+    ])
+    result = await toolset.get("reject").invoke("{}")
+    assert json.loads(result.content)["detail"] == "no such object"
+    # The Relay Tool boundary rewraps handler bugs as RuntimeError; the
+    # tolerant layer must let that propagate, not convert it.
+    with pytest.raises(RuntimeError, match="TypeError: wiring bug"):
+        await toolset.get("explode").invoke("{}")

--- a/tests/test_render_tolerant.py
+++ b/tests/test_render_tolerant.py
@@ -40,7 +40,7 @@ def test_relay_wrapped_type_name_classifies_from_text() -> None:
     # Relay re-raises with the cause chain erased; only the message keeps
     # the original class name.
     wrapped = RuntimeError(
-        "internal error: FrameUnavailable: No camera frame available — please try again."
+        "internal error: FrameUnavailable: No camera frame available, please try again."
     )
     assert as_unavailable(wrapped, "the camera") is not None
     assert as_unavailable(RuntimeError("RPCError: no feed"), "the camera") is not None

--- a/tests/test_xr_render_demo_supervisor.py
+++ b/tests/test_xr_render_demo_supervisor.py
@@ -140,6 +140,51 @@ async def test_mixed_vision_and_mutation_request_still_verifies(monkeypatch) -> 
     assert loop_calls == 2
 
 
+async def test_verification_never_offers_repeat_when_mutation_undelegated(monkeypatch) -> None:
+    """A change-requesting utterance whose first pass delegated no mutating
+    subagent must get a verification nudge with no repeat-your-answer out."""
+    supervisor, _fake = _make_supervisor()
+    nudges: list[str] = []
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        nudges.extend(m.content for m in messages if m.role == "user" and "Verified scene" in m.content)
+        return SimpleNamespace(
+            content="Recolored it to match the wall.",
+            messages=list(messages),
+            tool_calls=(),
+        )
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    await supervisor.handle(SceneRequest(
+        transcript="Make the sphere the same color as the wall.", participant_id="alice"))
+    assert len(nudges) == 1
+    assert "repeat your final answer" not in nudges[0]
+    assert "never" in nudges[0]
+
+
+async def test_verification_offers_repeat_after_mutating_delegation(monkeypatch) -> None:
+    """When a mutating subagent did run and reported no change, the nudge
+    keeps the repeat-answer path for honest failure replies."""
+    supervisor, _fake = _make_supervisor()
+    nudges: list[str] = []
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        nudges.extend(m.content for m in messages if m.role == "user" and "Verified scene" in m.content)
+        return SimpleNamespace(
+            content="I couldn't find that object.",
+            messages=list(messages),
+            tool_calls=(SimpleNamespace(call=SimpleNamespace(name="appearance_agent")),),
+        )
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    await supervisor.handle(SceneRequest(
+        transcript="Paint the sphere crimson.", participant_id="alice"))
+    assert len(nudges) == 1
+    assert "repeat your final answer" in nudges[0]
+
+
 async def test_turn_tasks_run_in_forked_relay_context(monkeypatch) -> None:
     """Detached turn tasks must not inherit the subscriber's live Relay scope
     stack; each turn gets a forked context."""

--- a/tests/test_xr_render_demo_supervisor.py
+++ b/tests/test_xr_render_demo_supervisor.py
@@ -136,9 +136,10 @@ async def test_mixed_vision_and_mutation_request_still_verifies(monkeypatch) -> 
 
     reply = await supervisor.handle(SceneRequest(
         transcript="Look at the room and create a sphere.", participant_id="alice"))
-    # The creation half never happened, so the vision-only reply is an
-    # unsupported claim of completion; the guard replaces it.
-    assert "nothing in the scene was changed" in reply.response
+    # The creation half never happened: the claim-free vision answer keeps
+    # its content and gains the no-change fact.
+    assert reply.response.startswith("The room looks tidy.")
+    assert reply.response.endswith("Nothing in the scene was changed.")
     assert loop_calls == 2
 
 
@@ -168,6 +169,77 @@ async def test_verification_never_offers_repeat_when_mutation_undelegated(monkey
     assert "Recolored" not in reply.response
     assert "nothing in the scene was changed" in reply.response
     assert _fake.objects == {}
+
+
+async def test_gate_keeps_claim_free_explanations(monkeypatch) -> None:
+    """A claim-free failure explanation keeps its why; the no-change fact is
+    appended, never substituted."""
+    supervisor, _fake = _make_supervisor()
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        return SimpleNamespace(
+            content="The camera is unavailable, so I could not read your shirt color.",
+            messages=list(messages),
+            tool_calls=(),
+        )
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    reply = await supervisor.handle(SceneRequest(
+        transcript="Make the box the color of my shirt.", participant_id="alice"))
+    assert reply.response.startswith("The camera is unavailable")
+    assert reply.response.endswith("Nothing in the scene was changed.")
+
+
+def test_status_questions_are_not_mutation_intent() -> None:
+    from xr_render_demo_worker.supervisor import _wants_mutation
+
+    assert not _wants_mutation("Did you move the cube?")
+    assert not _wants_mutation("Have you added the sphere yet?")
+    assert not _wants_mutation("Was the cube removed?")
+    assert _wants_mutation("Can you move the cube?")
+    assert _wants_mutation("Move the cube.")
+
+
+async def test_already_satisfied_reply_stands_on_evidence(monkeypatch) -> None:
+    """A recolor that found the requested state already holding records
+    satisfied evidence; the model's reply stands despite no scene diff."""
+    from xr_render_demo_worker._trace import current_mutation_evidence
+
+    supervisor, _fake = _make_supervisor()
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        current_mutation_evidence.get().satisfied += 1
+        return SimpleNamespace(
+            content="The sphere is already green.",
+            messages=list(messages),
+            tool_calls=(SimpleNamespace(call=SimpleNamespace(name="appearance_agent")),),
+        )
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    reply = await supervisor.handle(SceneRequest(
+        transcript="Make the sphere green.", participant_id="alice"))
+    assert reply.response == "The sphere is already green."
+
+
+async def test_rejected_mutation_without_evidence_gets_honest_reply(monkeypatch) -> None:
+    """A delegated mutating agent whose tool call was rejected leaves no
+    evidence; a non-question reply is replaced with the honest text."""
+    supervisor, _fake = _make_supervisor()
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        return SimpleNamespace(
+            content="Recolored the box to match your shirt.",
+            messages=list(messages),
+            tool_calls=(SimpleNamespace(call=SimpleNamespace(name="appearance_agent")),),
+        )
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    reply = await supervisor.handle(SceneRequest(
+        transcript="Make the box the color of my shirt.", participant_id="alice"))
+    assert "nothing in the scene was changed" in reply.response
 
 
 async def test_verification_preserves_clarifying_questions(monkeypatch) -> None:

--- a/tests/test_xr_render_demo_supervisor.py
+++ b/tests/test_xr_render_demo_supervisor.py
@@ -136,7 +136,9 @@ async def test_mixed_vision_and_mutation_request_still_verifies(monkeypatch) -> 
 
     reply = await supervisor.handle(SceneRequest(
         transcript="Look at the room and create a sphere.", participant_id="alice"))
-    assert reply.response == "The room looks tidy."
+    # The creation half never happened, so the vision-only reply is an
+    # unsupported claim of completion; the guard replaces it.
+    assert "nothing in the scene was changed" in reply.response
     assert loop_calls == 2
 
 
@@ -156,11 +158,35 @@ async def test_verification_never_offers_repeat_when_mutation_undelegated(monkey
 
     monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
 
-    await supervisor.handle(SceneRequest(
+    reply = await supervisor.handle(SceneRequest(
         transcript="Make the sphere the same color as the wall.", participant_id="alice"))
     assert len(nudges) == 1
     assert "repeat your final answer" not in nudges[0]
     assert "never" in nudges[0]
+    # The model repeated its false success anyway; the deterministic guard
+    # must replace it, and the scene must be untouched.
+    assert "Recolored" not in reply.response
+    assert "nothing in the scene was changed" in reply.response
+    assert _fake.objects == {}
+
+
+async def test_verification_preserves_clarifying_questions(monkeypatch) -> None:
+    """A question reply after a no-change verification pass is a legitimate
+    ask-back, not an unsupported claim."""
+    supervisor, _fake = _make_supervisor()
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        return SimpleNamespace(
+            content="What color is the wall?",
+            messages=list(messages),
+            tool_calls=(),
+        )
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    reply = await supervisor.handle(SceneRequest(
+        transcript="Make the sphere the same color as the wall.", participant_id="alice"))
+    assert reply.response == "What color is the wall?"
 
 
 async def test_verification_offers_repeat_after_mutating_delegation(monkeypatch) -> None:

--- a/tests/test_xr_render_demo_wire.py
+++ b/tests/test_xr_render_demo_wire.py
@@ -152,6 +152,11 @@ def test_truncated_transcripts_detected() -> None:
     assert _is_truncated("Can you put the sphere on")
     assert _is_truncated("Can you move the cube to")
     assert _is_truncated("Put it near the ring in")
+    # Neither terminal punctuation nor an embedded wh-word makes a dangling
+    # preposition complete.
+    assert _is_truncated("Can you put the sphere on.")
+    assert _is_truncated("Can you tell me what color to")
+    assert _is_truncated("Move what I selected to")
 
 
 # ── models profile round-trip ─────────────────────────────────────────────────

--- a/tests/test_xr_render_demo_wire.py
+++ b/tests/test_xr_render_demo_wire.py
@@ -132,11 +132,16 @@ def test_truncated_transcripts_detected() -> None:
     assert _is_truncated("Add a red sphere in")
     assert not _is_truncated("Add a red sphere in front of me.")
     assert _truncated_reply("Add a red sphere in") is not None
-    # Complete preposition-final questions are not truncation.
     assert not _is_truncated("What am I looking at?")
     assert not _is_truncated("What are you looking at")
+    assert not _is_truncated('"What are you looking at')
     assert not _is_truncated("Where is it at?")
     assert _is_truncated("Put the sphere on the")
+    assert _is_truncated("Can you put the sphere on the")
+    assert _is_truncated("What color is the")
+    assert _is_truncated("Is the sphere behind the")
+    assert not _is_truncated("Add a cube that matches the wall I'm looking at.")
+    assert _is_truncated("Move the sphere in")
 
 
 # ── models profile round-trip ─────────────────────────────────────────────────

--- a/tests/test_xr_render_demo_wire.py
+++ b/tests/test_xr_render_demo_wire.py
@@ -137,11 +137,21 @@ def test_truncated_transcripts_detected() -> None:
     assert not _is_truncated('"What are you looking at')
     assert not _is_truncated("Where is it at?")
     assert _is_truncated("Put the sphere on the")
+    assert _is_truncated("Put the sphere on the.")
+    assert _is_truncated("Put the sphere on the…")
     assert _is_truncated("Can you put the sphere on the")
     assert _is_truncated("What color is the")
     assert _is_truncated("Is the sphere behind the")
     assert not _is_truncated("Add a cube that matches the wall I'm looking at.")
+    assert not _is_truncated("Add a cube that matches the wall I'm looking at")
+    assert not _is_truncated("Make a sphere match what I'm looking at")
+    assert not _is_truncated('“What are you looking at”')
     assert _is_truncated("Move the sphere in")
+    # Auxiliaries are not the wh-exemption: a polite request cut at a
+    # preposition is still a cut.
+    assert _is_truncated("Can you put the sphere on")
+    assert _is_truncated("Can you move the cube to")
+    assert _is_truncated("Put it near the ring in")
 
 
 # ── models profile round-trip ─────────────────────────────────────────────────

--- a/tests/test_xr_render_demo_wire.py
+++ b/tests/test_xr_render_demo_wire.py
@@ -157,6 +157,11 @@ def test_truncated_transcripts_detected() -> None:
     assert _is_truncated("Can you put the sphere on.")
     assert _is_truncated("Can you tell me what color to")
     assert _is_truncated("Move what I selected to")
+    # A bare -ing noun is not a progressive construction.
+    assert _is_truncated("Put the lamp on the ceiling in")
+    assert _is_truncated("Hang it on the railing above")
+    assert _is_truncated("Move the cube near the painting behind")
+    assert _is_truncated("Put it in the opening near")
 
 
 # ── models profile round-trip ─────────────────────────────────────────────────

--- a/tests/test_xr_render_demo_wire.py
+++ b/tests/test_xr_render_demo_wire.py
@@ -132,6 +132,11 @@ def test_truncated_transcripts_detected() -> None:
     assert _is_truncated("Add a red sphere in")
     assert not _is_truncated("Add a red sphere in front of me.")
     assert _truncated_reply("Add a red sphere in") is not None
+    # Complete preposition-final questions are not truncation.
+    assert not _is_truncated("What am I looking at?")
+    assert not _is_truncated("What are you looking at")
+    assert not _is_truncated("Where is it at?")
+    assert _is_truncated("Put the sphere on the")
 
 
 # ── models profile round-trip ─────────────────────────────────────────────────


### PR DESCRIPTION
Perception fixes to the xr-render-demo sample (#345 follow-up). Color requests
that depend on the real world now observe it or fail honestly, with the
guarantees in structure rather than prompt heuristics (per review feedback):

- **Typed color source.** The mutating tools take `color_kind`
  (`literal` | `scene_object` | `physical`) plus `color_value`; the model
  declares the source through the schema and code dispatches on it with no
  phrase reinterpretation. Literal words are repaired ("teel"), scene copies
  resolve against the scene only (failures surface as the ask-back, never a
  camera query), and physical sources ("my shirt", "the wall") run one camera
  observation.
- **Closed observation grammar.** `resolve_physical_color`'s VLM must answer
  `VISIBLE r g b` (each 0..1) or `UNKNOWN`, full-match; prose, hedges, and
  out-of-range replies fail closed. One observation per phrase per turn.
- **Evidence-backed success.** A per-turn record counts scene writes actually
  applied (and recolors that found the color already in place). Without
  evidence, a completion claim is replaced with a fixed honest no-change
  sentence and any other non-question reply gets the no-change fact appended;
  clarifying questions pass through. Evidence is per turn, not per delegated
  task (documented).
- **Transport outages classified by exception type**, including Relay-wrapped
  `FrameUnavailable`/`RPCError` where the cause chain is erased; ordinary
  English ("disabled") and local bugs no longer match.
- **Truncation detection works on unpunctuated input**: leading wh-questions
  and progressive constructions ("the wall I'm staring at") read as complete;
  punctuation, embedded wh-words, and bare -ing nouns ("the ceiling in") do
  not exempt a dangling preposition.
- **Eval/test hardening**: prompt vocabulary disjoint from all eval text
  (audit also scans the model-visible tool text in code), grammar-faithful
  physical-color fake that validates the requested source, and unit matrices
  for source dispatch, the grammar, the evidence gate, and truncation.

## Test plan

Unit 85/85, ruff and prompt audit clean. Offline: subagents 48/49, routing
21/23, utterances 32/34 (remainders are documented pre-existing failures or
accepted probabilistic routing misses). Live: manipulation 13/13, garble
10/10; wall-recolor probe with no camera 8+ consecutive honest no-change
replies (previously false success); with an injected camera frame, recolors
land with the color measured from the frame.
