### PR TITLE
fix(native): avoid global metrics callback pointer

### DIFF
--- a/client-samples/native/StreamKit/src/Backends/LiveKit/LiveKitBackend.cpp
+++ b/client-samples/native/StreamKit/src/Backends/LiveKit/LiveKitBackend.cpp
@@ -58,7 +58,10 @@ namespace streamkit {
 
 namespace {
 
-inline thread_local LiveKitBackend* metrics_callback_backend = nullptr;
+LiveKitBackend*& MetricsCallbackBackend() {
+    static thread_local LiveKitBackend* backend = nullptr;
+    return backend;
+}
 
 #if STREAMKIT_HAVE_LIVEKIT
 // Lazy one-shot initialise of the SDK's global state. livekit::initialize()
@@ -786,14 +789,15 @@ void LiveKitBackend::DeliverNetworkMetrics(const NetworkMetrics& metrics,
     }
     callback = on_network_metrics;
 
-    auto* previous_backend = metrics_callback_backend;
-    metrics_callback_backend = this;
+    auto*& callback_backend = MetricsCallbackBackend();
+    auto* previous_backend = callback_backend;
+    callback_backend = this;
     try {
         callback(metrics);
     } catch (...) { // NOSONAR - user callbacks may throw any exception type.
         // User callback failures do not stop telemetry or escape the worker.
     }
-    metrics_callback_backend = previous_backend;
+    callback_backend = previous_backend;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -802,7 +806,7 @@ void LiveKitBackend::DeliverNetworkMetrics(const NetworkMetrics& metrics,
 
 void LiveKitBackend::TearDown() {
     std::unique_lock teardown_lock(teardown_mutex_, std::defer_lock);
-    if (metrics_callback_backend == this) {
+    if (MetricsCallbackBackend() == this) {
         // An application-thread teardown may be joining this worker. In that
         // case this call is redundant and must not wait for the owner.
         if (!teardown_lock.try_lock()) return;


### PR DESCRIPTION
## Summary

- move the metrics callback thread-local pointer from namespace scope into function-local storage
- preserve callback-triggered teardown deadlock avoidance while satisfying Sonar rule cpp:S5421
- address the open maintainability finding in LiveKitBackend.cpp: https://sonar.nvidia.com/project/issues?impactSoftwareQualities=MAINTAINABILITY&issueStatuses=OPEN%2CCONFIRMED&open=f5e82743-9c73-4302-8c42-5ea3c2751075&id=SW-Cloud_XR_XR-AI_xr-ai

## Validation

- native StreamKit stub-mode configure and build with tests enabled
- CTest: 6/6 tests passed
- git diff --check