### PR TITLE
fix(voice): eliminate return audio underruns

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -119,7 +119,7 @@ change, even when an individual dependency publishes newer Python wheels.
   - `xr-ai-models` → [`xr-ai-models`](agent-sdk/xr-ai-models/) (local, editable)
   - `xr-ai-vad` → [`xr-ai-vad`](utils/xr-ai-vad/) (local, editable)
   - `xr-ai-voicegate` → [`xr-ai-voicegate`](utils/xr-ai-voicegate/) (local, editable)
-  - `pipecat-ai>=1.3`
+  - `pipecat-ai>=1.6`
   - `nltk!=3.10.1`
   - `numpy>=1.24`
   - `scipy>=1.11`

--- a/agent-sdk/xr-ai-voice/pyproject.toml
+++ b/agent-sdk/xr-ai-voice/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "xr-ai-models",
     "xr-ai-vad",
     "xr-ai-voicegate",
-    "pipecat-ai>=1.3",
+    "pipecat-ai>=1.6",
     # NLTK 3.10.1 rejects its dependencies from in-project virtual environments.
     "nltk!=3.10.1",
     "numpy>=1.24",

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_frames.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_frames.py
@@ -6,8 +6,8 @@
 Everything pipecat already ships (``InputAudioRawFrame``,
 ``OutputAudioRawFrame``, ``TranscriptionFrame``, ``UserStartedSpeakingFrame``,
 ``UserStoppedSpeakingFrame``, ``InterruptionFrame``, ``TextFrame``) is reused
-directly — only the participant lifecycle and the voicegate-emitted query
-frame live here.
+directly — only participant lifecycle, voice-gate queries, and synthesized-text
+response boundaries live here.
 """
 from __future__ import annotations
 
@@ -55,7 +55,20 @@ class GatedQueryFrame(DataFrame):
 
 
 @dataclass
-class AssistantResponseEndFrame(DataFrame):
+class TextResponseEndFrame(DataFrame):
+    """One participant-scoped sequence of synthesized text has ended.
+
+    Every producer that emits ``TextFrame`` objects for one utterance follows
+    them with this frame. ``StreamingTtsProcessor`` uses it to flush trailing
+    text and place the audio boundary behind all synthesis already queued for
+    the participant.
+    """
+
+    pid: str
+
+
+@dataclass
+class AssistantResponseEndFrame(TextResponseEndFrame):
     """A single assistant turn finished emitting ``TextFrame``s.
 
     Emitted by the private assistant processor when a query completes
@@ -70,6 +83,5 @@ class AssistantResponseEndFrame(DataFrame):
     was interrupted out of saying.
     """
 
-    pid: str
     text: str
     pts_us: int

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_pipeline.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_pipeline.py
@@ -70,6 +70,9 @@ def _build_voice_pipeline(
         transport  = transport,
         text_topic = text_topic,
     )
+    voice_gate_proc.set_tts_response_active_probe(
+        streaming_tts.has_active_response,
+    )
     vad_stt = VadSttProcessor(
         stt=stt,
         vad_cfg=vad_cfg,

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_processors/streaming_tts.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_processors/streaming_tts.py
@@ -77,6 +77,7 @@ class _TtsPidState:
     """Per-participant streaming state: pending text + its ordered sender."""
 
     __slots__ = (
+        "active_responses",
         "pending",
         "response_sentences",
         "sender_task",
@@ -85,6 +86,7 @@ class _TtsPidState:
     )
 
     def __init__(self) -> None:
+        self.active_responses: int = 0
         self.pending: str = ""
         self.response_sentences: int = 0
         self.sender_task: asyncio.Task | None = None
@@ -186,6 +188,11 @@ class StreamingTtsProcessor(FrameProcessor):
             )
         return st.sender_queue
 
+    def has_active_response(self, pid: str) -> bool:
+        """Return whether ordered response audio is still open for ``pid``."""
+        st = self._by_pid.get(pid)
+        return bool(st is not None and st.active_responses)
+
     async def _handle_text(self, frame: TextFrame) -> None:
         if not frame.text:
             return
@@ -266,6 +273,8 @@ class StreamingTtsProcessor(FrameProcessor):
         logger.info("tts sentence dispatch pid={!r} len={}", pid, len(sentence))
         queue = self._ensure_sender(pid)
         st = self._state(pid)
+        if not st.response_sentences:
+            st.active_responses += 1
         st.response_sentences += 1
         st.synth_seq += 1
         task  = asyncio.create_task(
@@ -296,6 +305,9 @@ class StreamingTtsProcessor(FrameProcessor):
                     stopped = TTSStoppedFrame()
                     stopped.transport_destination = item.pid
                     await self.push_frame(stopped)
+                    st = self._by_pid.get(item.pid)
+                    if st is not None and st.active_responses:
+                        st.active_responses -= 1
                     continue
                 task, pid = item
                 try:

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_processors/streaming_tts.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_processors/streaming_tts.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import asyncio
 import re
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import nemo_relay
@@ -38,6 +39,7 @@ from pipecat.frames.frames import (
     Frame,
     InterruptionFrame,
     TextFrame,
+    TTSStoppedFrame,
 )
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 
@@ -60,13 +62,27 @@ _SENTENCE_END = re.compile(r"(?<=[.!?])\s+")
 _TRAILING_SENTENCE_END = re.compile(r"""[.!?]["')\]]*\s*$""")
 
 
+@dataclass(frozen=True, slots=True)
+class _TtsResponseBoundary:
+    """Ordered marker placed behind every sentence in one assistant response."""
+
+    pid: str
+
+
 class _TtsPidState:
     """Per-participant streaming state: pending text + its ordered sender."""
 
-    __slots__ = ("pending", "sender_task", "sender_queue", "synth_seq")
+    __slots__ = (
+        "pending",
+        "response_sentences",
+        "sender_task",
+        "sender_queue",
+        "synth_seq",
+    )
 
     def __init__(self) -> None:
         self.pending: str = ""
+        self.response_sentences: int = 0
         self.sender_task: asyncio.Task | None = None
         self.sender_queue: asyncio.Queue | None = None
         self.synth_seq: int = 0
@@ -187,6 +203,15 @@ class StreamingTtsProcessor(FrameProcessor):
             st.pending = ""
             await self._dispatch_sentence(sentence, pid=frame.pid)
 
+        # The output transport aggregates small frames into 40 ms chunks. Put
+        # the boundary on the same FIFO as synthesis so it arrives only after
+        # every WAV in this response; Pipecat then flushes and silence-pads the
+        # final partial chunk instead of carrying it into the next response.
+        if st is not None and st.response_sentences:
+            queue = self._ensure_sender(frame.pid)
+            await queue.put(_TtsResponseBoundary(pid=frame.pid))
+            st.response_sentences = 0
+
         if not self._text_topic or self._transport is None:
             return
         if not frame.text:
@@ -233,6 +258,7 @@ class StreamingTtsProcessor(FrameProcessor):
         logger.info("tts sentence dispatch pid={!r} len={}", pid, len(sentence))
         queue = self._ensure_sender(pid)
         st = self._state(pid)
+        st.response_sentences += 1
         st.synth_seq += 1
         task  = asyncio.create_task(
             self._synthesize(sentence, pid=pid),
@@ -258,6 +284,11 @@ class StreamingTtsProcessor(FrameProcessor):
                 item = await queue.get()
                 if item is None:
                     return
+                if isinstance(item, _TtsResponseBoundary):
+                    stopped = TTSStoppedFrame()
+                    stopped.transport_destination = item.pid
+                    await self.push_frame(stopped)
+                    continue
                 task, pid = item
                 try:
                     wav = await task
@@ -306,6 +337,8 @@ class StreamingTtsProcessor(FrameProcessor):
                 except asyncio.QueueEmpty:
                     break
                 if item is None:
+                    continue
+                if isinstance(item, _TtsResponseBoundary):
                     continue
                 synth_task, _ = item
                 synth_task.cancel()

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_processors/streaming_tts.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_processors/streaming_tts.py
@@ -48,7 +48,11 @@ from xr_ai_models import TTSService
 from xr_ai_voicegate import VoiceGate
 
 from .._audio import wav_to_output_frames
-from .._frames import AssistantResponseEndFrame, ParticipantLeftFrame
+from .._frames import (
+    AssistantResponseEndFrame,
+    ParticipantLeftFrame,
+    TextResponseEndFrame,
+)
 
 if TYPE_CHECKING:
     from .._transport import HubVoiceTransport
@@ -147,8 +151,10 @@ class StreamingTtsProcessor(FrameProcessor):
             await self.push_frame(frame, direction)
             return
 
-        if isinstance(frame, AssistantResponseEndFrame):
-            await self._handle_response_end(frame)
+        if isinstance(frame, TextResponseEndFrame):
+            await self._handle_text_response_end(frame)
+            if isinstance(frame, AssistantResponseEndFrame):
+                await self._echo_assistant_response(frame)
             # Forward the marker so any tail processor / sink that tracks turn
             # boundaries still sees it.
             await self.push_frame(frame, direction)
@@ -189,13 +195,13 @@ class StreamingTtsProcessor(FrameProcessor):
         self._state(pid).pending += frame.text
         await self._flush_complete_sentences(pid)
 
-    async def _handle_response_end(self, frame: AssistantResponseEndFrame) -> None:
-        """Flush ``frame.pid``'s trailing pending text, then send the data echo.
+    async def _handle_text_response_end(self, frame: TextResponseEndFrame) -> None:
+        """Flush trailing text and queue its participant-scoped audio boundary.
 
-        The assistant may finish a turn with text that has no sentence-final
-        punctuation (e.g. an aborted partial answer); the boundary regex would
-        leave that fragment buffered forever. End-of-response flushes it so the
-        user hears the tail of the reply.
+        A producer may finish an utterance with text that has no sentence-final
+        punctuation. The boundary regex would leave that fragment buffered
+        forever, so end-of-response flushes it before placing the boundary on
+        the same ordered queue as synthesis.
         """
         st = self._by_pid.get(frame.pid)
         if st is not None and st.pending.strip():
@@ -212,6 +218,8 @@ class StreamingTtsProcessor(FrameProcessor):
             await queue.put(_TtsResponseBoundary(pid=frame.pid))
             st.response_sentences = 0
 
+    async def _echo_assistant_response(self, frame: AssistantResponseEndFrame) -> None:
+        """Send one completed assistant response on the configured data topic."""
         if not self._text_topic or self._transport is None:
             return
         if not frame.text:

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_processors/voice_gate.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_processors/voice_gate.py
@@ -24,6 +24,7 @@ from pipecat.frames.frames import (
     Frame,
     InterruptionFrame,
     TextFrame,
+    TTSStoppedFrame,
     TranscriptionFrame,
     UserStartedSpeakingFrame,
 )
@@ -121,6 +122,10 @@ class VoiceGateProcessor(FrameProcessor):
             return
         for out in frames:
             await self.push_frame(out)
+        if frames:
+            stopped = TTSStoppedFrame()
+            stopped.transport_destination = pid
+            await self.push_frame(stopped)
 
     # ── pipecat frame entrypoint ──────────────────────────────────────────────
 

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_processors/voice_gate.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_processors/voice_gate.py
@@ -7,9 +7,9 @@ pipecat ``FrameProcessor``.
 Maps gate events to frames:
 
 - ``on_query(pid, text, fresh_match)``    → ``GatedQueryFrame``
-- ``on_stop(pid)``                        → ``InterruptionFrame`` + ``TextFrame("Okay, I will stop.")``
+- ``on_stop(pid)``                        → ``InterruptionFrame`` + bounded stop-ack text
 - ``on_phrase_only(pid)``                 → no frame (internal state only)
-- ``on_participant_joined(pid)``          → ``TextFrame`` with the greeting (only when ``format_phrase_help`` returns text)
+- ``on_participant_joined(pid)``          → bounded greeting text (only when ``format_phrase_help`` returns text)
 
 The processor also acts as the gate's ``AudioSink`` so the chime and
 stop-ack play out via the same audio path as TTS. Partial transcripts can
@@ -34,7 +34,12 @@ from xr_ai_models import TTSService
 from xr_ai_voicegate import VoiceGate, VoiceGateConfig
 
 from .._audio import wav_to_output_frames
-from .._frames import GatedQueryFrame, ParticipantJoinedFrame, ParticipantLeftFrame
+from .._frames import (
+    GatedQueryFrame,
+    ParticipantJoinedFrame,
+    ParticipantLeftFrame,
+    TextResponseEndFrame,
+)
 
 
 _STOP_ACK_TEXT = "Okay, I will stop."
@@ -193,9 +198,7 @@ class VoiceGateProcessor(FrameProcessor):
         f = InterruptionFrame()
         f.transport_source = pid
         await self.push_frame(f)
-        ack = TextFrame(text=_STOP_ACK_TEXT)
-        ack.transport_destination = pid
-        await self.push_frame(ack)
+        await self._emit_text_response(pid, _STOP_ACK_TEXT)
 
     async def _on_gate_phrase_only(self, pid: str) -> None:
         await self._emit_chime(pid, early=False)
@@ -221,6 +224,11 @@ class VoiceGateProcessor(FrameProcessor):
             # into a wake word, so stay silent.
             return
         logger.info("greeting emit pid={!r}", pid)
-        frame = TextFrame(text=greeting)
+        await self._emit_text_response(pid, greeting)
+
+    async def _emit_text_response(self, pid: str, text: str) -> None:
+        """Emit one addressed utterance and its synthesis-order boundary."""
+        frame = TextFrame(text=text)
         frame.transport_destination = pid
         await self.push_frame(frame)
+        await self.push_frame(TextResponseEndFrame(pid=pid))

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_processors/voice_gate.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_processors/voice_gate.py
@@ -18,6 +18,7 @@ acknowledge a wake phrase before the complete command is available.
 from __future__ import annotations
 
 import time
+from collections.abc import Callable
 
 from loguru import logger
 from pipecat.frames.frames import (
@@ -81,6 +82,7 @@ class VoiceGateProcessor(FrameProcessor):
             on_participant_joined = self._on_gate_participant_joined,
         )
         self._early_wake_ack: set[str] = set()
+        self._tts_response_active: Callable[[str], bool] = lambda _pid: False
         self._feeding_speech_transcript = False
         # Speech-onset timestamp (µs) of the transcript currently being fed to
         # the gate. ``VoiceGate.feed`` invokes ``_on_gate_query`` synchronously,
@@ -97,6 +99,13 @@ class VoiceGateProcessor(FrameProcessor):
     def early_wake_ack_enabled(self) -> bool:
         """Whether partial STT should probe for an early wake acknowledgement."""
         return self._gate.wake_ack_enabled
+
+    def set_tts_response_active_probe(
+        self,
+        probe: Callable[[str], bool],
+    ) -> None:
+        """Bind the downstream ordered-TTS activity check used by chimes."""
+        self._tts_response_active = probe
 
     async def handle_partial_transcript(self, pid: str, text: str) -> bool:
         """Handle a partial transcript and acknowledge a complete wake phrase.
@@ -127,7 +136,12 @@ class VoiceGateProcessor(FrameProcessor):
             return
         for out in frames:
             await self.push_frame(out)
-        if frames:
+        # A chime may arrive from the early wake probe while response audio is
+        # still flowing through StreamingTtsProcessor. Its raw frames can join
+        # that stream, but a stop marker here would pad-flush the response in
+        # the middle of a word. The response's own ordered marker will flush
+        # both. An idle chime still needs its marker so a short tail is audible.
+        if frames and not self._tts_response_active(pid):
             stopped = TTSStoppedFrame()
             stopped.transport_destination = pid
             await self.push_frame(stopped)

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_transport.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_transport.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from collections.abc import Awaitable, Callable
 
 import numpy as np
 from loguru import logger
@@ -104,6 +105,7 @@ class DeviceIOHubInputTransport(BaseInputTransport):
         ep: ProcessorEndpoint,
         params: TransportParams,
         *,
+        return_audio_primer: Callable[[str], Awaitable[None]] | None = None,
         started_event: asyncio.Event | None = None,
         **kwargs,
     ):
@@ -112,6 +114,11 @@ class DeviceIOHubInputTransport(BaseInputTransport):
         self._ep_task: asyncio.Task | None = None
         self._started = False
         self._started_event = started_event
+        self._return_audio_primer = return_audio_primer
+        # ProcessorEndpoint detaches lifecycle callbacks. Capture their order
+        # synchronously, before detachment, so a slow join pre-roll cannot let a
+        # later leave overtake the participant's join frame.
+        self._participant_event_tails: dict[str, asyncio.Future[None]] = {}
         self._ep.on_audio(self._on_hub_audio)
         self._ep.on_participant(self._on_hub_participant)
 
@@ -176,8 +183,28 @@ class DeviceIOHubInputTransport(BaseInputTransport):
         frame.pts = chunk.pts_us * 1_000
         await self.push_frame(frame)
 
-    async def _on_hub_participant(self, event: ParticipantEvent) -> None:
-        """Translate hub ``ParticipantEvent`` into pipecat lifecycle frames.
+    def _on_hub_participant(self, event: ParticipantEvent) -> Awaitable[None]:
+        """Serialize one participant's detached lifecycle callbacks."""
+        pid = event.participant_id
+        predecessor = self._participant_event_tails.get(pid)
+        completed = asyncio.get_running_loop().create_future()
+        self._participant_event_tails[pid] = completed
+
+        async def deliver() -> None:
+            try:
+                if predecessor is not None:
+                    await asyncio.shield(predecessor)
+                await self._deliver_hub_participant(event)
+            finally:
+                if not completed.done():
+                    completed.set_result(None)
+                if self._participant_event_tails.get(pid) is completed:
+                    self._participant_event_tails.pop(pid, None)
+
+        return deliver()
+
+    async def _deliver_hub_participant(self, event: ParticipantEvent) -> None:
+        """Translate an ordered hub event into a pipecat lifecycle frame.
 
         The hub publishes one event per LiveKit join/leave; downstream
         processors (``VoiceGateProcessor`` greeting hook,
@@ -193,7 +220,16 @@ class DeviceIOHubInputTransport(BaseInputTransport):
         if not self._started:
             return
         if event.joined:
-            await self._prime_return_audio(event.participant_id)
+            if self._return_audio_primer is not None:
+                try:
+                    await self._return_audio_primer(event.participant_id)
+                except Exception:
+                    # Track preparation improves first-response quality but
+                    # must never suppress participant lifecycle delivery.
+                    logger.opt(exception=True).warning(
+                        "return-audio pre-roll failed pid={!r}",
+                        event.participant_id,
+                    )
             await self.push_frame(
                 ParticipantJoinedFrame(participant_id=event.participant_id),
             )
@@ -201,36 +237,6 @@ class DeviceIOHubInputTransport(BaseInputTransport):
             await self.push_frame(
                 ParticipantLeftFrame(participant_id=event.participant_id),
             )
-
-    async def _prime_return_audio(self, pid: str) -> None:
-        """Queue silence before any greeting or response for a new participant."""
-        samples = round(TTS_NATIVE_SAMPLE_RATE * _RETURN_AUDIO_CHUNK_S)
-        data = bytes(samples * NUM_CHANNELS * np.dtype(np.float32).itemsize)
-        chunks = round(_RETURN_AUDIO_PREROLL_S / _RETURN_AUDIO_CHUNK_S)
-        pts_us = time.time_ns() // 1_000
-        try:
-            for index in range(chunks):
-                await self._ep.send_return_audio(AudioChunk(
-                    pts_us=pts_us + round(index * _RETURN_AUDIO_CHUNK_S * 1_000_000),
-                    sample_rate=TTS_NATIVE_SAMPLE_RATE,
-                    channels=NUM_CHANNELS,
-                    samples=samples,
-                    data=data,
-                    participant_id=pid,
-                    track_id="tts",
-                ))
-            logger.info(
-                "return-audio pre-roll queued pid={!r} duration_ms={:.0f}",
-                pid,
-                _RETURN_AUDIO_PREROLL_S * 1_000,
-            )
-        except Exception:
-            # Track preparation improves first-response quality but must not
-            # suppress participant lifecycle delivery if the hub is stopping.
-            logger.opt(exception=True).warning(
-                "return-audio pre-roll failed pid={!r}", pid,
-            )
-
 
 # ── Output ────────────────────────────────────────────────────────────────────
 
@@ -267,6 +273,41 @@ class DeviceIOHubOutputTransport(BaseOutputTransport):
         logger.info("fallback target participant set pid={!r}", pid)
         self._target_participant = pid
         self._missing_target_warned = False
+
+    async def prime_return_audio(self, pid: str) -> None:
+        """Queue and account for silence before a participant's first speech."""
+        samples = round(TTS_NATIVE_SAMPLE_RATE * _RETURN_AUDIO_CHUNK_S)
+        data = bytes(samples * NUM_CHANNELS * np.dtype(np.float32).itemsize)
+        chunks = round(_RETURN_AUDIO_PREROLL_S / _RETURN_AUDIO_CHUNK_S)
+        pts_us = time.time_ns() // 1_000
+        lock = self._return_audio_locks.setdefault(pid, asyncio.Lock())
+        async with lock:
+            now_s = _monotonic_s()
+            buffered_until_s = max(
+                self._return_audio_deadline_s.get(pid, now_s),
+                now_s,
+            )
+            for index in range(chunks):
+                await self._ep.send_return_audio(AudioChunk(
+                    pts_us=pts_us + round(index * _RETURN_AUDIO_CHUNK_S * 1_000_000),
+                    sample_rate=TTS_NATIVE_SAMPLE_RATE,
+                    channels=NUM_CHANNELS,
+                    samples=samples,
+                    data=data,
+                    participant_id=pid,
+                    track_id="tts",
+                ))
+                buffered_until_s = (
+                    max(buffered_until_s, _monotonic_s())
+                    + _RETURN_AUDIO_CHUNK_S
+                )
+                # Preserve partial accounting if a later IPC send fails.
+                self._return_audio_deadline_s[pid] = buffered_until_s
+        logger.info(
+            "return-audio pre-roll queued pid={!r} duration_ms={:.0f}",
+            pid,
+            _RETURN_AUDIO_PREROLL_S * 1_000,
+        )
 
     async def start(self, frame: StartFrame):
         await super().start(frame)
@@ -319,15 +360,19 @@ class DeviceIOHubOutputTransport(BaseOutputTransport):
 
     async def _release_destination(self, pid: str) -> None:
         """Tear down a departed participant's ``MediaSender``."""
-        self._return_audio_deadline_s.pop(pid, None)
-        self._return_audio_locks.pop(pid, None)
-        sender = self._media_senders.pop(pid, None)
-        if sender is None:
-            return
-        try:
-            await sender.cancel(CancelFrame())
-        except Exception:
-            logger.opt(exception=True).debug("media sender cancel failed pid={!r}", pid)
+        lock = self._return_audio_locks.setdefault(pid, asyncio.Lock())
+        async with lock:
+            sender = self._media_senders.pop(pid, None)
+            if sender is not None:
+                try:
+                    await sender.cancel(CancelFrame())
+                except Exception:
+                    logger.opt(exception=True).debug(
+                        "media sender cancel failed pid={!r}", pid,
+                    )
+            self._return_audio_deadline_s.pop(pid, None)
+        if self._return_audio_locks.get(pid) is lock:
+            self._return_audio_locks.pop(pid, None)
         if self._target_participant == pid:
             self._target_participant = ""
 
@@ -367,10 +412,15 @@ class DeviceIOHubOutputTransport(BaseOutputTransport):
                 sender = self._media_senders.get(pid)
                 if sender is not None:
                     await sender.handle_interruptions(frame)
-                self._return_audio_deadline_s.pop(pid, None)
+                lock = self._return_audio_locks.setdefault(pid, asyncio.Lock())
+                async with lock:
+                    self._return_audio_deadline_s.pop(pid, None)
             else:
                 for sender in list(self._media_senders.values()):
                     await sender.handle_interruptions(frame)
+                for reset_pid, lock in list(self._return_audio_locks.items()):
+                    async with lock:
+                        self._return_audio_deadline_s.pop(reset_pid, None)
                 self._return_audio_deadline_s.clear()
             return
 
@@ -484,13 +534,14 @@ class HubVoiceTransport(BaseTransport):
         )
 
         self._input_started = asyncio.Event()
+        self._output = DeviceIOHubOutputTransport(self._ep, params, name=self._output_name)
         self._input = DeviceIOHubInputTransport(
             self._ep,
             params,
             name=self._input_name,
+            return_audio_primer=self._output.prime_return_audio,
             started_event=self._input_started,
         )
-        self._output = DeviceIOHubOutputTransport(self._ep, params, name=self._output_name)
 
     def input(self) -> DeviceIOHubInputTransport:
         """Return the Pipecat input transport backed by DeviceIOHub."""

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_transport.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_transport.py
@@ -331,12 +331,27 @@ class DeviceIOHubOutputTransport(BaseOutputTransport):
             if self._return_audio_preroll_tasks.get(pid) is task:
                 self._return_audio_preroll_tasks.pop(pid, None)
 
-    async def _wait_return_audio_preroll(self, pid: str) -> None:
-        """Keep real speech ordered behind an active pre-roll."""
+    async def _wait_return_audio_preroll(self, pid: str) -> bool:
+        """Keep real speech ordered behind an active pre-roll.
+
+        Return ``False`` when participant cleanup cancelled the pre-roll so
+        the waiting audio frame is dropped without cancelling Pipecat's
+        long-lived media-sender task. Cancellation of the caller itself must
+        still propagate through the shield.
+        """
         task = self._return_audio_preroll_tasks.get(pid)
         if task is None:
-            return
-        await asyncio.shield(task)
+            return True
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            waiter = asyncio.current_task()
+            if waiter is not None and waiter.cancelling():
+                raise
+            if task.cancelled():
+                return False
+            raise
+        return True
 
     async def _cancel_return_audio_preroll(self, pid: str) -> None:
         task = self._return_audio_preroll_tasks.pop(pid, None)
@@ -347,6 +362,7 @@ class DeviceIOHubOutputTransport(BaseOutputTransport):
         try:
             await task
         except asyncio.CancelledError:
+            # Expected after cancelling this participant's pre-roll above.
             pass
 
     async def _cancel_all_return_audio_prerolls(self) -> None:
@@ -544,7 +560,8 @@ class DeviceIOHubOutputTransport(BaseOutputTransport):
                 self._missing_target_warned = True
             return False
         num_samples = len(frame.audio) // (2 * frame.num_channels)
-        await self._wait_return_audio_preroll(pid)
+        if not await self._wait_return_audio_preroll(pid):
+            return False
         lock = self._return_audio_locks.setdefault(pid, asyncio.Lock())
         async with lock:
             # Send immediately while the estimated downstream reserve is below

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_transport.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_transport.py
@@ -105,7 +105,7 @@ class DeviceIOHubInputTransport(BaseInputTransport):
         ep: ProcessorEndpoint,
         params: TransportParams,
         *,
-        return_audio_primer: Callable[[str], Awaitable[None]] | None = None,
+        return_audio_primer: Callable[[str], None] | None = None,
         started_event: asyncio.Event | None = None,
         **kwargs,
     ):
@@ -116,8 +116,8 @@ class DeviceIOHubInputTransport(BaseInputTransport):
         self._started_event = started_event
         self._return_audio_primer = return_audio_primer
         # ProcessorEndpoint detaches lifecycle callbacks. Capture their order
-        # synchronously, before detachment, so a slow join pre-roll cannot let a
-        # later leave overtake the participant's join frame.
+        # synchronously, before detachment, so later lifecycle work cannot
+        # overtake a participant's join frame.
         self._participant_event_tails: dict[str, asyncio.Future[None]] = {}
         self._ep.on_audio(self._on_hub_audio)
         self._ep.on_participant(self._on_hub_participant)
@@ -222,12 +222,12 @@ class DeviceIOHubInputTransport(BaseInputTransport):
         if event.joined:
             if self._return_audio_primer is not None:
                 try:
-                    await self._return_audio_primer(event.participant_id)
+                    self._return_audio_primer(event.participant_id)
                 except Exception:
                     # Track preparation improves first-response quality but
                     # must never suppress participant lifecycle delivery.
                     logger.opt(exception=True).warning(
-                        "return-audio pre-roll failed pid={!r}",
+                        "return-audio pre-roll start failed pid={!r}",
                         event.participant_id,
                     )
             await self.push_frame(
@@ -259,6 +259,7 @@ class DeviceIOHubOutputTransport(BaseOutputTransport):
         # rate instead of looking like an unbounded producer burst.
         self._return_audio_deadline_s: dict[str, float] = {}
         self._return_audio_locks: dict[str, asyncio.Lock] = {}
+        self._return_audio_preroll_tasks: dict[str, asyncio.Task[None]] = {}
 
     @property
     def target_participant(self) -> str:
@@ -274,39 +275,112 @@ class DeviceIOHubOutputTransport(BaseOutputTransport):
         self._target_participant = pid
         self._missing_target_warned = False
 
-    async def prime_return_audio(self, pid: str) -> None:
-        """Queue and account for silence before a participant's first speech."""
+    def start_return_audio_preroll(self, pid: str) -> None:
+        """Start one ordered 320 ms return-track pre-roll for ``pid``."""
+        current = self._return_audio_preroll_tasks.get(pid)
+        if current is not None and not current.done():
+            return
+        task = asyncio.create_task(
+            self._run_return_audio_preroll(pid),
+            name=f"return-audio-preroll-{pid}",
+        )
+        self._return_audio_preroll_tasks[pid] = task
+
+    async def _run_return_audio_preroll(self, pid: str) -> None:
+        """Pace silence at audio rate so a small hub queue cannot drop it."""
         samples = round(TTS_NATIVE_SAMPLE_RATE * _RETURN_AUDIO_CHUNK_S)
         data = bytes(samples * NUM_CHANNELS * np.dtype(np.float32).itemsize)
         chunks = round(_RETURN_AUDIO_PREROLL_S / _RETURN_AUDIO_CHUNK_S)
         pts_us = time.time_ns() // 1_000
         lock = self._return_audio_locks.setdefault(pid, asyncio.Lock())
-        async with lock:
-            now_s = _monotonic_s()
-            buffered_until_s = max(
-                self._return_audio_deadline_s.get(pid, now_s),
-                now_s,
+        task = asyncio.current_task()
+        try:
+            async with lock:
+                for index in range(chunks):
+                    await self._send_paced_return_audio(
+                        AudioChunk(
+                            pts_us=(
+                                pts_us
+                                + round(
+                                    index * _RETURN_AUDIO_CHUNK_S * 1_000_000,
+                                )
+                            ),
+                            sample_rate=TTS_NATIVE_SAMPLE_RATE,
+                            channels=NUM_CHANNELS,
+                            samples=samples,
+                            data=data,
+                            participant_id=pid,
+                            track_id="tts",
+                        ),
+                        target_buffer_s=_RETURN_AUDIO_CHUNK_S,
+                    )
+            logger.info(
+                "return-audio pre-roll queued pid={!r} duration_ms={:.0f}",
+                pid,
+                _RETURN_AUDIO_PREROLL_S * 1_000,
             )
-            for index in range(chunks):
-                await self._ep.send_return_audio(AudioChunk(
-                    pts_us=pts_us + round(index * _RETURN_AUDIO_CHUNK_S * 1_000_000),
-                    sample_rate=TTS_NATIVE_SAMPLE_RATE,
-                    channels=NUM_CHANNELS,
-                    samples=samples,
-                    data=data,
-                    participant_id=pid,
-                    track_id="tts",
-                ))
-                buffered_until_s = (
-                    max(buffered_until_s, _monotonic_s())
-                    + _RETURN_AUDIO_CHUNK_S
-                )
-                # Preserve partial accounting if a later IPC send fails.
-                self._return_audio_deadline_s[pid] = buffered_until_s
-        logger.info(
-            "return-audio pre-roll queued pid={!r} duration_ms={:.0f}",
-            pid,
-            _RETURN_AUDIO_PREROLL_S * 1_000,
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            # Track preparation improves first-response quality but failure
+            # cannot take down the detached participant callback or TTS sender.
+            logger.opt(exception=True).warning(
+                "return-audio pre-roll failed pid={!r}", pid,
+            )
+        finally:
+            if self._return_audio_preroll_tasks.get(pid) is task:
+                self._return_audio_preroll_tasks.pop(pid, None)
+
+    async def _wait_return_audio_preroll(self, pid: str) -> None:
+        """Keep real speech ordered behind an active pre-roll."""
+        task = self._return_audio_preroll_tasks.get(pid)
+        if task is None:
+            return
+        await asyncio.shield(task)
+
+    async def _cancel_return_audio_preroll(self, pid: str) -> None:
+        task = self._return_audio_preroll_tasks.pop(pid, None)
+        if task is None:
+            return
+        if not task.done():
+            task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    async def _cancel_all_return_audio_prerolls(self) -> None:
+        tasks = list(self._return_audio_preroll_tasks.values())
+        self._return_audio_preroll_tasks.clear()
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def _send_paced_return_audio(
+        self,
+        chunk: AudioChunk,
+        *,
+        target_buffer_s: float,
+    ) -> None:
+        """Send one lock-protected chunk with a bounded downstream reserve."""
+        duration_s = chunk.samples / chunk.sample_rate
+        now_s = _monotonic_s()
+        buffered_until_s = max(
+            self._return_audio_deadline_s.get(chunk.participant_id, now_s),
+            now_s,
+        )
+        delay_s = max(
+            0.0,
+            buffered_until_s + duration_s - now_s - target_buffer_s,
+        )
+        if delay_s > 1e-9:
+            await _sleep_s(delay_s)
+        await self._ep.send_return_audio(chunk)
+        sent_s = _monotonic_s()
+        self._return_audio_deadline_s[chunk.participant_id] = (
+            max(buffered_until_s, sent_s) + duration_s
         )
 
     async def start(self, frame: StartFrame):
@@ -360,6 +434,7 @@ class DeviceIOHubOutputTransport(BaseOutputTransport):
 
     async def _release_destination(self, pid: str) -> None:
         """Tear down a departed participant's ``MediaSender``."""
+        await self._cancel_return_audio_preroll(pid)
         lock = self._return_audio_locks.setdefault(pid, asyncio.Lock())
         async with lock:
             sender = self._media_senders.pop(pid, None)
@@ -377,11 +452,13 @@ class DeviceIOHubOutputTransport(BaseOutputTransport):
             self._target_participant = ""
 
     async def stop(self, frame: EndFrame):
+        await self._cancel_all_return_audio_prerolls()
         self._return_audio_deadline_s.clear()
         self._return_audio_locks.clear()
         await super().stop(frame)
 
     async def cancel(self, frame: CancelFrame):
+        await self._cancel_all_return_audio_prerolls()
         self._return_audio_deadline_s.clear()
         self._return_audio_locks.clear()
         await super().cancel(frame)
@@ -467,27 +544,13 @@ class DeviceIOHubOutputTransport(BaseOutputTransport):
                 self._missing_target_warned = True
             return False
         num_samples = len(frame.audio) // (2 * frame.num_channels)
-        duration_s = num_samples / frame.sample_rate
+        await self._wait_return_audio_preroll(pid)
         lock = self._return_audio_locks.setdefault(pid, asyncio.Lock())
         async with lock:
-            now_s = _monotonic_s()
-            buffered_until_s = max(
-                self._return_audio_deadline_s.get(pid, now_s),
-                now_s,
-            )
             # Send immediately while the estimated downstream reserve is below
             # the target. Once full, wait only long enough to make room for this
             # frame. A scheduler/IPC stall drains the estimate and therefore
             # causes subsequent frames to catch up instead of preserving a gap.
-            delay_s = max(
-                0.0,
-                buffered_until_s + duration_s
-                - now_s
-                - _RETURN_AUDIO_TARGET_BUFFER_S,
-            )
-            if delay_s:
-                await _sleep_s(delay_s)
-
             chunk = AudioChunk(
                 pts_us=time.time_ns() // 1_000,
                 sample_rate=frame.sample_rate,
@@ -497,10 +560,9 @@ class DeviceIOHubOutputTransport(BaseOutputTransport):
                 participant_id=pid,
                 track_id="tts",
             )
-            await self._ep.send_return_audio(chunk)
-            sent_s = _monotonic_s()
-            self._return_audio_deadline_s[pid] = (
-                max(buffered_until_s, sent_s) + duration_s
+            await self._send_paced_return_audio(
+                chunk,
+                target_buffer_s=_RETURN_AUDIO_TARGET_BUFFER_S,
             )
         return True
 
@@ -539,7 +601,7 @@ class HubVoiceTransport(BaseTransport):
             self._ep,
             params,
             name=self._input_name,
-            return_audio_primer=self._output.prime_return_audio,
+            return_audio_primer=self._output.start_return_audio_preroll,
             started_event=self._input_started,
         )
 

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_transport.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_transport.py
@@ -51,6 +51,18 @@ SAMPLE_RATE            = 16_000
 NUM_CHANNELS           = 1
 TTS_NATIVE_SAMPLE_RATE = 22_050
 
+# Keep a small amount of audio queued ahead of LiveKit playout. An exact-rate
+# producer has no reserve for normal event-loop or IPC latency, so every late
+# wakeup becomes an audible underrun. The hub still enforces its independent
+# hard queue bound for faulty producers.
+_RETURN_AUDIO_TARGET_BUFFER_S = 0.12
+
+# The return track is created lazily by the LiveKit connector when it receives
+# the first audio chunk. Put silence at the head of that new track so its
+# publication/subscription handshake cannot consume the start of real speech.
+_RETURN_AUDIO_PREROLL_S = 0.32
+_RETURN_AUDIO_CHUNK_S = 0.04
+
 
 def _monotonic_s() -> float:
     return asyncio.get_running_loop().time()
@@ -181,12 +193,42 @@ class DeviceIOHubInputTransport(BaseInputTransport):
         if not self._started:
             return
         if event.joined:
+            await self._prime_return_audio(event.participant_id)
             await self.push_frame(
                 ParticipantJoinedFrame(participant_id=event.participant_id),
             )
         else:
             await self.push_frame(
                 ParticipantLeftFrame(participant_id=event.participant_id),
+            )
+
+    async def _prime_return_audio(self, pid: str) -> None:
+        """Queue silence before any greeting or response for a new participant."""
+        samples = round(TTS_NATIVE_SAMPLE_RATE * _RETURN_AUDIO_CHUNK_S)
+        data = bytes(samples * NUM_CHANNELS * np.dtype(np.float32).itemsize)
+        chunks = round(_RETURN_AUDIO_PREROLL_S / _RETURN_AUDIO_CHUNK_S)
+        pts_us = time.time_ns() // 1_000
+        try:
+            for index in range(chunks):
+                await self._ep.send_return_audio(AudioChunk(
+                    pts_us=pts_us + round(index * _RETURN_AUDIO_CHUNK_S * 1_000_000),
+                    sample_rate=TTS_NATIVE_SAMPLE_RATE,
+                    channels=NUM_CHANNELS,
+                    samples=samples,
+                    data=data,
+                    participant_id=pid,
+                    track_id="tts",
+                ))
+            logger.info(
+                "return-audio pre-roll queued pid={!r} duration_ms={:.0f}",
+                pid,
+                _RETURN_AUDIO_PREROLL_S * 1_000,
+            )
+        except Exception:
+            # Track preparation improves first-response quality but must not
+            # suppress participant lifecycle delivery if the hub is stopping.
+            logger.opt(exception=True).warning(
+                "return-audio pre-roll failed pid={!r}", pid,
             )
 
 
@@ -379,9 +421,22 @@ class DeviceIOHubOutputTransport(BaseOutputTransport):
         lock = self._return_audio_locks.setdefault(pid, asyncio.Lock())
         async with lock:
             now_s = _monotonic_s()
-            deadline_s = self._return_audio_deadline_s.get(pid, now_s)
-            if deadline_s > now_s:
-                await _sleep_s(deadline_s - now_s)
+            buffered_until_s = max(
+                self._return_audio_deadline_s.get(pid, now_s),
+                now_s,
+            )
+            # Send immediately while the estimated downstream reserve is below
+            # the target. Once full, wait only long enough to make room for this
+            # frame. A scheduler/IPC stall drains the estimate and therefore
+            # causes subsequent frames to catch up instead of preserving a gap.
+            delay_s = max(
+                0.0,
+                buffered_until_s + duration_s
+                - now_s
+                - _RETURN_AUDIO_TARGET_BUFFER_S,
+            )
+            if delay_s:
+                await _sleep_s(delay_s)
 
             chunk = AudioChunk(
                 pts_us=time.time_ns() // 1_000,
@@ -393,7 +448,10 @@ class DeviceIOHubOutputTransport(BaseOutputTransport):
                 track_id="tts",
             )
             await self._ep.send_return_audio(chunk)
-            self._return_audio_deadline_s[pid] = _monotonic_s() + duration_s
+            sent_s = _monotonic_s()
+            self._return_audio_deadline_s[pid] = (
+                max(buffered_until_s, sent_s) + duration_s
+            )
         return True
 
 

--- a/docs/source/components/server-runtime.md
+++ b/docs/source/components/server-runtime.md
@@ -187,7 +187,10 @@ per-participant pipe that a flush can drain to interrupt playback.
 `return_audio_max_buffer_s` (3 seconds by default) is also a hard
 per-participant duration bound: if a custom or faulty producer runs ahead of
 playback, the oldest queued frames are dropped without affecting any other
-participant.
+participant. Set this value to at least `0.12` when using the built-in voice
+transport, which maintains a 120 ms reserve. Smaller values remain available
+for custom producers whose chunk size and pacing fit within the configured
+bound.
 
 ## Agent status aggregation
 

--- a/docs/source/reference/agent-sdk-voice.md
+++ b/docs/source/reference/agent-sdk-voice.md
@@ -74,6 +74,16 @@ independent agents cannot merge accidentally.
 caption channel. The echo describes intended completed text, not client playback
 acknowledgement.
 
+When a participant joins, the voice transport sends 320 ms of paced silence.
+The first chunk causes the hub to publish the return track, and the remaining
+interval gives the participant time to subscribe before an immediate greeting
+or response. If no output follows immediately, the pre-roll drains and does not
+delay a later response. During speech, the sender maintains up to 120 ms of
+downstream reserve to absorb ordinary event-loop and IPC jitter. It sends
+initial chunks immediately rather than waiting to fill the reserve, and
+interruption flushes participant-scoped queued audio. The hub setting
+`return_audio_max_buffer_s` must be at least `0.12` for built-in voice output.
+
 (multiple-voice-producers)=
 ## Multiple speech producers
 

--- a/docs/source/reference/migrations.md
+++ b/docs/source/reference/migrations.md
@@ -29,8 +29,10 @@ and command to `device_io_hub`. Rename `xr_media_hub.yaml` to
   independently for each participant in DeviceIOHub.
   `return_audio_max_buffer_s` defaults to 3 seconds; a custom or faulty producer
   that exceeds the queued-audio duration limit loses its oldest queued frames.
-  Increase the value for intentionally bursty custom producers, or decrease it
-  for a tighter memory and latency bound.
+  The built-in voice transport requires at least `0.12` to maintain its 120 ms
+  reserve. Increase the value for intentionally bursty custom producers, or
+  decrease it for a tighter memory and latency bound when using a compatible
+  custom producer.
 
 ## Removed SDK compatibility surfaces
 

--- a/services/device-io-hub/device_io_hub.yaml
+++ b/services/device-io-hub/device_io_hub.yaml
@@ -31,8 +31,9 @@ lk_skip_external_ip_validation: false
 
 # ── Return audio pacing ───────────────────────────────────────────────────────
 # Maximum queued TTS audio per participant. Built-in voice output is paced
-# before IPC; if a custom or faulty producer bursts past this hard duration
-# bound, the oldest queued frames are dropped.
+# before IPC and requires at least 0.12 seconds for its jitter reserve. If a
+# custom or faulty producer bursts past this hard duration bound, the oldest
+# queued frames are dropped.
 return_audio_max_buffer_s: 3.0
 
 # ── Web client server ─────────────────────────────────────────────────────────

--- a/tests/test_return_audio_pacing.py
+++ b/tests/test_return_audio_pacing.py
@@ -215,3 +215,53 @@ async def test_room_client_applies_buffer_limit_per_participant(monkeypatch):
         assert alice_source is not bob_source
     finally:
         await asyncio.gather(alice_pipe.close(), bob_pipe.close())
+
+
+async def test_voice_preroll_pacing_does_not_overflow_120ms_pipe(monkeypatch):
+    """The shared voice primer remains intact in the real bounded hub pipe."""
+    from pipecat.transports.base_transport import TransportParams
+    from xr_ai_voice import _transport as voice_transport_module
+    from xr_ai_voice._transport import DeviceIOHubOutputTransport
+
+    class _ImmediateSource:
+        def __init__(self) -> None:
+            self.captured: list[object] = []
+
+        async def capture_frame(self, frame) -> None:
+            self.captured.append(frame)
+
+        def clear_queue(self) -> None:
+            return None
+
+    now_s = 100.0
+    source = _ImmediateSource()
+    pipe = _ReturnAudioPipe(source, participant_id="alice", max_buffer_s=0.12)
+
+    async def fake_sleep(delay_s: float) -> None:
+        nonlocal now_s
+        now_s += delay_s
+        await asyncio.sleep(0)
+
+    class _PipeEndpoint:
+        async def send_return_audio(self, chunk) -> None:
+            pipe.push(
+                _FakeFrame(
+                    f"pre-roll-{len(source.captured) + pipe.queued_frames}",
+                    samples_per_channel=chunk.samples,
+                    sample_rate=chunk.sample_rate,
+                )
+            )
+
+    monkeypatch.setattr(voice_transport_module, "_monotonic_s", lambda: now_s)
+    monkeypatch.setattr(voice_transport_module, "_sleep_s", fake_sleep)
+    output = DeviceIOHubOutputTransport(_PipeEndpoint(), TransportParams())
+    try:
+        output.start_return_audio_preroll("alice")
+        await output._wait_return_audio_preroll("alice")  # noqa: SLF001
+        await asyncio.sleep(0)
+
+        assert pipe.dropped_frames == 0
+        assert len(source.captured) + pipe.queued_frames == 8
+        assert output._return_audio_deadline_s["alice"] == pytest.approx(100.32)  # noqa: SLF001
+    finally:
+        await pipe.close()

--- a/tests/test_voice_pipeline.py
+++ b/tests/test_voice_pipeline.py
@@ -34,6 +34,7 @@ from pipecat.frames.frames import (
     OutputAudioRawFrame,
     TextFrame,
     TranscriptionFrame,
+    TTSStoppedFrame,
     UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
 )
@@ -198,6 +199,7 @@ class _CallbackStubEndpoint:
         self.run_started = asyncio.Event()
         self.run_finished = asyncio.Event()
         self.ready_to_receive = asyncio.Event()
+        self.return_audio = []
 
     def on_audio(self, cb) -> None:
         self.audio_cb = cb
@@ -214,6 +216,9 @@ class _CallbackStubEndpoint:
 
     def stop(self) -> None:
         self.run_finished.set()
+
+    async def send_return_audio(self, chunk) -> None:
+        self.return_audio.append(chunk)
 
 
 # ════════════════════════════════════════════════════════════════════════════
@@ -1078,6 +1083,9 @@ async def test_voice_gate_processor_chime_routes_through_pipeline_audio_path():
     audio_out = [f for f in sink.frames if isinstance(f, OutputAudioRawFrame)]
     assert audio_out, "chime should have emitted at least one OutputAudioRawFrame"
     assert all(f.transport_destination == "pid-1" for f in audio_out)
+    boundaries = [f for f in sink.frames if isinstance(f, TTSStoppedFrame)]
+    assert len(boundaries) == 1
+    assert boundaries[0].transport_destination == "pid-1"
 
 
 @pytest.mark.asyncio
@@ -1805,6 +1813,99 @@ async def test_streaming_tts_sentence_boundary_triggers_synth():
 
 
 @pytest.mark.asyncio
+async def test_streaming_tts_queues_scoped_boundary_after_response_audio():
+    tts = _FakeTts(sample_rate=22050)
+    gate = VoiceGate(VoiceGateConfig(), audio_sink=_NullSink(), tts=tts)
+    proc = StreamingTtsProcessor(tts=tts, voice_gate=gate)
+    text = TextFrame(text="hello world.")
+    text.transport_destination = "alice"
+
+    sink = await _run_chain(
+        proc,
+        sends=[
+            text,
+            AssistantResponseEndFrame(
+                pid="alice",
+                text="hello world.",
+                pts_us=1,
+            ),
+        ],
+    )
+
+    audio_indices = [
+        index
+        for index, frame in enumerate(sink.frames)
+        if isinstance(frame, OutputAudioRawFrame)
+    ]
+    boundaries = [
+        (index, frame)
+        for index, frame in enumerate(sink.frames)
+        if isinstance(frame, TTSStoppedFrame)
+    ]
+    assert audio_indices
+    assert len(boundaries) == 1
+    boundary_index, boundary = boundaries[0]
+    assert boundary_index > max(audio_indices)
+    assert boundary.transport_destination == "alice"
+
+
+@pytest.mark.asyncio
+async def test_response_boundary_flushes_each_partial_output_chunk():
+    """Two short replies must remain two clips, not one cross-turn chunk."""
+    from pipecat.transports.base_transport import TransportParams
+    from xr_ai_voice._transport import (
+        TTS_NATIVE_SAMPLE_RATE,
+        DeviceIOHubOutputTransport,
+    )
+
+    class _ShortTts(_FakeTts):
+        async def synthesize(self, text: str, **_kwargs) -> bytes:
+            self.calls.append(text)
+            return _silence_wav(self.sample_rate, ms=27)
+
+    class _StubEndpoint:
+        def __init__(self) -> None:
+            self.chunks = []
+
+        async def send_return_audio(self, chunk) -> None:
+            self.chunks.append(chunk)
+
+    endpoint = _StubEndpoint()
+    tts = _ShortTts(sample_rate=TTS_NATIVE_SAMPLE_RATE)
+    gate = VoiceGate(VoiceGateConfig(), audio_sink=_NullSink(), tts=tts)
+    streaming = StreamingTtsProcessor(tts=tts, voice_gate=gate)
+    output = DeviceIOHubOutputTransport(
+        endpoint,
+        TransportParams(
+            audio_out_enabled=True,
+            audio_out_sample_rate=TTS_NATIVE_SAMPLE_RATE,
+            audio_out_channels=1,
+        ),
+    )
+    first = TextFrame(text="first.")
+    first.transport_destination = "alice"
+    second = TextFrame(text="second.")
+    second.transport_destination = "alice"
+
+    await _run_chain(
+        streaming,
+        output,
+        sends=[
+            first,
+            AssistantResponseEndFrame(pid="alice", text="first.", pts_us=1),
+            second,
+            AssistantResponseEndFrame(pid="alice", text="second.", pts_us=2),
+        ],
+        settle_s=0.2,
+    )
+
+    assert tts.calls == ["first.", "second."]
+    assert len(endpoint.chunks) == 2
+    assert all(chunk.participant_id == "alice" for chunk in endpoint.chunks)
+    assert endpoint.chunks[0].samples == endpoint.chunks[1].samples
+
+
+@pytest.mark.asyncio
 async def test_streaming_tts_parallel_synth_keeps_order():
     """Out-of-order completion of synth tasks must NOT reorder the
     output audio: the ordered sender awaits in FIFO. ``call_starts``
@@ -2125,6 +2226,10 @@ async def test_input_transport_emits_participant_joined_frame():
     frame = pushed[0]
     assert isinstance(frame, ParticipantJoinedFrame)
     assert frame.participant_id == "web-client"
+    assert len(ep.return_audio) == 8
+    assert sum(chunk.samples for chunk in ep.return_audio) / 22_050 == pytest.approx(0.32)
+    assert all(chunk.participant_id == "web-client" for chunk in ep.return_audio)
+    assert all(not any(chunk.data) for chunk in ep.return_audio)
 
 
 @pytest.mark.asyncio
@@ -2876,7 +2981,7 @@ async def test_output_transport_writes_audio_to_target_participant():
 
 @pytest.mark.asyncio
 async def test_output_transport_paces_return_audio_before_ipc(monkeypatch):
-    """Normal TTS cannot flood DeviceIOHub's hard participant queue bound."""
+    """Normal TTS builds bounded reserve, then advances at playback rate."""
     from xr_ai_voice import _transport as transport_module
     from xr_ai_voice._transport import DeviceIOHubOutputTransport
     from pipecat.transports.base_transport import TransportParams
@@ -2907,8 +3012,51 @@ async def test_output_transport_paces_return_audio_before_ipc(monkeypatch):
     for _ in range(60):
         assert await transport.write_audio_frame(frame) is True
 
-    assert sent_at == pytest.approx([100.0 + i * 0.02 for i in range(60)])
-    assert sleeps == pytest.approx([0.02] * 59)
+    expected = [100.0] * 6 + [100.0 + (i - 5) * 0.02 for i in range(6, 60)]
+    assert sent_at == pytest.approx(expected)
+    assert sleeps == pytest.approx([0.02] * 54)
+
+
+@pytest.mark.asyncio
+async def test_output_transport_reserve_absorbs_periodic_ipc_stalls(monkeypatch):
+    """Sub-reserve endpoint stalls must not create modeled playout gaps."""
+    from pipecat.transports.base_transport import TransportParams
+    from xr_ai_voice import _transport as transport_module
+    from xr_ai_voice._transport import DeviceIOHubOutputTransport
+
+    now_s = 100.0
+    arrivals: list[float] = []
+
+    async def fake_sleep(delay_s: float) -> None:
+        nonlocal now_s
+        now_s += delay_s
+
+    class _StubEndpoint:
+        async def send_return_audio(self, _chunk) -> None:
+            nonlocal now_s
+            if (len(arrivals) + 1) % 10 == 0:
+                now_s += 0.065
+            arrivals.append(now_s)
+
+    monkeypatch.setattr(transport_module, "_monotonic_s", lambda: now_s)
+    monkeypatch.setattr(transport_module, "_sleep_s", fake_sleep)
+    transport = DeviceIOHubOutputTransport(_StubEndpoint(), TransportParams())
+    transport.set_target_participant("web-client")
+    frame = OutputAudioRawFrame(
+        audio=b"\x00\x00" * 320,
+        sample_rate=16_000,
+        num_channels=1,
+    )
+
+    for _ in range(80):
+        assert await transport.write_audio_frame(frame) is True
+
+    playout_until = arrivals[0]
+    starvation_s = 0.0
+    for arrival_s in arrivals:
+        starvation_s += max(0.0, arrival_s - playout_until)
+        playout_until = max(playout_until, arrival_s) + 0.02
+    assert starvation_s == pytest.approx(0.0)
 
 
 @pytest.mark.asyncio

--- a/tests/test_voice_pipeline.py
+++ b/tests/test_voice_pipeline.py
@@ -1944,6 +1944,75 @@ async def test_response_boundary_flushes_each_partial_output_chunk():
 
 
 @pytest.mark.asyncio
+async def test_incremental_voice_output_flushes_one_final_partial_chunk():
+    """Incremental assistant output closes once through TTS and Pipecat."""
+    from pipecat.transports.base_transport import TransportParams
+    from xr_ai_voice._transport import (
+        TTS_NATIVE_SAMPLE_RATE,
+        DeviceIOHubOutputTransport,
+    )
+
+    class _ShortTts(_FakeTts):
+        async def synthesize(self, text: str, **_kwargs) -> bytes:
+            self.calls.append(text)
+            return _silence_wav(self.sample_rate, ms=27)
+
+    class _StubEndpoint:
+        def __init__(self) -> None:
+            self.chunks = []
+
+        async def send_return_audio(self, chunk) -> None:
+            self.chunks.append(chunk)
+
+    async def ignore_query(_query: VoiceQuery) -> None:
+        return None
+
+    async def response_chunks() -> AsyncIterator[str]:
+        yield "incremental "
+        await asyncio.sleep(0)
+        yield "response."
+
+    endpoint = _StubEndpoint()
+    tts = _ShortTts(sample_rate=TTS_NATIVE_SAMPLE_RATE)
+    gate = VoiceGate(VoiceGateConfig(), audio_sink=_NullSink(), tts=tts)
+    io_processor = _VoiceIOProcessor(ignore_query)
+    streaming = StreamingTtsProcessor(tts=tts, voice_gate=gate)
+    output = DeviceIOHubOutputTransport(
+        endpoint,
+        TransportParams(
+            audio_out_enabled=True,
+            audio_out_sample_rate=TTS_NATIVE_SAMPLE_RATE,
+            audio_out_channels=1,
+        ),
+    )
+    sink = _CaptureSink()
+    worker = PipelineWorker(
+        Pipeline([io_processor, streaming, output, sink]),
+        cancel_on_idle_timeout=False,
+        enable_rtvi=False,
+    )
+    runner = WorkerRunner()
+    await runner.add_workers(worker)
+
+    async def drive() -> None:
+        await asyncio.sleep(0.05)
+        await io_processor.enqueue_response("alice", response_chunks(), pts_us=7)
+        await io_processor._inflight["alice"]  # noqa: SLF001
+        await asyncio.sleep(0.1)
+        await worker.queue_frame(EndFrame())
+
+    await asyncio.gather(runner.run(), drive())
+
+    assert tts.calls == ["incremental response."]
+    assert len(endpoint.chunks) == 1
+    assert endpoint.chunks[0].participant_id == "alice"
+    assert endpoint.chunks[0].samples / TTS_NATIVE_SAMPLE_RATE == pytest.approx(
+        0.04,
+        abs=0.001,
+    )
+
+
+@pytest.mark.asyncio
 async def test_interrupt_drains_boundary_parked_behind_slow_tts():
     """Teardown must skip an ordered boundary while cancelling synthesis."""
     class _SlowTts(_FakeTts):
@@ -2412,13 +2481,14 @@ async def test_input_transport_populates_transport_source_from_chunk_pid():
 
 
 @pytest.mark.asyncio
-async def test_input_transport_emits_participant_joined_frame():
+async def test_input_transport_emits_participant_joined_frame(monkeypatch):
     """``ParticipantEvent(joined=True)`` from the hub must surface as a
     ``ParticipantJoinedFrame`` on the pipecat pipeline — otherwise the
     voice gate never greets and the assistant never steers the output
     transport at a participant, so every TTS chunk gets dropped by
     ``DeviceIOHubOutputTransport.write_audio_frame``."""
     from xr_ai_hub import ParticipantEvent
+    from xr_ai_voice import _transport as transport_module
     from xr_ai_voice._transport import (
         SAMPLE_RATE,
         DeviceIOHubInputTransport,
@@ -2427,6 +2497,14 @@ async def test_input_transport_emits_participant_joined_frame():
     from pipecat.transports.base_transport import TransportParams
 
     ep = _CallbackStubEndpoint()
+    now_s = 100.0
+
+    async def fake_sleep(delay_s: float) -> None:
+        nonlocal now_s
+        now_s += delay_s
+
+    monkeypatch.setattr(transport_module, "_monotonic_s", lambda: now_s)
+    monkeypatch.setattr(transport_module, "_sleep_s", fake_sleep)
     params = TransportParams(
         audio_in_enabled=True,
         audio_in_sample_rate=SAMPLE_RATE,
@@ -2436,7 +2514,7 @@ async def test_input_transport_emits_participant_joined_frame():
     transport = DeviceIOHubInputTransport(
         ep,
         params,
-        return_audio_primer=output.prime_return_audio,
+        return_audio_primer=output.start_return_audio_preroll,
     )
     transport._started = True
 
@@ -2459,6 +2537,7 @@ async def test_input_transport_emits_participant_joined_frame():
     frame = pushed[0]
     assert isinstance(frame, ParticipantJoinedFrame)
     assert frame.participant_id == "web-client"
+    await output._wait_return_audio_preroll("web-client")  # noqa: SLF001
     assert len(ep.return_audio) == 8
     assert sum(chunk.samples for chunk in ep.return_audio) / 22_050 == pytest.approx(0.32)
     assert all(chunk.participant_id == "web-client" for chunk in ep.return_audio)
@@ -2494,7 +2573,7 @@ async def test_input_transport_emits_join_when_return_audio_preroll_fails():
             audio_in_sample_rate=SAMPLE_RATE,
             audio_in_channels=1,
         ),
-        return_audio_primer=output.prime_return_audio,
+        return_audio_primer=output.start_return_audio_preroll,
     )
     transport._started = True
     pushed: list[Frame] = []
@@ -2507,6 +2586,7 @@ async def test_input_transport_emits_join_when_return_audio_preroll_fails():
     await ep.participant_cb(
         ParticipantEvent(participant_id="web-client", joined=True, pts_us=0),
     )
+    await output._wait_return_audio_preroll("web-client")  # noqa: SLF001
 
     assert ep.return_audio_attempts == 1
     assert len(pushed) == 1
@@ -2515,28 +2595,34 @@ async def test_input_transport_emits_join_when_return_audio_preroll_fails():
 
 
 @pytest.mark.asyncio
-async def test_input_transport_preserves_join_leave_order_during_preroll():
-    """Detached leave delivery cannot overtake a join blocked on priming."""
+async def test_input_transport_does_not_delay_join_for_paced_preroll(monkeypatch):
+    """Greeting and application join work can overlap track preparation."""
     from pipecat.transports.base_transport import TransportParams
     from xr_ai_hub import ParticipantEvent
-    from xr_ai_voice._transport import SAMPLE_RATE, DeviceIOHubInputTransport
+    from xr_ai_voice import _transport as transport_module
+    from xr_ai_voice._transport import (
+        DeviceIOHubInputTransport,
+        DeviceIOHubOutputTransport,
+    )
 
-    primer_started = asyncio.Event()
-    release_primer = asyncio.Event()
+    now_s = 100.0
+    pacing_started = asyncio.Event()
+    release_pacing = asyncio.Event()
 
-    async def slow_primer(_pid: str) -> None:
-        primer_started.set()
-        await release_primer.wait()
+    async def blocking_sleep(delay_s: float) -> None:
+        nonlocal now_s
+        pacing_started.set()
+        await release_pacing.wait()
+        now_s += delay_s
 
+    monkeypatch.setattr(transport_module, "_monotonic_s", lambda: now_s)
+    monkeypatch.setattr(transport_module, "_sleep_s", blocking_sleep)
     ep = _CallbackStubEndpoint()
+    output = DeviceIOHubOutputTransport(ep, TransportParams())
     transport = DeviceIOHubInputTransport(
         ep,
-        TransportParams(
-            audio_in_enabled=True,
-            audio_in_sample_rate=SAMPLE_RATE,
-            audio_in_channels=1,
-        ),
-        return_audio_primer=slow_primer,
+        TransportParams(),
+        return_audio_primer=output.start_return_audio_preroll,
     )
     transport._started = True
     pushed: list[Frame] = []
@@ -2546,19 +2632,84 @@ async def test_input_transport_preserves_join_leave_order_during_preroll():
 
     transport.push_frame = capture  # type: ignore[method-assign]
 
+    await ep.participant_cb(
+        ParticipantEvent(participant_id="web-client", joined=True, pts_us=0),
+    )
+    await pacing_started.wait()
+
+    assert [type(frame) for frame in pushed] == [ParticipantJoinedFrame]
+    assert len(ep.return_audio) == 1
+    assert not output._return_audio_preroll_tasks["web-client"].done()  # noqa: SLF001
+
+    speech = OutputAudioRawFrame(
+        audio=b"\x01\x00" * 640,
+        sample_rate=16_000,
+        num_channels=1,
+    )
+    speech.transport_destination = "web-client"
+    speech_task = asyncio.create_task(output.write_audio_frame(speech))
+    await asyncio.sleep(0)
+    assert len(ep.return_audio) == 1
+
+    release_pacing.set()
+    await asyncio.gather(
+        output._wait_return_audio_preroll("web-client"),  # noqa: SLF001
+        speech_task,
+    )
+    assert len(ep.return_audio) == 9
+    assert all(not any(chunk.data) for chunk in ep.return_audio[:8])
+    assert any(ep.return_audio[-1].data)
+
+
+@pytest.mark.asyncio
+async def test_input_transport_preserves_join_leave_order_during_join_delivery():
+    """Detached leave delivery cannot overtake a join still in the pipeline."""
+    from pipecat.transports.base_transport import TransportParams
+    from xr_ai_hub import ParticipantEvent
+    from xr_ai_voice._transport import SAMPLE_RATE, DeviceIOHubInputTransport
+
+    primer_started: list[str] = []
+    join_delivery_started = asyncio.Event()
+    release_join_delivery = asyncio.Event()
+
+    def start_primer(pid: str) -> None:
+        primer_started.append(pid)
+
+    ep = _CallbackStubEndpoint()
+    transport = DeviceIOHubInputTransport(
+        ep,
+        TransportParams(
+            audio_in_enabled=True,
+            audio_in_sample_rate=SAMPLE_RATE,
+            audio_in_channels=1,
+        ),
+        return_audio_primer=start_primer,
+    )
+    transport._started = True
+    pushed: list[Frame] = []
+
+    async def capture(frame, direction=FrameDirection.DOWNSTREAM):
+        if isinstance(frame, ParticipantJoinedFrame):
+            join_delivery_started.set()
+            await release_join_delivery.wait()
+        pushed.append(frame)
+
+    transport.push_frame = capture  # type: ignore[method-assign]
+
     join = ep.participant_cb(
         ParticipantEvent(participant_id="web-client", joined=True, pts_us=1),
     )
     join_task = asyncio.create_task(join)
-    await primer_started.wait()
+    await join_delivery_started.wait()
     leave = ep.participant_cb(
         ParticipantEvent(participant_id="web-client", joined=False, pts_us=2),
     )
     leave_task = asyncio.create_task(leave)
     await asyncio.sleep(0)
 
+    assert primer_started == ["web-client"]
     assert pushed == []
-    release_primer.set()
+    release_join_delivery.set()
     await asyncio.gather(join_task, leave_task)
 
     assert [type(frame) for frame in pushed] == [
@@ -3316,8 +3467,10 @@ async def test_output_transport_writes_audio_to_target_participant():
 
 
 @pytest.mark.asyncio
-async def test_output_transport_accounts_preroll_before_pacing(monkeypatch):
-    """Real pre-roll backlog must reduce the pacer's initial burst."""
+async def test_output_transport_paces_preroll_within_small_hub_buffer(monkeypatch):
+    """The full pre-roll and following speech fit a 120 ms hub queue."""
+    from collections import deque
+
     from pipecat.transports.base_transport import TransportParams
     from xr_ai_voice import _transport as transport_module
     from xr_ai_voice._transport import DeviceIOHubOutputTransport
@@ -3331,30 +3484,64 @@ async def test_output_transport_accounts_preroll_before_pacing(monkeypatch):
         sleeps.append(delay_s)
         now_s += delay_s
 
-    class _StubEndpoint:
-        async def send_return_audio(self, _chunk) -> None:
+    class _BoundedEndpoint:
+        def __init__(self) -> None:
+            self.queued: deque[float] = deque()
+            self.last_update_s = now_s
+            self.dropped_s = 0.0
+
+        def _drain(self) -> None:
+            elapsed_s = now_s - self.last_update_s
+            self.last_update_s = now_s
+            while self.queued and elapsed_s > 0:
+                if elapsed_s + 1e-9 >= self.queued[0]:
+                    elapsed_s -= self.queued.popleft()
+                else:
+                    self.queued[0] -= elapsed_s
+                    elapsed_s = 0.0
+
+        async def send_return_audio(self, chunk) -> None:
+            self._drain()
+            duration_s = chunk.samples / chunk.sample_rate
+            while self.queued and sum(self.queued) + duration_s > 0.12 + 1e-9:
+                self.dropped_s += self.queued.popleft()
+            self.queued.append(duration_s)
             sent_at.append(now_s)
+
+        @property
+        def playout_until_s(self) -> float:
+            self._drain()
+            return now_s + sum(self.queued)
 
     monkeypatch.setattr(transport_module, "_monotonic_s", lambda: now_s)
     monkeypatch.setattr(transport_module, "_sleep_s", fake_sleep)
-    transport = DeviceIOHubOutputTransport(_StubEndpoint(), TransportParams())
+    endpoint = _BoundedEndpoint()
+    transport = DeviceIOHubOutputTransport(endpoint, TransportParams())
 
-    await transport.prime_return_audio("alice")
+    transport.start_return_audio_preroll("alice")
+    await transport._wait_return_audio_preroll("alice")  # noqa: SLF001
 
-    assert sent_at == [100.0] * 8
+    assert sent_at == pytest.approx([100.0 + index * 0.04 for index in range(8)])
+    assert sleeps == pytest.approx([0.04] * 7)
+    assert endpoint.dropped_s == pytest.approx(0.0)
+    assert transport._return_audio_preroll_tasks == {}  # noqa: SLF001
     assert transport._return_audio_deadline_s["alice"] == pytest.approx(100.32)  # noqa: SLF001
+    assert endpoint.playout_until_s == pytest.approx(100.32)
 
     frame = OutputAudioRawFrame(
-        audio=b"\x00\x00" * 320,
+        audio=b"\x00\x00" * 640,
         sample_rate=16_000,
         num_channels=1,
     )
     frame.transport_destination = "alice"
-    assert await transport.write_audio_frame(frame) is True
+    for _ in range(3):
+        assert await transport.write_audio_frame(frame) is True
 
-    assert sleeps == pytest.approx([0.22])
-    assert sent_at[-1] == pytest.approx(100.22)
-    assert transport._return_audio_deadline_s["alice"] == pytest.approx(100.34)  # noqa: SLF001
+    assert sent_at[-3:] == pytest.approx([100.28, 100.28, 100.32])
+    assert sleeps == pytest.approx([0.04] * 8)
+    assert endpoint.dropped_s == pytest.approx(0.0)
+    assert transport._return_audio_deadline_s["alice"] == pytest.approx(100.44)  # noqa: SLF001
+    assert endpoint.playout_until_s == pytest.approx(100.44)
 
 
 @pytest.mark.asyncio
@@ -3599,6 +3786,52 @@ async def test_output_transport_releases_media_sender_on_participant_left():
     assert "alice" not in transport._media_senders   # noqa: SLF001
     # The fallback target is cleared when the bound target participant leaves.
     assert transport.target_participant == ""
+
+
+@pytest.mark.asyncio
+async def test_output_transport_release_cancels_active_preroll(monkeypatch):
+    """A quick leave cannot retain a paced primer or its output state."""
+    from pipecat.transports.base_transport import TransportParams
+    from xr_ai_voice import _transport as transport_module
+    from xr_ai_voice._transport import DeviceIOHubOutputTransport
+
+    now_s = 100.0
+    pacing_started = asyncio.Event()
+
+    async def blocking_sleep(_delay_s: float) -> None:
+        pacing_started.set()
+        await asyncio.Event().wait()
+
+    class _StubEndpoint:
+        def __init__(self) -> None:
+            self.chunks = []
+
+        async def send_return_audio(self, chunk) -> None:
+            self.chunks.append(chunk)
+
+    monkeypatch.setattr(transport_module, "_monotonic_s", lambda: now_s)
+    monkeypatch.setattr(transport_module, "_sleep_s", blocking_sleep)
+    endpoint = _StubEndpoint()
+    transport = DeviceIOHubOutputTransport(endpoint, TransportParams())
+
+    transport.start_return_audio_preroll("alice")
+    await pacing_started.wait()
+    speech = OutputAudioRawFrame(
+        audio=b"\x00\x00" * 640,
+        sample_rate=16_000,
+        num_channels=1,
+    )
+    speech.transport_destination = "alice"
+    speech_task = asyncio.create_task(transport.write_audio_frame(speech))
+    await asyncio.sleep(0)
+    await transport._release_destination("alice")  # noqa: SLF001
+
+    with pytest.raises(asyncio.CancelledError):
+        await speech_task
+    assert len(endpoint.chunks) == 1
+    assert "alice" not in transport._return_audio_preroll_tasks  # noqa: SLF001
+    assert "alice" not in transport._return_audio_deadline_s  # noqa: SLF001
+    assert "alice" not in transport._return_audio_locks  # noqa: SLF001
 
 
 @pytest.mark.asyncio

--- a/tests/test_voice_pipeline.py
+++ b/tests/test_voice_pipeline.py
@@ -3826,12 +3826,127 @@ async def test_output_transport_release_cancels_active_preroll(monkeypatch):
     await asyncio.sleep(0)
     await transport._release_destination("alice")  # noqa: SLF001
 
-    with pytest.raises(asyncio.CancelledError):
-        await speech_task
+    assert await speech_task is False
     assert len(endpoint.chunks) == 1
     assert "alice" not in transport._return_audio_preroll_tasks  # noqa: SLF001
     assert "alice" not in transport._return_audio_deadline_s  # noqa: SLF001
     assert "alice" not in transport._return_audio_locks  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_preroll_cancellation_keeps_default_media_sender_alive(monkeypatch):
+    """Participant cleanup cannot cancel Pipecat's shared audio task."""
+    from pipecat.frames.frames import CancelFrame, StartFrame
+    from pipecat.transports.base_transport import TransportParams
+    from pipecat.utils.asyncio.task_manager import TaskManager
+    from xr_ai_voice import _transport as transport_module
+    from xr_ai_voice._transport import DeviceIOHubOutputTransport
+
+    pacing_started = asyncio.Event()
+    speech_waiting = asyncio.Event()
+    bob_received = asyncio.Event()
+
+    async def blocking_sleep(_delay_s: float) -> None:
+        pacing_started.set()
+        await asyncio.Event().wait()
+
+    class _StubEndpoint:
+        def __init__(self) -> None:
+            self.participant_ids: list[str] = []
+
+        async def send_return_audio(self, chunk) -> None:
+            self.participant_ids.append(chunk.participant_id)
+            if chunk.participant_id == "bob":
+                bob_received.set()
+
+    params = TransportParams(
+        audio_out_enabled=True,
+        audio_out_sample_rate=16_000,
+        audio_out_channels=1,
+        audio_out_end_silence_secs=0,
+    )
+    endpoint = _StubEndpoint()
+    transport = DeviceIOHubOutputTransport(
+        endpoint,
+        params,
+        task_manager=TaskManager(),
+    )
+    await transport.process_frame(StartFrame(), FrameDirection.DOWNSTREAM)
+    default_sender = transport._media_senders[None]  # noqa: SLF001
+    original_wait = transport._wait_return_audio_preroll  # noqa: SLF001
+
+    async def tracked_wait(pid: str) -> bool:
+        speech_waiting.set()
+        return await original_wait(pid)
+
+    monkeypatch.setattr(transport_module, "_sleep_s", blocking_sleep)
+    monkeypatch.setattr(transport, "_wait_return_audio_preroll", tracked_wait)
+
+    try:
+        transport.set_target_participant("alice")
+        transport.start_return_audio_preroll("alice")
+        await pacing_started.wait()
+
+        speech = OutputAudioRawFrame(
+            audio=b"\x00\x00" * 640,
+            sample_rate=16_000,
+            num_channels=1,
+        )
+        await transport._handle_frame(speech)  # noqa: SLF001
+        await speech_waiting.wait()
+        await transport._release_destination("alice")  # noqa: SLF001
+
+        audio_task = default_sender._audio_task  # noqa: SLF001
+        assert audio_task is not None
+        assert not audio_task.done()
+
+        transport.set_target_participant("bob")
+        await transport._handle_frame(speech)  # noqa: SLF001
+        await asyncio.wait_for(bob_received.wait(), timeout=1.0)
+
+        assert not audio_task.done()
+        assert endpoint.participant_ids == ["alice", "bob"]
+    finally:
+        await transport.cancel(CancelFrame())
+
+
+@pytest.mark.asyncio
+async def test_waiting_speech_task_cancellation_still_propagates(monkeypatch):
+    """Shielding the pre-roll cannot swallow cancellation of its waiter."""
+    from pipecat.transports.base_transport import TransportParams
+    from xr_ai_voice import _transport as transport_module
+    from xr_ai_voice._transport import DeviceIOHubOutputTransport
+
+    pacing_started = asyncio.Event()
+
+    async def blocking_sleep(_delay_s: float) -> None:
+        pacing_started.set()
+        await asyncio.Event().wait()
+
+    class _StubEndpoint:
+        async def send_return_audio(self, _chunk) -> None:
+            return
+
+    monkeypatch.setattr(transport_module, "_sleep_s", blocking_sleep)
+    transport = DeviceIOHubOutputTransport(_StubEndpoint(), TransportParams())
+    transport.start_return_audio_preroll("alice")
+    await pacing_started.wait()
+
+    speech = OutputAudioRawFrame(
+        audio=b"\x00\x00" * 640,
+        sample_rate=16_000,
+        num_channels=1,
+    )
+    speech.transport_destination = "alice"
+    speech_task = asyncio.create_task(transport.write_audio_frame(speech))
+    await asyncio.sleep(0)
+    speech_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await speech_task
+    assert "alice" in transport._return_audio_preroll_tasks  # noqa: SLF001
+
+    await transport._cancel_all_return_audio_prerolls()  # noqa: SLF001
 
 
 @pytest.mark.asyncio

--- a/tests/test_voice_pipeline.py
+++ b/tests/test_voice_pipeline.py
@@ -1098,6 +1098,35 @@ async def test_voice_gate_processor_chime_routes_through_pipeline_audio_path():
 
 
 @pytest.mark.asyncio
+async def test_voice_gate_processor_chime_does_not_stop_active_response():
+    """An early chime cannot pad-flush another response in mid-utterance."""
+    cfg = VoiceGateConfig(magic_phrases=("agent",), listening_chime=True)
+    proc = VoiceGateProcessor(cfg=cfg, tts=_FakeTts())
+    proc.gate.observe_tts_wav(_silence_wav(24000))
+    active_probes: list[str] = []
+
+    def response_active(pid: str) -> bool:
+        active_probes.append(pid)
+        return True
+
+    proc.set_tts_response_active_probe(response_active)
+    sink = await _run_chain(
+        proc,
+        sends=[
+            TranscriptionFrame(
+                text="agent, what time is it",
+                user_id="pid-1",
+                timestamp="t",
+            )
+        ],
+    )
+
+    assert active_probes == ["pid-1"]
+    assert any(isinstance(f, OutputAudioRawFrame) for f in sink.frames)
+    assert not any(isinstance(f, TTSStoppedFrame) for f in sink.frames)
+
+
+@pytest.mark.asyncio
 async def test_voice_gate_processor_never_falls_back_to_late_chime_for_speech_query():
     cfg = VoiceGateConfig(magic_phrases=("agent",), listening_chime=True)
     proc = VoiceGateProcessor(cfg=cfg, tts=_FakeTts())
@@ -1914,6 +1943,48 @@ async def test_response_boundary_flushes_each_partial_output_chunk():
     assert endpoint.chunks[0].samples == endpoint.chunks[1].samples
 
 
+@pytest.mark.asyncio
+async def test_interrupt_drains_boundary_parked_behind_slow_tts():
+    """Teardown must skip an ordered boundary while cancelling synthesis."""
+    class _SlowTts(_FakeTts):
+        def __init__(self) -> None:
+            super().__init__()
+            self.cancelled = asyncio.Event()
+
+        async def synthesize(self, text: str, **_kwargs) -> bytes:
+            self.calls.append(text)
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                self.cancelled.set()
+                raise
+
+    tts = _SlowTts()
+    gate = VoiceGate(VoiceGateConfig(), audio_sink=_NullSink(), tts=tts)
+    proc = StreamingTtsProcessor(tts=tts, voice_gate=gate)
+    text = TextFrame(text="slow response.")
+    text.transport_destination = "alice"
+    interruption = InterruptionFrame()
+    interruption.transport_source = "alice"
+
+    await _run_chain(
+        proc,
+        sends=[
+            text,
+            AssistantResponseEndFrame(
+                pid="alice",
+                text="slow response.",
+                pts_us=1,
+            ),
+            interruption,
+        ],
+        per_send_delay_s=0.03,
+    )
+
+    assert tts.cancelled.is_set()
+    assert proc._by_pid == {}  # noqa: SLF001
+
+
 def _constant_wav(sample_rate: int, *, ms: int, value: int) -> bytes:
     samples = max(1, int(sample_rate * ms / 1000))
     pcm = np.full(samples, value, dtype=np.int16).tobytes()
@@ -2351,6 +2422,7 @@ async def test_input_transport_emits_participant_joined_frame():
     from xr_ai_voice._transport import (
         SAMPLE_RATE,
         DeviceIOHubInputTransport,
+        DeviceIOHubOutputTransport,
     )
     from pipecat.transports.base_transport import TransportParams
 
@@ -2360,7 +2432,12 @@ async def test_input_transport_emits_participant_joined_frame():
         audio_in_sample_rate=SAMPLE_RATE,
         audio_in_channels=1,
     )
-    transport = DeviceIOHubInputTransport(ep, params)
+    output = DeviceIOHubOutputTransport(ep, TransportParams())
+    transport = DeviceIOHubInputTransport(
+        ep,
+        params,
+        return_audio_primer=output.prime_return_audio,
+    )
     transport._started = True
 
     pushed: list[Frame] = []
@@ -2393,7 +2470,11 @@ async def test_input_transport_emits_join_when_return_audio_preroll_fails():
     """Track priming is best-effort and cannot suppress participant lifecycle."""
     from pipecat.transports.base_transport import TransportParams
     from xr_ai_hub import ParticipantEvent
-    from xr_ai_voice._transport import SAMPLE_RATE, DeviceIOHubInputTransport
+    from xr_ai_voice._transport import (
+        SAMPLE_RATE,
+        DeviceIOHubInputTransport,
+        DeviceIOHubOutputTransport,
+    )
 
     class _FailingEndpoint(_CallbackStubEndpoint):
         def __init__(self) -> None:
@@ -2405,6 +2486,7 @@ async def test_input_transport_emits_join_when_return_audio_preroll_fails():
             raise RuntimeError("return audio unavailable")
 
     ep = _FailingEndpoint()
+    output = DeviceIOHubOutputTransport(ep, TransportParams())
     transport = DeviceIOHubInputTransport(
         ep,
         TransportParams(
@@ -2412,6 +2494,7 @@ async def test_input_transport_emits_join_when_return_audio_preroll_fails():
             audio_in_sample_rate=SAMPLE_RATE,
             audio_in_channels=1,
         ),
+        return_audio_primer=output.prime_return_audio,
     )
     transport._started = True
     pushed: list[Frame] = []
@@ -2429,6 +2512,60 @@ async def test_input_transport_emits_join_when_return_audio_preroll_fails():
     assert len(pushed) == 1
     assert isinstance(pushed[0], ParticipantJoinedFrame)
     assert pushed[0].participant_id == "web-client"
+
+
+@pytest.mark.asyncio
+async def test_input_transport_preserves_join_leave_order_during_preroll():
+    """Detached leave delivery cannot overtake a join blocked on priming."""
+    from pipecat.transports.base_transport import TransportParams
+    from xr_ai_hub import ParticipantEvent
+    from xr_ai_voice._transport import SAMPLE_RATE, DeviceIOHubInputTransport
+
+    primer_started = asyncio.Event()
+    release_primer = asyncio.Event()
+
+    async def slow_primer(_pid: str) -> None:
+        primer_started.set()
+        await release_primer.wait()
+
+    ep = _CallbackStubEndpoint()
+    transport = DeviceIOHubInputTransport(
+        ep,
+        TransportParams(
+            audio_in_enabled=True,
+            audio_in_sample_rate=SAMPLE_RATE,
+            audio_in_channels=1,
+        ),
+        return_audio_primer=slow_primer,
+    )
+    transport._started = True
+    pushed: list[Frame] = []
+
+    async def capture(frame, direction=FrameDirection.DOWNSTREAM):
+        pushed.append(frame)
+
+    transport.push_frame = capture  # type: ignore[method-assign]
+
+    join = ep.participant_cb(
+        ParticipantEvent(participant_id="web-client", joined=True, pts_us=1),
+    )
+    join_task = asyncio.create_task(join)
+    await primer_started.wait()
+    leave = ep.participant_cb(
+        ParticipantEvent(participant_id="web-client", joined=False, pts_us=2),
+    )
+    leave_task = asyncio.create_task(leave)
+    await asyncio.sleep(0)
+
+    assert pushed == []
+    release_primer.set()
+    await asyncio.gather(join_task, leave_task)
+
+    assert [type(frame) for frame in pushed] == [
+        ParticipantJoinedFrame,
+        ParticipantLeftFrame,
+    ]
+    assert transport._participant_event_tails == {}  # noqa: SLF001
 
 
 @pytest.mark.asyncio
@@ -3179,6 +3316,48 @@ async def test_output_transport_writes_audio_to_target_participant():
 
 
 @pytest.mark.asyncio
+async def test_output_transport_accounts_preroll_before_pacing(monkeypatch):
+    """Real pre-roll backlog must reduce the pacer's initial burst."""
+    from pipecat.transports.base_transport import TransportParams
+    from xr_ai_voice import _transport as transport_module
+    from xr_ai_voice._transport import DeviceIOHubOutputTransport
+
+    now_s = 100.0
+    sent_at: list[float] = []
+    sleeps: list[float] = []
+
+    async def fake_sleep(delay_s: float) -> None:
+        nonlocal now_s
+        sleeps.append(delay_s)
+        now_s += delay_s
+
+    class _StubEndpoint:
+        async def send_return_audio(self, _chunk) -> None:
+            sent_at.append(now_s)
+
+    monkeypatch.setattr(transport_module, "_monotonic_s", lambda: now_s)
+    monkeypatch.setattr(transport_module, "_sleep_s", fake_sleep)
+    transport = DeviceIOHubOutputTransport(_StubEndpoint(), TransportParams())
+
+    await transport.prime_return_audio("alice")
+
+    assert sent_at == [100.0] * 8
+    assert transport._return_audio_deadline_s["alice"] == pytest.approx(100.32)  # noqa: SLF001
+
+    frame = OutputAudioRawFrame(
+        audio=b"\x00\x00" * 320,
+        sample_rate=16_000,
+        num_channels=1,
+    )
+    frame.transport_destination = "alice"
+    assert await transport.write_audio_frame(frame) is True
+
+    assert sleeps == pytest.approx([0.22])
+    assert sent_at[-1] == pytest.approx(100.22)
+    assert transport._return_audio_deadline_s["alice"] == pytest.approx(100.34)  # noqa: SLF001
+
+
+@pytest.mark.asyncio
 async def test_output_transport_paces_return_audio_before_ipc(monkeypatch):
     """Normal TTS builds bounded reserve, then advances at playback rate."""
     from xr_ai_voice import _transport as transport_module
@@ -3256,6 +3435,72 @@ async def test_output_transport_reserve_absorbs_periodic_ipc_stalls(monkeypatch)
         starvation_s += max(0.0, arrival_s - playout_until)
         playout_until = max(playout_until, arrival_s) + 0.02
     assert starvation_s == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_output_transport_interrupt_cannot_restore_stale_reserve(monkeypatch):
+    """An interruption during pacing clears the deadline after the writer."""
+    from pipecat.transports.base_transport import TransportParams
+    from xr_ai_voice import _transport as transport_module
+    from xr_ai_voice._transport import DeviceIOHubOutputTransport
+
+    now_s = 100.0
+    sleep_started = asyncio.Event()
+    release_sleep = asyncio.Event()
+    sleeps: list[float] = []
+    sends: list[float] = []
+
+    async def blocking_sleep(delay_s: float) -> None:
+        nonlocal now_s
+        sleeps.append(delay_s)
+        sleep_started.set()
+        await release_sleep.wait()
+        now_s += delay_s
+
+    class _StubEndpoint:
+        async def send_return_audio(self, _chunk) -> None:
+            sends.append(now_s)
+
+    class _StubSender:
+        def __init__(self) -> None:
+            self.interruptions = 0
+
+        async def handle_interruptions(self, _frame) -> None:
+            self.interruptions += 1
+
+    monkeypatch.setattr(transport_module, "_monotonic_s", lambda: now_s)
+    monkeypatch.setattr(transport_module, "_sleep_s", blocking_sleep)
+    transport = DeviceIOHubOutputTransport(_StubEndpoint(), TransportParams())
+    sender = _StubSender()
+    transport._media_senders["alice"] = sender  # noqa: SLF001
+    transport._return_audio_deadline_s["alice"] = 100.12  # noqa: SLF001
+    frame = OutputAudioRawFrame(
+        audio=b"\x00\x00" * 320,
+        sample_rate=16_000,
+        num_channels=1,
+    )
+    frame.transport_destination = "alice"
+
+    write_task = asyncio.create_task(transport.write_audio_frame(frame))
+    await sleep_started.wait()
+    interruption = InterruptionFrame()
+    interruption.transport_source = "alice"
+    interrupt_task = asyncio.create_task(
+        transport._handle_frame(interruption),  # noqa: SLF001
+    )
+    await asyncio.sleep(0)
+
+    assert not interrupt_task.done()
+    release_sleep.set()
+    await asyncio.gather(write_task, interrupt_task)
+
+    assert sender.interruptions == 1
+    assert "alice" not in transport._return_audio_deadline_s  # noqa: SLF001
+    assert len(sleeps) == 1
+
+    assert await transport.write_audio_frame(frame) is True
+    assert len(sleeps) == 1
+    assert len(sends) == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_voice_pipeline.py
+++ b/tests/test_voice_pipeline.py
@@ -51,6 +51,7 @@ from xr_ai_voice._frames import (
     GatedQueryFrame,
     ParticipantJoinedFrame,
     ParticipantLeftFrame,
+    TextResponseEndFrame,
 )
 from xr_ai_voice._processors import (
     _VoiceIOProcessor,
@@ -1011,6 +1012,11 @@ async def test_voice_gate_processor_stop_emits_interruption_and_ack_text():
     assert indices_interrupt[0] < indices_text[0]
     ack = next(f for f in sink.frames if isinstance(f, TextFrame))
     assert ack.text == "Okay, I will stop."
+    boundary_indices = [
+        i for i, f in enumerate(sink.frames) if isinstance(f, TextResponseEndFrame)
+    ]
+    assert len(boundary_indices) == 1
+    assert indices_text[0] < boundary_indices[0]
 
 
 @pytest.mark.asyncio
@@ -1025,6 +1031,9 @@ async def test_voice_gate_processor_greeting_emitted_when_phrases_configured():
     texts = [f for f in sink.frames if isinstance(f, TextFrame)]
     assert len(texts) == 1
     assert texts[0].text.startswith("To talk to me")
+    boundaries = [f for f in sink.frames if isinstance(f, TextResponseEndFrame)]
+    assert len(boundaries) == 1
+    assert boundaries[0].pid == "pid-1"
     assert any(isinstance(f, ParticipantJoinedFrame) for f in sink.frames)
 
 
@@ -1905,6 +1914,153 @@ async def test_response_boundary_flushes_each_partial_output_chunk():
     assert endpoint.chunks[0].samples == endpoint.chunks[1].samples
 
 
+def _constant_wav(sample_rate: int, *, ms: int, value: int) -> bytes:
+    samples = max(1, int(sample_rate * ms / 1000))
+    pcm = np.full(samples, value, dtype=np.int16).tobytes()
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm)
+    return buf.getvalue()
+
+
+class _TaggedShortTts(_FakeTts):
+    """Sub-40 ms WAVs with distinct samples for gate and assistant text."""
+
+    async def synthesize(self, text: str, **_kwargs) -> bytes:
+        self.calls.append(text)
+        value = 2_000 if text.startswith("answer:") else 1_000
+        return _constant_wav(self.sample_rate, ms=27, value=value)
+
+
+class _BoundaryEndpoint:
+    def __init__(self) -> None:
+        self.chunks = []
+
+    async def send_return_audio(self, chunk) -> None:
+        self.chunks.append(chunk)
+
+
+def _nonzero_sample_values(chunk) -> set[int]:
+    samples = np.frombuffer(chunk.data, dtype=np.float32)
+    restored = np.rint(samples * 32767).astype(np.int16)
+    return {
+        int(round(value / 1_000) * 1_000)
+        for value in restored.tolist()
+        if value
+    }
+
+
+def _has_silence_padding(chunk) -> bool:
+    return bool(np.any(np.frombuffer(chunk.data, dtype=np.float32) == 0.0))
+
+
+@pytest.mark.asyncio
+async def test_greeting_boundary_flushes_before_assistant_response():
+    """A short greeting tail must not share a 40 ms chunk with the reply."""
+    from pipecat.transports.base_transport import TransportParams
+    from xr_ai_voice._transport import (
+        TTS_NATIVE_SAMPLE_RATE,
+        DeviceIOHubOutputTransport,
+    )
+
+    endpoint = _BoundaryEndpoint()
+    tts = _TaggedShortTts(sample_rate=TTS_NATIVE_SAMPLE_RATE)
+    gate = VoiceGateProcessor(
+        cfg=VoiceGateConfig(magic_phrases=("agent",)),
+        tts=tts,
+    )
+    assistant = _StringAssistant()
+    streaming = StreamingTtsProcessor(tts=tts, voice_gate=gate.gate)
+    output = DeviceIOHubOutputTransport(
+        endpoint,
+        TransportParams(
+            audio_out_enabled=True,
+            audio_out_sample_rate=TTS_NATIVE_SAMPLE_RATE,
+            audio_out_channels=1,
+        ),
+    )
+
+    await _run_chain(
+        gate,
+        assistant,
+        streaming,
+        output,
+        sends=[
+            ParticipantJoinedFrame(participant_id="alice"),
+            GatedQueryFrame(
+                participant_id="alice",
+                text="next",
+                fresh_match=False,
+                pts_us=1,
+            ),
+        ],
+        settle_s=0.4,
+    )
+
+    # The two-sentence greeting occupies two chunks. Its padded tail is
+    # completed before the independently padded assistant chunk begins.
+    assert [_nonzero_sample_values(c) for c in endpoint.chunks] == [
+        {1_000},
+        {1_000},
+        {2_000},
+    ]
+    assert _has_silence_padding(endpoint.chunks[1])
+    assert _has_silence_padding(endpoint.chunks[2])
+
+
+@pytest.mark.asyncio
+async def test_stop_ack_boundary_flushes_before_next_response():
+    """A short stop acknowledgement must not share a chunk with later text."""
+    from pipecat.transports.base_transport import TransportParams
+    from xr_ai_voice._transport import (
+        TTS_NATIVE_SAMPLE_RATE,
+        DeviceIOHubOutputTransport,
+    )
+
+    endpoint = _BoundaryEndpoint()
+    tts = _TaggedShortTts(sample_rate=TTS_NATIVE_SAMPLE_RATE)
+    gate = VoiceGateProcessor(
+        cfg=VoiceGateConfig(magic_phrases=("agent",)),
+        tts=tts,
+    )
+    assistant = _StringAssistant()
+    streaming = StreamingTtsProcessor(tts=tts, voice_gate=gate.gate)
+    output = DeviceIOHubOutputTransport(
+        endpoint,
+        TransportParams(
+            audio_out_enabled=True,
+            audio_out_sample_rate=TTS_NATIVE_SAMPLE_RATE,
+            audio_out_channels=1,
+        ),
+    )
+
+    await _run_chain(
+        gate,
+        assistant,
+        streaming,
+        output,
+        sends=[
+            TranscriptionFrame(text="stop", user_id="alice", timestamp="t"),
+            GatedQueryFrame(
+                participant_id="alice",
+                text="next",
+                fresh_match=False,
+                pts_us=2,
+            ),
+        ],
+        settle_s=0.4,
+    )
+
+    assert [_nonzero_sample_values(c) for c in endpoint.chunks] == [
+        {1_000},
+        {2_000},
+    ]
+    assert all(_has_silence_padding(c) for c in endpoint.chunks)
+
+
 @pytest.mark.asyncio
 async def test_streaming_tts_parallel_synth_keeps_order():
     """Out-of-order completion of synth tasks must NOT reorder the
@@ -2230,6 +2386,49 @@ async def test_input_transport_emits_participant_joined_frame():
     assert sum(chunk.samples for chunk in ep.return_audio) / 22_050 == pytest.approx(0.32)
     assert all(chunk.participant_id == "web-client" for chunk in ep.return_audio)
     assert all(not any(chunk.data) for chunk in ep.return_audio)
+
+
+@pytest.mark.asyncio
+async def test_input_transport_emits_join_when_return_audio_preroll_fails():
+    """Track priming is best-effort and cannot suppress participant lifecycle."""
+    from pipecat.transports.base_transport import TransportParams
+    from xr_ai_hub import ParticipantEvent
+    from xr_ai_voice._transport import SAMPLE_RATE, DeviceIOHubInputTransport
+
+    class _FailingEndpoint(_CallbackStubEndpoint):
+        def __init__(self) -> None:
+            super().__init__()
+            self.return_audio_attempts = 0
+
+        async def send_return_audio(self, _chunk) -> None:
+            self.return_audio_attempts += 1
+            raise RuntimeError("return audio unavailable")
+
+    ep = _FailingEndpoint()
+    transport = DeviceIOHubInputTransport(
+        ep,
+        TransportParams(
+            audio_in_enabled=True,
+            audio_in_sample_rate=SAMPLE_RATE,
+            audio_in_channels=1,
+        ),
+    )
+    transport._started = True
+    pushed: list[Frame] = []
+
+    async def capture(frame, direction=FrameDirection.DOWNSTREAM):
+        pushed.append(frame)
+
+    transport.push_frame = capture  # type: ignore[method-assign]
+
+    await ep.participant_cb(
+        ParticipantEvent(participant_id="web-client", joined=True, pts_us=0),
+    )
+
+    assert ep.return_audio_attempts == 1
+    assert len(pushed) == 1
+    assert isinstance(pushed[0], ParticipantJoinedFrame)
+    assert pushed[0].participant_id == "web-client"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Preserve the one-time 320 ms return-track pre-roll, but send its eight 40 ms silence chunks at audio cadence so a supported 120 ms hub queue retains all of them.
- Run pre-roll as a participant-scoped output task: join, greeting synthesis, and application work proceed concurrently, while real speech remains ordered behind the silence.
- Maintain a bounded 120 ms downstream speech reserve and catch up after event-loop or IPC stalls instead of preserving them as audible gaps.
- Use one participant-scoped text-response boundary for greetings, stop acknowledgements, and assistant responses, ordered behind synthesis so every final partial Pipecat chunk is padded and flushed independently.
- Require `pipecat-ai>=1.6`, serialize participant lifecycle work, clear pacing state safely across interruptions, and prevent wake chimes from mid-response pad-flushing.
- Document the pre-roll and compatible hub-buffer behavior, with regression coverage for bounded hub queues, failure, concurrency, leave/shutdown teardown, incremental output, pacing stalls, and utterance boundaries.

## Root cause

Return audio originally had no jitter reserve, so ordinary scheduling and IPC delays reached the hub as late chunks and caused playout underruns. The return track was also created lazily from the first real speech, allowing setup to consume the beginning of a response, and partial aggregation chunks were not explicitly flushed after every source of synthesized text.

The first pre-roll implementation burst all 320 ms through IPC and modeled every chunk as retained. A 120 ms hub queue could drop 200 ms while the sender still delayed speech against a 320 ms deadline, creating an empty-track gap. Pacing the complete 320 ms pre-roll at 40 ms cadence keeps the hub queue and local deadline aligned without delaying text or greeting synthesis.

The fix lives in the shared xr-ai-voice and hub return-audio path, so voice-enabled agent samples receive the same behavior without sample-specific changes.

## Validation

- From `tests/`: `uv run pytest test_voice_pipeline.py -q`: 104 passed
- From `tests/`: `uv run pytest test_return_audio_pacing.py -q`: 17 passed
- From `tests/`: `uv run pytest -q -m "not gpu"`: 1,297 passed, 10 deselected
- Real 120 ms `_ReturnAudioPipe`: all eight pre-roll chunks retained, zero drops
- At the declared floor: Pipecat 1.6.0 boundary/chime cases: 5 passed
- Documentation API check, configuration-documentation tests, dependency map, and Python compilation: passed
- Manual simple-vlm-example session: response audio was materially smoother, including response starts