### PR TITLE
Fix idle tea assistant routing

### DIFF
--- a/agent-samples/tea-making-sample/README.md
+++ b/agent-samples/tea-making-sample/README.md
@@ -118,8 +118,11 @@ development network or put it behind an authenticated TLS proxy.
   and workflow paths.
 - `yaml/workflow.yaml` defines the tea steps, typed state, evidence gates, and
   user-facing messages.
-- `worker/tea_making_worker/prompts/` is the default source for model prompts;
-  explicit inline YAML values override those files.
+- `worker/tea_making_worker/prompts/` is the default source for model prompts.
+  An inline `foreground_prompt` or `foreground_prompt_file` replaces the shared
+  foreground instructions, while the packaged idle or active route policy is
+  always appended. Other prompt and prompt-file settings replace their matching
+  packaged files.
 - `yaml/voice_gate.yaml` is the checked-in wake-word configuration. Set
   `voice_gate_yaml: voice_gate.always-on.yaml` in the worker YAML to dispatch
   every finalized utterance without a wake phrase.

--- a/agent-samples/tea-making-sample/eval/cases.yaml
+++ b/agent-samples/tea-making-sample/eval/cases.yaml
@@ -8,6 +8,10 @@
   query: What is the capital of France?
   expected_tool: null
   forbidden_response: I can only help with the active tea guide right now.
+- name: idle-routes-visible-shirt-color
+  query: What color is the shirt?
+  expected_tool: current_view
+  forbidden_response: I can only help with the active tea guide right now.
 - name: start-tea-guide
   query: Help me make a cup of tea.
   expected_tool: workflow__start
@@ -81,6 +85,13 @@
   route: active
   step: start_steeping
   query: Please translate good morning into Japanese.
+  expected_tool: null
+  expected_response: I can only help with the active tea guide right now.
+
+- name: active-rejects-unrelated-visual-question
+  route: active
+  step: fill_water
+  query: What color is the person's shirt?
   expected_tool: null
   expected_response: I can only help with the active tea guide right now.
 

--- a/agent-samples/tea-making-sample/eval/eval.py
+++ b/agent-samples/tea-making-sample/eval/eval.py
@@ -13,6 +13,7 @@ from typing import Any
 import yaml
 from tea_making_worker.background_context import BackgroundContextAgent
 from tea_making_worker.change_watch import ChangeWatchAgent
+from tea_making_worker.config import load_config
 from tea_making_worker.foreground import ForegroundAgent
 from tea_making_worker.spec import load_workflow
 from tea_making_worker.transcript import TranscriptAgent
@@ -23,10 +24,10 @@ from xr_ai_tools.image import ImageRegistry
 from xr_ai_tools.tool_calling import tool_definitions
 
 _SAMPLE = Path(__file__).resolve().parents[1]
-_PROMPTS = _SAMPLE / "worker" / "tea_making_worker" / "prompts"
 
 
 def _build_agents(llm: LLMService) -> tuple[ForegroundAgent, GuidanceAgent]:
+    config = load_config(_SAMPLE / "yaml" / "tea_making_worker.yaml")
     images = SimpleNamespace(
         images=ImageRegistry(),
         get_current_frame=SimpleNamespace(),
@@ -70,7 +71,7 @@ def _build_agents(llm: LLMService) -> tuple[ForegroundAgent, GuidanceAgent]:
         change_watch=change_watch,
         transcript=transcript,
         video_log=video_log,
-        prompt=(_PROMPTS / "foreground_prompt.txt").read_text(encoding="utf-8"),
+        prompt=config.foreground_prompt,
     )
     return foreground, guidance
 

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/config.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/config.py
@@ -14,6 +14,10 @@ import yaml
 _PACKAGE = Path(__file__).resolve().parent
 
 
+class _PackagedPrompt(str):
+    """Mark prompt text loaded from a package default rather than an override."""
+
+
 @dataclass(frozen=True, slots=True)
 class WorkerConfig:
     models_config: Path
@@ -71,7 +75,8 @@ def _prompt(data: dict[str, Any], config_path: Path | None, name: str) -> str:
         if configured is not None
         else _PACKAGE / "prompts" / f"{name}.txt"
     )
-    return path.read_text(encoding="utf-8").strip()
+    text = path.read_text(encoding="utf-8").strip()
+    return _PackagedPrompt(text) if configured is None else text
 
 
 def _positive(data: dict[str, Any], name: str, default: float) -> float:

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/config.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/config.py
@@ -14,10 +14,6 @@ import yaml
 _PACKAGE = Path(__file__).resolve().parent
 
 
-class _PackagedPrompt(str):
-    """Mark prompt text loaded from a package default rather than an override."""
-
-
 @dataclass(frozen=True, slots=True)
 class WorkerConfig:
     models_config: Path
@@ -75,8 +71,7 @@ def _prompt(data: dict[str, Any], config_path: Path | None, name: str) -> str:
         if configured is not None
         else _PACKAGE / "prompts" / f"{name}.txt"
     )
-    text = path.read_text(encoding="utf-8").strip()
-    return _PackagedPrompt(text) if configured is None else text
+    return path.read_text(encoding="utf-8").strip()
 
 
 def _positive(data: dict[str, Any], name: str, default: float) -> float:

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/foreground.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/foreground.py
@@ -33,7 +33,6 @@ from xr_ai_voice import (
 
 from .background_context import BackgroundContextAgent
 from .change_watch import ChangeWatchAgent
-from .config import _PackagedPrompt
 from .events import (
     FOREGROUND_RECORD_TOPIC,
     INTERRUPTED_TOPIC,
@@ -85,7 +84,6 @@ class ForegroundAgent(Agent):
         self._change_watch = change_watch
         self._transcript = transcript
         self._video_log = video_log
-        self._uses_default_route_policy = isinstance(prompt, _PackagedPrompt)
         self._prompt = prompt.strip()
         self._vlm_timeout_s = vlm_timeout_s
         self._tasks: dict[str, asyncio.Task[None]] = {}
@@ -269,7 +267,7 @@ class ForegroundAgent(Agent):
                 ctx=ctx,
                 timestamp_us=timestamp_us,
             )
-            system_prompt = self._with_default_route_policy(_IDLE_PROMPT)
+            system_prompt = self._with_route_policy(_IDLE_PROMPT)
             route = "root"
         else:
             active_tools = self._guidance.active_tools(participant_id)
@@ -280,15 +278,13 @@ class ForegroundAgent(Agent):
                 self._background_tools(participant_id),
             )
             system_prompt = (
-                f"{self._with_default_route_policy(_ACTIVE_PROMPT)}"
+                f"{self._with_route_policy(_ACTIVE_PROMPT)}"
                 f"\n\nActive tea guide:\n{active_context}"
             )
             route = "tea"
         return system_prompt, tools, route
 
-    def _with_default_route_policy(self, route_prompt: str) -> str:
-        if not getattr(self, "_uses_default_route_policy", False):
-            return self._prompt
+    def _with_route_policy(self, route_prompt: str) -> str:
         return f"{self._prompt}\n\n{route_prompt}"
 
     def _root_tools(

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/foreground.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/foreground.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import suppress
+from pathlib import Path
 
 import nemo_relay
 from loguru import logger
@@ -48,6 +49,9 @@ from .workflow import GuidanceAgent
 from .workflow_tools import CurrentViewRequest, rag_lookup_tool
 
 _MAX_TOOL_ROUNDS = 4
+_PROMPTS = Path(__file__).resolve().parent / "prompts"
+_IDLE_PROMPT = (_PROMPTS / "foreground_idle.txt").read_text(encoding="utf-8").strip()
+_ACTIVE_PROMPT = (_PROMPTS / "foreground_active.txt").read_text(encoding="utf-8").strip()
 
 
 class ForegroundAgent(Agent):
@@ -263,7 +267,7 @@ class ForegroundAgent(Agent):
                 ctx=ctx,
                 timestamp_us=timestamp_us,
             )
-            system_prompt = self._prompt
+            system_prompt = f"{self._prompt}\n\n{_IDLE_PROMPT}"
             route = "root"
         else:
             active_tools = self._guidance.active_tools(participant_id)
@@ -273,7 +277,10 @@ class ForegroundAgent(Agent):
                 active_tools,
                 self._background_tools(participant_id),
             )
-            system_prompt = f"{self._prompt}\n\nActive tea guide:\n{active_context}"
+            system_prompt = (
+                f"{self._prompt}\n\n{_ACTIVE_PROMPT}"
+                f"\n\nActive tea guide:\n{active_context}"
+            )
             route = "tea"
         return system_prompt, tools, route
 

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/foreground.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/foreground.py
@@ -33,6 +33,7 @@ from xr_ai_voice import (
 
 from .background_context import BackgroundContextAgent
 from .change_watch import ChangeWatchAgent
+from .config import _PackagedPrompt
 from .events import (
     FOREGROUND_RECORD_TOPIC,
     INTERRUPTED_TOPIC,
@@ -50,7 +51,6 @@ from .workflow_tools import CurrentViewRequest, rag_lookup_tool
 
 _MAX_TOOL_ROUNDS = 4
 _PROMPTS = Path(__file__).resolve().parent / "prompts"
-_DEFAULT_PROMPT = (_PROMPTS / "foreground_prompt.txt").read_text(encoding="utf-8").strip()
 _IDLE_PROMPT = (_PROMPTS / "foreground_idle.txt").read_text(encoding="utf-8").strip()
 _ACTIVE_PROMPT = (_PROMPTS / "foreground_active.txt").read_text(encoding="utf-8").strip()
 
@@ -85,6 +85,7 @@ class ForegroundAgent(Agent):
         self._change_watch = change_watch
         self._transcript = transcript
         self._video_log = video_log
+        self._uses_default_route_policy = isinstance(prompt, _PackagedPrompt)
         self._prompt = prompt.strip()
         self._vlm_timeout_s = vlm_timeout_s
         self._tasks: dict[str, asyncio.Task[None]] = {}
@@ -286,7 +287,7 @@ class ForegroundAgent(Agent):
         return system_prompt, tools, route
 
     def _with_default_route_policy(self, route_prompt: str) -> str:
-        if self._prompt != _DEFAULT_PROMPT:
+        if not getattr(self, "_uses_default_route_policy", False):
             return self._prompt
         return f"{self._prompt}\n\n{route_prompt}"
 

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/foreground.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/foreground.py
@@ -50,6 +50,7 @@ from .workflow_tools import CurrentViewRequest, rag_lookup_tool
 
 _MAX_TOOL_ROUNDS = 4
 _PROMPTS = Path(__file__).resolve().parent / "prompts"
+_DEFAULT_PROMPT = (_PROMPTS / "foreground_prompt.txt").read_text(encoding="utf-8").strip()
 _IDLE_PROMPT = (_PROMPTS / "foreground_idle.txt").read_text(encoding="utf-8").strip()
 _ACTIVE_PROMPT = (_PROMPTS / "foreground_active.txt").read_text(encoding="utf-8").strip()
 
@@ -267,7 +268,7 @@ class ForegroundAgent(Agent):
                 ctx=ctx,
                 timestamp_us=timestamp_us,
             )
-            system_prompt = f"{self._prompt}\n\n{_IDLE_PROMPT}"
+            system_prompt = self._with_default_route_policy(_IDLE_PROMPT)
             route = "root"
         else:
             active_tools = self._guidance.active_tools(participant_id)
@@ -278,11 +279,16 @@ class ForegroundAgent(Agent):
                 self._background_tools(participant_id),
             )
             system_prompt = (
-                f"{self._prompt}\n\n{_ACTIVE_PROMPT}"
+                f"{self._with_default_route_policy(_ACTIVE_PROMPT)}"
                 f"\n\nActive tea guide:\n{active_context}"
             )
             route = "tea"
         return system_prompt, tools, route
+
+    def _with_default_route_policy(self, route_prompt: str) -> str:
+        if self._prompt != _DEFAULT_PROMPT:
+            return self._prompt
+        return f"{self._prompt}\n\n{route_prompt}"
 
     def _root_tools(
         self,

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/foreground_active.txt
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/foreground_active.txt
@@ -1,0 +1,7 @@
+The tea guide is active. Answer from the current step and its sparse state.
+Never call a workflow control unless the user clearly and directly commands
+that guide action. Use visual tools only for facts relevant to the active tea
+guide or its current step. Decline requests unrelated to both the guide and its
+background applications without answering them, calling a tool, or changing
+guide state; reply exactly:
+I can only help with the active tea guide right now.

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/foreground_idle.txt
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/foreground_idle.txt
@@ -1,5 +1,3 @@
 The tea guide is idle. Act as a general-purpose assistant and answer unrelated
 questions normally. Start tea guidance only when the user explicitly asks to
 make or start tea. Do not apply restrictions that belong to an active guide.
-Use current_view for current-scene questions such as what someone is holding or
-the color of visible clothing.

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/foreground_idle.txt
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/foreground_idle.txt
@@ -1,3 +1,5 @@
 The tea guide is idle. Act as a general-purpose assistant and answer unrelated
 questions normally. Start tea guidance only when the user explicitly asks to
 make or start tea. Do not apply restrictions that belong to an active guide.
+Use current_view for current-scene questions such as what someone is holding or
+the color of visible clothing.

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/foreground_idle.txt
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/foreground_idle.txt
@@ -1,0 +1,3 @@
+The tea guide is idle. Act as a general-purpose assistant and answer unrelated
+questions normally. Start tea guidance only when the user explicitly asks to
+make or start tea. Do not apply restrictions that belong to an active guide.

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/foreground_prompt.txt
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/foreground_prompt.txt
@@ -1,13 +1,7 @@
-Route each request to the smallest matching tool. When the tea guide is idle,
-start it only when the user explicitly asks to make or start tea. When it is
-active, answer from the current step and its sparse state. While the tea guide
-is active, never call a workflow control unless the user clearly and directly
-commands that guide action. While the tea guide is active, decline requests
-unrelated to both the guide and its background applications without answering
-them, calling a tool, or changing guide state; reply exactly:
-I can only help with the active tea guide right now.
-Use current_view for current or deictic visual questions and rag_lookup for tea
-or hot-water facts.
+Route each request to the smallest matching tool. Use current_view only for a
+question about a visible fact in the current camera scene, such as what someone
+is holding or the color of visible clothing. Answer general-knowledge questions
+directly without calling current_view. Use rag_lookup for tea or hot-water facts.
 Use application_context__query for recent background observations. Start, stop,
 or query a background application only through its named controls. Never claim
 to see the scene without calling a visual tool. Answer briefly for voice.

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/foreground_prompt.txt
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/foreground_prompt.txt
@@ -1,7 +1,8 @@
+This shared policy is followed by a packaged idle or active route policy.
 Route each request to the smallest matching tool. Use current_view only for a
-question about a visible fact in the current camera scene, such as what someone
-is holding or the color of visible clothing. Answer general-knowledge questions
-directly without calling current_view. Use rag_lookup for tea or hot-water facts.
+question about a visible fact in the current camera scene. Answer
+general-knowledge questions directly without calling current_view. Use
+rag_lookup for tea or hot-water facts.
 Use application_context__query for recent background observations. Start, stop,
 or query a background application only through its named controls. Never claim
 to see the scene without calling a visual tool. Answer briefly for voice.

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/foreground_prompt.txt
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/foreground_prompt.txt
@@ -1,4 +1,3 @@
-This shared policy is followed by a packaged idle or active route policy.
 Route each request to the smallest matching tool. Use current_view only for a
 question about a visible fact in the current camera scene. Answer
 general-knowledge questions directly without calling current_view. Use

--- a/agent-samples/tea-making-sample/yaml/tea_making_worker.yaml
+++ b/agent-samples/tea-making-sample/yaml/tea_making_worker.yaml
@@ -6,6 +6,11 @@ models_config: models.local.json
 workflow_config: workflow.yaml
 voice_gate_yaml: voice_gate.yaml
 
+# Choose one to replace the shared foreground instructions. The packaged idle
+# or active route policy is always appended after the configured shared prompt.
+# foreground_prompt: <inline shared foreground instructions>
+# foreground_prompt_file: ../worker/tea_making_worker/prompts/foreground_prompt.txt
+
 rag_endpoint: tcp://127.0.0.1:8340
 artifacts_dir: ../artifacts
 

--- a/docs/source/reference/tea-making-sample.md
+++ b/docs/source/reference/tea-making-sample.md
@@ -151,7 +151,7 @@ locks, and participant cleanup.
 | `guidance_voice.py` | Guidance notice speech policy | Add another presentation channel |
 | `file_output.py` | Participant JSONL artifacts | Replace files with backend persistence |
 | `web_events.py` | Explicit typed event-to-view projections | Select or reshape live presentation topics |
-| `prompts/` | Default model instructions | Tune one agent without duplicating prompts in YAML |
+| `prompts/` | Shared model instructions and packaged route policies | Tune configurable prompts without duplicating them in YAML |
 | `yaml/workflow.yaml` | Five-step procedure and evidence contract | Define a different guided task |
 | `rag-documents/` | Sample retrieval corpus | Replace with domain documents or a backend |
 
@@ -174,6 +174,11 @@ independent background applications. For a request unrelated to all of those,
 the model must call no tool, leave guide state unchanged, and reply exactly “I
 can only help with the active tea guide right now.” The rule is scoped to the
 active route; the idle root assistant can answer ordinary questions.
+
+An inline `foreground_prompt` or `foreground_prompt_file` overrides only the
+shared foreground instructions. The packaged idle or active policy is appended
+after that shared prompt so configuration overrides cannot remove route
+selection, active-guide refusal, or workflow-control safeguards.
 
 There is exactly one model loop. The foreground agent does not ask one model to
 route to another agent, and background agents never capture a foreground turn.

--- a/tests/test_tea_making_sample.py
+++ b/tests/test_tea_making_sample.py
@@ -1346,10 +1346,13 @@ def test_foreground_prompt_has_route_eval_cases() -> None:
         _WORKER / "tea_making_worker/prompts/foreground_active.txt"
     ).read_text()
     refusal = "I can only help with the active tea guide right now."
+    idle_model_prompt = f"{common_prompt}\n\n{idle_prompt}".lower()
+    active_model_prompt = f"{common_prompt}\n\n{active_prompt}".lower()
     assert refusal not in common_prompt
     assert refusal not in idle_prompt
-    assert "color of visible clothing" not in common_prompt
-    assert "color of visible clothing" in idle_prompt
+    for worked_example_term in ("holding", "color", "shirt", "clothing"):
+        assert worked_example_term not in idle_model_prompt
+        assert worked_example_term not in active_model_prompt
     assert "general-purpose assistant" in idle_prompt
     assert f"reply exactly:\n{refusal}" in active_prompt
 

--- a/tests/test_tea_making_sample.py
+++ b/tests/test_tea_making_sample.py
@@ -46,10 +46,7 @@ from tea_making_worker.background_context import (  # noqa: E402  # pyright: ign
     BackgroundContextAgent,
 )
 from tea_making_worker.change_watch import ChangeWatchAgent  # noqa: E402  # pyright: ignore[reportMissingImports]
-from tea_making_worker.config import (  # noqa: E402  # pyright: ignore[reportMissingImports]
-    _PackagedPrompt,
-    load_config,
-)
+from tea_making_worker.config import load_config  # noqa: E402  # pyright: ignore[reportMissingImports]
 from tea_making_worker.events import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     BACKGROUND_FACT_TOPIC,
     CHANGE_WATCH_RECORD_TOPIC,
@@ -1321,7 +1318,6 @@ def test_default_prompts_come_from_packaged_files(tmp_path: Path) -> None:
         config.foreground_prompt
         == (prompt_dir / "foreground_prompt.txt").read_text().strip()
     )
-    assert isinstance(config.foreground_prompt, _PackagedPrompt)
     assert (
         config.video_delta_prompt
         == (prompt_dir / "video_delta_prompt.txt").read_text().strip()
@@ -1336,9 +1332,6 @@ def test_default_prompts_come_from_packaged_files(tmp_path: Path) -> None:
     override.write_text("foreground_prompt_file: matching-prompt.txt\n")
     matching_config = load_config(override)
     assert matching_config.foreground_prompt == config.foreground_prompt
-    assert not isinstance(
-        matching_config.foreground_prompt, _PackagedPrompt
-    )
 
 
 def test_foreground_prompt_has_route_eval_cases() -> None:
@@ -1355,6 +1348,8 @@ def test_foreground_prompt_has_route_eval_cases() -> None:
     refusal = "I can only help with the active tea guide right now."
     assert refusal not in common_prompt
     assert refusal not in idle_prompt
+    assert "color of visible clothing" not in common_prompt
+    assert "color of visible clothing" in idle_prompt
     assert "general-purpose assistant" in idle_prompt
     assert f"reply exactly:\n{refusal}" in active_prompt
 
@@ -1425,20 +1420,33 @@ def test_foreground_prompt_has_route_eval_cases() -> None:
     assert active_visual["expected_response"] == refusal
 
 
-def test_foreground_route_injects_only_its_policy() -> None:
-    foreground = object.__new__(ForegroundAgent)
-    foreground._prompt = (
-        _WORKER / "tea_making_worker/prompts/foreground_prompt.txt"
-    ).read_text().strip()
-    foreground._uses_default_route_policy = True
-    foreground._guidance = SimpleNamespace(
-        active_context=lambda participant_id: (
-            None if participant_id == "idle" else '{"step":"fill_water"}'
-        ),
-        active_tools=lambda _participant_id: ToolSet(()),
+def _foreground_for_route_test(prompt: str) -> ForegroundAgent:
+    images = SimpleNamespace(images=ImageRegistry())
+    foreground = ForegroundAgent(
+        llm=SimpleNamespace(),  # type: ignore[arg-type]
+        images=images,  # type: ignore[arg-type]
+        vlm=SimpleNamespace(),  # type: ignore[arg-type]
+        rag=SimpleNamespace(),  # type: ignore[arg-type]
+        guidance=SimpleNamespace(
+            active_context=lambda participant_id: (
+                None if participant_id == "idle" else '{"step":"fill_water"}'
+            ),
+            active_tools=lambda _participant_id: ToolSet(()),
+        ),  # type: ignore[arg-type]
+        background_context=SimpleNamespace(),  # type: ignore[arg-type]
+        change_watch=SimpleNamespace(),  # type: ignore[arg-type]
+        transcript=SimpleNamespace(),  # type: ignore[arg-type]
+        video_log=SimpleNamespace(),  # type: ignore[arg-type]
+        prompt=prompt,
     )
     foreground._root_tools = lambda *_args, **_kwargs: ToolSet(())
     foreground._background_tools = lambda *_args, **_kwargs: ToolSet(())
+    return foreground
+
+
+def test_foreground_route_appends_policy_through_constructor() -> None:
+    config = load_config(_SAMPLE / "yaml/tea_making_worker.yaml")
+    foreground = _foreground_for_route_test(config.foreground_prompt)
 
     idle_prompt, _, idle_route = foreground._prepare_route(
         "idle", ctx=None, timestamp_us=None
@@ -1456,31 +1464,27 @@ def test_foreground_route_injects_only_its_policy() -> None:
     assert refusal in active_prompt
 
 
-def test_foreground_route_preserves_explicit_prompt_override() -> None:
-    foreground = object.__new__(ForegroundAgent)
-    foreground._prompt = (
-        _WORKER / "tea_making_worker/prompts/foreground_prompt.txt"
-    ).read_text().strip()
-    foreground._uses_default_route_policy = False
-    foreground._guidance = SimpleNamespace(
-        active_context=lambda participant_id: (
-            None if participant_id == "idle" else '{"step":"fill_water"}'
-        ),
-        active_tools=lambda _participant_id: ToolSet(()),
-    )
-    foreground._root_tools = lambda *_args, **_kwargs: ToolSet(())
-    foreground._background_tools = lambda *_args, **_kwargs: ToolSet(())
+def test_foreground_route_appends_policy_to_prompt_override(tmp_path: Path) -> None:
+    override = tmp_path / "worker.yaml"
+    override.write_text("foreground_prompt: Explicit override\n")
+    config = load_config(override)
+    foreground = _foreground_for_route_test(config.foreground_prompt)
 
-    idle_prompt, _, _ = foreground._prepare_route(
+    idle_prompt, _, idle_route = foreground._prepare_route(
         "idle", ctx=None, timestamp_us=None
     )
-    active_prompt, _, _ = foreground._prepare_route(
+    active_prompt, _, active_route = foreground._prepare_route(
         "active", ctx=None, timestamp_us=None
     )
     refusal = "I can only help with the active tea guide right now."
 
-    assert idle_prompt == foreground._prompt
-    assert active_prompt == (
-        f'{foreground._prompt}\n\nActive tea guide:\n{{"step":"fill_water"}}'
+    assert idle_route == "root"
+    assert idle_prompt.startswith("Explicit override\n\n")
+    assert "general-purpose assistant" in idle_prompt
+    assert refusal not in idle_prompt
+    assert active_route == "tea"
+    assert active_prompt.startswith("Explicit override\n\n")
+    assert refusal in active_prompt
+    assert active_prompt.endswith(
+        'Active tea guide:\n{"step":"fill_water"}'
     )
-    assert refusal not in active_prompt

--- a/tests/test_tea_making_sample.py
+++ b/tests/test_tea_making_sample.py
@@ -1414,7 +1414,7 @@ def test_foreground_prompt_has_route_eval_cases() -> None:
 
 def test_foreground_route_injects_only_its_policy() -> None:
     foreground = object.__new__(ForegroundAgent)
-    foreground._prompt = "Common policy."
+    foreground._prompt = foreground_module._DEFAULT_PROMPT
     foreground._guidance = SimpleNamespace(
         active_context=lambda participant_id: (
             None if participant_id == "idle" else '{"step":"fill_water"}'
@@ -1438,3 +1438,30 @@ def test_foreground_route_injects_only_its_policy() -> None:
     assert active_route == "tea"
     assert "general-purpose assistant" not in active_prompt
     assert refusal in active_prompt
+
+
+def test_foreground_route_preserves_explicit_prompt_override() -> None:
+    foreground = object.__new__(ForegroundAgent)
+    foreground._prompt = "Explicit override."
+    foreground._guidance = SimpleNamespace(
+        active_context=lambda participant_id: (
+            None if participant_id == "idle" else '{"step":"fill_water"}'
+        ),
+        active_tools=lambda _participant_id: ToolSet(()),
+    )
+    foreground._root_tools = lambda *_args, **_kwargs: ToolSet(())
+    foreground._background_tools = lambda *_args, **_kwargs: ToolSet(())
+
+    idle_prompt, _, _ = foreground._prepare_route(
+        "idle", ctx=None, timestamp_us=None
+    )
+    active_prompt, _, _ = foreground._prepare_route(
+        "active", ctx=None, timestamp_us=None
+    )
+    refusal = "I can only help with the active tea guide right now."
+
+    assert idle_prompt == "Explicit override."
+    assert active_prompt == (
+        'Explicit override.\n\nActive tea guide:\n{"step":"fill_water"}'
+    )
+    assert refusal not in active_prompt

--- a/tests/test_tea_making_sample.py
+++ b/tests/test_tea_making_sample.py
@@ -36,6 +36,7 @@ _SAMPLE = _ROOT / "agent-samples" / "tea-making-sample"
 _WORKER = _SAMPLE / "worker"
 sys.path.insert(0, str(_WORKER))
 
+import tea_making_worker.config as config_module  # noqa: E402  # pyright: ignore[reportMissingImports]
 import tea_making_worker.foreground as foreground_module  # noqa: E402  # pyright: ignore[reportMissingImports]
 from tea_making_worker.app import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     _CLIENT_TEXT_TOPIC,
@@ -1318,6 +1319,7 @@ def test_default_prompts_come_from_packaged_files(tmp_path: Path) -> None:
         config.foreground_prompt
         == (prompt_dir / "foreground_prompt.txt").read_text().strip()
     )
+    assert isinstance(config.foreground_prompt, config_module._PackagedPrompt)
     assert (
         config.video_delta_prompt
         == (prompt_dir / "video_delta_prompt.txt").read_text().strip()
@@ -1326,6 +1328,15 @@ def test_default_prompts_come_from_packaged_files(tmp_path: Path) -> None:
     override = tmp_path / "worker.yaml"
     override.write_text("foreground_prompt: Explicit override\n")
     assert load_config(override).foreground_prompt == "Explicit override"
+
+    matching_prompt = tmp_path / "matching-prompt.txt"
+    matching_prompt.write_text((prompt_dir / "foreground_prompt.txt").read_text())
+    override.write_text("foreground_prompt_file: matching-prompt.txt\n")
+    matching_config = load_config(override)
+    assert matching_config.foreground_prompt == config.foreground_prompt
+    assert not isinstance(
+        matching_config.foreground_prompt, config_module._PackagedPrompt
+    )
 
 
 def test_foreground_prompt_has_route_eval_cases() -> None:
@@ -1414,7 +1425,10 @@ def test_foreground_prompt_has_route_eval_cases() -> None:
 
 def test_foreground_route_injects_only_its_policy() -> None:
     foreground = object.__new__(ForegroundAgent)
-    foreground._prompt = foreground_module._DEFAULT_PROMPT
+    foreground._prompt = (
+        _WORKER / "tea_making_worker/prompts/foreground_prompt.txt"
+    ).read_text().strip()
+    foreground._uses_default_route_policy = True
     foreground._guidance = SimpleNamespace(
         active_context=lambda participant_id: (
             None if participant_id == "idle" else '{"step":"fill_water"}'
@@ -1442,7 +1456,10 @@ def test_foreground_route_injects_only_its_policy() -> None:
 
 def test_foreground_route_preserves_explicit_prompt_override() -> None:
     foreground = object.__new__(ForegroundAgent)
-    foreground._prompt = "Explicit override."
+    foreground._prompt = (
+        _WORKER / "tea_making_worker/prompts/foreground_prompt.txt"
+    ).read_text().strip()
+    foreground._uses_default_route_policy = False
     foreground._guidance = SimpleNamespace(
         active_context=lambda participant_id: (
             None if participant_id == "idle" else '{"step":"fill_water"}'
@@ -1460,8 +1477,8 @@ def test_foreground_route_preserves_explicit_prompt_override() -> None:
     )
     refusal = "I can only help with the active tea guide right now."
 
-    assert idle_prompt == "Explicit override."
+    assert idle_prompt == foreground._prompt
     assert active_prompt == (
-        'Explicit override.\n\nActive tea guide:\n{"step":"fill_water"}'
+        f'{foreground._prompt}\n\nActive tea guide:\n{{"step":"fill_water"}}'
     )
     assert refusal not in active_prompt

--- a/tests/test_tea_making_sample.py
+++ b/tests/test_tea_making_sample.py
@@ -1330,12 +1330,20 @@ def test_default_prompts_come_from_packaged_files(tmp_path: Path) -> None:
 
 def test_foreground_prompt_has_route_eval_cases() -> None:
     cases = yaml.safe_load((_SAMPLE / "eval/cases.yaml").read_text())
-    prompt = (
+    common_prompt = (
         _WORKER / "tea_making_worker/prompts/foreground_prompt.txt"
     ).read_text()
+    idle_prompt = (
+        _WORKER / "tea_making_worker/prompts/foreground_idle.txt"
+    ).read_text()
+    active_prompt = (
+        _WORKER / "tea_making_worker/prompts/foreground_active.txt"
+    ).read_text()
     refusal = "I can only help with the active tea guide right now."
-    assert "While the tea guide is active, decline requests" in prompt
-    assert f"reply exactly:\n{refusal}" in prompt
+    assert refusal not in common_prompt
+    assert refusal not in idle_prompt
+    assert "general-purpose assistant" in idle_prompt
+    assert f"reply exactly:\n{refusal}" in active_prompt
 
     root_cases = [case for case in cases if case.get("route", "root") == "root"]
     assert {case["expected_tool"] for case in root_cases} == {
@@ -1388,3 +1396,45 @@ def test_foreground_prompt_has_route_eval_cases() -> None:
         if case["name"] == "idle-answers-unrelated-general-knowledge"
     )
     assert idle_unrelated["forbidden_response"] == refusal
+    idle_visual = next(
+        case
+        for case in root_cases
+        if case["name"] == "idle-routes-visible-shirt-color"
+    )
+    assert idle_visual["expected_tool"] == "current_view"
+    assert idle_visual["forbidden_response"] == refusal
+    active_visual = next(
+        case
+        for case in active_cases
+        if case["name"] == "active-rejects-unrelated-visual-question"
+    )
+    assert active_visual["expected_tool"] is None
+    assert active_visual["expected_response"] == refusal
+
+
+def test_foreground_route_injects_only_its_policy() -> None:
+    foreground = object.__new__(ForegroundAgent)
+    foreground._prompt = "Common policy."
+    foreground._guidance = SimpleNamespace(
+        active_context=lambda participant_id: (
+            None if participant_id == "idle" else '{"step":"fill_water"}'
+        ),
+        active_tools=lambda _participant_id: ToolSet(()),
+    )
+    foreground._root_tools = lambda *_args, **_kwargs: ToolSet(())
+    foreground._background_tools = lambda *_args, **_kwargs: ToolSet(())
+
+    idle_prompt, _, idle_route = foreground._prepare_route(
+        "idle", ctx=None, timestamp_us=None
+    )
+    active_prompt, _, active_route = foreground._prepare_route(
+        "active", ctx=None, timestamp_us=None
+    )
+    refusal = "I can only help with the active tea guide right now."
+
+    assert idle_route == "root"
+    assert "general-purpose assistant" in idle_prompt
+    assert refusal not in idle_prompt
+    assert active_route == "tea"
+    assert "general-purpose assistant" not in active_prompt
+    assert refusal in active_prompt

--- a/tests/test_tea_making_sample.py
+++ b/tests/test_tea_making_sample.py
@@ -36,7 +36,6 @@ _SAMPLE = _ROOT / "agent-samples" / "tea-making-sample"
 _WORKER = _SAMPLE / "worker"
 sys.path.insert(0, str(_WORKER))
 
-import tea_making_worker.config as config_module  # noqa: E402  # pyright: ignore[reportMissingImports]
 import tea_making_worker.foreground as foreground_module  # noqa: E402  # pyright: ignore[reportMissingImports]
 from tea_making_worker.app import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     _CLIENT_TEXT_TOPIC,
@@ -47,7 +46,10 @@ from tea_making_worker.background_context import (  # noqa: E402  # pyright: ign
     BackgroundContextAgent,
 )
 from tea_making_worker.change_watch import ChangeWatchAgent  # noqa: E402  # pyright: ignore[reportMissingImports]
-from tea_making_worker.config import load_config  # noqa: E402  # pyright: ignore[reportMissingImports]
+from tea_making_worker.config import (  # noqa: E402  # pyright: ignore[reportMissingImports]
+    _PackagedPrompt,
+    load_config,
+)
 from tea_making_worker.events import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     BACKGROUND_FACT_TOPIC,
     CHANGE_WATCH_RECORD_TOPIC,
@@ -1319,7 +1321,7 @@ def test_default_prompts_come_from_packaged_files(tmp_path: Path) -> None:
         config.foreground_prompt
         == (prompt_dir / "foreground_prompt.txt").read_text().strip()
     )
-    assert isinstance(config.foreground_prompt, config_module._PackagedPrompt)
+    assert isinstance(config.foreground_prompt, _PackagedPrompt)
     assert (
         config.video_delta_prompt
         == (prompt_dir / "video_delta_prompt.txt").read_text().strip()
@@ -1335,7 +1337,7 @@ def test_default_prompts_come_from_packaged_files(tmp_path: Path) -> None:
     matching_config = load_config(override)
     assert matching_config.foreground_prompt == config.foreground_prompt
     assert not isinstance(
-        matching_config.foreground_prompt, config_module._PackagedPrompt
+        matching_config.foreground_prompt, _PackagedPrompt
     )
 
 


### PR DESCRIPTION
## Summary

- split common, idle-only, and active-only foreground policies so the active-guide refusal is absent from idle model context
- make idle mode explicitly general-purpose while routing only visible current-scene questions to `current_view`
- limit active visual-tool use to the tea guide and its current step
- always append the packaged idle or active route policy after the configurable shared foreground prompt, without adding configuration fields or constructor parameters
- remove worked examples from all model-visible prompt fragments and audit the complete idle and active prompt compositions for eval overlap
- document `foreground_prompt` and `foreground_prompt_file` semantics in the checked-in worker YAML, sample README, and published reference
- add symmetric idle and active shirt-color regression cases plus real-constructor coverage for packaged and overridden prompts

## Validation

- `UV_PROJECT_ENVIRONMENT=../.venv uv run pytest test_tea_making_sample.py -q` — 39 passed
- live Omni foreground routing evaluation — all 23 cases passed
- `ruff 0.15.16 check` on changed Python files
- strict Sphinx documentation build with warnings treated as errors
- wheel build includes all three foreground prompt files
- SPDX header check on changed source files
- `git diff --check`