### PR TITLE
docs: finish main consistency cleanup

### DIFF
--- a/agent-samples/xr-render-demo/README.md
+++ b/agent-samples/xr-render-demo/README.md
@@ -18,7 +18,7 @@ browser-based Web-XR experience.
 ## Prerequisites
 
 Install the Vulkan loader and headers. For the default WebRTC profile, also make
-Node.js 18 or newer with npm available on `PATH`. On Linux x86_64, the first run
+Node.js 20.19.0 or newer with npm available on `PATH`. On Linux x86_64, the first run
 downloads the pinned LOVR build; on other platforms, set `LOVR_BIN` or
 `lovr_bin` to a compatible build. The first WebRTC run also creates the Web-XR
 vendor bundle. Later runs reuse those files.

--- a/docs/source/components/ai-services.md
+++ b/docs/source/components/ai-services.md
@@ -519,10 +519,11 @@ cleanup.
   When `recordings_dir` is empty, participant discovery returns an empty list
   and recorded-media operations return `recording_disabled`.
 - Ports are configurable — avoid conflicts with LiveKit (7880–7882) and hub (8080, 8090).
-- Standalone service YAMLs live beside the services that support direct local
-  launch. When copying one into `agent-samples/<name>/yaml/`, set
-  `model_cache` to `../../../models` so it still resolves to the repository's
-  `models/` directory.
+- Standalone service YAMLs live beside services for direct single-service
+  launches; they are not sample configuration. Shared deployments use the
+  hardware-specific YAML under
+  `agent-samples/model-servers/yaml/<gpu-profile>/`, while samples reuse the
+  resulting endpoints through their models JSON.
 - The generic NIM wrapper has no service-local YAML. Use a hardware profile
   under `agent-samples/model-servers/yaml/<gpu-profile>/`; its
   `nim_<role>_server.yaml` files use `nim_cache`, normally

--- a/docs/source/components/ai-services.md
+++ b/docs/source/components/ai-services.md
@@ -118,7 +118,9 @@ Process(
 
 The launcher skips reuse-only entries completely: it does not start, order, or
 readiness-check them. Start `model_servers` separately before the application
-sample. Application capability services such as RAG remain sample-owned and
+sample. At startup, the sample worker probes endpoints whose models JSON entry
+uses `readiness: health` and keeps waiting until those reused services are
+available. Application capability services such as RAG remain sample-owned and
 keep their configuration with the sample that launches them.
 
 ## Calling these from a worker

--- a/docs/source/components/ai-services.md
+++ b/docs/source/components/ai-services.md
@@ -104,7 +104,8 @@ its hardware-specific server YAML, and copy compatible endpoint entries into
 the sample's models JSON with `deployment.ownership` set to `reused`.
 
 Declare each model dependency in the sample orchestrator as reuse-only so the
-process list records startup ordering without starting or stopping the server:
+process list records the external dependency without transferring lifecycle
+ownership to the sample:
 
 ```python
 Process(
@@ -115,9 +116,10 @@ Process(
 )
 ```
 
-Start `model_servers` before the application sample. Application capability
-services such as RAG remain sample-owned and keep their configuration with the
-sample that launches them.
+The launcher skips reuse-only entries completely: it does not start, order, or
+readiness-check them. Start `model_servers` separately before the application
+sample. Application capability services such as RAG remain sample-owned and
+keep their configuration with the sample that launches them.
 
 ## Calling these from a worker
 

--- a/docs/source/components/ai-services.md
+++ b/docs/source/components/ai-services.md
@@ -92,77 +92,32 @@ verify free space first. Keep the old directories until the relocated services
 start successfully without network access. Recreate project environments with
 `uv sync`; do not copy `.venv` directories across the move.
 
+(adding-a-server-to-a-sample)=
 
-## Adding a server to a sample
+## Connecting a sample to shared model services
 
-**1 — Add the process to the orchestrator:**
+Model services are operator-owned by the persistent `model-servers` stack.
+Application samples reuse those endpoints; they do not own model processes or
+copy server YAML into their own configuration directories. Follow
+{doc}`/guides/customizing-model-servers` to select a deployment profile, tune
+its hardware-specific server YAML, and copy compatible endpoint entries into
+the sample's models JSON with `deployment.ownership` set to `reused`.
+
+Declare each model dependency in the sample orchestrator as reuse-only so the
+process list records startup ordering without starting or stopping the server:
 
 ```python
-PROCESSES = [
-    Process("hub",    "../../services/device-io-hub",                    "device_io_hub"),
-    Process("vlm",    "../../services/vlm-server",               "vlm_server",
-            config="yaml/vlm_server.yaml"),   # ← add as needed
-    # Pick ONE LLM backend per sample — they bind different default ports
-    # (8106 or 8107) so running more than one at once is allowed but
-    # usually unnecessary.
-    Process("llm",    "../../services/llama-nemotron-llm",       "llama_nemotron_llm_server",
-            config="yaml/llama_nemotron_llm_server.yaml"),
-    # Process("llm",  "../../services/nemotron3-nano-llm",       "nemotron3_nano_llm_server",
-    #         config="yaml/nemotron3_nano_llm_server.yaml"),
-    Process("stt",    "../../services/stt-server",               "stt_server",
-            config="yaml/stt_server.yaml"),
-    # Add these together when the application uses native document retrieval.
-    Process("embedding", "../../services/embedding-server",      "embedding_server",
-            config="yaml/embedding_server.yaml"),
-    Process("rag",    "../../services/rag-service",               "rag_service",
-            config="yaml/rag_service.yaml"),
-    # Pick one TTS server
-    Process("tts",    "../../services/piper-tts",                 "piper_tts_server",
-            config="yaml/piper_tts_server.yaml"),
-    # Process("tts",  "../../services/magpie-tts",                "magpie_tts_server",
-    #         config="yaml/magpie_tts_server.yaml"),
-    Process("worker", "worker",                                   "my_agent_worker"),
-]
+Process(
+    "vlm",
+    "../../services/vlm-server",
+    "vlm_server",
+    launch_mode="reuse",
+)
 ```
 
-The agent samples in this repository (`simple-vlm-example`,
-`tea-making-sample`, and `xr-render-demo`) support Piper TTS — it runs on CPU
-with ~100 ms/sentence latency and avoids the NeMo dep tree. Magpie is still a
-supported NVIDIA TTS option with better voice quality and multilingual support
-when GPU is available; samples that own TTS can select its process and YAML.
-
-**2 — Copy the reference YAML to your sample's `yaml/` directory:**
-
-```bash
-mkdir -p yaml
-cp ../../services/vlm-server/vlm_server.yaml ./yaml/vlm_server.yaml
-# Pick ONE LLM YAML — copy the one matching the Process you picked above.
-cp ../../services/llama-nemotron-llm/llama_nemotron_llm_server.yaml ./yaml/llama_nemotron_llm_server.yaml
-# cp ../../services/nemotron3-nano-llm/nemotron3_nano_llm_server.yaml ./yaml/nemotron3_nano_llm_server.yaml
-cp ../../services/stt-server/stt_server.yaml ./yaml/stt_server.yaml
-cp ../../services/embedding-server/embedding_server.yaml ./yaml/embedding_server.yaml
-cp ../../services/rag-service/rag_service.yaml ./yaml/rag_service.yaml
-cp ../../services/piper-tts/piper_tts_server.yaml ./yaml/piper_tts_server.yaml
-# Or for Magpie (multilingual, GPU, ~2-5 s/sentence):
-cp ../../services/magpie-tts/magpie_tts_server.yaml ./yaml/magpie_tts_server.yaml
-cp ../../services/video-memory-service/video_memory_service.yaml ./yaml/video_memory_service.yaml
-```
-
-The standalone model-service YAMLs contain `model_cache: ../../models` for their
-original `services/<project>/` location. After copying them one level deeper
-into `agent-samples/<name>/yaml/`, change that value to `../../../models` so
-the cache still resolves to the repository-root `models/` directory. Capability
-and capability configurations without a `model_cache` key need no change.
-
-`simple-vlm-example` does not copy model-service YAML or launch model servers.
-Its fixed `yaml/models.json` points at operator-owned STT, VLM, and TTS
-endpoints; the sample orchestrator only launches its hub and worker.
-
-Edit the YAML as needed (model, port, device, etc.). Set every copied path
-explicitly with `Process(config=...)`; the launcher does not discover files by
-command name.
-For RAG, also point `rag_service.yaml` at an application-owned document
-directory and a model profile containing an `embedding` role.
+Start `model_servers` before the application sample. Application capability
+services such as RAG remain sample-owned and keep their configuration with the
+sample that launches them.
 
 ## Calling these from a worker
 
@@ -502,7 +457,7 @@ cleanup.
   for commercial use under the
   [NVIDIA Open Model License](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/)
   and the
-  [Llama 3.1 Community License](https://www.llama.com/llama3_1/license/).
+  [Llama 3.1 Community License](https://github.com/meta-llama/llama-models/blob/main/models/llama3_1/LICENSE).
 - **nemotron3-nano-llm** is a thin wrapper around `vllm serve` for
   `NVIDIA-Nemotron-3-Nano-30B-A3B-{NVFP4,FP8}` (auto-selected by GPU compute
   capability). vLLM handles tool calling (`qwen3_coder` parser), reasoning

--- a/docs/source/components/launcher-and-process-model.md
+++ b/docs/source/components/launcher-and-process-model.md
@@ -54,8 +54,8 @@ def run() -> None:
 
 ## Rules
 
-- **Stack items start in declaration order** — members of a `Parallel` item
-  start concurrently, and the launcher waits for each `Process` or every
+- **Spawned stack items start in declaration order** — members of a `Parallel`
+  item start concurrently, and the launcher waits for each `Process` or every
   `Parallel` member to create its `--ready-file` before starting the next item.
   Declare items in dependency order (hub before workers and application
   processes after the services they call).
@@ -83,10 +83,19 @@ The stack is declared as a sequence of `Process` or `Parallel` items:
 
 ```python
 PROCESSES = [
-    Process("hub",    "../../services/device-io-hub", "device_io_hub"),
+    Process("vlm", "../../services/vlm-server", "vlm_server",
+            launch_mode="reuse"),
+    Process(
+        "embedding", "../../services/embedding-server", "embedding_server",
+        launch_mode="reuse",
+    ),
+    Process("hub", "../../services/device-io-hub", "device_io_hub",
+            config="yaml/device_io_hub.yaml"),
     Parallel([
-        Process("stt", "../../services/stt-server", "stt_server"),
-        Process("tts", "../../services/piper-tts",  "piper_tts_server"),
+        Process("video-memory", "../../services/video-memory-service",
+                "video_memory_service", config="yaml/video_memory_service.yaml"),
+        Process("rag", "../../services/rag-service", "rag_service",
+                config="yaml/rag_service.yaml"),
     ]),
     Process("worker", "worker", "my_agent_worker"),
 ]

--- a/docs/source/components/launcher-and-process-model.md
+++ b/docs/source/components/launcher-and-process-model.md
@@ -54,11 +54,11 @@ def run() -> None:
 
 ## Rules
 
-- **Spawned stack items start in declaration order** — members of a `Parallel`
-  item start concurrently, and the launcher waits for each `Process` or every
-  `Parallel` member to create its `--ready-file` before starting the next item.
-  Declare items in dependency order (hub before workers and application
-  processes after the services they call).
+- **Spawned stack items start in declaration order** — non-`reuse` members of a
+  `Parallel` item start concurrently, and the launcher waits for each spawned
+  `Process` or `Parallel` member to create its `--ready-file` before starting
+  the next item. Declare items in dependency order (hub before workers and
+  application processes after the services they call).
 - **Every spawned process accepts `--ready-file <path>`** and must `Path(path).touch()`
   when it is fully initialized and ready to serve requests.
 - **Native voice workers** pass the ready file to `VoiceAgent`; its private
@@ -74,12 +74,13 @@ def run() -> None:
 
 The stack is declared as a sequence of `Process` or `Parallel` items:
 
-- `Process` — started alone; the launcher waits for it to signal ready before
-  moving on.
-- `Parallel([p1, p2, ...])` — all processes in the group are started at once;
-  the launcher waits for *every* member to signal ready before the next item
-  in the sequence begins. If any member exits before signaling ready, the
-  launcher shuts everything down, just as it would for a serial process.
+- `Process` — when not configured with `launch_mode="reuse"`, started alone;
+  the launcher waits for it to signal ready before moving on.
+- `Parallel([p1, p2, ...])` — all non-`reuse` processes in the group are started
+  at once; the launcher waits for every spawned member to signal ready before
+  the next item in the sequence begins. If any spawned member exits before
+  signaling ready, the launcher shuts everything down, just as it would for a
+  serial process.
 
 ```python
 PROCESSES = [
@@ -103,7 +104,8 @@ PROCESSES = [
 
 ## How `run_stack` works
 
-For each process the launcher:
+For each spawned process (an entry not configured with `launch_mode="reuse"`),
+the launcher:
 
 1. Resolves the project directory and YAML configuration from the sample root (`base`
    — all relative paths in `Process.project` and `Process.config` are resolved
@@ -117,9 +119,9 @@ For each process the launcher:
 4. Once all processes are ready, monitors them: any exit triggers a graceful
    shutdown of the rest (SIGTERM, escalating to SIGKILL after a timeout).
 
-Each process is responsible for creating its own ready file at the moment it
-is fully initialized and able to serve requests — after model warm-up, after
-the IPC socket connects, after the HTTP server starts listening, etc.
+Each spawned process is responsible for creating its own ready file at the
+moment it is fully initialized and able to serve requests — after model warm-up,
+after the IPC socket connects, after the HTTP server starts listening, etc.
 
 Pass `exit_after_ready=True` to `run_stack` to return immediately once
 everything is ready instead of monitoring — useful for launchers whose

--- a/docs/source/getting_started/credentials.md
+++ b/docs/source/getting_started/credentials.md
@@ -66,8 +66,8 @@ is reused without any further setup.
 
 **Required for the NIM model backend and restricted `nvcr.io` image pulls.** It
 authenticates those container pulls and **hosted NVIDIA NIM** inference
-endpoints — a `models.yaml` entry with `api_key_env: NGC_API_KEY` sends it as
-the `Authorization: Bearer` token (refer to
+inference endpoints — a models JSON entry with `api_key_env: NGC_API_KEY` sends
+it as the `Authorization: Bearer` token (refer to
 {doc}`AI services — hosting models on NVIDIA NIM </components/ai-services>`).
 
 The `vlm_llm_nim` model-server profile calls

--- a/docs/source/getting_started/networking.md
+++ b/docs/source/getting_started/networking.md
@@ -15,7 +15,7 @@ ports. Open only the externally reachable ports required by the deployment.
 | 7882 | UDP | LiveKit WebRTC UDP media (DTLS/SRTP — already encrypted) |
 | 8080 | TCP | Web client, token server, and `wss://` `/rtc` proxy (HTTPS; the normal LiveKit signaling entry point for shipped clients) |
 | 8092 | TCP | Optional live agent-event viewer (plain HTTP — bound to 127.0.0.1 by default; do not expose to an untrusted network) |
-| 48322 | TCP | CloudXR WSS proxy (`auto-webrtc` clients only; unused by `auto-native` Apple clients) |
+| 48322 | TCP | CloudXR WSS proxy (WebRTC profiles; unused by native Apple clients) |
 
 ## Ubuntu or Debian (`ufw`)
 

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -301,9 +301,9 @@ additional host prerequisites:
 
 - **Vulkan loader + headers** — the CloudXR compositor and LOVR render through
   Vulkan, so install them before running the demo: `sudo apt install libvulkan-dev`
-- **Node.js 18+ with npm** on PATH for WebRTC profiles — the orchestrator builds
-  the web vendor bundle on first run (skipped for native profiles and on
-  subsequent runs).
+- **Node.js 20.19.0+ with npm** on PATH for WebRTC profiles — the orchestrator
+  builds the web vendor bundle on first run (skipped for native profiles and
+  on subsequent runs).
 
 Start XR Render:
 

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -275,8 +275,9 @@ dev.
 Under the hood, the orchestrator launches the hub, CloudXR runtime, typed
 capability processes, and the worker alongside the reused model endpoints. The
 worker calls those processes through Relay-managed native tools. The voice
-runtime runs quick-acks and a Nemotron-30B agentic tool-calling loop over scene,
-tracking, spatial math, vision, and video-memory tools. Refer to the
+runtime runs quick-acks and a Nemotron-3-Nano-Omni-30B-A3B-Reasoning agentic
+tool-calling loop over scene, tracking, spatial math, vision, and video-memory
+tools. Refer to the
 {doc}`xr-render-demo reference </reference/xr-render-demo>` for the full process
 map, agentic-loop details, and XR session lifecycle.
 
@@ -300,8 +301,9 @@ additional host prerequisites:
 
 - **Vulkan loader + headers** — the CloudXR compositor and LOVR render through
   Vulkan, so install them before running the demo: `sudo apt install libvulkan-dev`
-- **Node.js 18+ with npm** on PATH — the orchestrator builds the web vendor
-  bundle on first run (skipped on subsequent runs).
+- **Node.js 18+ with npm** on PATH for WebRTC profiles — the orchestrator builds
+  the web vendor bundle on first run (skipped for native profiles and on
+  subsequent runs).
 
 Start XR Render:
 
@@ -317,8 +319,9 @@ uv run main.py
 ```
 
 On first run the orchestrator automatically downloads the pinned LOVR version to
-`deps/lovr/` inside the repository and builds the web vendor bundle (requires npm
-and network access). Both steps are skipped on subsequent runs.
+`deps/lovr/` inside the repository. For WebRTC profiles it also builds the web
+vendor bundle, which requires npm and network access. Existing artifacts are
+reused on subsequent runs.
 
 ```{note}
 On **DGX Spark** (aarch64), LOVR does not publish a prebuilt aarch64 Linux

--- a/docs/source/getting_started/requirements.md
+++ b/docs/source/getting_started/requirements.md
@@ -33,7 +33,7 @@ NVDEC.
 | Requirement | Version | Notes |
 |---|---|---|
 | OS | Linux | Ubuntu 22.04 or 24.04 recommended; WSL2 is not officially supported (refer to [Windows (WSL2)](#windows-wsl2) below) |
-| Python | 3.11 or 3.12 | 3.10 and 3.13 are not supported |
+| Python | 3.11 or 3.12 recommended | other versions are not officially supported |
 | [uv](https://docs.astral.sh/uv/) | latest | dependency manager used by all samples |
 | NVIDIA driver | 580+ | required for CUDA 13 model containers and DeviceIOHub hardware codecs |
 | Docker | 24+ | required by the checked-in model-server profiles, which use vLLM containers from NGC and Docker Hub |

--- a/docs/source/getting_started/requirements.md
+++ b/docs/source/getting_started/requirements.md
@@ -33,7 +33,7 @@ NVDEC.
 | Requirement | Version | Notes |
 |---|---|---|
 | OS | Linux | Ubuntu 22.04 or 24.04 recommended; WSL2 is not officially supported (refer to [Windows (WSL2)](#windows-wsl2) below) |
-| Python | 3.11 or 3.12 recommended | other versions are not officially supported |
+| Python | 3.11 or 3.12 | tested and currently allowed; supporting other versions requires updating `requires-python` and CI |
 | [uv](https://docs.astral.sh/uv/) | latest | dependency manager used by all samples |
 | NVIDIA driver | 580+ | required for CUDA 13 model containers and DeviceIOHub hardware codecs |
 | Docker | 24+ | required by the checked-in model-server profiles, which use vLLM containers from NGC and Docker Hub |

--- a/docs/source/getting_started/requirements.md
+++ b/docs/source/getting_started/requirements.md
@@ -38,7 +38,7 @@ NVDEC.
 | NVIDIA driver | 580+ | required for CUDA 13 model containers and DeviceIOHub hardware codecs |
 | Docker | 24+ | required by the checked-in model-server profiles, which use vLLM containers from NGC and Docker Hub |
 | NVIDIA Container Toolkit | latest | required: configures the `nvidia` runtime that gives Docker access to the GPU |
-| Node.js | 18+ with npm | required for xr-render-demo's default WebRTC profile: the orchestrator builds the web vendor bundle on first run |
+| Node.js | 20.19.0+ with npm | required for xr-render-demo's default WebRTC profile: the orchestrator builds the web vendor bundle on first run |
 
 `uv` handles all Python dependencies per-sample — no global `pip install` or
 virtual-environment setup needed. If you do not have it:

--- a/docs/source/guides/adding-a-sample.md
+++ b/docs/source/guides/adding-a-sample.md
@@ -137,12 +137,14 @@ version = "0.1.0"
 requires-python = ">=3.11,<3.13"
 dependencies = [
     "xr-ai-hub-client",
+    "xr-ai-logging",
     "xr-ai-models",
     # add task-specific deps here: numpy, torch, etc.
 ]
 
 [tool.uv.sources]
 xr-ai-hub-client  = { path = "../../../agent-sdk/xr-ai-hub", editable = true }
+xr-ai-logging = { path = "../../../utils/xr-ai-logging", editable = true }
 xr-ai-models = { path = "../../../agent-sdk/xr-ai-models", editable = true }
 
 [project.scripts]
@@ -240,6 +242,7 @@ from xr_ai_hub import (          # ← import only what you use
     AudioChunk, DataMessage, FrameSignal, ParticipantEvent, ProcessorEndpoint,
     Subscribe,                     # ← only needed when scoping subscriptions
 )
+from xr_ai_logging import setup_logging
 
 log = logging.getLogger("<snake_name>")
 
@@ -251,6 +254,7 @@ class <CamelName>Agent:            # ← FILL IN agent logic
 
     def __init__(self) -> None:
         self._ep = ProcessorEndpoint(sub_addr=_HUB_PUB, push_addr=_HUB_PUSH)
+        self._ep_task: asyncio.Task[None] | None = None
         self._ep.on_frame(self._on_frame)       # ← remove callbacks you don't use
         self._ep.on_audio(self._on_audio)
         self._ep.on_data(self._on_data)
@@ -265,20 +269,29 @@ class <CamelName>Agent:            # ← FILL IN agent logic
 
     # ── lifecycle ─────────────────────────────────────────────────────────────
 
-    async def run(self) -> None:
-        await self._ep.run()        # ← start any background tasks before this line
+    async def run(self, ready_file: Path | None = None) -> None:
+        # ← start any application background tasks before the endpoint task
+        self._ep_task = asyncio.create_task(self._ep.run(), name="hub-endpoint")
+        await self._ep.wait_until_running()
+        if ready_file:
+            ready_file.touch()
+        try:
+            await self._ep_task
+        except asyncio.CancelledError:
+            pass
+        finally:
+            self._ep_task = None
 
     def shutdown(self) -> None:
         # ← cancel any background tasks here first
+        if self._ep_task:
+            self._ep_task.cancel()
         self._ep.stop()
         self._ep.close()
 
 
 async def main(ready_file: Path | None = None) -> None:
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s %(name)s %(levelname)s %(message)s",
-    )
+    setup_logging("worker")
 
     agent = <CamelName>Agent()
 
@@ -286,12 +299,9 @@ async def main(ready_file: Path | None = None) -> None:
     for sig in (signal.SIGINT, signal.SIGTERM):
         loop.add_signal_handler(sig, agent.shutdown)
 
-    if ready_file:
-        ready_file.touch()
-
     log.info("<snake_name> connecting  sub=%s  push=%s", _HUB_PUB, _HUB_PUSH)
     try:
-        await agent.run()
+        await agent.run(ready_file=ready_file)
     finally:
         agent.shutdown()
 

--- a/docs/source/guides/adding-cloudxr.md
+++ b/docs/source/guides/adding-cloudxr.md
@@ -59,7 +59,8 @@ clients, not both. Change the profile and restart the stack when switching.
 | `client-samples/web-xr/` | `auto-webrtc` | used |
 | `client-samples/ios-visionos/` | `auto-native` | unused |
 | Other native CloudXR clients | `auto-native` | unused |
-| Meta Quest 3 with CloudXR.js | `quest3` | used |
+| Meta Quest 2/3/3S with CloudXR.js | `auto-webrtc` | used |
+| Meta Quest 3 with fixed device defaults | `quest3` | used |
 
 The runtime also accepts the device-specific profiles `apple-vision-pro`,
 `ipad-pro`, and `quest3`. The static `quest3` profile is a valid alternative

--- a/docs/source/guides/adding-cloudxr.md
+++ b/docs/source/guides/adding-cloudxr.md
@@ -58,8 +58,6 @@ clients, not both. Change the profile and restart the stack when switching.
 |---|---|---|
 | `client-samples/web-xr/` | `auto-webrtc` | used |
 | `client-samples/ios-visionos/` | `auto-native` | unused |
-| Other native CloudXR clients | `auto-native` | unused |
-| Meta Quest 2/3/3S with CloudXR.js | `auto-webrtc` | used |
 
 The runtime also accepts the device-specific profiles `apple-vision-pro`,
 `ipad-pro`, and `quest3`. Use `auto-webrtc` for the Quest 2/3/3S path documented in the

--- a/docs/source/guides/adding-cloudxr.md
+++ b/docs/source/guides/adding-cloudxr.md
@@ -39,13 +39,13 @@ cloudxr_install_dir: ~/.cloudxr
 accept_eula: true
 
 # Device profile — controls transport and XR device defaults.
-# Valid: auto-native | auto-webrtc | apple-vision-pro | ipad-pro
+# Valid: auto-native | auto-webrtc | apple-vision-pro | ipad-pro | quest3
 cloudxr_env:
   NV_DEVICE_PROFILE: auto-webrtc
 
 # ── Ports (do not conflict with LiveKit) ──────────────────────────────────────
 # CloudXR native service:  localhost:49100  (internal)
-# WSS proxy (TLS):         0.0.0.0:48322   (XR clients connect here; auto-webrtc only)
+# WSS proxy (TLS):         0.0.0.0:48322   (XR clients connect here; WebRTC profiles only)
 ```
 
 ## Select one client profile
@@ -61,18 +61,20 @@ clients, not both. Change the profile and restart the stack when switching.
 | Other native CloudXR clients | `auto-native` | unused |
 | Meta Quest 3 with CloudXR.js | `quest3` | used |
 
-The runtime also accepts the device-specific native profiles
-`apple-vision-pro` and `ipad-pro`. Quest clients run CloudXR.js in the headset
-browser and therefore use the WebRTC profile rather than a native profile.
+The runtime also accepts the device-specific profiles `apple-vision-pro`,
+`ipad-pro`, and `quest3`. The static `quest3` profile is a valid alternative
+when fixed Quest 3 defaults are preferred. Use `auto-webrtc` for the general
+Quest 2/3/3S path so the runtime waits for the CloudXR.js client and discovers
+its device settings dynamically.
 
 ## Notes
 
 - CloudXR and the DeviceIOHub are **independent stacks**. CloudXR streams
   simulation and render content through the transport selected by the device
   profile; the hub handles agent media via LiveKit. They share no ports.
-- The `auto-webrtc` profile starts a WSS proxy on port 48322 for WebRTC
-  signaling. The `auto-native` profile uses a direct native transport and does
-  not need the proxy.
+- WebRTC profiles (`auto-webrtc` and `quest3`) start a WSS proxy on port 48322
+  for signaling. Native profiles use a direct native transport and do not need
+  the proxy.
 - After CloudXR is ready, activate its environment to run an OpenXR app against
   it. Run this in a separate terminal each time you start a new shell against a
   running stack:

--- a/docs/source/guides/adding-cloudxr.md
+++ b/docs/source/guides/adding-cloudxr.md
@@ -39,7 +39,7 @@ cloudxr_install_dir: ~/.cloudxr
 accept_eula: true
 
 # Device profile — controls transport and XR device defaults.
-# Valid: auto-native | auto-webrtc | apple-vision-pro | ipad-pro | quest3
+# Valid: auto-native | auto-webrtc | apple-vision-pro | ipad-pro
 cloudxr_env:
   NV_DEVICE_PROFILE: auto-webrtc
 
@@ -61,8 +61,9 @@ clients, not both. Change the profile and restart the stack when switching.
 | Other native CloudXR clients | `auto-native` | unused |
 | Meta Quest 3 with CloudXR.js | `quest3` | used |
 
-Device-specific profiles such as `apple-vision-pro`, `ipad-pro`, and `quest3`
-are also accepted when their fixed device defaults are preferred.
+The runtime also accepts the device-specific native profiles
+`apple-vision-pro` and `ipad-pro`. Quest clients run CloudXR.js in the headset
+browser and therefore use the WebRTC profile rather than a native profile.
 
 ## Notes
 

--- a/docs/source/guides/adding-cloudxr.md
+++ b/docs/source/guides/adding-cloudxr.md
@@ -59,7 +59,7 @@ clients, not both. Change the profile and restart the stack when switching.
 | `client-samples/web-xr/` | `auto-webrtc` | used |
 | `client-samples/ios-visionos/` | `auto-native` | unused |
 
-The runtime also accepts the device-specific profiles `apple-vision-pro`,
+The runtime also accepts the legacy device-specific profiles `apple-vision-pro`,
 `ipad-pro`, and `quest3`. Use `auto-webrtc` for the Quest 2/3/3S path documented in the
 [CloudXR.js requirements](https://docs.nvidia.com/cloudxr-sdk/latest/requirement/cloudxrjs_req.html)
 so the runtime waits for the client and discovers its device settings

--- a/docs/source/guides/adding-cloudxr.md
+++ b/docs/source/guides/adding-cloudxr.md
@@ -62,9 +62,7 @@ clients, not both. Change the profile and restart the stack when switching.
 | Meta Quest 2/3/3S with CloudXR.js | `auto-webrtc` | used |
 
 The runtime also accepts the device-specific profiles `apple-vision-pro`,
-`ipad-pro`, and `quest3`; `quest3` remains listed for compatibility, not as a
-recommended configuration. Use `auto-webrtc` for xr-render-demo and other
-CloudXR.js clients, including the Quest 2/3/3S path documented in the
+`ipad-pro`, and `quest3`. Use `auto-webrtc` for the Quest 2/3/3S path documented in the
 [CloudXR.js requirements](https://docs.nvidia.com/cloudxr-sdk/latest/requirement/cloudxrjs_req.html)
 so the runtime waits for the client and discovers its device settings
 dynamically.

--- a/docs/source/guides/adding-cloudxr.md
+++ b/docs/source/guides/adding-cloudxr.md
@@ -64,8 +64,10 @@ clients, not both. Change the profile and restart the stack when switching.
 The runtime also accepts the device-specific profiles `apple-vision-pro`,
 `ipad-pro`, and `quest3`. The static `quest3` profile is a valid alternative
 when fixed Quest 3 defaults are preferred. Use `auto-webrtc` for the general
-Quest 2/3/3S path so the runtime waits for the CloudXR.js client and discovers
-its device settings dynamically.
+Quest 2/3/3S path documented in the
+[CloudXR.js requirements](https://docs.nvidia.com/cloudxr-sdk/latest/requirement/cloudxrjs_req.html)
+so the runtime waits for the client and discovers its device settings
+dynamically.
 
 ## Notes
 

--- a/docs/source/guides/adding-cloudxr.md
+++ b/docs/source/guides/adding-cloudxr.md
@@ -62,9 +62,9 @@ clients, not both. Change the profile and restart the stack when switching.
 | Meta Quest 2/3/3S with CloudXR.js | `auto-webrtc` | used |
 
 The runtime also accepts the device-specific profiles `apple-vision-pro`,
-`ipad-pro`, and `quest3`. The static `quest3` profile is a valid alternative
-when fixed Quest 3 defaults are preferred. Use `auto-webrtc` for the general
-Quest 2/3/3S path documented in the
+`ipad-pro`, and `quest3`; `quest3` remains listed for compatibility, not as a
+recommended configuration. Use `auto-webrtc` for xr-render-demo and other
+CloudXR.js clients, including the Quest 2/3/3S path documented in the
 [CloudXR.js requirements](https://docs.nvidia.com/cloudxr-sdk/latest/requirement/cloudxrjs_req.html)
 so the runtime waits for the client and discovers its device settings
 dynamically.

--- a/docs/source/guides/adding-cloudxr.md
+++ b/docs/source/guides/adding-cloudxr.md
@@ -60,7 +60,6 @@ clients, not both. Change the profile and restart the stack when switching.
 | `client-samples/ios-visionos/` | `auto-native` | unused |
 | Other native CloudXR clients | `auto-native` | unused |
 | Meta Quest 2/3/3S with CloudXR.js | `auto-webrtc` | used |
-| Meta Quest 3 with fixed device defaults | `quest3` | used |
 
 The runtime also accepts the device-specific profiles `apple-vision-pro`,
 `ipad-pro`, and `quest3`. The static `quest3` profile is a valid alternative

--- a/docs/source/guides/customizing-model-servers.md
+++ b/docs/source/guides/customizing-model-servers.md
@@ -39,6 +39,9 @@ The shipped profiles are:
 - `vlm_llm_nim`: local STT, Piper TTS, and embedding plus self-hosted
   Nemotron-3 Nano Omni and Cosmos3-Nano Reasoner NIM containers.
 
+The shared profiles use Piper TTS. Magpie remains available as a standalone
+service, but is not integrated into the persistent model stack.
+
 Copy the closest profile under a new name:
 
 ```bash

--- a/tests/test_docs_versions.py
+++ b/tests/test_docs_versions.py
@@ -409,6 +409,7 @@ def test_service_root_commands_declare_their_working_directory() -> None:
 
 
 def test_reworded_headings_keep_compatibility_anchors() -> None:
+    ai_services = (_ROOT / "docs/source/components/ai-services.md").read_text()
     clients = (_ROOT / "docs/source/getting_started/clients.md").read_text()
     hub = (_ROOT / "docs/source/reference/agent-sdk-hub.md").read_text()
     models = (_ROOT / "docs/source/reference/agent-sdk-models.md").read_text()
@@ -430,6 +431,7 @@ def test_reworded_headings_keep_compatibility_anchors() -> None:
     ):
         assert f"({anchor})=" in clients
     for page, anchors in (
+        (ai_services, ("adding-a-server-to-a-sample",)),
         (
             hub,
             (

--- a/tests/test_launcher_cloudxr_env.py
+++ b/tests/test_launcher_cloudxr_env.py
@@ -132,6 +132,9 @@ class TestIsNativeProfile:
     def test_webrtc_profile_is_not_native(self):
         assert is_native_profile("auto-webrtc") is False
 
+    def test_quest3_profile_is_not_native(self):
+        assert is_native_profile("quest3") is False
+
     def test_empty_string_is_not_native(self):
         assert is_native_profile("") is False
 


### PR DESCRIPTION
## Summary

- replace the sample-owned model-server recipe with the persistent shared `model-servers` ownership contract
- make the raw-IPC sample scaffold use shared logging and touch its ready file only after `ProcessorEndpoint` enters the receive loop
- recommend `auto-webrtc` for xr-render-demo and Quest 2/3/3S CloudXR.js clients; retain `quest3` only as an accepted compatibility value
- use the exact Nemotron Omni model name and raise the CloudXR.js Node.js minimum to 20.19.0
- align the hosted NIM credential example with models JSON and replace the broken Llama 3.1 license URL

## Relationship to #428

PR #428 already fixes the hub codec-GPU requirement, dual-Ada profile coverage, most scaffold naming/configuration drift, conditional Node.js wording in requirements and the sample README, and the stale XR-render STT description.

This follow-up starts from current `main` and addresses the findings that #428 leaves partial or unresolved. In particular, #428 still gives model services to sample orchestrators. For Quest, this PR makes `auto-webrtc` the sole recommended xr-render-demo and CloudXR.js path; `quest3` remains listed only as an accepted compatibility value.

## Review update

- retained `quest3` in the valid profile list for compatibility while making `auto-webrtc` the sole Quest recommendation
- removed the remaining instruction to copy standalone model-service YAML into a sample and aligned the networking table with both WebRTC profiles
- clarified that reuse-only launcher entries are dependency metadata only; the launcher does not start, order, or readiness-check them

## Follow-up review update

- preserved the published `#adding-a-server-to-a-sample` fragment and registered it in the compatibility-anchor regression test
- replaced the canonical sample-owned STT/TTS process example with reused model dependencies and sample-owned capability services
- clarified worker-side endpoint health probing for reuse-only services
- documented that shared profiles use Piper while Magpie remains a standalone service outside the persistent model stack
- classified the accepted `quest3` compatibility value as WebRTC rather than native and linked the Quest 2/3/3S `auto-webrtc` guidance to NVIDIA CloudXR.js requirements
- raised the Node.js minimum to 20.19.0 in the quickstart, canonical requirements, and XR sample README

## Validation

- focused documentation and CloudXR tests (`40 passed`)
- strict Sphinx documentation build (`make -C docs strict`)
- Ruff 0.15.16 (`ruff check .`)
- generated dependency map check
- `git diff --check`
