### PR TITLE
fix(tea): reject unrelated active-guide queries

### DIFF
--- a/agent-samples/tea-making-sample/README.md
+++ b/agent-samples/tea-making-sample/README.md
@@ -63,6 +63,29 @@ finalized when its rewrite completes; playback pacing does not delay the Agent
 panel. An urgent interruption may stop audio after the complete intended text
 has already appeared.
 
+## Foreground behavior
+
+While tea guidance is active, foreground requests remain limited to the current
+step, tea-guide status and controls, and the independent background
+applications. An unrelated request receives exactly “I can only help with the
+active tea guide right now.” without calling a tool or changing guide state.
+When guidance is idle, ordinary questions are not subject to that refusal.
+
+## Foreground routing eval
+
+The live-model eval checks idle and active first actions, exact unrelated-query
+refusal, valid guide controls, current-step questions, visual routing, and
+background-application controls. Start `model-servers` so the configured Omni
+LLM endpoint on port 8108 is healthy, then run from the repository root:
+
+```bash
+uv run --project agent-samples/tea-making-sample/worker \
+  python agent-samples/tea-making-sample/eval/eval.py
+```
+
+The command prints one `PASS` or `FAIL` line per case and exits nonzero when a
+tool choice, argument schema, or response contract does not match.
+
 ## File outputs
 
 Background task output is retained under the sample's `artifacts/` directory:

--- a/agent-samples/tea-making-sample/eval/cases.yaml
+++ b/agent-samples/tea-making-sample/eval/cases.yaml
@@ -4,6 +4,10 @@
 - name: idle-conversation
   query: Hello there.
   expected_tool: null
+- name: idle-answers-unrelated-general-knowledge
+  query: What is the capital of France?
+  expected_tool: null
+  forbidden_response: I can only help with the active tea guide right now.
 - name: start-tea-guide
   query: Help me make a cup of tea.
   expected_tool: workflow__start
@@ -26,35 +30,59 @@
   query: What did the background watchers report recently?
   expected_tool: application_context__query
 
+- name: active-answers-current-step-question
+  route: active
+  step: fill_water
+  query: What should I do at this step?
+  expected_tool: null
+  forbidden_response: I can only help with the active tea guide right now.
+
+- name: active-routes-workflow-status
+  route: active
+  step: heat_water
+  query: What is the status of my tea guide?
+  expected_tool: workflow__status
+
+- name: active-routes-step-visual-question
+  route: active
+  step: fill_water
+  query: Check whether there is visibly water inside my kettle.
+  expected_tool: current_view
+
+- name: active-starts-background-watch
+  route: active
+  step: start_steeping
+  query: Start watching in the background for spills near the kettle.
+  expected_tool: change_watch__start
+
 - name: active-rejects-general-knowledge-at-completed-timer
   route: active
   step: steep_timer
   state_updates: {steeping_complete: true}
   query: What is the capital of France?
   expected_tool: null
-  expected_response_pattern: "(?i)I can only help with the active tea guide"
-  forbidden_response_pattern: "(?i)\\bParis\\b"
+  expected_response: I can only help with the active tea guide right now.
 
 - name: active-rejects-unrelated-explanation
   route: active
   step: heat_water
   query: Could you explain how eclipses happen?
   expected_tool: null
-  expected_response_pattern: "(?i)I can only help with the active tea guide"
+  expected_response: I can only help with the active tea guide right now.
 
 - name: active-rejects-unrelated-control-word
   route: active
   step: fill_water
   query: My supervisor said I should advance my career. Any advice?
   expected_tool: null
-  expected_response_pattern: "(?i)I can only help with the active tea guide"
+  expected_response: I can only help with the active tea guide right now.
 
 - name: active-rejects-unrelated-translation
   route: active
   step: start_steeping
   query: Please translate good morning into Japanese.
   expected_tool: null
-  expected_response_pattern: "(?i)I can only help with the active tea guide"
+  expected_response: I can only help with the active tea guide right now.
 
 - name: active-advances-on-direct-command
   route: active

--- a/agent-samples/tea-making-sample/eval/cases.yaml
+++ b/agent-samples/tea-making-sample/eval/cases.yaml
@@ -1,19 +1,81 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-- query: Hello there.
+- name: idle-conversation
+  query: Hello there.
   expected_tool: null
-- query: Help me make a cup of tea.
+- name: start-tea-guide
+  query: Help me make a cup of tea.
   expected_tool: workflow__start
-- query: What am I holding right now?
+- name: inspect-current-view
+  query: What am I holding right now?
   expected_tool: current_view
-- query: What temperature is generally recommended for white tea?
+- name: retrieve-tea-fact
+  query: What temperature is generally recommended for white tea?
   expected_tool: rag_lookup
-- query: Start watching for a spill near the kettle.
+- name: start-change-watch
+  query: Start watching for a spill near the kettle.
   expected_tool: change_watch__start
-- query: Start recording our conversation.
+- name: start-transcript
+  query: Start recording our conversation.
   expected_tool: transcript__start
-- query: Start a general visual activity log.
+- name: start-video-log
+  query: Start a general visual activity log.
   expected_tool: video_log__start
-- query: What did the background watchers report recently?
+- name: query-background-context
+  query: What did the background watchers report recently?
   expected_tool: application_context__query
+
+- name: active-rejects-general-knowledge-at-completed-timer
+  route: active
+  step: steep_timer
+  state_updates: {steeping_complete: true}
+  query: What is the capital of France?
+  expected_tool: null
+  expected_response_pattern: "(?i)I can only help with the active tea guide"
+  forbidden_response_pattern: "(?i)\\bParis\\b"
+
+- name: active-rejects-unrelated-explanation
+  route: active
+  step: heat_water
+  query: Could you explain how eclipses happen?
+  expected_tool: null
+  expected_response_pattern: "(?i)I can only help with the active tea guide"
+
+- name: active-rejects-unrelated-control-word
+  route: active
+  step: fill_water
+  query: My supervisor said I should advance my career. Any advice?
+  expected_tool: null
+  expected_response_pattern: "(?i)I can only help with the active tea guide"
+
+- name: active-rejects-unrelated-translation
+  route: active
+  step: start_steeping
+  query: Please translate good morning into Japanese.
+  expected_tool: null
+  expected_response_pattern: "(?i)I can only help with the active tea guide"
+
+- name: active-advances-on-direct-command
+  route: active
+  step: fill_water
+  query: Move on to the following tea step.
+  expected_tool: workflow__advance
+
+- name: active-resets-on-direct-command
+  route: active
+  step: heat_water
+  query: End this tea-making session.
+  expected_tool: workflow__reset
+
+- name: active-restarts-on-direct-command
+  route: active
+  step: start_steeping
+  query: Begin the tea instructions again from the first step.
+  expected_tool: workflow__restart
+
+- name: active-routes-timer-question
+  route: active
+  step: steep_timer
+  query: How many seconds are left before steeping is done?
+  expected_tool: clock__timer

--- a/agent-samples/tea-making-sample/eval/eval.py
+++ b/agent-samples/tea-making-sample/eval/eval.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Live-model routing eval for idle and active tea-guide turns."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import yaml
+from tea_making_worker.background_context import BackgroundContextAgent
+from tea_making_worker.change_watch import ChangeWatchAgent
+from tea_making_worker.foreground import ForegroundAgent, _merge_tool_sets
+from tea_making_worker.spec import load_workflow
+from tea_making_worker.transcript import TranscriptAgent
+from tea_making_worker.video_log import VideoLogAgent
+from tea_making_worker.workflow import GuidanceAgent
+from xr_ai_models import ChatMessage, LLMService, load_models_config, make_llm
+from xr_ai_tools.image import ImageRegistry
+from xr_ai_tools.tool_calling import tool_definitions
+
+_SAMPLE = Path(__file__).resolve().parents[1]
+_PROMPTS = _SAMPLE / "worker" / "tea_making_worker" / "prompts"
+
+
+def _build_agents(llm: LLMService) -> tuple[ForegroundAgent, GuidanceAgent]:
+    images = SimpleNamespace(
+        images=ImageRegistry(),
+        get_current_frame=SimpleNamespace(),
+    )
+    placeholder = SimpleNamespace()
+    guidance = GuidanceAgent(
+        workflow=load_workflow(_SAMPLE / "yaml" / "workflow.yaml"),
+        llm=llm,
+        current_frame=images.get_current_frame,
+        image_query=placeholder,
+        rag=placeholder,
+    )
+    change_watch = ChangeWatchAgent(
+        images=images,
+        vlm=placeholder,
+        llm=llm,
+        caption_prompt="Caption the current view.",
+        event_prompt="Compare the views.",
+        default_instruction="important changes",
+        interval_s=2.0,
+    )
+    transcript = TranscriptAgent(
+        llm=llm,
+        summary_prompt="Summarize the transcript.",
+    )
+    video_log = VideoLogAgent(
+        images=images,
+        vlm=placeholder,
+        llm=llm,
+        caption_prompt="Caption the current view.",
+        delta_prompt="Compare the views.",
+        interval_s=2.0,
+    )
+    foreground = ForegroundAgent(
+        llm=llm,
+        images=images,
+        vlm=placeholder,
+        rag=placeholder,
+        guidance=guidance,
+        background_context=BackgroundContextAgent(),
+        change_watch=change_watch,
+        transcript=transcript,
+        video_log=video_log,
+        prompt=(_PROMPTS / "foreground_prompt.txt").read_text(encoding="utf-8"),
+    )
+    return foreground, guidance
+
+
+def _active_route(
+    foreground: ForegroundAgent,
+    guidance: GuidanceAgent,
+    case: dict[str, Any],
+    participant_id: str,
+) -> tuple[str, Any]:
+    target_step = str(case["step"])
+    session = guidance.store.get(participant_id)
+    guidance.store.start(session)
+    while session.step_id != target_step:
+        if not session.active or session.step_id is None:
+            raise ValueError(f"cannot reach active step {target_step!r}")
+        if session.step_id == "start_steeping" and target_step == "steep_timer":
+            observation = "A tea bag is immersed in the water."
+            guidance.store.observe(session, observation)
+            guidance.store.observe(session, observation)
+            result = guidance.store.commit(
+                session,
+                {"steeping_started_at_us": 1, "steeping_started": True},
+                "",
+            )
+            if not result.accepted or not result.complete:
+                raise ValueError("could not complete start_steeping for timer eval")
+            guidance.store.advance(session, skip=False)
+        else:
+            guidance.store.advance(session, skip=True)
+    state_updates = dict(case.get("state_updates", {}))
+    if state_updates:
+        result = guidance.store.commit(session, state_updates, "")
+        if not result.accepted:
+            raise ValueError(f"state updates for {case['name']!r} were rejected: {state_updates!r}")
+    context = guidance.active_context(participant_id)
+    active_tools = guidance.active_tools(participant_id)
+    if context is None or active_tools is None:
+        raise ValueError(f"case {case['name']!r} did not produce an active route")
+    tools = _merge_tool_sets(
+        active_tools,
+        foreground._background_tools(participant_id),
+    )
+    return f"{foreground._prompt}\n\nActive tea guide:\n{context}", tools
+
+
+async def main() -> None:
+    cases = yaml.safe_load((_SAMPLE / "eval" / "cases.yaml").read_text(encoding="utf-8"))
+    llm = make_llm(load_models_config(_SAMPLE / "yaml" / "models.local.json"), "llm")
+    foreground, guidance = _build_agents(llm)
+    failures: list[str] = []
+    try:
+        for index, case in enumerate(cases):
+            participant_id = f"tea-eval-{index}"
+            if case.get("route", "root") == "active":
+                system_prompt, tools = _active_route(
+                    foreground,
+                    guidance,
+                    case,
+                    participant_id,
+                )
+            else:
+                system_prompt = foreground._prompt
+                tools = foreground._root_tools(
+                    participant_id,
+                    ctx=None,
+                    timestamp_us=None,
+                )
+            response = await llm.chat(
+                (
+                    ChatMessage(role="system", content=system_prompt),
+                    ChatMessage(role="user", content=case["query"]),
+                ),
+                tools=tool_definitions(tools),
+                max_tokens=256,
+                temperature=0.0,
+                enable_thinking=False,
+            )
+            calls = response.tool_calls or []
+            actual_tools = [call.name for call in calls]
+            expected_tool = case["expected_tool"]
+            expected_tools = [] if expected_tool is None else [expected_tool]
+            errors: list[str] = []
+            for call in calls:
+                tool = tools.get(call.name)
+                if tool is None:
+                    errors.append(f"unknown tool {call.name!r}")
+                    continue
+                try:
+                    tool.request_model.model_validate_json(call.arguments)
+                except ValueError as exc:
+                    errors.append(f"invalid {call.name!r} arguments: {exc}")
+            content = response.content or ""
+            expected_pattern = case.get("expected_response_pattern")
+            if expected_pattern and re.search(expected_pattern, content) is None:
+                errors.append(f"response did not match {expected_pattern!r}")
+            forbidden_pattern = case.get("forbidden_response_pattern")
+            if forbidden_pattern and re.search(forbidden_pattern, content):
+                errors.append(f"response matched forbidden {forbidden_pattern!r}")
+            passed = actual_tools == expected_tools and not errors
+            label = "PASS" if passed else "FAIL"
+            print(f"{label} {case['name']}: tools={actual_tools!r} content={content!r}")
+            if not passed:
+                failures.append(
+                    f"{case['name']}: expected {expected_tools!r}, received {actual_tools!r}; errors={errors!r}"
+                )
+    finally:
+        await llm.close()
+    if failures:
+        raise SystemExit("\n".join(failures))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/agent-samples/tea-making-sample/eval/eval.py
+++ b/agent-samples/tea-making-sample/eval/eval.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import asyncio
-import re
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -14,7 +13,7 @@ from typing import Any
 import yaml
 from tea_making_worker.background_context import BackgroundContextAgent
 from tea_making_worker.change_watch import ChangeWatchAgent
-from tea_making_worker.foreground import ForegroundAgent, _merge_tool_sets
+from tea_making_worker.foreground import ForegroundAgent
 from tea_making_worker.spec import load_workflow
 from tea_making_worker.transcript import TranscriptAgent
 from tea_making_worker.video_log import VideoLogAgent
@@ -77,11 +76,10 @@ def _build_agents(llm: LLMService) -> tuple[ForegroundAgent, GuidanceAgent]:
 
 
 def _active_route(
-    foreground: ForegroundAgent,
     guidance: GuidanceAgent,
     case: dict[str, Any],
     participant_id: str,
-) -> tuple[str, Any]:
+) -> None:
     target_step = str(case["step"])
     session = guidance.store.get(participant_id)
     guidance.store.start(session)
@@ -107,15 +105,12 @@ def _active_route(
         result = guidance.store.commit(session, state_updates, "")
         if not result.accepted:
             raise ValueError(f"state updates for {case['name']!r} were rejected: {state_updates!r}")
-    context = guidance.active_context(participant_id)
-    active_tools = guidance.active_tools(participant_id)
-    if context is None or active_tools is None:
+    if guidance.active_context(participant_id) is None:
         raise ValueError(f"case {case['name']!r} did not produce an active route")
-    tools = _merge_tool_sets(
-        active_tools,
-        foreground._background_tools(participant_id),
-    )
-    return f"{foreground._prompt}\n\nActive tea guide:\n{context}", tools
+
+
+def _normalize_response(text: str) -> str:
+    return " ".join(text.split())
 
 
 async def main() -> None:
@@ -127,18 +122,20 @@ async def main() -> None:
         for index, case in enumerate(cases):
             participant_id = f"tea-eval-{index}"
             if case.get("route", "root") == "active":
-                system_prompt, tools = _active_route(
-                    foreground,
+                _active_route(
                     guidance,
                     case,
                     participant_id,
                 )
-            else:
-                system_prompt = foreground._prompt
-                tools = foreground._root_tools(
-                    participant_id,
-                    ctx=None,
-                    timestamp_us=None,
+            system_prompt, tools, route = foreground._prepare_route(
+                participant_id,
+                ctx=None,
+                timestamp_us=None,
+            )
+            expected_route = "tea" if case.get("route", "root") == "active" else "root"
+            if route != expected_route:
+                raise ValueError(
+                    f"case {case['name']!r} prepared route {route!r}, expected {expected_route!r}"
                 )
             response = await llm.chat(
                 (
@@ -146,7 +143,7 @@ async def main() -> None:
                     ChatMessage(role="user", content=case["query"]),
                 ),
                 tools=tool_definitions(tools),
-                max_tokens=256,
+                max_tokens=512,
                 temperature=0.0,
                 enable_thinking=False,
             )
@@ -165,12 +162,17 @@ async def main() -> None:
                 except ValueError as exc:
                     errors.append(f"invalid {call.name!r} arguments: {exc}")
             content = response.content or ""
-            expected_pattern = case.get("expected_response_pattern")
-            if expected_pattern and re.search(expected_pattern, content) is None:
-                errors.append(f"response did not match {expected_pattern!r}")
-            forbidden_pattern = case.get("forbidden_response_pattern")
-            if forbidden_pattern and re.search(forbidden_pattern, content):
-                errors.append(f"response matched forbidden {forbidden_pattern!r}")
+            normalized_content = _normalize_response(content)
+            expected_response = case.get("expected_response")
+            if expected_response is not None and normalized_content != _normalize_response(
+                str(expected_response)
+            ):
+                errors.append(f"response did not equal {expected_response!r}")
+            forbidden_response = case.get("forbidden_response")
+            if forbidden_response is not None and _normalize_response(
+                str(forbidden_response)
+            ) in normalized_content:
+                errors.append(f"response contained forbidden {forbidden_response!r}")
             passed = actual_tools == expected_tools and not errors
             label = "PASS" if passed else "FAIL"
             print(f"{label} {case['name']}: tools={actual_tools!r} content={content!r}")

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/foreground.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/foreground.py
@@ -191,25 +191,11 @@ class ForegroundAgent(Agent):
         *,
         timestamp_us: int | None = None,
     ) -> tuple[str, list[str], bool]:
-        active_context = self._guidance.active_context(participant_id)
-        if active_context is None:
-            tools = self._root_tools(
-                participant_id,
-                ctx=ctx,
-                timestamp_us=timestamp_us,
-            )
-            system_prompt = self._prompt
-            route = "root"
-        else:
-            active_tools = self._guidance.active_tools(participant_id)
-            if active_tools is None:
-                raise RuntimeError("active tea context has no active tool set")
-            tools = _merge_tool_sets(
-                active_tools,
-                self._background_tools(participant_id),
-            )
-            system_prompt = f"{self._prompt}\n\nActive tea guide:\n{active_context}"
-            route = "tea"
+        system_prompt, tools, route = self._prepare_route(
+            participant_id,
+            ctx=ctx,
+            timestamp_us=timestamp_us,
+        )
 
         round_index = 0
 
@@ -260,6 +246,36 @@ class ForegroundAgent(Agent):
             and bool(result.tool_calls)
             and result.tool_calls[-1].call.name == "current_view",
         )
+
+    def _prepare_route(
+        self,
+        participant_id: str,
+        *,
+        ctx: RuntimeContext | None,
+        timestamp_us: int | None,
+    ) -> tuple[str, ToolSet, str]:
+        """Return the production prompt, tools, and route for one participant."""
+
+        active_context = self._guidance.active_context(participant_id)
+        if active_context is None:
+            tools = self._root_tools(
+                participant_id,
+                ctx=ctx,
+                timestamp_us=timestamp_us,
+            )
+            system_prompt = self._prompt
+            route = "root"
+        else:
+            active_tools = self._guidance.active_tools(participant_id)
+            if active_tools is None:
+                raise RuntimeError("active tea context has no active tool set")
+            tools = _merge_tool_sets(
+                active_tools,
+                self._background_tools(participant_id),
+            )
+            system_prompt = f"{self._prompt}\n\nActive tea guide:\n{active_context}"
+            route = "tea"
+        return system_prompt, tools, route
 
     def _root_tools(
         self,

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/foreground_prompt.txt
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/foreground_prompt.txt
@@ -1,11 +1,13 @@
 Route each request to the smallest matching tool. When the tea guide is idle,
 start it only when the user explicitly asks to make or start tea. When it is
-active, answer from the current step and its sparse state. Use current_view for
-current or deictic visual questions and rag_lookup for tea or hot-water facts.
-While the tea guide is active, never call a workflow control unless the user
-clearly and directly commands that guide action. Decline unrelated requests
-without answering them, calling a tool, or changing guide state; reply exactly:
+active, answer from the current step and its sparse state. While the tea guide
+is active, never call a workflow control unless the user clearly and directly
+commands that guide action. While the tea guide is active, decline requests
+unrelated to both the guide and its background applications without answering
+them, calling a tool, or changing guide state; reply exactly:
 I can only help with the active tea guide right now.
+Use current_view for current or deictic visual questions and rag_lookup for tea
+or hot-water facts.
 Use application_context__query for recent background observations. Start, stop,
 or query a background application only through its named controls. Never claim
 to see the scene without calling a visual tool. Answer briefly for voice.

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/foreground_prompt.txt
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/foreground_prompt.txt
@@ -2,6 +2,10 @@ Route each request to the smallest matching tool. When the tea guide is idle,
 start it only when the user explicitly asks to make or start tea. When it is
 active, answer from the current step and its sparse state. Use current_view for
 current or deictic visual questions and rag_lookup for tea or hot-water facts.
+While the tea guide is active, never call a workflow control unless the user
+clearly and directly commands that guide action. Decline unrelated requests
+without answering them, calling a tool, or changing guide state; reply exactly:
+I can only help with the active tea guide right now.
 Use application_context__query for recent background observations. Start, stop,
 or query a background application only through its named controls. Never claim
 to see the scene without calling a visual tool. Answer briefly for voice.

--- a/docs/source/reference/tea-making-sample.md
+++ b/docs/source/reference/tea-making-sample.md
@@ -170,6 +170,12 @@ participant has an active step.
 - With an active workflow, it receives the current step's tools plus explicit
   workflow controls and compact sparse state.
 
+Active turns may address the current step, guide status and controls, or the
+independent background applications. For a request unrelated to all of those,
+the model must call no tool, leave guide state unchanged, and reply exactly “I
+can only help with the active tea guide right now.” The rule is scoped to the
+active route; the idle root assistant can answer ordinary questions.
+
 There is exactly one model loop. The foreground agent does not ask one model to
 route to another agent, and background agents never capture a foreground turn.
 `current_view` is a direct-return exception within that loop: after the route is
@@ -381,6 +387,17 @@ Test deterministic behavior separately from model quality:
 4. Test background lifecycle, deduplication, summary windows, and cancellation.
 5. Add routing evals for prompt-controlled tool choices.
 6. Run the live pipeline to evaluate visual evidence and model prompts.
+
+The checked-in live-model routing eval shares the production foreground's
+root-versus-active prompt and tool preparation. It validates the first model
+action, tool arguments, exact active-guide refusal, and positive active-guide
+routes. Start `model-servers` so the configured Omni LLM endpoint on port 8108
+is healthy, then run from the repository root:
+
+```bash
+uv run --project agent-samples/tea-making-sample/worker \
+  python agent-samples/tea-making-sample/eval/eval.py
+```
 
 When debugging, inspect the workflow, background, foreground, and Relay JSONL
 files as separate stages. This shows whether the problem came from evidence,

--- a/tests/test_tea_making_sample.py
+++ b/tests/test_tea_making_sample.py
@@ -1330,7 +1330,8 @@ def test_default_prompts_come_from_packaged_files(tmp_path: Path) -> None:
 
 def test_foreground_prompt_has_route_eval_cases() -> None:
     cases = yaml.safe_load((_SAMPLE / "eval/cases.yaml").read_text())
-    assert {case["expected_tool"] for case in cases} == {
+    root_cases = [case for case in cases if case.get("route", "root") == "root"]
+    assert {case["expected_tool"] for case in root_cases} == {
         None,
         "application_context__query",
         "change_watch__start",
@@ -1340,3 +1341,14 @@ def test_foreground_prompt_has_route_eval_cases() -> None:
         "video_log__start",
         "workflow__start",
     }
+    active_cases = [case for case in cases if case.get("route") == "active"]
+    assert {case["expected_tool"] for case in active_cases} == {
+        None,
+        "clock__timer",
+        "workflow__advance",
+        "workflow__reset",
+        "workflow__restart",
+    }
+    unrelated_cases = [case for case in active_cases if case["expected_tool"] is None]
+    assert len(unrelated_cases) >= 4
+    assert all("expected_response_pattern" in case for case in unrelated_cases)

--- a/tests/test_tea_making_sample.py
+++ b/tests/test_tea_making_sample.py
@@ -1330,6 +1330,13 @@ def test_default_prompts_come_from_packaged_files(tmp_path: Path) -> None:
 
 def test_foreground_prompt_has_route_eval_cases() -> None:
     cases = yaml.safe_load((_SAMPLE / "eval/cases.yaml").read_text())
+    prompt = (
+        _WORKER / "tea_making_worker/prompts/foreground_prompt.txt"
+    ).read_text()
+    refusal = "I can only help with the active tea guide right now."
+    assert "While the tea guide is active, decline requests" in prompt
+    assert f"reply exactly:\n{refusal}" in prompt
+
     root_cases = [case for case in cases if case.get("route", "root") == "root"]
     assert {case["expected_tool"] for case in root_cases} == {
         None,
@@ -1344,11 +1351,40 @@ def test_foreground_prompt_has_route_eval_cases() -> None:
     active_cases = [case for case in cases if case.get("route") == "active"]
     assert {case["expected_tool"] for case in active_cases} == {
         None,
+        "change_watch__start",
         "clock__timer",
+        "current_view",
         "workflow__advance",
         "workflow__reset",
         "workflow__restart",
+        "workflow__status",
     }
-    unrelated_cases = [case for case in active_cases if case["expected_tool"] is None]
+    unrelated_cases = [case for case in active_cases if "expected_response" in case]
     assert len(unrelated_cases) >= 4
-    assert all("expected_response_pattern" in case for case in unrelated_cases)
+    assert all(case["expected_tool"] is None for case in unrelated_cases)
+    assert all(case["expected_response"] == refusal for case in unrelated_cases)
+    assert all("expected_response_pattern" not in case for case in cases)
+
+    positive_active_names = {
+        case["name"]
+        for case in active_cases
+        if case.get("forbidden_response") == refusal
+        or case["expected_tool"] in {
+            "change_watch__start",
+            "current_view",
+            "workflow__status",
+        }
+    }
+    assert {
+        "active-answers-current-step-question",
+        "active-routes-workflow-status",
+        "active-routes-step-visual-question",
+        "active-starts-background-watch",
+    } <= positive_active_names
+
+    idle_unrelated = next(
+        case
+        for case in root_cases
+        if case["name"] == "idle-answers-unrelated-general-knowledge"
+    )
+    assert idle_unrelated["forbidden_response"] == refusal


### PR DESCRIPTION
## Summary
- keep active tea guidance state unchanged for unrelated requests
- require explicit whole-request intent before calling workflow controls
- add live-model routing coverage for active steps, completed timer state, control-word collisions, and valid controls

## Design note
A prompt-only mode that answered unrelated questions was evaluated but not included. It still selected `workflow__reset` or `workflow__advance` in two of four adversarial cases, so it did not satisfy the state-preservation contract. A reliable answer mode would need a separate intent or control guard and should be designed independently.

## Testing
- `PYTHONPATH=services/device-io-hub .../pytest tests/test_tea_making_sample.py -q` — 37 passed
- `PYTHONPATH=agent-samples/tea-making-sample/worker .../python agent-samples/tea-making-sample/eval/eval.py` — 16 passed against the local Omni endpoint
- Ruff and `git diff --check`