### PR TITLE
Align shared model servers on Piper TTS and Nemotron Omni

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,13 +396,7 @@ This demo has two extra host prerequisites beyond the shared
 - **npm 18+** on PATH — the orchestrator builds the web vendor bundle on first
   run (skipped on subsequent runs).
 
-Start the shared model stack, which includes Piper TTS:
-
-```bash
-uv run --project agent-samples/model-servers model_servers
-```
-
-Then start XR Render:
+Start XR Render:
 
 ```bash
 cd agent-samples/xr-render-demo

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ avoiding GPU overcommit.
 
 The default profile starts Nemotron-3 Nano Omni (8108, serving both the
 reactive and agent LLM roles), Cosmos3 Nano Reasoner (8100), STT (8103),
-and embeddings (8109).
+Piper TTS (8105), and embeddings (8109).
 
 ```bash
 uv run model_servers --models vlm_llm_nim
@@ -249,14 +249,13 @@ Uses the text-output Reasoner from `nvidia/Cosmos3-Nano` by default. Refer to th
 runtime-selection details.
 
 The sample always reuses model services and never starts or stops them. Start
-the repository-default VLM and STT, then start Piper TTS in a terminal:
+the repository-default shared stack, which includes VLM, STT, and Piper TTS:
 
 ```bash
 uv run --project agent-samples/model-servers model_servers
-uv run --project services/piper-tts piper_tts_server
 ```
 
-The first command may download model weights on its first run and requires the
+The command may download model weights on its first run and requires the
 credentials described in the
 [credentials guide](docs/source/getting_started/credentials.md).
 
@@ -334,15 +333,11 @@ recent monitor history. Accepted STT and typed queries, monitoring records,
 foreground turns, and Relay telemetry are written as JSONL under `artifacts/`;
 the shared connection web client remains available on port 8080.
 
-The sample always uses Cosmos for visual inference. Start `model-servers` and
-Piper TTS in separate terminals, then run the sample in another terminal:
+The sample always uses Cosmos for visual inference. Start the shared
+`model-servers` stack, including Piper TTS, then run the sample:
 
 ```bash
 uv run --project agent-samples/model-servers model_servers
-```
-
-```bash
-uv run --project services/piper-tts piper_tts_server
 ```
 
 ```bash
@@ -401,10 +396,10 @@ This demo has two extra host prerequisites beyond the shared
 - **npm 18+** on PATH — the orchestrator builds the web vendor bundle on first
   run (skipped on subsequent runs).
 
-Start Piper TTS in a separate terminal:
+Start the shared model stack, which includes Piper TTS:
 
 ```bash
-uv run --project services/piper-tts piper_tts_server
+uv run --project agent-samples/model-servers model_servers
 ```
 
 Then start XR Render:

--- a/README.md
+++ b/README.md
@@ -206,9 +206,9 @@ tens of minutes. On subsequent runs the containers restart in under a minute.
 Which servers start is a deployment profile: `--models <name|path>` selects
 `default`, `vlm_llm_nim` (LLM and VLM as self-hosted NIM containers;
 requires docker + `NGC_API_KEY`), or any profile JSON of your own. The NIM
-profile serves Nemotron-3-Nano and Cosmos3-Nano Reasoner. Starting a profile
-stops persisted servers outside it first and aborts if they cannot be stopped,
-avoiding GPU overcommit.
+profile serves Nemotron-3 Nano Omni and Cosmos3-Nano Reasoner. Starting a
+profile stops persisted servers outside it first and aborts if they cannot be
+stopped, avoiding GPU overcommit.
 
 The default profile starts Nemotron-3 Nano Omni (8108, serving both the
 reactive and agent LLM roles), Cosmos3 Nano Reasoner (8100), STT (8103),

--- a/agent-samples/lab-instrument-monitoring/README.md
+++ b/agent-samples/lab-instrument-monitoring/README.md
@@ -20,21 +20,14 @@ By default, the sample uses Nemotron Omni for foreground tool routing and Cosmos
 for image inference. It reuses those services, STT, and Piper TTS; the sample
 never starts or stops model services.
 
-Start the model server stack in one terminal:
+Start the shared model-server stack, which includes Piper TTS:
 
 ```bash
 uv sync --project agent-samples/model-servers
 uv run --project agent-samples/model-servers model_servers
 ```
 
-Start Piper TTS in a second terminal:
-
-```bash
-uv sync --project services/piper-tts
-uv run --project services/piper-tts piper_tts_server
-```
-
-Then start the sample in a third terminal:
+Then start the sample in another terminal:
 
 ```bash
 uv sync --project agent-samples/lab-instrument-monitoring

--- a/agent-samples/model-servers/main.py
+++ b/agent-samples/model-servers/main.py
@@ -14,12 +14,13 @@ containers. Shipped profiles (yaml/models.<name>.json):
 
   default
     stt        — nvidia/parakeet-tdt-0.6b-v3        port 8103  (NeMo ASR)
+    tts        — en_US-lessac-medium                 port 8105  (Piper; CPU)
     omni       — Nemotron-3-Nano-Omni-30B-A3B       port 8108  (vLLM; llm + agent_llm)
     vlm        — nvidia/Cosmos3-Nano Reasoner       port 8100  (vLLM)
     embedding  — nvidia/llama-nemotron-embed-1b-v2  port 8109  (vLLM)
 
   vlm_llm_nim
-    stt + embedding local; the LLM and VLM as self-hosted NIM containers
+    stt + tts + embedding local; the LLM and VLM as self-hosted NIM containers
     (Nemotron-3-Nano port 8110, Cosmos3-Nano Reasoner port 8100). Requires
     docker + NGC_API_KEY. Samples may reuse these endpoints.
 
@@ -82,6 +83,7 @@ _MODEL_SERVICES: dict[str, tuple[str, str, str]] = {
     "llm-nim":   ("../../services/nim-server", "nim_server", "nim_llm_server"),
     "vlm-nim":   ("../../services/nim-server", "nim_server", "nim_vlm_server"),
     "stt":       ("../../services/stt-server", "stt_server", "stt_server"),
+    "tts":       ("../../services/piper-tts", "piper_tts_server", "piper_tts_server"),
     "agent-llm": (
         "../../services/nemotron3-nano-llm",
         "nemotron3_nano_llm_server",

--- a/agent-samples/model-servers/main.py
+++ b/agent-samples/model-servers/main.py
@@ -21,8 +21,8 @@ containers. Shipped profiles (yaml/models.<name>.json):
 
   vlm_llm_nim
     stt + tts + embedding local; the LLM and VLM as self-hosted NIM containers
-    (Nemotron-3-Nano port 8110, Cosmos3-Nano Reasoner port 8100). Requires
-    docker + NGC_API_KEY. Samples may reuse these endpoints.
+    (Nemotron-3-Nano-Omni port 8110, Cosmos3-Nano Reasoner port 8100).
+    Requires docker + NGC_API_KEY. Samples may reuse these endpoints.
 
 Per-service placement (GPUs, ports, KV budgets) lives in the per-GPU-profile
 YAML directory; a service may ship a profile-specific config variant named

--- a/agent-samples/model-servers/yaml/96G_blackwell/nim_llm_server.yaml
+++ b/agent-samples/model-servers/yaml/96G_blackwell/nim_llm_server.yaml
@@ -1,17 +1,16 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Self-hosted NIM: LLM (serves both the `llm` and `agent_llm` roles).
-# Nemotron-3-Nano's A3B MoE decode is fast enough to cover the reactive and
-# agent roles. Swap in
-# any LLM NIM from https://catalog.ngc.nvidia.com.
+# Self-hosted Nemotron-3-Nano-Omni NIM (serves both the `llm` and
+# `agent_llm` roles). This matches the model family used by the default local
+# deployment. Swap in any compatible NIM from https://catalog.ngc.nvidia.com.
 # To adapt a sample, copy the `llm` entry from
 # ../models.vlm_llm_nim.json into its active models JSON, change only
 # `deployment.ownership` from `managed` to `reused`, and keep service
 # `llm-nim` on port 8110. Duplicate it as `agent_llm` when the sample uses
 # that role.
 # UNTESTED ESTIMATE for this GPU profile; validated values are dual_48G_ada's.
-image:     nvcr.io/nim/nvidia/nemotron-3-nano:2.0.10
+image:     nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:2.0.4-variant
 http_port: 8110
 
 nim_cache: ../../../../models/nim
@@ -20,6 +19,5 @@ cuda_visible_devices: "0"
 env:
   NIM_MAX_MODEL_LEN: "32768"
   NIM_KVCACHE_PERCENT: "0.4"
-  # nemotron_v3 is the parser built into this NIM (nano_v3 is absent);
-  # without tool-calling flags the agentic loop gets no tool calls.
+  # Match the local Omni deployment's reasoning and tool-call parsers.
   NIM_PASSTHROUGH_ARGS: "--enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser nemotron_v3"

--- a/agent-samples/model-servers/yaml/96G_blackwell/nim_llm_server.yaml
+++ b/agent-samples/model-servers/yaml/96G_blackwell/nim_llm_server.yaml
@@ -9,7 +9,8 @@
 # `deployment.ownership` from `managed` to `reused`, and keep service
 # `llm-nim` on port 8110. Duplicate it as `agent_llm` when the sample uses
 # that role.
-# UNTESTED ESTIMATE for this GPU profile; validated values are dual_48G_ada's.
+# Verify startup and memory use on the target 96 GB Blackwell GPU before
+# deployment.
 image:     nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:2.0.4-variant
 http_port: 8110
 
@@ -18,6 +19,5 @@ nim_cache: ../../../../models/nim
 cuda_visible_devices: "0"
 env:
   NIM_MAX_MODEL_LEN: "32768"
-  NIM_KVCACHE_PERCENT: "0.4"
   # Match the local Omni deployment's reasoning and tool-call parsers.
-  NIM_PASSTHROUGH_ARGS: "--enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser nemotron_v3"
+  NIM_PASSTHROUGH_ARGS: "--gpu-memory-utilization 0.4 --enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser nemotron_v3"

--- a/agent-samples/model-servers/yaml/96G_blackwell/piper_tts_server.yaml
+++ b/agent-samples/model-servers/yaml/96G_blackwell/piper_tts_server.yaml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Shared CPU Piper TTS service.
+voice: en_US-lessac-medium
+port: 8105
+use_cuda: false
+model_cache: ../../../../models

--- a/agent-samples/model-servers/yaml/96G_blackwell/piper_tts_server.yaml
+++ b/agent-samples/model-servers/yaml/96G_blackwell/piper_tts_server.yaml
@@ -5,4 +5,5 @@
 voice: en_US-lessac-medium
 port: 8105
 use_cuda: false
+startup_timeout_s: 600
 model_cache: ../../../../models

--- a/agent-samples/model-servers/yaml/dual_48G_ada/nim_llm_server.yaml
+++ b/agent-samples/model-servers/yaml/dual_48G_ada/nim_llm_server.yaml
@@ -1,16 +1,15 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Self-hosted NIM: LLM (serves both the `llm` and `agent_llm` roles).
-# Nemotron-3-Nano's A3B MoE decode is fast enough to cover the reactive and
-# agent roles. Swap in
-# any LLM NIM from https://catalog.ngc.nvidia.com.
+# Self-hosted Nemotron-3-Nano-Omni NIM (serves both the `llm` and
+# `agent_llm` roles). This matches the model family used by the default local
+# deployment. Swap in any compatible NIM from https://catalog.ngc.nvidia.com.
 # To adapt a sample, copy the `llm` entry from
 # ../models.vlm_llm_nim.json into its active models JSON, change only
 # `deployment.ownership` from `managed` to `reused`, and keep service
 # `llm-nim` on port 8110. Duplicate it as `agent_llm` when the sample uses
 # that role.
-image:     nvcr.io/nim/nvidia/nemotron-3-nano:2.0.10
+image:     nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:2.0.4-variant
 http_port: 8110
 
 nim_cache: ../../../../models/nim
@@ -19,6 +18,5 @@ cuda_visible_devices: "1"
 env:
   NIM_MAX_MODEL_LEN: "32768"
   NIM_KVCACHE_PERCENT: "0.8"
-  # nemotron_v3 is the parser built into this NIM (nano_v3 is absent);
-  # without tool-calling flags the agentic loop gets no tool calls.
+  # Match the local Omni deployment's reasoning and tool-call parsers.
   NIM_PASSTHROUGH_ARGS: "--enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser nemotron_v3"

--- a/agent-samples/model-servers/yaml/dual_48G_ada/nim_llm_server.yaml
+++ b/agent-samples/model-servers/yaml/dual_48G_ada/nim_llm_server.yaml
@@ -9,6 +9,8 @@
 # `deployment.ownership` from `managed` to `reused`, and keep service
 # `llm-nim` on port 8110. Duplicate it as `agent_llm` when the sample uses
 # that role.
+# RTX Ada is not listed for this Omni NIM; verify startup and memory use on
+# target hardware before deployment.
 image:     nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:2.0.4-variant
 http_port: 8110
 
@@ -17,6 +19,5 @@ nim_cache: ../../../../models/nim
 cuda_visible_devices: "1"
 env:
   NIM_MAX_MODEL_LEN: "32768"
-  NIM_KVCACHE_PERCENT: "0.8"
   # Match the local Omni deployment's reasoning and tool-call parsers.
-  NIM_PASSTHROUGH_ARGS: "--enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser nemotron_v3"
+  NIM_PASSTHROUGH_ARGS: "--gpu-memory-utilization 0.8 --enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser nemotron_v3"

--- a/agent-samples/model-servers/yaml/dual_48G_ada/piper_tts_server.yaml
+++ b/agent-samples/model-servers/yaml/dual_48G_ada/piper_tts_server.yaml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Shared CPU Piper TTS service.
+voice: en_US-lessac-medium
+port: 8105
+use_cuda: false
+model_cache: ../../../../models

--- a/agent-samples/model-servers/yaml/dual_48G_ada/piper_tts_server.yaml
+++ b/agent-samples/model-servers/yaml/dual_48G_ada/piper_tts_server.yaml
@@ -5,4 +5,5 @@
 voice: en_US-lessac-medium
 port: 8105
 use_cuda: false
+startup_timeout_s: 600
 model_cache: ../../../../models

--- a/agent-samples/model-servers/yaml/models.default.json
+++ b/agent-samples/model-servers/yaml/models.default.json
@@ -13,6 +13,19 @@
         "service": "stt"
       }
     },
+    "tts": {
+      "adapter": {
+        "preset": "piper_tts"
+      },
+      "endpoint": {
+        "base_url": "http://localhost:8105",
+        "readiness": "health"
+      },
+      "deployment": {
+        "ownership": "managed",
+        "service": "tts"
+      }
+    },
     "llm": {
       "adapter": {
         "preset": "nemotron_omni"

--- a/agent-samples/model-servers/yaml/models.vlm_llm_nim.json
+++ b/agent-samples/model-servers/yaml/models.vlm_llm_nim.json
@@ -27,18 +27,10 @@
       }
     },
     "llm": {
-      "category": "llm",
       "adapter": {
-        "kind": "openai_compat",
-        "model_name": "nvidia/nemotron-3-nano",
-        "capabilities": {
-          "tool_calls": true
-        },
-        "default_extras": {
-          "chat_template_kwargs": {
-            "enable_thinking": false
-          }
-        }
+        "preset": "nemotron_omni",
+        "model_name": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
+        "reasoning_field": "reasoning"
       },
       "endpoint": {
         "base_url": "http://localhost:8110",

--- a/agent-samples/model-servers/yaml/models.vlm_llm_nim.json
+++ b/agent-samples/model-servers/yaml/models.vlm_llm_nim.json
@@ -13,6 +13,19 @@
         "service": "stt"
       }
     },
+    "tts": {
+      "adapter": {
+        "preset": "piper_tts"
+      },
+      "endpoint": {
+        "base_url": "http://localhost:8105",
+        "readiness": "health"
+      },
+      "deployment": {
+        "ownership": "managed",
+        "service": "tts"
+      }
+    },
     "llm": {
       "category": "llm",
       "adapter": {

--- a/agent-samples/model-servers/yaml/spark/nim_llm_server.yaml
+++ b/agent-samples/model-servers/yaml/spark/nim_llm_server.yaml
@@ -9,7 +9,8 @@
 # `deployment.ownership` from `managed` to `reused`, and keep service
 # `llm-nim` on port 8110. Duplicate it as `agent_llm` when the sample uses
 # that role.
-# UNTESTED ESTIMATE for this GPU profile; validated values are dual_48G_ada's.
+# GB10 is not listed for this Omni NIM; verify startup and memory use on target
+# hardware before deployment.
 image:     nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:2.0.4-variant
 http_port: 8110
 
@@ -18,6 +19,5 @@ nim_cache: ../../../../models/nim
 cuda_visible_devices: "0"
 env:
   NIM_MAX_MODEL_LEN: "32768"
-  NIM_KVCACHE_PERCENT: "0.35"
   # Match the local Omni deployment's reasoning and tool-call parsers.
-  NIM_PASSTHROUGH_ARGS: "--enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser nemotron_v3"
+  NIM_PASSTHROUGH_ARGS: "--gpu-memory-utilization 0.35 --enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser nemotron_v3"

--- a/agent-samples/model-servers/yaml/spark/nim_llm_server.yaml
+++ b/agent-samples/model-servers/yaml/spark/nim_llm_server.yaml
@@ -1,17 +1,16 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Self-hosted NIM: LLM (serves both the `llm` and `agent_llm` roles).
-# Nemotron-3-Nano's A3B MoE decode is fast enough to cover the reactive and
-# agent roles. Swap in
-# any LLM NIM from https://catalog.ngc.nvidia.com.
+# Self-hosted Nemotron-3-Nano-Omni NIM (serves both the `llm` and
+# `agent_llm` roles). This matches the model family used by the default local
+# deployment. Swap in any compatible NIM from https://catalog.ngc.nvidia.com.
 # To adapt a sample, copy the `llm` entry from
 # ../models.vlm_llm_nim.json into its active models JSON, change only
 # `deployment.ownership` from `managed` to `reused`, and keep service
 # `llm-nim` on port 8110. Duplicate it as `agent_llm` when the sample uses
 # that role.
 # UNTESTED ESTIMATE for this GPU profile; validated values are dual_48G_ada's.
-image:     nvcr.io/nim/nvidia/nemotron-3-nano:2.0.10
+image:     nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:2.0.4-variant
 http_port: 8110
 
 nim_cache: ../../../../models/nim
@@ -20,6 +19,5 @@ cuda_visible_devices: "0"
 env:
   NIM_MAX_MODEL_LEN: "32768"
   NIM_KVCACHE_PERCENT: "0.35"
-  # nemotron_v3 is the parser built into this NIM (nano_v3 is absent);
-  # without tool-calling flags the agentic loop gets no tool calls.
+  # Match the local Omni deployment's reasoning and tool-call parsers.
   NIM_PASSTHROUGH_ARGS: "--enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser nemotron_v3"

--- a/agent-samples/model-servers/yaml/spark/piper_tts_server.yaml
+++ b/agent-samples/model-servers/yaml/spark/piper_tts_server.yaml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Shared CPU Piper TTS service.
+voice: en_US-lessac-medium
+port: 8105
+use_cuda: false
+model_cache: ../../../../models

--- a/agent-samples/model-servers/yaml/spark/piper_tts_server.yaml
+++ b/agent-samples/model-servers/yaml/spark/piper_tts_server.yaml
@@ -5,4 +5,5 @@
 voice: en_US-lessac-medium
 port: 8105
 use_cuda: false
+startup_timeout_s: 600
 model_cache: ../../../../models

--- a/agent-samples/simple-vlm-example/README.md
+++ b/agent-samples/simple-vlm-example/README.md
@@ -42,12 +42,10 @@ No MCP client or MCP tool invocation is part of this sample.
 The sample reuses model services and never starts or stops them. Its fixed
 `yaml/models.json` expects Parakeet STT on port 8103, Cosmos3-Nano on port
 8100, and Piper TTS on port 8105. Start compatible services before the sample.
-For the repository defaults, run these from the repository root (the Piper
-command stays in the foreground):
+For the repository defaults, run the shared stack from the repository root:
 
 ```bash
 uv run --project agent-samples/model-servers model_servers
-uv run --project services/piper-tts piper_tts_server
 ```
 
 Then, in another terminal:

--- a/agent-samples/tea-making-sample/README.md
+++ b/agent-samples/tea-making-sample/README.md
@@ -16,11 +16,10 @@ responsibilities, and how to adapt the sample.
 
 ## Run it
 
-Start the reusable model services, then start Piper TTS in a terminal:
+Start the reusable model services, including Piper TTS:
 
 ```bash
 uv run --project agent-samples/model-servers model_servers
-uv run --project services/piper-tts piper_tts_server
 ```
 
 Then start the tea stack from the repository root:

--- a/agent-samples/xr-render-demo/README.md
+++ b/agent-samples/xr-render-demo/README.md
@@ -109,7 +109,6 @@ changes). Offline cases in `harness.py` exercise the prompt without a live stack
 ```bash
 # Start model services first:
 uv run --project agent-samples/model-servers model_servers
-uv run --project services/piper-tts piper_tts_server
 
 # Start the demo stack in another terminal:
 uv run --project agent-samples/xr-render-demo xr_render_demo

--- a/agent-samples/xr-render-demo/main.py
+++ b/agent-samples/xr-render-demo/main.py
@@ -19,10 +19,9 @@ runs alongside as its own stream; neither stack passes through the other.
 Prerequisites
 -------------
 All model services must already be running before this demo starts. The sample
-never starts or stops them. Start the shared model stack and Piper TTS:
+never starts or stops them. The shared model stack includes Piper TTS:
 
     uv run --project agent-samples/model-servers model_servers
-    uv run --project services/piper-tts piper_tts_server
 
 How to run (from the repo root or any directory):
     uv run --project agent-samples/xr-render-demo xr_render_demo

--- a/docs/source/components/ai-services.md
+++ b/docs/source/components/ai-services.md
@@ -265,7 +265,7 @@ uv run --project agent-samples/model-servers model_servers --models vlm_llm_nim
 ```
 
 - `vlm_llm_nim`: Nemotron-3-Nano and Cosmos3-Nano Reasoner as NIM
-  containers, with STT and embedding served locally. Samples reuse these
+  containers, with STT, Piper TTS, and embedding served locally. Samples reuse these
   endpoints; they never launch or stop the containers.
 
 To adapt a sample, copy the relevant `llm` and `vlm` entries from
@@ -359,7 +359,8 @@ Either way vLLM keeps running after the orchestrator exits.
 The STT server follows the same pattern without Docker: `stt_server` spawns
 its persistent process with `start_new_session=True`, reuses a healthy server
 that survived a previous stack run, and is stopped by the same
-`model_servers --stop` cleanup.
+`model_servers --stop` cleanup. The CPU Piper server is also launched as a
+persistent shared service and is stopped by the same command.
 
 Docker containers carry a fingerprint of their image, GPU assignment, model
 cache, environment, bootstrap packages, complete vLLM command, and a versioned

--- a/docs/source/components/ai-services.md
+++ b/docs/source/components/ai-services.md
@@ -264,7 +264,7 @@ image and ports) or as a local server:
 uv run --project agent-samples/model-servers model_servers --models vlm_llm_nim
 ```
 
-- `vlm_llm_nim`: Nemotron-3-Nano and Cosmos3-Nano Reasoner as NIM
+- `vlm_llm_nim`: Nemotron-3 Nano Omni and Cosmos3-Nano Reasoner as NIM
   containers, with STT, Piper TTS, and embedding served locally. Samples reuse these
   endpoints; they never launch or stop the containers.
 

--- a/docs/source/components/ai-services.md
+++ b/docs/source/components/ai-services.md
@@ -377,10 +377,10 @@ uv run --project agent-samples/xr-render-demo xr_render_demo --stop
 
 Cleanup locates labelled Docker containers before inspecting ports, then
 stops them with `docker stop` (escalating to `docker kill` after 20 s).
-Pip-mode processes must carry the `XR_AI_VLLM_MANAGED` and
-`XR_AI_VLLM_PORT` ownership markers before cleanup sends `SIGTERM` or
-`SIGKILL`. Unknown listeners and failed inspection abort cleanup without
-sending a signal; absent servers are silently skipped.
+Locally persisted processes (pip-mode vLLM and Piper) must carry the
+`XR_AI_VLLM_MANAGED` and `XR_AI_VLLM_PORT` ownership markers before cleanup
+sends `SIGTERM` or `SIGKILL`. Unknown listeners and failed inspection abort
+cleanup without sending a signal; absent servers are silently skipped.
 
 The target ports and container names match the defaults in the per-profile YAML files.
 

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -61,7 +61,7 @@ Which servers start is a deployment profile selected with
 `--models <name|path>`. The default starts Nemotron-3 Nano Omni (8108,
 serving both LLM roles), Cosmos3 Nano Reasoner (8100), STT (8103), Piper TTS
 (8105), and embeddings (8109); `vlm_llm_nim` serves the LLM and VLM as self-hosted NIM
-containers (Nemotron-3-Nano and Cosmos3-Nano Reasoner; requires docker and
+containers (Nemotron-3 Nano Omni and Cosmos3-Nano Reasoner; requires docker and
 `NGC_API_KEY`). Starting a profile stops persisted servers outside it first
 and aborts if they cannot be stopped, avoiding GPU overcommit.
 

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -270,13 +270,7 @@ This demo has two extra host prerequisites beyond the shared
 - **npm 18+** on PATH — the orchestrator builds the web vendor bundle on first
   run (skipped on subsequent runs).
 
-Start the shared model stack, which includes Piper TTS:
-
-```bash
-uv run --project agent-samples/model-servers model_servers
-```
-
-Then start XR Render:
+Start XR Render:
 
 ```bash
 cd agent-samples/xr-render-demo

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -59,8 +59,8 @@ tens of minutes). On subsequent runs the containers restart in under a minute.
 
 Which servers start is a deployment profile selected with
 `--models <name|path>`. The default starts Nemotron-3 Nano Omni (8108,
-serving both LLM roles), Cosmos3 Nano Reasoner (8100), STT (8103), and
-embeddings (8109); `vlm_llm_nim` serves the LLM and VLM as self-hosted NIM
+serving both LLM roles), Cosmos3 Nano Reasoner (8100), STT (8103), Piper TTS
+(8105), and embeddings (8109); `vlm_llm_nim` serves the LLM and VLM as self-hosted NIM
 containers (Nemotron-3-Nano and Cosmos3-Nano Reasoner; requires docker and
 `NGC_API_KEY`). Starting a profile stops persisted servers outside it first
 and aborts if they cannot be stopped, avoiding GPU overcommit.
@@ -94,14 +94,13 @@ Uses the text-output Reasoner from `nvidia/Cosmos3-Nano` by default. Refer to
 The sample always reuses model services and never starts or stops them. Its
 fixed `yaml/models.json` expects Parakeet STT on port 8103, Cosmos3-Nano on
 port 8100, and Piper TTS on port 8105. Start the repository defaults first
-from the repository root (the Piper command stays in the foreground):
+from the repository root:
 
 ```bash
 uv run --project agent-samples/model-servers model_servers
-uv run --project services/piper-tts piper_tts_server
 ```
 
-The first command may download model weights on its first run and requires the
+The command may download model weights on its first run and requires the
 credentials described in the {doc}`credentials guide
 </getting_started/credentials>`. The model services remain running across
 sample restarts.
@@ -177,14 +176,10 @@ final pre-gate transcript, foreground-turn, and Relay JSONL files under `artifac
 and intentionally serves no sample-specific monitoring web UI. Its fixed model
 configuration uses Cosmos for visual inference.
 
-Start `model-servers` and Piper TTS in separate terminals:
+Start the shared `model-servers` stack, which includes Piper TTS:
 
 ```bash
 uv run --project agent-samples/model-servers model_servers
-```
-
-```bash
-uv run --project services/piper-tts piper_tts_server
 ```
 
 Then start the sample in another terminal:
@@ -211,11 +206,10 @@ and visual inference. Records are written as JSON Lines under the sample's
 `artifacts/` directory. A separate live event viewer presents selected runtime
 events without replacing those durable records.
 
-Start the shared model services and Piper TTS first, then launch the sample:
+Start the shared model services, including Piper TTS, then launch the sample:
 
 ```bash
 uv run --project agent-samples/model-servers model_servers
-uv run --project services/piper-tts piper_tts_server
 
 uv run --project agent-samples/tea-making-sample tea_making_sample
 ```
@@ -276,10 +270,10 @@ This demo has two extra host prerequisites beyond the shared
 - **npm 18+** on PATH — the orchestrator builds the web vendor bundle on first
   run (skipped on subsequent runs).
 
-Start Piper TTS in a separate terminal:
+Start the shared model stack, which includes Piper TTS:
 
 ```bash
-uv run --project services/piper-tts piper_tts_server
+uv run --project agent-samples/model-servers model_servers
 ```
 
 Then start XR Render:

--- a/docs/source/guides/customizing-model-servers.md
+++ b/docs/source/guides/customizing-model-servers.md
@@ -37,7 +37,7 @@ The shipped profiles are:
 - `default`: local Parakeet STT, Piper TTS, Nemotron Omni, Cosmos3-Nano
   Reasoner, and Nemotron embedding services.
 - `vlm_llm_nim`: local STT, Piper TTS, and embedding plus self-hosted
-  Nemotron-3-Nano and Cosmos3-Nano Reasoner NIM containers.
+  Nemotron-3 Nano Omni and Cosmos3-Nano Reasoner NIM containers.
 
 Copy the closest profile under a new name:
 

--- a/docs/source/guides/customizing-model-servers.md
+++ b/docs/source/guides/customizing-model-servers.md
@@ -34,10 +34,10 @@ selects the deployment profile independently.
 
 The shipped profiles are:
 
-- `default`: local Parakeet STT, Nemotron Omni, Cosmos3-Nano Reasoner, and
-  Nemotron embedding services.
-- `vlm_llm_nim`: local STT and embedding plus self-hosted Nemotron-3-Nano and
-  Cosmos3-Nano Reasoner NIM containers.
+- `default`: local Parakeet STT, Piper TTS, Nemotron Omni, Cosmos3-Nano
+  Reasoner, and Nemotron embedding services.
+- `vlm_llm_nim`: local STT, Piper TTS, and embedding plus self-hosted
+  Nemotron-3-Nano and Cosmos3-Nano Reasoner NIM containers.
 
 Copy the closest profile under a new name:
 

--- a/docs/source/reference/tea-making-sample.md
+++ b/docs/source/reference/tea-making-sample.md
@@ -37,11 +37,10 @@ ownership, and event composition are reusable.
 ## Quick start
 
 Run commands from the repository root. The tea sample reuses all model
-services, so start the shared stack and Piper TTS first:
+services, so start the shared stack, including Piper TTS, first:
 
 ```bash
 uv run --project agent-samples/model-servers model_servers
-uv run --project services/piper-tts piper_tts_server
 ```
 
 Then launch the sample:

--- a/services/piper-tts/piper_tts_server.yaml
+++ b/services/piper-tts/piper_tts_server.yaml
@@ -11,4 +11,5 @@
 voice:       en_US-lessac-medium
 port:        8105
 use_cuda:    false    # CPU is fast enough (~100 ms/sentence)
+startup_timeout_s: 600
 model_cache: ../../models

--- a/services/piper-tts/piper_tts_server/__main__.py
+++ b/services/piper-tts/piper_tts_server/__main__.py
@@ -296,10 +296,25 @@ def _health_url_ok(health_url: str) -> bool:
         return False
 
 
-def _port_open(port: int) -> bool:
-    """Return True if a process is already listening on the local port."""
+def _probe_host(bind_host: str) -> str:
+    """Return a reachable local address for a configured bind host."""
+    return {
+        "": "127.0.0.1",
+        "0.0.0.0": "127.0.0.1",
+        "::": "::1",
+    }.get(bind_host, bind_host)
+
+
+def _health_url(host: str, port: int) -> str:
+    """Return the health URL for a concrete probe host and port."""
+    url_host = f"[{host}]" if ":" in host else host
+    return f"http://{url_host}:{port}/health"
+
+
+def _port_open(host: str, port: int) -> bool:
+    """Return True if a process is already listening on the probe address."""
     try:
-        with socket.create_connection(("127.0.0.1", port), timeout=1):
+        with socket.create_connection((host, port), timeout=1):
             return True
     except OSError:
         return False
@@ -509,13 +524,14 @@ def run() -> None:
         return
 
     port = int(cfg.get("port", _DEFAULT_PORT))
+    probe_host = _probe_host(str(cfg.get("host", "0.0.0.0")))
     try:
         startup_timeout_s = _parse_startup_timeout(
             cfg.get("startup_timeout_s", _DEFAULT_STARTUP_TIMEOUT_S)
         )
     except ValueError as exc:
         raise SystemExit(f"[piper_tts_server] {exc}") from exc
-    health_url = f"http://127.0.0.1:{port}/health"
+    health_url = _health_url(probe_host, port)
 
     if _health_url_ok(health_url):
         print(
@@ -527,7 +543,7 @@ def run() -> None:
         _idle_until_stopped(health_url)
         return
 
-    if _port_open(port):
+    if _port_open(probe_host, port):
         raise SystemExit(
             f"[piper_tts_server] port {port} is already in use, but its "
             "/health endpoint is not healthy"

--- a/services/piper-tts/piper_tts_server/__main__.py
+++ b/services/piper-tts/piper_tts_server/__main__.py
@@ -422,44 +422,66 @@ def _idle_until_stopped(
     poll_s: float = 5.0,
 ) -> None:
     """Keep the wrapper alive while the persisted server is still running."""
+    pending_signal: int | None = None
+
+    def _stop_owned_child(signum, _frame) -> None:
+        nonlocal pending_signal
+        if pending_signal is not None:
+            return
+        pending_signal = signum
+        raise SystemExit(128 + signum)
+
+    previous_handlers = {}
+    if process is not None:
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            previous_handlers[sig] = signal.signal(sig, _stop_owned_child)
+
     health_failures = 0
-    while True:
-        if process is None:
-            time.sleep(poll_s)
-        else:
-            try:
-                returncode = process.wait(timeout=poll_s)
-            except subprocess.TimeoutExpired:
-                pass
+    try:
+        while True:
+            if process is None:
+                time.sleep(poll_s)
             else:
-                if returncode != 0:
-                    raise SystemExit(
-                        "[piper_tts_server] persistent server exited "
-                        f"with status {returncode}"
-                    )
+                try:
+                    returncode = process.wait(timeout=poll_s)
+                except subprocess.TimeoutExpired:
+                    pass
+                else:
+                    if returncode != 0:
+                        raise SystemExit(
+                            "[piper_tts_server] persistent server exited "
+                            f"with status {returncode}"
+                        )
+                    return
+
+            if _health_url_ok(health_url):
+                health_failures = 0
+                continue
+
+            if process is None:
                 return
 
-        if _health_url_ok(health_url):
-            health_failures = 0
-            continue
+            health_failures += 1
+            if health_failures < _IDLE_HEALTH_FAILURE_LIMIT:
+                print(
+                    f"[piper_tts_server] health endpoint unreachable "
+                    f"({health_failures}/{_IDLE_HEALTH_FAILURE_LIMIT}); retrying",
+                    flush=True,
+                )
+                continue
 
-        if process is None:
-            return
-
-        health_failures += 1
-        if health_failures < _IDLE_HEALTH_FAILURE_LIMIT:
-            print(
-                f"[piper_tts_server] health endpoint unreachable "
-                f"({health_failures}/{_IDLE_HEALTH_FAILURE_LIMIT}); retrying",
-                flush=True,
+            raise SystemExit(
+                f"[piper_tts_server] persistent server failed "
+                f"{_IDLE_HEALTH_FAILURE_LIMIT} consecutive health checks; terminated"
             )
-            continue
-
-        _terminate_process(process)
-        raise SystemExit(
-            f"[piper_tts_server] persistent server failed "
-            f"{_IDLE_HEALTH_FAILURE_LIMIT} consecutive health checks; terminated"
-        )
+    except (KeyboardInterrupt, SystemExit):
+        pending_signal = pending_signal or 0
+        if process is not None:
+            _terminate_process(process)
+        raise
+    finally:
+        for sig, handler in previous_handlers.items():
+            signal.signal(sig, handler)
 
 
 def run() -> None:

--- a/services/piper-tts/piper_tts_server/__main__.py
+++ b/services/piper-tts/piper_tts_server/__main__.py
@@ -32,6 +32,7 @@ import argparse
 import asyncio
 import io
 import math
+import os
 import signal
 import socket
 import subprocess
@@ -381,6 +382,7 @@ def _start_persistent_server(
     cmd: list[str],
     health_url: str,
     startup_timeout_s: float,
+    env: dict[str, str] | None = None,
 ) -> subprocess.Popen:
     """Start the detached server and return it once its health check passes."""
     process: subprocess.Popen | None = None
@@ -398,7 +400,7 @@ def _start_persistent_server(
     try:
         for sig in (signal.SIGINT, signal.SIGTERM):
             previous_handlers[sig] = signal.signal(sig, _abort_startup)
-        process = subprocess.Popen(cmd, start_new_session=True)
+        process = subprocess.Popen(cmd, env=env, start_new_session=True)
         if pending_signal is not None:
             raise SystemExit(128 + pending_signal)
         _wait_until_healthy(process, health_url, startup_timeout_s)
@@ -518,7 +520,15 @@ def run() -> None:
         flush=True,
     )
     try:
-        process = _start_persistent_server(cmd, health_url, startup_timeout_s)
+        process = _start_persistent_server(
+            cmd,
+            health_url,
+            startup_timeout_s,
+            env=os.environ | {
+                "XR_AI_VLLM_MANAGED": "1",
+                "XR_AI_VLLM_PORT": str(port),
+            },
+        )
     except (RuntimeError, TimeoutError) as exc:
         raise SystemExit(f"[piper_tts_server] {exc}") from exc
 

--- a/services/piper-tts/piper_tts_server/__main__.py
+++ b/services/piper-tts/piper_tts_server/__main__.py
@@ -24,22 +24,34 @@ Config keys
     port:         int   HTTP port (default: 8105)
     host:         str   Bind address (default: "0.0.0.0")
     use_cuda:     bool  Run ONNX on CUDA (default: false — CPU is fast enough)
+    startup_timeout_s: float  Seconds allowed for a cold start (default: 600)
     model_cache:  str   Voice model cache path, resolved relative to this YAML.
                         Default: ../../models
 """
 import argparse
+import asyncio
 import io
+import math
+import signal
+import socket
+import subprocess
 import sys
 import threading
+import time
+import urllib.request
 import wave
+from contextlib import suppress
 from pathlib import Path
 
 import yaml
 from loguru import logger
 from xr_ai_logging import setup_logging
 
-_DEFAULT_PORT   = 8105
-_HF_REPO        = "rhasspy/piper-voices"
+_DEFAULT_PORT              = 8105
+_DEFAULT_STARTUP_TIMEOUT_S = 600.0
+_PROCESS_STOP_TIMEOUT_S    = 10.0
+_IDLE_HEALTH_FAILURE_LIMIT = 3
+_HF_REPO                   = "rhasspy/piper-voices"
 
 # Exit code for "the voice could not be obtained for environmental reasons"
 # (offline with an empty cache, or a transient HuggingFace download failure),
@@ -49,6 +61,21 @@ _EXIT_VOICE_UNAVAILABLE = 3
 
 _TRUE_BOOL_STRINGS = {"1", "true", "yes", "on"}
 _FALSE_BOOL_STRINGS = {"0", "false", "no", "off"}
+
+
+def _parse_startup_timeout(value: object) -> float:
+    """Return a positive finite startup timeout from user configuration."""
+    try:
+        timeout_s = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "'startup_timeout_s' must be a finite number greater than zero"
+        ) from exc
+    if not math.isfinite(timeout_s) or timeout_s <= 0:
+        raise ValueError(
+            "'startup_timeout_s' must be a finite number greater than zero"
+        )
+    return timeout_s
 
 
 def _parse_config_bool(value: object, key: str) -> bool:
@@ -213,8 +240,6 @@ class _PiperBackend:
 
 
 def _build_app(cfg: dict, model_cache: Path):
-    import asyncio
-
     from fastapi import FastAPI
     from fastapi.responses import Response
     from pydantic import BaseModel
@@ -261,8 +286,25 @@ def _build_app(cfg: dict, model_cache: Path):
     return app, backend
 
 
-async def _run(cfg: dict, yaml_dir: Path, ready_file: Path | None = None) -> None:
-    import asyncio
+def _health_url_ok(health_url: str) -> bool:
+    """Return True if *health_url* answers successfully."""
+    try:
+        with urllib.request.urlopen(health_url, timeout=2) as response:
+            return response.status == 200
+    except Exception:
+        return False
+
+
+def _port_open(port: int) -> bool:
+    """Return True if a process is already listening on the local port."""
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=1):
+            return True
+    except OSError:
+        return False
+
+
+async def _run(cfg: dict, yaml_dir: Path) -> None:
     import uvicorn
 
     if not cfg.get("voice"):
@@ -281,16 +323,144 @@ async def _run(cfg: dict, yaml_dir: Path, ready_file: Path | None = None) -> Non
     config = uvicorn.Config(app, host=host, port=port, log_level="warning")
     server = uvicorn.Server(config)
 
-    logger.info("Ready  →  http://localhost:{}/v1", port)
-    if ready_file:
-        ready_file.touch()
+    logger.info("Starting HTTP server on http://localhost:{}/v1", port)
     await server.serve()
     logger.info("Stopped.")
 
 
-def run() -> None:
-    import asyncio
+def _wait_until_healthy(
+    process: subprocess.Popen,
+    health_url: str,
+    timeout_s: float,
+    poll_s: float = 1.0,
+) -> None:
+    """Wait for health while reporting a detached server crash immediately."""
+    deadline = time.monotonic() + timeout_s
+    while True:
+        returncode = process.poll()
+        if returncode is not None:
+            raise RuntimeError(
+                f"server exited with status {returncode} before becoming healthy"
+            )
+        if _health_url_ok(health_url):
+            return
 
+        remaining_s = deadline - time.monotonic()
+        if remaining_s <= 0:
+            raise TimeoutError(
+                f"server did not become healthy within {timeout_s:g} seconds"
+            )
+
+        try:
+            returncode = process.wait(timeout=min(poll_s, remaining_s))
+        except subprocess.TimeoutExpired:
+            continue
+        raise RuntimeError(
+            f"server exited with status {returncode} before becoming healthy"
+        )
+
+
+def _terminate_process(
+    process: subprocess.Popen,
+    timeout_s: float = _PROCESS_STOP_TIMEOUT_S,
+) -> None:
+    """Terminate and reap a detached server, escalating if it does not stop."""
+    if process.poll() is not None:
+        return
+    with suppress(ProcessLookupError):
+        process.terminate()
+    try:
+        process.wait(timeout=timeout_s)
+    except subprocess.TimeoutExpired:
+        with suppress(ProcessLookupError):
+            process.kill()
+        process.wait()
+
+
+def _start_persistent_server(
+    cmd: list[str],
+    health_url: str,
+    startup_timeout_s: float,
+) -> subprocess.Popen:
+    """Start the detached server and return it once its health check passes."""
+    process: subprocess.Popen | None = None
+    pending_signal: int | None = None
+
+    def _abort_startup(signum, _frame) -> None:
+        nonlocal pending_signal
+        if pending_signal is not None:
+            return
+        pending_signal = signum
+        if process is not None:
+            raise SystemExit(128 + signum)
+
+    previous_handlers = {}
+    try:
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            previous_handlers[sig] = signal.signal(sig, _abort_startup)
+        process = subprocess.Popen(cmd, start_new_session=True)
+        if pending_signal is not None:
+            raise SystemExit(128 + pending_signal)
+        _wait_until_healthy(process, health_url, startup_timeout_s)
+    except (Exception, KeyboardInterrupt, SystemExit):
+        pending_signal = pending_signal or 0
+        if process is not None:
+            _terminate_process(process)
+        raise
+    finally:
+        for sig, handler in previous_handlers.items():
+            signal.signal(sig, handler)
+    assert process is not None
+    return process
+
+
+def _idle_until_stopped(
+    health_url: str,
+    process: subprocess.Popen | None = None,
+    poll_s: float = 5.0,
+) -> None:
+    """Keep the wrapper alive while the persisted server is still running."""
+    health_failures = 0
+    while True:
+        if process is None:
+            time.sleep(poll_s)
+        else:
+            try:
+                returncode = process.wait(timeout=poll_s)
+            except subprocess.TimeoutExpired:
+                pass
+            else:
+                if returncode != 0:
+                    raise SystemExit(
+                        "[piper_tts_server] persistent server exited "
+                        f"with status {returncode}"
+                    )
+                return
+
+        if _health_url_ok(health_url):
+            health_failures = 0
+            continue
+
+        if process is None:
+            return
+
+        health_failures += 1
+        if health_failures < _IDLE_HEALTH_FAILURE_LIMIT:
+            print(
+                f"[piper_tts_server] health endpoint unreachable "
+                f"({health_failures}/{_IDLE_HEALTH_FAILURE_LIMIT}); retrying",
+                flush=True,
+            )
+            continue
+
+        _terminate_process(process)
+        raise SystemExit(
+            f"[piper_tts_server] persistent server failed "
+            f"{_IDLE_HEALTH_FAILURE_LIMIT} consecutive health checks; terminated"
+        )
+
+
+def run() -> None:
     sys.stdout.reconfigure(line_buffering=True)
     sys.stderr.reconfigure(line_buffering=True)
 
@@ -299,6 +469,8 @@ def run() -> None:
     p = argparse.ArgumentParser(add_help=False)
     p.add_argument("--config",     type=Path, default=None)
     p.add_argument("--ready-file", type=Path, default=None)
+    p.add_argument("--_serve",     action="store_true",
+                   help=argparse.SUPPRESS)
     ns, _ = p.parse_known_args()
 
     cfg: dict = {}
@@ -308,7 +480,52 @@ def run() -> None:
         with open(ns.config) as f:
             cfg = yaml.safe_load(f) or {}
 
-    asyncio.run(_run(cfg, yaml_dir, ready_file=ns.ready_file))
+    if ns._serve:
+        asyncio.run(_run(cfg, yaml_dir))
+        return
+
+    port = int(cfg.get("port", _DEFAULT_PORT))
+    try:
+        startup_timeout_s = _parse_startup_timeout(
+            cfg.get("startup_timeout_s", _DEFAULT_STARTUP_TIMEOUT_S)
+        )
+    except ValueError as exc:
+        raise SystemExit(f"[piper_tts_server] {exc}") from exc
+    health_url = f"http://127.0.0.1:{port}/health"
+
+    if _health_url_ok(health_url):
+        print(
+            f"[piper_tts_server] already running on port {port} — reusing",
+            flush=True,
+        )
+        if ns.ready_file:
+            ns.ready_file.touch()
+        _idle_until_stopped(health_url)
+        return
+
+    if _port_open(port):
+        raise SystemExit(
+            f"[piper_tts_server] port {port} is already in use, but its "
+            "/health endpoint is not healthy"
+        )
+
+    cmd = [sys.executable, "-m", "piper_tts_server", "--_serve"]
+    if ns.config:
+        cmd += ["--config", str(ns.config)]
+    print(
+        f"[piper_tts_server] starting persistent server on port {port} "
+        f"(startup timeout: {startup_timeout_s:g}s)…",
+        flush=True,
+    )
+    try:
+        process = _start_persistent_server(cmd, health_url, startup_timeout_s)
+    except (RuntimeError, TimeoutError) as exc:
+        raise SystemExit(f"[piper_tts_server] {exc}") from exc
+
+    print(f"[piper_tts_server] Ready  →  http://localhost:{port}/v1", flush=True)
+    if ns.ready_file:
+        ns.ready_file.touch()
+    _idle_until_stopped(health_url, process)
 
 
 if __name__ == "__main__":

--- a/tests/test_model_servers.py
+++ b/tests/test_model_servers.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import os.path
+import shlex
 import sys
 from pathlib import Path
 
@@ -156,17 +157,25 @@ def test_nim_profiles_serve_cosmos3_nano_reasoner(config_path: Path) -> None:
 )
 def test_nim_profiles_serve_nemotron_omni(config_path: Path) -> None:
     config = yaml.safe_load(config_path.read_text())
+    env = config["env"]
+    args = shlex.split(env["NIM_PASSTHROUGH_ARGS"])
+    expected_budget = {
+        "spark": "0.35",
+        "96G_blackwell": "0.4",
+        "dual_48G_ada": "0.8",
+    }[config_path.parent.name]
 
     assert config["image"] == (
         "nvcr.io/nim/nvidia/"
         "nemotron-3-nano-omni-30b-a3b-reasoning:2.0.4-variant"
     )
-    assert "--reasoning-parser nemotron_v3" in (
-        config["env"]["NIM_PASSTHROUGH_ARGS"]
-    )
-    assert "--tool-call-parser qwen3_coder" in (
-        config["env"]["NIM_PASSTHROUGH_ARGS"]
-    )
+    assert "NIM_KVCACHE_PERCENT" not in env
+    memory_index = args.index("--gpu-memory-utilization")
+    assert args[memory_index + 1] == expected_budget
+    assert "--reasoning-parser" in args
+    assert args[args.index("--reasoning-parser") + 1] == "nemotron_v3"
+    assert "--tool-call-parser" in args
+    assert args[args.index("--tool-call-parser") + 1] == "qwen3_coder"
 
 
 def test_custom_profiles_can_still_launch_riva_speech_nims(

--- a/tests/test_model_servers.py
+++ b/tests/test_model_servers.py
@@ -45,8 +45,15 @@ def test_default_profile_uses_omni_and_cosmos(monkeypatch: pytest.MonkeyPatch) -
 
     processes, credentials = _model_servers._build_processes("default")
 
-    assert [process.name for process in processes] == ["stt", "omni", "vlm", "embedding"]
-    assert [process.port for process in processes] == [8103, 8108, 8100, 8109]
+    assert [process.name for process in processes] == [
+        "stt", "tts", "omni", "vlm", "embedding",
+    ]
+    assert [process.port for process in processes] == [8103, 8105, 8108, 8100, 8109]
+    tts = next(process for process in processes if process.name == "tts")
+    assert tts.project == "../../services/piper-tts"
+    assert tts.command == "piper_tts_server"
+    assert Path(tts.config).name == "piper_tts_server.yaml"
+    assert tts.launch_mode == "persist"
     assert credentials == ()
 
 
@@ -102,6 +109,7 @@ def test_known_ports_are_discovered_from_service_yaml() -> None:
         ("llm-nim", 8110),
         ("vlm-nim", 8100),
         ("stt", 8103),
+        ("tts", 8105),
         ("agent-llm", 8107),
         ("omni", 8108),
         ("vlm", 8100),
@@ -117,9 +125,9 @@ def test_nim_profile_mixes_nim_containers_and_local_servers(
     processes, credentials = _model_servers._build_processes("vlm_llm_nim")
 
     assert [process.name for process in processes] == [
-        "llm-nim", "vlm-nim", "stt", "embedding",
+        "llm-nim", "vlm-nim", "stt", "tts", "embedding",
     ]
-    assert [process.port for process in processes] == [8110, 8100, 8103, 8109]
+    assert [process.port for process in processes] == [8110, 8100, 8103, 8105, 8109]
     assert credentials == ("NGC_API_KEY",)
 
 
@@ -232,6 +240,7 @@ def test_stop_cleans_every_service(monkeypatch: pytest.MonkeyPatch) -> None:
         ("llm-nim", 8110),
         ("vlm-nim", 8100),
         ("stt", 8103),
+        ("tts", 8105),
         ("agent-llm", 8107),
         ("omni", 8108),
         ("vlm", 8100),

--- a/tests/test_model_servers.py
+++ b/tests/test_model_servers.py
@@ -146,6 +146,29 @@ def test_nim_profiles_serve_cosmos3_nano_reasoner(config_path: Path) -> None:
     assert config["env"]["NIM_MODEL_SIZE"] == "nano"
 
 
+@pytest.mark.parametrize(
+    "config_path",
+    sorted(
+        (_REPO_ROOT / "agent-samples/model-servers/yaml").glob(
+            "*/nim_llm_server.yaml"
+        )
+    ),
+)
+def test_nim_profiles_serve_nemotron_omni(config_path: Path) -> None:
+    config = yaml.safe_load(config_path.read_text())
+
+    assert config["image"] == (
+        "nvcr.io/nim/nvidia/"
+        "nemotron-3-nano-omni-30b-a3b-reasoning:2.0.4-variant"
+    )
+    assert "--reasoning-parser nemotron_v3" in (
+        config["env"]["NIM_PASSTHROUGH_ARGS"]
+    )
+    assert "--tool-call-parser qwen3_coder" in (
+        config["env"]["NIM_PASSTHROUGH_ARGS"]
+    )
+
+
 def test_custom_profiles_can_still_launch_riva_speech_nims(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_nim_docker.py
+++ b/tests/test_nim_docker.py
@@ -203,9 +203,14 @@ def test_model_servers_nim_profile_parses() -> None:
     cfg = load_models_config(_MS_YAML / "models.vlm_llm_nim.json")
     llm = cfg.llm("llm")
     assert llm.kind == "openai_compat"
-    assert llm.model_name == "nvidia/nemotron-3-nano"
-    # The NIM chat template defaults thinking ON (local vLLM off); without
-    # the pin, non-thinking agent calls truncate mid-reasoning.
+    assert llm.model_name == (
+        "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
+    )
+    assert llm.reasoning_field == "reasoning"
+    assert llm.capabilities.get("vision") is True
+    assert llm.capabilities.get("video") is True
+    # The NIM chat template defaults thinking on; without the pin,
+    # non-thinking agent calls can truncate mid-reasoning.
     assert llm.default_extras["chat_template_kwargs"] == {"enable_thinking": False}
     vlm = cfg.vlm("vlm")
     assert vlm.model_name == "nvidia/cosmos3-nano-reasoner"

--- a/tests/test_piper_tts.py
+++ b/tests/test_piper_tts.py
@@ -150,6 +150,24 @@ async def test_piper_wait_reports_child_exit_before_health(monkeypatch) -> None:
     process.wait.assert_not_called()
 
 
+async def test_piper_marks_persistent_child_for_cleanup(monkeypatch) -> None:
+    module = _load_piper_main_module()
+    process = Mock()
+    start = Mock(return_value=process)
+    monkeypatch.setattr(module, "setup_logging", lambda *_args: None)
+    monkeypatch.setattr(module, "_health_url_ok", lambda _url: False)
+    monkeypatch.setattr(module, "_port_open", lambda _port: False)
+    monkeypatch.setattr(module, "_start_persistent_server", start)
+    monkeypatch.setattr(module, "_idle_until_stopped", lambda *_args: None)
+    monkeypatch.setattr(module.sys, "argv", ["piper_tts_server"])
+
+    module.run()
+
+    child_env = start.call_args.kwargs["env"]
+    assert child_env["XR_AI_VLLM_MANAGED"] == "1"
+    assert child_env["XR_AI_VLLM_PORT"] == "8105"
+
+
 class _ServerExited(Exception):
     """Raised when piper_tts_server exits before binding its port.
 

--- a/tests/test_piper_tts.py
+++ b/tests/test_piper_tts.py
@@ -111,6 +111,56 @@ async def test_piper_reuses_healthy_persistent_server(
     idle.assert_called_once_with("http://127.0.0.1:8105/health")
 
 
+async def test_piper_probes_configured_non_loopback_host(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_piper_main_module()
+    config_path = tmp_path / "piper.yaml"
+    config_path.write_text(yaml.safe_dump({"host": "192.0.2.10", "port": 8123}))
+    health = Mock(return_value=False)
+    port_open = Mock(return_value=False)
+    process = Mock()
+    start = Mock(return_value=process)
+    idle = Mock()
+    monkeypatch.setattr(module, "setup_logging", lambda *_args: None)
+    monkeypatch.setattr(module, "_health_url_ok", health)
+    monkeypatch.setattr(module, "_port_open", port_open)
+    monkeypatch.setattr(module, "_start_persistent_server", start)
+    monkeypatch.setattr(module, "_idle_until_stopped", idle)
+    monkeypatch.setattr(
+        module.sys,
+        "argv",
+        ["piper_tts_server", "--config", str(config_path)],
+    )
+
+    module.run()
+
+    expected_health_url = "http://192.0.2.10:8123/health"
+    health.assert_called_once_with(expected_health_url)
+    port_open.assert_called_once_with("192.0.2.10", 8123)
+    assert start.call_args.args[1] == expected_health_url
+    idle.assert_called_once_with(expected_health_url, process)
+
+
+@pytest.mark.parametrize(
+    ("bind_host", "expected_probe_host", "expected_health_url"),
+    (
+        ("0.0.0.0", "127.0.0.1", "http://127.0.0.1:8105/health"),
+        ("::", "::1", "http://[::1]:8105/health"),
+    ),
+)
+async def test_piper_normalizes_wildcard_probe_hosts(
+    bind_host: str,
+    expected_probe_host: str,
+    expected_health_url: str,
+) -> None:
+    module = _load_piper_main_module()
+    probe_host = module._probe_host(bind_host)
+
+    assert probe_host == expected_probe_host
+    assert module._health_url(probe_host, 8105) == expected_health_url
+
+
 async def test_piper_rejects_unhealthy_listener_without_signaling_ready(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -119,7 +169,7 @@ async def test_piper_rejects_unhealthy_listener_without_signaling_ready(
     start = Mock(side_effect=AssertionError("must not launch into an occupied port"))
     monkeypatch.setattr(module, "setup_logging", lambda *_args: None)
     monkeypatch.setattr(module, "_health_url_ok", lambda _url: False)
-    monkeypatch.setattr(module, "_port_open", lambda _port: True)
+    monkeypatch.setattr(module, "_port_open", lambda _host, _port: True)
     monkeypatch.setattr(module, "_start_persistent_server", start)
     monkeypatch.setattr(
         module.sys,
@@ -156,7 +206,7 @@ async def test_piper_marks_persistent_child_for_cleanup(monkeypatch) -> None:
     start = Mock(return_value=process)
     monkeypatch.setattr(module, "setup_logging", lambda *_args: None)
     monkeypatch.setattr(module, "_health_url_ok", lambda _url: False)
-    monkeypatch.setattr(module, "_port_open", lambda _port: False)
+    monkeypatch.setattr(module, "_port_open", lambda _host, _port: False)
     monkeypatch.setattr(module, "_start_persistent_server", start)
     monkeypatch.setattr(module, "_idle_until_stopped", lambda *_args: None)
     monkeypatch.setattr(module.sys, "argv", ["piper_tts_server"])

--- a/tests/test_piper_tts.py
+++ b/tests/test_piper_tts.py
@@ -29,6 +29,7 @@ import socket  # used by local _port_open below; _pick_port moved to _helpers_su
 import subprocess
 import urllib.request
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 import yaml
@@ -43,6 +44,12 @@ _PIPER_PROJECT = _REPO_ROOT / "services" / "piper-tts"
 _PIPER_BIN     = _PIPER_PROJECT / ".venv" / "bin" / "piper_tts_server"
 _PIPER_YAML    = _PIPER_PROJECT / "piper_tts_server.yaml"
 _DEFAULT_PORT  = 8105
+_PIPER_CONFIGS = (
+    _PIPER_YAML,
+    _REPO_ROOT / "agent-samples/model-servers/yaml/spark/piper_tts_server.yaml",
+    _REPO_ROOT / "agent-samples/model-servers/yaml/96G_blackwell/piper_tts_server.yaml",
+    _REPO_ROOT / "agent-samples/model-servers/yaml/dual_48G_ada/piper_tts_server.yaml",
+)
 
 # Must match _EXIT_VOICE_UNAVAILABLE in piper_tts_server/__main__.py: the
 # server uses this exit code when the voice can't be obtained for
@@ -71,6 +78,76 @@ async def test_piper_config_rejects_unknown_use_cuda_string() -> None:
     module = _load_piper_main_module()
     with pytest.raises(ValueError, match="use_cuda"):
         module._parse_config_bool("sometimes", "use_cuda")
+
+
+@pytest.mark.parametrize("config_path", _PIPER_CONFIGS)
+async def test_piper_configs_allow_cold_start(config_path: Path) -> None:
+    module = _load_piper_main_module()
+    config = yaml.safe_load(config_path.read_text())
+    assert config["startup_timeout_s"] == module._DEFAULT_STARTUP_TIMEOUT_S
+
+
+async def test_piper_reuses_healthy_persistent_server(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_piper_main_module()
+    ready_file = tmp_path / "ready"
+    idle = Mock()
+    start = Mock(side_effect=AssertionError("must not launch a second server"))
+    monkeypatch.setattr(module, "setup_logging", lambda *_args: None)
+    monkeypatch.setattr(module, "_health_url_ok", lambda _url: True)
+    monkeypatch.setattr(module, "_idle_until_stopped", idle)
+    monkeypatch.setattr(module, "_start_persistent_server", start)
+    monkeypatch.setattr(
+        module.sys,
+        "argv",
+        ["piper_tts_server", "--ready-file", str(ready_file)],
+    )
+
+    module.run()
+
+    assert ready_file.exists()
+    start.assert_not_called()
+    idle.assert_called_once_with("http://127.0.0.1:8105/health")
+
+
+async def test_piper_rejects_unhealthy_listener_without_signaling_ready(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_piper_main_module()
+    ready_file = tmp_path / "ready"
+    start = Mock(side_effect=AssertionError("must not launch into an occupied port"))
+    monkeypatch.setattr(module, "setup_logging", lambda *_args: None)
+    monkeypatch.setattr(module, "_health_url_ok", lambda _url: False)
+    monkeypatch.setattr(module, "_port_open", lambda _port: True)
+    monkeypatch.setattr(module, "_start_persistent_server", start)
+    monkeypatch.setattr(
+        module.sys,
+        "argv",
+        ["piper_tts_server", "--ready-file", str(ready_file)],
+    )
+
+    with pytest.raises(SystemExit, match="port 8105 is already in use"):
+        module.run()
+
+    assert not ready_file.exists()
+    start.assert_not_called()
+
+
+async def test_piper_wait_reports_child_exit_before_health(monkeypatch) -> None:
+    module = _load_piper_main_module()
+    process = Mock()
+    process.poll.return_value = 98
+    monkeypatch.setattr(
+        module,
+        "_health_url_ok",
+        lambda _url: pytest.fail("health must not mask a failed bind"),
+    )
+
+    with pytest.raises(RuntimeError, match="exited with status 98"):
+        module._wait_until_healthy(process, "http://health", timeout_s=600)
+
+    process.wait.assert_not_called()
 
 
 class _ServerExited(Exception):
@@ -187,7 +264,7 @@ async def test_piper_tts_smoke(tmp_path: Path) -> None:
     env = {**os.environ, "XR_AI_LOG_ROOT": str(tmp_path / "logs")}
 
     proc = subprocess.Popen(
-        [str(_PIPER_BIN), "--config", str(cfg_path)],
+        [str(_PIPER_BIN), "--_serve", "--config", str(cfg_path)],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         env=env,

--- a/tests/test_piper_tts.py
+++ b/tests/test_piper_tts.py
@@ -168,6 +168,38 @@ async def test_piper_marks_persistent_child_for_cleanup(monkeypatch) -> None:
     assert child_env["XR_AI_VLLM_PORT"] == "8105"
 
 
+async def test_piper_terminates_owned_child_when_wrapper_is_stopped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_piper_main_module()
+    process = Mock()
+    terminate = Mock()
+    handlers = {
+        module.signal.SIGINT: module.signal.SIG_DFL,
+        module.signal.SIGTERM: module.signal.SIG_DFL,
+    }
+
+    def install_handler(sig, handler):
+        previous = handlers[sig]
+        handlers[sig] = handler
+        return previous
+
+    def receive_sigterm(*, timeout):
+        handlers[module.signal.SIGTERM](module.signal.SIGTERM, None)
+
+    monkeypatch.setattr(module.signal, "signal", install_handler)
+    monkeypatch.setattr(module, "_terminate_process", terminate)
+    process.wait.side_effect = receive_sigterm
+
+    with pytest.raises(SystemExit) as exc_info:
+        module._idle_until_stopped("http://health", process, poll_s=0.01)
+
+    assert exc_info.value.code == 128 + module.signal.SIGTERM
+    terminate.assert_called_once_with(process)
+    assert handlers[module.signal.SIGINT] is module.signal.SIG_DFL
+    assert handlers[module.signal.SIGTERM] is module.signal.SIG_DFL
+
+
 class _ServerExited(Exception):
     """Raised when piper_tts_server exits before binding its port.
 

--- a/tests/test_vllm_stop.py
+++ b/tests/test_vllm_stop.py
@@ -64,3 +64,19 @@ def test_pip_ownership_marker_matches_service_port(tmp_path, monkeypatch) -> Non
 
     assert xr_ai_vllm._docker.is_xr_ai_server_process(1234, "omni", 8108)
     assert not xr_ai_vllm._docker.is_xr_ai_server_process(1234, "omni", 8107)
+
+
+def test_in_process_service_command_identifies_shared_piper(tmp_path, monkeypatch) -> None:
+    proc_root = tmp_path / "proc" / "1234"
+    proc_root.mkdir(parents=True)
+    (proc_root / "cmdline").write_text(
+        "uv\0run\0--project\0services/piper-tts\0piper_tts_server"
+    )
+    monkeypatch.setattr(
+        xr_ai_vllm._docker,
+        "Path",
+        lambda _path: proc_root / _path.rsplit("/", 1)[-1],
+    )
+
+    assert xr_ai_vllm._docker.is_xr_ai_server_process(1234, "tts", 8105)
+    assert not xr_ai_vllm._docker.is_xr_ai_server_process(1234, "stt", 8105)

--- a/tests/test_vllm_stop.py
+++ b/tests/test_vllm_stop.py
@@ -66,11 +66,28 @@ def test_pip_ownership_marker_matches_service_port(tmp_path, monkeypatch) -> Non
     assert not xr_ai_vllm._docker.is_xr_ai_server_process(1234, "omni", 8107)
 
 
-def test_in_process_service_command_identifies_shared_piper(tmp_path, monkeypatch) -> None:
+def test_unmarked_piper_process_is_not_owned(tmp_path, monkeypatch) -> None:
     proc_root = tmp_path / "proc" / "1234"
     proc_root.mkdir(parents=True)
     (proc_root / "cmdline").write_text(
         "uv\0run\0--project\0services/piper-tts\0piper_tts_server"
+    )
+    (proc_root / "environ").write_bytes(b"PATH=/bin\0")
+    monkeypatch.setattr(
+        xr_ai_vllm._docker,
+        "Path",
+        lambda _path: proc_root / _path.rsplit("/", 1)[-1],
+    )
+
+    assert not xr_ai_vllm._docker.is_xr_ai_server_process(1234, "tts", 8105)
+
+
+def test_piper_ownership_marker_matches_service_port(tmp_path, monkeypatch) -> None:
+    proc_root = tmp_path / "proc" / "1234"
+    proc_root.mkdir(parents=True)
+    (proc_root / "cmdline").write_text("python\0-m\0piper_tts_server\0--_serve")
+    (proc_root / "environ").write_bytes(
+        b"XR_AI_VLLM_MANAGED=1\0XR_AI_VLLM_PORT=8105\0"
     )
     monkeypatch.setattr(
         xr_ai_vllm._docker,
@@ -79,4 +96,4 @@ def test_in_process_service_command_identifies_shared_piper(tmp_path, monkeypatc
     )
 
     assert xr_ai_vllm._docker.is_xr_ai_server_process(1234, "tts", 8105)
-    assert not xr_ai_vllm._docker.is_xr_ai_server_process(1234, "stt", 8105)
+    assert not xr_ai_vllm._docker.is_xr_ai_server_process(1234, "tts", 8104)

--- a/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
@@ -937,7 +937,6 @@ def is_xr_ai_server_process(pid: int, label: str, port: int) -> bool:
         return False
     in_process_servers = {
         "stt": "stt_server",
-        "tts": "piper_tts_server",
     }
     if expected_command := in_process_servers.get(label):
         return expected_command in command

--- a/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
@@ -935,8 +935,12 @@ def is_xr_ai_server_process(pid: int, label: str, port: int) -> bool:
         command = Path(f"/proc/{pid}/cmdline").read_text(errors="replace")
     except OSError:
         return False
-    if label == "stt":
-        return "stt_server" in command
+    in_process_servers = {
+        "stt": "stt_server",
+        "tts": "piper_tts_server",
+    }
+    if expected_command := in_process_servers.get(label):
+        return expected_command in command
     try:
         environment = Path(f"/proc/{pid}/environ").read_bytes()
     except OSError:


### PR DESCRIPTION
## Summary

- add CPU Piper TTS to both shipped model-server profiles on port 8105
- keep every voice-enabled sample reuse-only so one shared TTS instance serves Simple VLM, Lab Instrument Monitoring, Tea Making, and XR Render
- health-gate Piper readiness, reuse an existing healthy listener, fail on an unhealthy occupied port, and mark the persisted child for safe cleanup ownership
- replace the plain Nemotron-3-Nano LLM NIM with the certified Nemotron-3-Nano-Omni `2.0.4-variant` NIM so the NIM and local deployments use the same LLM family
- align the NIM adapter's model ID, thinking default, reasoning field, tool capability, and multimodal capabilities with the Omni deployment
- pass each profile's GPU memory budget through the supported vLLM `--gpu-memory-utilization` argument instead of the unsupported `NIM_KVCACHE_PERCENT` variable
- update sample quickstarts, model-server guidance, and focused configuration tests

## Why

The earlier reuse refactor switched every sample to expect an externally owned TTS endpoint, but the shared model-server profiles did not actually start one. Workers therefore remained stuck waiting for TTS unless Piper was launched manually.

The default deployment already serves Nemotron-3 Nano Omni for its LLM roles, while `vlm_llm_nim` still served plain Nemotron-3-Nano. That made model behavior depend on the serving backend. The NIM profile now uses NVIDIA's canonical Omni NIM image and model ID while retaining Cosmos3-Nano Reasoner as its VLM.

## Validation

- 66 focused model-server configuration, Piper lifecycle, cleanup ownership, and generated-config documentation tests passed after the latest review fixes
- the live CPU Piper synthesis smoke test passed
- Ruff passed on all changed Python files
- prior GitHub tests, lint, docs, SPDX, lock-check, and CodeQL workflows passed; checks for the latest head are running
- the Omni NIM environment variables and passthrough flag match NVIDIA's 2.0.4 VLM NIM reference

The NIM container was not started in this development environment. The shipped GB10 and RTX Ada profiles are explicitly marked for target-hardware startup and memory validation; NVIDIA's Omni support matrix does not list those GPUs as validated configurations.
