### PR TITLE
docs: align guides with current runtime

### DIFF
--- a/agent-samples/model-servers/yaml/spark/nemotron_omni_llm_server.yaml
+++ b/agent-samples/model-servers/yaml/spark/nemotron_omni_llm_server.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Nemotron-3-Nano-Omni — DGX Spark (GB10).
-# The NVFP4 model shares physical HBM with STT and the runtime, so retain the
+# The NVFP4 model shares unified memory with STT and the runtime, so retain the
 # conservative allocation used by the standard Nano stack.
 
 host: "0.0.0.0"

--- a/agent-samples/model-servers/yaml/spark/vlm_server.yaml
+++ b/agent-samples/model-servers/yaml/spark/vlm_server.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# VLM server — DGX Spark (GB10, ~120 GiB GPU-visible HBM).
+# VLM server — DGX Spark (GB10, ~120 GiB GPU-visible unified memory).
 #
 # vlm is THIRD in load order: STT → Omni → vlm.
 # free_at_startup ≈ 120 − 30 (Omni) − 2 (STT) ≈ 88 GiB.

--- a/agent-samples/xr-render-demo/README.md
+++ b/agent-samples/xr-render-demo/README.md
@@ -17,9 +17,10 @@ browser-based Web-XR experience.
 
 ## Prerequisites
 
-Install the Vulkan loader and headers and make Node.js 18 or newer with npm
-available on `PATH`. On its first run, the orchestrator downloads the pinned
-LOVR build and creates the Web-XR vendor bundle; later runs reuse those files.
+Install the Vulkan loader and headers. For the default WebRTC profile, also make
+Node.js 18 or newer with npm available on `PATH`. On its first run, the
+orchestrator downloads the pinned LOVR build for every profile and creates the
+Web-XR vendor bundle only for WebRTC profiles; later runs reuse those files.
 
 ## Configure
 

--- a/agent-samples/xr-render-demo/README.md
+++ b/agent-samples/xr-render-demo/README.md
@@ -18,9 +18,10 @@ browser-based Web-XR experience.
 ## Prerequisites
 
 Install the Vulkan loader and headers. For the default WebRTC profile, also make
-Node.js 18 or newer with npm available on `PATH`. On its first run, the
-orchestrator downloads the pinned LOVR build for every profile and creates the
-Web-XR vendor bundle only for WebRTC profiles; later runs reuse those files.
+Node.js 18 or newer with npm available on `PATH`. On Linux x86_64, the first run
+downloads the pinned LOVR build; on other platforms, set `LOVR_BIN` or
+`lovr_bin` to a compatible build. The first WebRTC run also creates the Web-XR
+vendor bundle. Later runs reuse those files.
 
 ## Configure
 

--- a/docs/source/components/agent-sdk.md
+++ b/docs/source/components/agent-sdk.md
@@ -54,9 +54,9 @@ details.
 
 Applications may publish selected compact payloads to `WEB_EVENT_TOPIC` for a
 `WebEventsAgent` to display. The viewer owns only a bounded live history and a
-loopback HTTP listener. It is not persistence, does not inspect every runtime
-topic, and does not enter model, voice, media, or hub authentication paths. The
-application explicitly selects which typed events to forward.
+loopback HTTP listener by default. It is not persistence, does not inspect every
+runtime topic, and does not enter model, voice, media, or hub authentication
+paths. The application explicitly selects which typed events to forward.
 
 Applications with multiple speech producers may place
 `VoiceAggregationAgent` before `VoiceAgent`. Producers publish candidate

--- a/docs/source/components/ai-services.md
+++ b/docs/source/components/ai-services.md
@@ -100,20 +100,27 @@ start successfully without network access. Recreate project environments with
 ```python
 PROCESSES = [
     Process("hub",    "../../services/device-io-hub",                    "device_io_hub"),
-    Process("vlm",    "../../services/vlm-server",               "vlm_server"),   # ← add as needed
+    Process("vlm",    "../../services/vlm-server",               "vlm_server",
+            config="yaml/vlm_server.yaml"),   # ← add as needed
     # Pick ONE LLM backend per sample — they bind different default ports
     # (8106 or 8107) so running more than one at once is allowed but
     # usually unnecessary.
-    Process("llm",    "../../services/llama-nemotron-llm",       "llama_nemotron_llm_server"),
-    # Process("llm",  "../../services/nemotron3-nano-llm",       "nemotron3_nano_llm_server"),
-    Process("stt",    "../../services/stt-server",               "stt_server"),
+    Process("llm",    "../../services/llama-nemotron-llm",       "llama_nemotron_llm_server",
+            config="yaml/llama_nemotron_llm_server.yaml"),
+    # Process("llm",  "../../services/nemotron3-nano-llm",       "nemotron3_nano_llm_server",
+    #         config="yaml/nemotron3_nano_llm_server.yaml"),
+    Process("stt",    "../../services/stt-server",               "stt_server",
+            config="yaml/stt_server.yaml"),
     # Add these together when the application uses native document retrieval.
-    Process("embedding", "../../services/embedding-server",      "embedding_server"),
+    Process("embedding", "../../services/embedding-server",      "embedding_server",
+            config="yaml/embedding_server.yaml"),
     Process("rag",    "../../services/rag-service",               "rag_service",
             config="yaml/rag_service.yaml"),
     # Pick one TTS server
-    Process("tts",    "../../services/piper-tts",                 "piper_tts_server"),
-    # Process("tts",  "../../services/magpie-tts",                "magpie_tts_server"),
+    Process("tts",    "../../services/piper-tts",                 "piper_tts_server",
+            config="yaml/piper_tts_server.yaml"),
+    # Process("tts",  "../../services/magpie-tts",                "magpie_tts_server",
+    #         config="yaml/magpie_tts_server.yaml"),
     Process("worker", "worker",                                   "my_agent_worker"),
 ]
 ```
@@ -151,8 +158,9 @@ and capability configurations without a `model_cache` key need no change.
 Its fixed `yaml/models.json` points at operator-owned STT, VLM, and TTS
 endpoints; the sample orchestrator only launches its hub and worker.
 
-Edit the YAML as needed (model, port, device, etc.). The launcher auto-discovers
-`yaml/<command>.yaml` in the sample root and passes it as `--config`.
+Edit the YAML as needed (model, port, device, etc.). Set every copied path
+explicitly with `Process(config=...)`; the launcher does not discover files by
+command name.
 For RAG, also point `rag_service.yaml` at an application-owned document
 directory and a model profile containing an `embedding` role.
 
@@ -307,9 +315,9 @@ Requirements: docker + NVIDIA Container Toolkit, `NGC_API_KEY` (used for the
 GPU-matched optimized engine from NGC on first start; multi-GB, cached
 under `models/nim/` for later runs), and GPU capacity for every container.
 `cuda_visible_devices` placement lives in the per-GPU-profile
-`nim_*_server.yaml` files (dual_48G_ada values are live-validated; the
-other profiles ship estimates). Readiness gates on each container's
-`/v1/health/ready`.
+`nim_*_server.yaml` files. Their adjacent comments record profile-specific
+validation status and hardware cautions; verify startup and capacity on the
+target host. Readiness gates on each container's `/v1/health/ready`.
 
 A NIM container serving something the samples don't ship is the same
 mechanism by hand: point an `openai_compat` entry's `base_url` at its port
@@ -393,7 +401,7 @@ All five vLLM-backed servers (`vlm_server`, `llama_nemotron_llm_server`,
 | `vllm_backend` | Runtime | Code fallback | Shipped standalone YAMLs | Use when |
 |---|---|---|---|---|
 | `pip` | `vllm serve` from the wrapper's venv | yes | no | Developing the wrapper in its local environment or using a custom pip installation. |
-| `docker` | `docker run nvcr.io/nvidia/vllm:<tag> vllm serve …` | no | yes | Running the pinned NVIDIA vLLM container used by the checked-in configurations. |
+| `docker` | `docker run <vllm_image> vllm serve …` | no | yes | Running the configured vLLM container used by the checked-in configurations. |
 
 Both modes honor identical configuration keys — same model, same port, same vLLM
 flags. The dispatcher lives in `utils/xr-ai-vllm/`. Switching is one YAML edit:
@@ -415,7 +423,8 @@ mirror, or a custom build.
   must succeed without `sudo`).
 - **NVIDIA Container Toolkit** so the `nvidia` runtime can expose GPUs:
   https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
-- **NGC pull access** for `nvcr.io/nvidia/vllm`. The wrapper auto-runs
+- **NGC pull access**, when the configured `vllm_image` is restricted or
+  requires authentication on `nvcr.io`. The wrapper auto-runs
   `docker login nvcr.io` if `NGC_API_KEY` is in the environment (loaded by
   `load_credentials()` from `~/.config/xr-ai/credentials.json` per
   {doc}`/getting_started/credentials`). Otherwise, log in manually once:
@@ -516,7 +525,7 @@ cleanup.
 - **nemotron-omni-llm** is a vLLM-backed multimodal LLM serving
   `Nemotron-3-Nano-Omni-30B-A3B-Reasoning` (text + video input) at port 8108.
   The YAML auto-selects between three model variants by detected GPU compute
-  capability: NVFP4 on Blackwell (SM100+), FP8 on Ada and Hopper, BF16 forced via
+  capability: NVFP4 on Blackwell (SM100+), FP8 on Ada, Hopper, and Ampere, BF16 forced via
   `use_bf16: true` for highest quality at the largest VRAM cost. Same
   OpenAI-compatible HTTP contract as the other LLM servers — swap the port to
   swap backends. Hosting backend is selectable per YAML (refer to *Choosing the

--- a/docs/source/components/launcher-and-process-model.md
+++ b/docs/source/components/launcher-and-process-model.md
@@ -5,20 +5,26 @@
 
 # Launcher and process model
 
-Every sample is self-contained: running it starts the DeviceIOHub and all required
-processes automatically. No separate server launch step.
+Application samples own their DeviceIOHub and worker processes. Model services may
+instead be declared with `launch_mode="reuse"` and started separately through the
+shared `model-servers` stack.
 
-Each sample has **two sub-projects**:
+An application sample has at least these two sub-projects:
 
 | Sub-project | Role | Dependencies |
 |---|---|---|
-| `<sample>/` | Orchestrator — declares process list in code, launches all | `xr-ai-launcher` only (stdlib) |
+| `<sample>/` | Orchestrator — declares owned and reused processes in code | `xr-ai-launcher`, `xr-ai-logging`, and sample-specific orchestration dependencies |
 | `<sample>/worker/` | Agent worker — connects to hub via IPC, runs agent logic | `xr-ai-hub-client`, numpy, etc. |
+
+Samples may add capability or eval sub-projects. `model-servers` is a dedicated
+orchestrator and has no worker sub-project.
 
 **Configuration convention** — the YAML configuration path for each process is declared
 explicitly in the orchestrator's `PROCESSES` list via the `config=` field of
 `Process`. The launcher passes it as `--config <path>` to the subprocess.
-All sample configuration files live in the `yaml/` directory. Omit `config=` for
+Application and service configuration normally lives in the sample's `yaml/`
+directory. A capability sub-project may keep its configuration beside that
+project, such as `xr-render-demo/scene/scene_service.yaml`. Omit `config=` for
 processes that use their own internal defaults.
 
 Samples that support interchangeable local and hosted models may set
@@ -53,7 +59,7 @@ def run() -> None:
   `Parallel` member to create its `--ready-file` before starting the next item.
   Declare items in dependency order (hub before workers and application
   processes after the services they call).
-- **Every process accepts `--ready-file <path>`** and must `Path(path).touch()`
+- **Every spawned process accepts `--ready-file <path>`** and must `Path(path).touch()`
   when it is fully initialized and ready to serve requests.
 - **Native voice workers** pass the ready file to `VoiceAgent`; its private
   media session touches it only after the input transport's hub IPC
@@ -61,7 +67,8 @@ def run() -> None:
 - `device_io_hub` always runs as its own process — never embedded in-process.
 - The worker never imports anything from `device_io_hub` or `xr_ai_launcher`.
 - Process management lives in `utils/xr-ai-launcher/`, not inside any process it manages.
-- `run_stack` is fail-fast: if any process exits, the rest are terminated.
+- `run_stack` is fail-fast while monitoring: if any spawned process exits, the
+  rest are terminated.
 
 ## Serial and parallel items
 
@@ -95,8 +102,9 @@ For each process the launcher:
 2. Spawns `uv run --project <dir> <command> --config <yaml> --ready-file <f>`
    in a new process group, so the whole group (`uv` plus its children) can be
    torn down together rather than leaving orphans.
-3. Waits for the process to create *<f>* (the ready file), printing a progress
-   line every five seconds so slow starts remain visible.
+3. Waits for the process to create *<f>* (the ready file), recording a DEBUG
+   progress line every five seconds. It is visible with `XR_AI_VERBOSE` and in
+   the per-run log.
 4. Once all processes are ready, monitors them: any exit triggers a graceful
    shutdown of the rest (SIGTERM, escalating to SIGKILL after a timeout).
 
@@ -128,7 +136,8 @@ its IPC receive loop is active.
 - `"persist"` — the launcher spawns this process but leaves it running on
   shutdown. Use for heavy model servers that need to survive stack restarts
   (e.g. vLLM containers). Cleanup is the caller's responsibility. The optional
-  `port` field is used to stop such persistent services.
+  `port` field is metadata; `model-servers` uses it to select cleanup targets,
+  while generic `run_stack` does not inspect it.
 - `"reuse"` — the launcher does **not** spawn this process; it is assumed to be
   already running (e.g. started by `model-servers`). The entry in the process
   list documents the dependency; the launcher skips it entirely and does not
@@ -187,8 +196,8 @@ drop, participant-joined).
 
 **`xr-ai-vllm`** — pluggable vLLM backend for inference services. Each
 vLLM-backed service can host vllm via `pip` (the pip-installed `vllm` CLI in
-the wrapper's venv, the default) or `docker` (`docker run nvcr.io/nvidia/vllm`,
-an NGC container), chosen per-server via `vllm_backend: pip|docker` in the
-service YAML. Both paths honor identical configuration keys; only the runtime hosting
+the wrapper's venv, the default) or `docker` (the image selected by
+`vllm_image`), chosen per-server via `vllm_backend: pip|docker` in the service
+YAML. Both paths honor identical configuration keys; only the runtime hosting
 vllm differs. Stdlib-only by contract, so the docker path stays light even when
 pip vllm is not installed.

--- a/docs/source/components/server-runtime.md
+++ b/docs/source/components/server-runtime.md
@@ -248,10 +248,13 @@ installable iOS profile.
 Set `web_server_tls: false` for the two cases where the hub does not
 terminate TLS itself: a TLS-terminating reverse proxy (nginx, Caddy,
 Cloudflare Tunnel) sits in front and speaks plain `http://` + `ws://` to the
-hub on the loopback, or localhost-only development where browsers already grant
-camera and microphone access on `http://localhost`. In that mode `/token`
-returns a plain
-`ws://` URL and the proxy carries plain WebSocket.
+hub, or localhost-only development where browsers already grant camera and
+microphone access on `http://localhost`. Bind the hub to loopback with
+`web_server_host: 127.0.0.1`, or source-restrict it with a firewall, when a
+reverse proxy is the public entry point. In this mode `/token` returns the
+direct `ws://<request-host>:<lk_port_ws>` URL, not the hub's `/rtc` proxy.
+Custom clients behind the TLS terminator must use the external same-origin
+`wss://` proxy URL and must not expose port 7880 publicly.
 
 For runtime symptoms and fixes, refer to
 {doc}`Troubleshooting </guides/troubleshooting>`.

--- a/docs/source/getting_started/clients.md
+++ b/docs/source/getting_started/clients.md
@@ -5,7 +5,8 @@
 
 # Connecting clients
 
-Every sample starts DeviceIOHub and then accepts one or more platform clients.
+Every interactive agent sample starts DeviceIOHub and then accepts one or more
+platform clients.
 This client reference is the canonical build and connection guide for the
 clients under `client-samples/`. Refer to {doc}`quickstart` for starting an
 agent sample and {doc}`networking` for firewall and TLS configuration.

--- a/docs/source/getting_started/credentials.md
+++ b/docs/source/getting_started/credentials.md
@@ -50,9 +50,10 @@ export HF_TOKEN=hf_xxx
 # 2. huggingface-cli login (writes ~/.cache/huggingface/token)
 huggingface-cli login
 
-# 3. Save it once for all samples (written to ~/.config/xr-ai/credentials.json
-#    and ~/.cache/huggingface/token)
-python3 -c "from xr_ai_launcher import ensure_credentials; ensure_credentials('HF_TOKEN')"
+# 3. From the repository root, save it once for all samples (written to
+#    ~/.config/xr-ai/credentials.json and ~/.cache/huggingface/token)
+uv run --project utils/xr-ai-launcher python -c \
+  "from xr_ai_launcher import ensure_credentials; ensure_credentials('HF_TOKEN')"
 ```
 
 Get a token at <https://huggingface.co/settings/tokens>. `HF_TOKEN` is also
@@ -63,10 +64,10 @@ is reused without any further setup.
 
 ## NGC API key (`NGC_API_KEY`)
 
-**Required only for the NIM model backend and `nvcr.io` image pulls.** It
-authenticates both `nvcr.io` container pulls and **hosted NVIDIA NIM**
-inference endpoints — a `models.yaml` entry with `api_key_env: NGC_API_KEY`
-sends it as the `Authorization: Bearer` token (refer to
+**Required for the NIM model backend and restricted `nvcr.io` image pulls.** It
+authenticates those container pulls and **hosted NVIDIA NIM** inference
+endpoints — a `models.yaml` entry with `api_key_env: NGC_API_KEY` sends it as
+the `Authorization: Bearer` token (refer to
 {doc}`AI services — hosting models on NVIDIA NIM </components/ai-services>`).
 
 The `vlm_llm_nim` model-server profile calls
@@ -82,7 +83,8 @@ To save it in the launcher credential store instead, run the interactive helper
 explicitly:
 
 ```bash
-python3 -c "from xr_ai_launcher import ensure_credentials; ensure_credentials('NGC_API_KEY')"
+uv run --project utils/xr-ai-launcher python -c \
+  "from xr_ai_launcher import ensure_credentials; ensure_credentials('NGC_API_KEY')"
 ```
 
 ## How a token is resolved

--- a/docs/source/getting_started/networking.md
+++ b/docs/source/getting_started/networking.md
@@ -147,11 +147,11 @@ On first run a self-signed certificate is generated at
 `~/.local/share/xr-ai/web-server.crt`. To use your own, set `cert_file`
 and `key_file` in `device_io_hub.yaml`.
 
-The generated certificate covers `localhost`, the hostname, and every local
-interface IP. When clients dial an address that is not on any local
-interface (the public IP of a NAT'd cloud VM such as Brev, a forwarding
-proxy's address, or a DNS name), list it in `device_io_hub.yaml` and the
-certificate is regenerated to include it on the next hub start:
+The generated certificate covers `localhost`, the hostname, and automatically
+discovered local IPv4 addresses. When clients dial an address that discovery
+misses, or one that is not local (the public IP of a NAT'd cloud VM such as Brev,
+a forwarding proxy's address, or a DNS name), list it in `device_io_hub.yaml` and
+the certificate is regenerated to include it on the next hub start:
 
 ```yaml
 web_server_extra_sans:

--- a/docs/source/getting_started/requirements.md
+++ b/docs/source/getting_started/requirements.md
@@ -7,24 +7,26 @@
 
 ## Hardware
 
-The bundled GPU profiles target a single NVIDIA RTX PRO 6000 Blackwell workstation
-GPU or an NVIDIA DGX Spark, both of which have enough VRAM to run the full model
-stack locally. These profiles are turnkey presets, not a hardware allowlist: you
-can run on other NVIDIA GPUs by tuning the per-server GPU-memory split. Refer to
-[Running on other GPUs](#running-on-other-gpus) below.
+The bundled GPU profiles target two 48 GB NVIDIA Ada GPUs, a single NVIDIA RTX PRO
+6000 Blackwell workstation GPU, or an NVIDIA DGX Spark. Each topology has enough
+GPU-visible memory to run the full model stack locally. These profiles are turnkey
+presets, not a hardware allowlist: you can run on other compatible NVIDIA GPUs by
+tuning the per-server GPU-memory split. Refer to [Running on other
+GPUs](#running-on-other-gpus) below.
 
-If you prefer not to run models on local hardware, model endpoints are plain
-URLs: point the worker configuration at a cloud NIM or model endpoint and no
-local GPU is required for the agent or DeviceIOHub.
+If you prefer not to run models on local hardware, point the worker configuration
+at cloud NIM or model endpoints. This removes the local model-service allocation,
+but the DeviceIOHub host still needs an NVIDIA GPU and driver that expose NVENC and
+NVDEC.
 
-| Sample | Local VRAM needed |
+| Sample | Local GPU-visible memory needed |
 |---|---|
 | model-servers (all models) | ~55 GB |
 | simple-vlm-example (requires model services) | Uses the model-services allocation |
 | lab-instrument-monitoring (requires model services) | Uses the model-services allocation |
 | tea-making-sample (requires model services) | Uses the model-services allocation |
 | xr-render-demo (requires model-servers) | ~55 GB for models and ~2 GB for CloudXR and the hub |
-| Hub only | none |
+| Hub only | No model allocation; NVENC and NVDEC are still required |
 
 ## Software
 
@@ -33,10 +35,10 @@ local GPU is required for the agent or DeviceIOHub.
 | OS | Linux | Ubuntu 22.04 or 24.04 recommended; WSL2 is not officially supported (refer to [Windows (WSL2)](#windows-wsl2) below) |
 | Python | 3.11 or 3.12 | 3.10 and 3.13 are not supported |
 | [uv](https://docs.astral.sh/uv/) | latest | dependency manager used by all samples |
-| NVIDIA driver | 570+ | required for local model inference |
+| NVIDIA driver | 580+ | required for CUDA 13 model containers and DeviceIOHub hardware codecs |
 | Docker | 24+ | required by the checked-in model-server profiles, which use vLLM containers from NGC and Docker Hub |
-| NVIDIA Container Toolkit | latest | required: gives Docker access to the GPU. Without it, `model_servers` fails with `failed to discover GPU vendor from CDI: no known GPU vendor found` |
-| Node.js | 18+ with npm | required for xr-render-demo: the orchestrator builds the web vendor bundle on first run |
+| NVIDIA Container Toolkit | latest | required: configures the `nvidia` runtime that gives Docker access to the GPU |
+| Node.js | 18+ with npm | required for xr-render-demo's default WebRTC profile: the orchestrator builds the web vendor bundle on first run |
 
 `uv` handles all Python dependencies per-sample — no global `pip install` or
 virtual-environment setup needed. If you do not have it:
@@ -53,7 +55,8 @@ install guide and run the CDI and runtime-configuration steps from there:
 Quick smoke-test once installed:
 
 ```bash
-docker run --rm --gpus all nvidia/cuda:13.0.3-base-ubuntu24.04 nvidia-smi
+docker run --rm --runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=all \
+  nvidia/cuda:13.0.3-base-ubuntu24.04 nvidia-smi
 ```
 
 ## GPU-profile prerequisites
@@ -145,9 +148,9 @@ profile you have explicitly copied and tuned; it does not validate that the mode
 servers fit the selected devices.
 
 ```{note}
-The model weights are independent of the GPU. Any NVIDIA GPU with enough VRAM for
-the models you load will run the stack; the profiles only encode where each server
-lands and how much memory it claims.
+The model weights are independent of the GPU. Any compatible NVIDIA GPU with
+enough memory for the models you load can run the stack; the profiles only encode
+where each server lands and how much memory it claims.
 ```
 
 ## Network

--- a/docs/source/guides/adding-a-sample.md
+++ b/docs/source/guides/adding-a-sample.md
@@ -17,7 +17,7 @@ Derive all other names from it mechanically:
 | Thing | Convention | Example |
 |---|---|---|
 | Sample directory | `agent-samples/<kebab-name>/` | `simple-vlm-example/` |
-| Orchestrator module | `<snake_name>.py` | `simple_vlm_example.py` |
+| Orchestrator module | `main.py` | `main.py` |
 | Orchestrator entry point | `<snake_name>` | `simple_vlm_example` |
 | Worker package | `<snake_name>_worker/` | `simple_vlm_example_worker/` |
 | Worker entry point | `<snake_name>_worker` | `simple_vlm_example_worker` |
@@ -94,6 +94,9 @@ Refer to {doc}`/reference/configuration` for the rendered reference.
 ## Orchestrator `pyproject.toml`
 
 ```text
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
@@ -102,10 +105,14 @@ build-backend = "hatchling.build"
 name = "<kebab-name>"
 version = "0.1.0"
 requires-python = ">=3.11,<3.13"
-dependencies = ["xr-ai-launcher"]
+dependencies = [
+    "xr-ai-launcher",
+    "xr-ai-logging",
+]
 
 [tool.uv.sources]
 xr-ai-launcher = { path = "../../utils/xr-ai-launcher", editable = true }
+xr-ai-logging  = { path = "../../utils/xr-ai-logging", editable = true }
 
 [project.scripts]
 <snake_name> = "main:run"
@@ -117,6 +124,9 @@ only-include = ["main.py"]
 ## Worker `pyproject.toml`
 
 ```text
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
@@ -147,6 +157,9 @@ packages = ["<snake_name>_worker"]
 Exact boilerplate — do not add logic here:
 
 ```python
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Name> agent orchestrator.  Runs the process stack for this sample.
 
@@ -156,16 +169,28 @@ How to run (from agent-samples/<name>/):
 from pathlib import Path
 
 from xr_ai_launcher import Process, run_stack
+from xr_ai_logging import setup_logging
 
 _BASE = Path(__file__).resolve().parent
 
 PROCESSES = [
-    Process("hub",    "../../services/device-io-hub", "device_io_hub"),
-    Process("worker", "worker",               "<snake_name>_worker"),
+    Process(
+        "hub",
+        "../../services/device-io-hub",
+        "device_io_hub",
+        config="yaml/device_io_hub.yaml",
+    ),
+    Process(
+        "worker",
+        "worker",
+        "<snake_name>_worker",
+        config="yaml/<snake_name>_worker.yaml",
+    ),
 ]
 
 
 def run() -> None:
+    setup_logging("orchestrator", namespace="<kebab-name>")
     run_stack(PROCESSES, _BASE)
 
 
@@ -182,6 +207,9 @@ to sibling `app.py` and `config.py` modules. Refer to
 for that shape. Fill in the sections marked `# ← FILL IN`.
 
 ```text
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Name> agent worker — <one-line description>.
 

--- a/docs/source/guides/adding-cloudxr.md
+++ b/docs/source/guides/adding-cloudxr.md
@@ -7,7 +7,7 @@
 
 `services/cloudxr-runtime/` is the shared CloudXR service.
 Any sample can stream XR content to a device by adding one line to its
-orchestrator and a configuration file in the sample root. For the broader
+orchestrator and a configuration file under the sample's `yaml/` directory. For the broader
 orchestrator pattern, refer to {doc}`adding-a-sample <adding-a-sample>`.
 
 ## 1 — Add the process to the orchestrator
@@ -15,16 +15,21 @@ orchestrator pattern, refer to {doc}`adding-a-sample <adding-a-sample>`.
 ```python
 PROCESSES = [
     Process("hub",     "../../services/device-io-hub",  "device_io_hub"),
-    Process("cloudxr", "../../services/cloudxr-runtime", "cloudxr_runtime"),  # ← add this
+    Process("cloudxr", "../../services/cloudxr-runtime", "cloudxr_runtime",
+            config="yaml/cloudxr_runtime.yaml"),  # ← add this
     Process("worker",  "worker",                "my_agent_worker"),
 ]
 ```
 
-## 2 — Add `cloudxr_runtime.yaml` to the sample root
+(2-add-cloudxr-runtime-yaml-to-the-sample-root)=
+## 2 — Add `cloudxr_runtime.yaml` to the sample's `yaml/` directory
 
-The launcher auto-discovers this file and passes it as `--config`.
+The `Process.config` value above passes this file as `--config`.
 
 ```yaml
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # CloudXR runtime configuration.
 cloudxr_install_dir: ~/.cloudxr
 
@@ -53,7 +58,8 @@ clients, not both. Change the profile and restart the stack when switching.
 |---|---|---|
 | `client-samples/web-xr/` | `auto-webrtc` | used |
 | `client-samples/ios-visionos/` | `auto-native` | unused |
-| Other native devices, including Quest 3 | `auto-native` | unused |
+| Other native CloudXR clients | `auto-native` | unused |
+| Meta Quest 3 with CloudXR.js | `quest3` | used |
 
 Device-specific profiles such as `apple-vision-pro`, `ipad-pro`, and `quest3`
 are also accepted when their fixed device defaults are preferred.

--- a/docs/source/guides/adding-cloudxr.md
+++ b/docs/source/guides/adding-cloudxr.md
@@ -21,7 +21,7 @@ PROCESSES = [
 ]
 ```
 
-(2-add-cloudxr-runtime-yaml-to-the-sample-root)=
+(add-cloudxr-runtime-yaml-to-the-sample-root)=
 ## 2 — Add `cloudxr_runtime.yaml` to the sample's `yaml/` directory
 
 The `Process.config` value above passes this file as `--config`.

--- a/docs/source/guides/contributing-and-conventions.md
+++ b/docs/source/guides/contributing-and-conventions.md
@@ -18,9 +18,8 @@ for the package dependency map.
 For a Python change:
 
 ```bash
-cd <affected-project>
-uv sync
-uv run pytest
+uv sync --project <affected-project>
+uv run --project tests pytest <affected-test-files>
 uv tool run ruff check <changed-python-files>
 ```
 

--- a/docs/source/guides/testing.md
+++ b/docs/source/guides/testing.md
@@ -12,10 +12,11 @@ required for the browser camera tests.
 
 ## Run the suite
 
+From the repository root:
+
 ```bash
-cd tests
-uv sync
-uv run pytest -v
+uv sync --project tests
+uv run --project tests pytest -v
 ```
 
 CI runs the same project on Python 3.11 and 3.12 with:

--- a/docs/source/guides/troubleshooting.md
+++ b/docs/source/guides/troubleshooting.md
@@ -167,9 +167,10 @@ curl -fsS http://127.0.0.1:8100/health   # vlm_server (default Cosmos VLM)
 curl -fsS http://127.0.0.1:8107/health   # superseded nemotron3_nano
 ```
 
-**Container post-mortem** — the wrapper streams `docker logs -f` into the
-per-run log file, so on the next run the actual vLLM error lands next to the
-wrapper messages. To inspect manually:
+**Container post-mortem** — during the current run, the wrapper streams
+`docker logs -f` into a sibling
+`/tmp/log_<sample>_<timestamp>/xr-ai-vllm-*.log` file. To inspect the retained
+container manually:
 
 ```bash
 docker ps -a --filter name=xr-ai-vllm-
@@ -177,23 +178,24 @@ docker logs --tail=200 <container-name>
 ```
 
 **Cause:** vLLM crashed during startup — common reasons: model weights
-missing or inaccessible in the bind-mounted `model_cache`, GPU not visible to
-the container (`nvidia-container-cli` or `--gpus`), HF token missing for a
+missing or inaccessible in the bind-mounted `model_cache`, the `nvidia` runtime
+not exposing the selected GPU, HF token missing for a
 gated model, or a reasoning-parser plugin file that is not present inside
 the container.
 
-**Fix:** read the container logs (the next run captures them automatically),
-address the root cause shown there, and retry. If the container was
-auto-removed by `--rm` before you could check, the next failed run will
-have the streamed output in the per-run log file — just re-run.
+**Fix:** read the current run's container log, address the root cause shown
+there, and retry. Failed containers remain available to `docker logs` until
+managed cleanup removes them.
 
-### `vllm_backend: docker` — `docker run` fails with `could not select device driver`
+(vllm-backend-docker-docker-run-fails-with-could-not-select-device-driver)=
+### `vllm_backend: docker` — the NVIDIA runtime is unavailable
 
-**Symptom:** `docker run` exits with a message mentioning `nvidia-container-cli`
-or "could not select device driver "" with capabilities: [[gpu]]".
+**Symptom:** `docker run` exits with a message that the `nvidia` runtime is
+unknown or unavailable, or with an `nvidia-container-cli` initialization error.
 
 **Cause:** the NVIDIA Container Toolkit is not installed (or the daemon was
-not restarted after install), so docker cannot honor `--gpus`.
+not restarted and configured after install), so Docker cannot use
+`--runtime=nvidia`.
 
 **Fix:** install the toolkit and restart docker:
 https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
@@ -214,8 +216,9 @@ OpenH264, which is royalty-bearing.
 **Fix:**
 - **Bare metal:** install or repair the NVIDIA driver. The libraries ship with the
   driver, not with CUDA.
-- **Docker:** pass `--gpus all` (or `--device /dev/nvidia*` plus the codec
-  device nodes) when starting the container.
+- **Docker:** use the NVIDIA runtime, request the needed devices with
+  `NVIDIA_VISIBLE_DEVICES`, and include `video` in
+  `NVIDIA_DRIVER_CAPABILITIES` when starting the container.
 
 ## Runtime and connection issues
 
@@ -273,7 +276,7 @@ validates against the system and user CA store, the same as iOS.
    automatically.
 
 Repeat for each hub host. Replace the auto-generated certificate with one from a
-public CA via `cert_file` or `key_file` in `device_io_hub.yaml` for
+public CA via `cert_file` and `key_file` in `device_io_hub.yaml` for
 production.
 
 ### iOS and visionOS — connection fails with certificate-trust errors
@@ -308,9 +311,9 @@ certificate's SubjectAlternativeName doesn't cover that IP. The hub detects
 local IPv4 addresses via a UDP-connect probe and auto-regenerates the
 certificate whenever the SAN is missing one (logged as `TLS: cached cert
 SAN is missing …; regenerating…`); just restart the hub and re-install the
-profile on the device. If the dialed address is not on any of the hub's
-interfaces, add it to `web_server_extra_sans` in `device_io_hub.yaml` and
-restart. Refer to {doc}`Networking </getting_started/networking>` for details.
+profile on the device. If the dialed address is absent from the certificate,
+add it to `web_server_extra_sans` in `device_io_hub.yaml` and restart. Refer to
+{doc}`Networking </getting_started/networking>` for details.
 To force regeneration, delete `~/.local/share/xr-ai/web-server.crt` and
 `web-server.key` before restarting.
 
@@ -321,7 +324,7 @@ SDK sends. Update to the latest DeviceIOHub and restart; the proxy
 forwards the `Authorization` header on `/rtc/validate` and the WebSocket.
 
 Repeat the install step per hub host, or replace the auto-generated certificate
-with a public-CA certificate via `cert_file` or `key_file` in `device_io_hub.yaml`
+with a public-CA certificate via `cert_file` and `key_file` in `device_io_hub.yaml`
 for production.
 
 ### iOS and visionOS — microphone or camera is interrupted
@@ -354,8 +357,8 @@ the IWER emulator built into the web client itself for desktop dev.
 **Symptom:** a vLLM server's weight load is fast,
 but the server then sits silent for several minutes before becoming healthy.
 
-**Cause:** CUDA graph capture + FlashInfer FP4 MoE autotune happen on first
-run after weight load. They are silent.
+**Cause:** CUDA graph capture and, for FP4 MoE models, FlashInfer autotuning
+happen on first run after weight load. They are silent.
 
 **Fix:** the default Omni profiles set `enforce_eager: false` to enable CUDA
 graph capture and maximize steady-state throughput, so this startup delay is

--- a/docs/source/reference/lab-instrument-monitoring.md
+++ b/docs/source/reference/lab-instrument-monitoring.md
@@ -49,7 +49,8 @@ accepted speech or typed query         ├─> current frame + generic VLM query
               └─> current readings             │
                                                ├─> change event ─┬─> voice aggregation
                                                ├─> lost event ───┤
-                                               └─> state event ──┴─> JSONL/backend
+                                               │                 └─> JSONL/backend
+                                               └─> state event ────> JSONL/backend
 ```
 
 `VoiceAgent` publishes participant-scoped queries and lifecycle events into

--- a/docs/source/reference/tea-making-sample.md
+++ b/docs/source/reference/tea-making-sample.md
@@ -250,8 +250,8 @@ capabilities exist, and the model decides how to use only those capabilities.
 `WorkflowStore` enforces the contract. An observation can update only fields
 listed in the active step's `writes`. Updates are atomic, validated against
 their declared types, and ignored after the step is complete. Completion emits
-a notice but never moves to the next step. Only explicit next, skip, reset, or
-restart controls change the participant's position.
+a notice but never moves to the next step. Only explicit start, next, skip,
+reset, or restart controls change the participant's position.
 
 The model can propose state only through the commit tool. It cannot mutate the
 session object directly. Deterministic clock and temperature tools perform

--- a/docs/source/reference/xr-render-demo.md
+++ b/docs/source/reference/xr-render-demo.md
@@ -12,7 +12,7 @@ mechanics shared with other samples, refer to
 
 ## Process stack
 
-The orchestrator (`xr_render_demo`, stdlib-only via `xr-ai-launcher`) reuses all
+The orchestrator (`xr_render_demo`, via `xr-ai-launcher`) reuses all
 model processes and starts its application processes serially; each owned
 process touches its ready file before the next starts. `run_stack` is fail-fast:
 any owned process exit terminates the application stack.
@@ -20,7 +20,7 @@ any owned process exit terminates the application stack.
 | Role | Ownership | Directory | Command | Port |
 |---|---|---|---|---|
 | hub | sample | `services/device-io-hub/` | `device_io_hub` | 8080 (HTTPS and `/rtc` WSS proxy); 7880 (plaintext LiveKit direct-debug path; firewall-restricted) |
-| cloudxr | sample | `services/cloudxr-runtime/` | `cloudxr_runtime` | 48322 (WSS proxy) |
+| cloudxr | sample | `services/cloudxr-runtime/` | `cloudxr_runtime` | 48322 (WSS proxy for WebRTC profiles; unused by `auto-native`) |
 | stt | reused | `services/stt-server/` | `stt_server` | 8103 |
 | tts | reused | `services/piper-tts/` | `piper_tts_server` | 8105 |
 | omni | reused | `services/nemotron-omni-llm/` | `nemotron_omni_llm_server` | 8108 (LLM) |
@@ -188,14 +188,12 @@ LiveKit mic (int16 PCM) → hub IPC (float32) → VoiceAgent
       accumulates        audio while speaking
       finalizes when     silence ≥ 0.8s AND speech ≥ 0.15s
                          OR max utterance length (30s) hit
-      filler filter      drops single- and multi-word filler utterances
-                         ("um", "uh", "yeah", "okay", "mm-hmm", etc.)
       STT call           POST multipart/form-data WAV → stt-server :8103
   → accepted participant query
 ```
 
-STT calls are serialized — an `stt_busy` flag prevents a new finalize while
-one is in-flight.
+The STT server serializes inference with a process-local lock because its shared
+NeMo model is not reentrant.
 
 ## TTS — Piper
 

--- a/services/device-io-hub/device_io_hub/transport/livekit/_hwcodec.py
+++ b/services/device-io-hub/device_io_hub/transport/livekit/_hwcodec.py
@@ -97,7 +97,8 @@ def _check_linux() -> None:
             missing,
             "Ensure the NVIDIA driver and CUDA Video SDK are installed and that\n"
             "  /dev/nvidia* devices are accessible to this process.\n"
-            "  In Docker: pass --gpus all  (or --device /dev/nvcuvid etc.).",
+            "  In Docker: use --runtime=nvidia with NVIDIA_VISIBLE_DEVICES=all\n"
+            "  and NVIDIA_DRIVER_CAPABILITIES=video.",
         )
 
 

--- a/services/nemotron-omni-llm/nemotron_omni_llm_server.yaml
+++ b/services/nemotron-omni-llm/nemotron_omni_llm_server.yaml
@@ -7,7 +7,7 @@
 #
 # GPU auto-selection:
 #   Blackwell (SM100+) → model_blackwell  (NVFP4, --kv-cache-dtype fp8)
-#   Ada / Hopper       → model_ada        (FP8,   --kv-cache-dtype fp8)
+#   Ada, Hopper, Ampere → model_ada        (FP8,   --kv-cache-dtype fp8)
 #   use_bf16: true     → model_bf16       (BF16,  no kv-cache quantisation)
 
 model_blackwell: nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4

--- a/tests/test_docs_versions.py
+++ b/tests/test_docs_versions.py
@@ -415,6 +415,8 @@ def test_reworded_headings_keep_compatibility_anchors() -> None:
     tools = (_ROOT / "docs/source/reference/agent-sdk-tools.md").read_text()
     voice = (_ROOT / "docs/source/reference/agent-sdk-voice.md").read_text()
     xr_render = (_ROOT / "docs/source/reference/xr-render-demo.md").read_text()
+    adding_cloudxr = (_ROOT / "docs/source/guides/adding-cloudxr.md").read_text()
+    troubleshooting = (_ROOT / "docs/source/guides/troubleshooting.md").read_text()
 
     for anchor in (
         "which-clients-exist",
@@ -459,6 +461,13 @@ def test_reworded_headings_keep_compatibility_anchors() -> None:
             (
                 "multiple-voice-producers",
                 "voice-tuning-and-data-echo",
+            ),
+        ),
+        (adding_cloudxr, ("add-cloudxr-runtime-yaml-to-the-sample-root",)),
+        (
+            troubleshooting,
+            (
+                "vllm-backend-docker-docker-run-fails-with-could-not-select-device-driver",
             ),
         ),
     ):

--- a/utils/xr-ai-launcher/xr_ai_launcher/_stack.py
+++ b/utils/xr-ai-launcher/xr_ai_launcher/_stack.py
@@ -7,8 +7,8 @@ Stack launcher with per-process readiness files.
 Design
 ------
 Every launchable sub-project is self-describing: it exposes an entry-point
-command and accepts ``--config <path>.yaml`` (auto-discovered) and
-``--ready-file <path>`` (injected by the launcher).
+command and accepts an explicitly configured ``--config <path>.yaml`` when
+needed and ``--ready-file <path>`` (injected by the launcher).
 
 The stack is declared as a sequence of ``Process`` or ``Parallel`` items:
 


### PR DESCRIPTION
## Summary

- document all three bundled GPU topologies, including dual 48 GB Ada, and align CUDA, driver, container-runtime, codec, and DGX Spark terminology with the shipped profiles
- make the sample, model-server, and CloudXR launcher examples runnable by passing configuration paths explicitly and including required logging and SPDX boilerplate
- align process ownership, persistence, TLS proxying, credential, container-log, certificate, WebRTC, STT, workflow, and event-flow descriptions with the current implementations
- preserve the two renamed published documentation fragments with compatibility labels

The audit was split across GPU/setup, SDK/services, and sample/client documentation, then each finding was reconciled against the current implementation. Approximate VRAM totals were left unchanged because the repository does not define one consistent measurement basis for them.

## Validation

- `UV_CACHE_DIR=/tmp/xr-ai-doc-audit-uv-cache uv run --project tests pytest -q tests/test_docs_versions.py tests/test_cli_documentation.py tests/test_config_documentation.py tests/test_service_layout.py tests/test_launcher_config.py tests/test_model_servers.py tests/test_cloudxr_service_layout.py tests/test_launcher_cloudxr_env.py tests/test_livekit_tls_san.py tests/test_launcher_stack.py` (`164 passed`)
- `make -C docs strict SPHINXBUILD=/tmp/xr-ai-docs-venv/bin/sphinx-build`
- `python3 .github/scripts/check_spdx_headers.py` (`627 file(s)`)
- both documented `uv run --project utils/xr-ai-launcher python -c ...` credential-helper imports
- `git diff --check`
