### PR TITLE
Gate xr render sample perception claims on turn observation evidence

### DIFF
--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/harness.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/harness.py
@@ -303,8 +303,11 @@ CASES = (
     Case(
         name="historical_vision",
         request="What color was the object I held ten seconds ago?",
-        vision="The previously held object was purple.",
+        # Phrased to lure a present-tense reply; the gate must steer the
+        # historical answer into past tense, never swallow it.
+        vision="In the recorded frame, the user is holding a purple mug.",
         required_tools=frozenset({"look_at_past_frame"}),
+        reply_contains="purple",
         # The supervisor's own conversation recall is the single expected
         # call; the camera's past is video, never the transcript.
         expected_call_counts=(("recall_conversation", 1),),

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/harness.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/harness.py
@@ -787,6 +787,16 @@ UTTERANCES = (
         forbidden_tools=_FORBID_MUTATIONS,
     ),
     Case(
+        name="basics_bare_holding_question",
+        # The perception gate's live regression: a bare hands question got
+        # answered from the model's prior instead of the camera.
+        request="What am I holding right now?",
+        vision="A hand holding a stapler.",
+        required_tools=frozenset({"look_at_current_frame"}),
+        forbidden_tools=_FORBID_MUTATIONS,
+        reply_contains="stapler",
+    ),
+    Case(
         name="basics_look_for_yourself",
         # Answering a clarifying question with "go observe" must re-enter
         # the pending request through the camera, never echo those words.

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/_physical_color.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/_physical_color.py
@@ -21,7 +21,7 @@ from xr_ai_tools.current_frame import CurrentFrameRequest, CurrentFrameTool
 from xr_ai_tools.vision import ImageQueryRequest, ImageQueryResult
 
 from ._tolerant import reraise_unavailable
-from ._trace import current_participant_id, current_trace_id
+from ._trace import current_participant_id, current_trace_id, record_evidence
 
 IMAGE_QUERY_SYSTEM_PROMPT = (
     'Reply with exactly "VISIBLE r g b", where r, g, b are numbers between 0 '
@@ -115,6 +115,7 @@ def make_physical_color_tool(
                 f"the camera view did not yield an observation of {source!r}: {result.text[:120]}"
             )
         logger.debug("physical color {!r} -> {}", source, resolved)
+        record_evidence("observed")
         if trace:
             cache[key] = resolved
         return ResolvedColor(r=resolved[0], g=resolved[1], b=resolved[2])

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/_trace.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/_trace.py
@@ -17,18 +17,21 @@ current_trace_id: ContextVar[str] = ContextVar("current_trace_id", default="")
 current_participant_id: ContextVar[str] = ContextVar("current_participant_id", default="")
 current_reference_time_us: ContextVar[int] = ContextVar("current_reference_time_us", default=0)
 
-EvidenceField = Literal["applied", "satisfied", "observed"]
+EvidenceField = Literal["applied", "satisfied", "observed", "observed_recorded"]
 
 
 class TurnEvidence:
     """Per-turn evidence counters the supervisor's gates read instead of
     trusting the model's wording: scene writes applied (or found already
-    satisfied) and camera observations actually made."""
+    satisfied), live camera observations made (`observed`), and recorded-frame
+    observations made (`observed_recorded`); only `observed` licenses a
+    present-tense perception claim."""
 
     def __init__(self) -> None:
         self.applied = 0
         self.satisfied = 0
         self.observed = 0
+        self.observed_recorded = 0
 
 
 current_turn_evidence: ContextVar[TurnEvidence | None] = ContextVar(

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/_trace.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/_trace.py
@@ -11,22 +11,32 @@ read them when selecting participant-scoped frames, memory, and scene views.
 """
 
 from contextvars import ContextVar
+from typing import Literal
 
 current_trace_id: ContextVar[str] = ContextVar("current_trace_id", default="")
 current_participant_id: ContextVar[str] = ContextVar("current_participant_id", default="")
 current_reference_time_us: ContextVar[int] = ContextVar("current_reference_time_us", default=0)
 
+EvidenceField = Literal["applied", "satisfied", "observed"]
 
-class MutationEvidence:
-    """Count of scene writes actually applied (or found already satisfied)
-    this turn; the supervisor's success gate reads it instead of trusting
-    the model's wording."""
+
+class TurnEvidence:
+    """Per-turn evidence counters the supervisor's gates read instead of
+    trusting the model's wording: scene writes applied (or found already
+    satisfied) and camera observations actually made."""
 
     def __init__(self) -> None:
         self.applied = 0
         self.satisfied = 0
+        self.observed = 0
 
 
-current_mutation_evidence: ContextVar[MutationEvidence | None] = ContextVar(
-    "current_mutation_evidence", default=None
+current_turn_evidence: ContextVar[TurnEvidence | None] = ContextVar(
+    "current_turn_evidence", default=None
 )
+
+
+def record_evidence(field: EvidenceField) -> None:
+    evidence = current_turn_evidence.get()
+    if evidence is not None:
+        setattr(evidence, field, getattr(evidence, field) + 1)

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/vision/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/vision/agent.py
@@ -15,7 +15,12 @@ from xr_ai_tools.video_memory import HistoricalFrameRequest, VideoMemoryTools
 from xr_ai_tools.vision import ImageQueryRequest, ImageQueryResult, ImageQueryTool
 
 from ..._tolerant import reraise_unavailable, tolerant_toolset
-from ..._trace import current_participant_id, current_reference_time_us, current_trace_id
+from ..._trace import (
+    current_participant_id,
+    current_reference_time_us,
+    current_trace_id,
+    record_evidence,
+)
 from ...models import SubagentResult, SubagentTask
 from ...scene import SceneContext
 
@@ -52,7 +57,10 @@ def make_vision_agent(
                 frame = await current_frame.execute(CurrentFrameRequest(participant_id=participant_id))
             except Exception as error:
                 reraise_unavailable(error, "the current camera view")
-            return await image_query.execute(ImageQueryRequest(image=frame.image, query=req.question))
+            result = await image_query.execute(ImageQueryRequest(image=frame.image, query=req.question))
+            if result.available:
+                record_evidence("observed")
+            return result
 
         tools = [
             Tool(
@@ -75,7 +83,11 @@ def make_vision_agent(
                     )
                 except Exception as error:
                     reraise_unavailable(error, "recorded video")
-                return await image_query.execute(ImageQueryRequest(image=frame.image, query=req.question))
+                # No "observed" evidence: a recorded frame cannot support a
+                # claim about what the user holds or wears right now.
+                return await image_query.execute(
+                    ImageQueryRequest(image=frame.image, query=req.question)
+                )
 
             tools.append(Tool(
                 "look_at_past_frame",

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/vision/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/vision/agent.py
@@ -57,7 +57,12 @@ def make_vision_agent(
                 frame = await current_frame.execute(CurrentFrameRequest(participant_id=participant_id))
             except Exception as error:
                 reraise_unavailable(error, "the current camera view")
-            result = await image_query.execute(ImageQueryRequest(image=frame.image, query=req.question))
+            try:
+                result = await image_query.execute(
+                    ImageQueryRequest(image=frame.image, query=req.question)
+                )
+            except Exception as error:
+                reraise_unavailable(error, "image analysis")
             if result.available:
                 record_evidence("observed")
             return result
@@ -83,11 +88,18 @@ def make_vision_agent(
                     )
                 except Exception as error:
                     reraise_unavailable(error, "recorded video")
-                # No "observed" evidence: a recorded frame cannot support a
-                # claim about what the user holds or wears right now.
-                return await image_query.execute(
-                    ImageQueryRequest(image=frame.image, query=req.question)
-                )
+                # A recorded observation never licenses a present-tense claim;
+                # the supervisor's gate uses it only to steer the reply toward
+                # the recorded moment.
+                try:
+                    result = await image_query.execute(
+                        ImageQueryRequest(image=frame.image, query=req.question)
+                    )
+                except Exception as error:
+                    reraise_unavailable(error, "image analysis")
+                if result.available:
+                    record_evidence("observed_recorded")
+                return result
 
             tools.append(Tool(
                 "look_at_past_frame",

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/spatial_ops.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/spatial_ops.py
@@ -31,14 +31,7 @@ from xr_render_scene import (
     UpdatePrimitiveRequest,
 )
 
-from ._trace import current_mutation_evidence
-
-
-def _record(field: str) -> None:
-    evidence = current_mutation_evidence.get()
-    if evidence is not None:
-        setattr(evidence, field, getattr(evidence, field) + 1)
-
+from ._trace import record_evidence
 
 _UserDirection = Literal["front", "back", "left", "right", "above", "below"]
 _AnchorRelation = Literal["toward_user", "away_from_user", "left_of", "right_of", "above", "below"]
@@ -159,7 +152,7 @@ class _Leaves:
     def _confirm(result: MutationResult) -> MutationResult:
         if not result.ok:
             raise ValueError(f"the scene rejected the change: {result.reason or 'unknown reason'}")
-        _record("applied")
+        record_evidence("applied")
         return result
 
     async def update(self, arguments: dict) -> MutationResult:
@@ -358,7 +351,7 @@ class _Leaves:
             )
             if not result.ok:
                 raise ValueError(f"the scene rejected the creation: {result.reason or 'unknown reason'}")
-            _record("applied")
+            record_evidence("applied")
             created = CreatedObject(id=result.id, x=x, y=y, z=z)
             if self.ledger is not None:
                 self.ledger.count += 1
@@ -642,7 +635,7 @@ def make_appearance_tools(
         if all(abs(have - want) < 1e-6 for have, want in zip(current, (r, g, b))):
             # Requested state already holds; record it so the supervisor's
             # success gate accepts an "already that color" reply.
-            _record("satisfied")
+            record_evidence("satisfied")
             return RecoloredObject(obj_id=target.id, r=r, g=g, b=b)
         await leaves.update({"obj_id": target.id, "r": r, "g": g, "b": b})
         return RecoloredObject(obj_id=target.id, r=r, g=g, b=b)

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor.py
@@ -25,11 +25,11 @@ from xr_render_scene import SceneTools
 
 from ._physical_color import IMAGE_QUERY_SYSTEM_PROMPT, make_physical_color_tool
 from ._trace import (
-    MutationEvidence,
-    current_mutation_evidence,
+    TurnEvidence,
     current_participant_id,
     current_reference_time_us,
     current_trace_id,
+    current_turn_evidence,
 )
 from .agents import (
     make_appearance_agent,
@@ -66,6 +66,8 @@ _PROGRESSIVE_SUBJECTS = frozenset(
 )
 
 _TRUNCATED_ASK = "I think I missed the end of that."
+
+_UNOBSERVED_REPLY = "I haven't been able to observe that, so I can't say."
 
 _CANCEL_PHRASES = frozenset({
     "never mind", "nevermind", "forget it", "forget that", "cancel", "cancel that", "no", "stop",
@@ -112,6 +114,37 @@ def _claims_completion(text: str) -> bool:
 
 def _is_question(text: str) -> bool:
     return text.rstrip().rstrip("\"'”’)").rstrip().endswith("?")
+
+
+_SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+")
+
+# Hands-and-body claims in our own reply: the only family a camera alone can
+# settle, since look-at and point-at answers come from tracking or scene data
+# and past tense from memory. Defense in depth over the model's dominant
+# register, not a paraphrase parser.
+_PERCEPTION_CLAIMS = re.compile(
+    r"\byou\s*(?:['’]re|\s+are|\s+(?:appears?|seems?)\s+to\s+be)"
+    r"(?:\s+\w+){0,2}\s+(?:holding|carrying|wearing|gripping)\b"
+    r"|\bin\s+your(?:\s+\w+){0,2}\s+(?:hands?|grasp|grip)\b",
+    re.IGNORECASE,
+)
+
+# An honest "I can't see" is the answer the gate wants, so it must survive it.
+_PERCEPTION_HEDGES = re.compile(
+    r"\bcan(?:['’]t|not)\b|\bcould(?:n['’]t|\s+not)\b|\bunable\b|\bnot\s+sure\b"
+    r"|\b(?:do|does|did)(?:n['’]t|\s+not)\s+know\b|\bno\s+camera\b|\bunavailable\b"
+    r"|\bhave(?:n['’]t|\s+not)\b",
+    re.IGNORECASE,
+)
+
+
+def _claims_perception(text: str) -> bool:
+    return any(
+        _PERCEPTION_CLAIMS.search(sentence)
+        and not _is_question(sentence)
+        and not _PERCEPTION_HEDGES.search(sentence)
+        for sentence in _SENTENCE_SPLIT.split(text)
+    )
 
 
 def _is_truncated(transcript: str) -> bool:
@@ -294,8 +327,8 @@ class SceneSupervisor:
     async def _handle_scene(
         self, request: SceneRequest, transcript: str, conversation: str
     ) -> SceneReply:
-        evidence = MutationEvidence()
-        current_mutation_evidence.set(evidence)
+        evidence = TurnEvidence()
+        current_turn_evidence.set(evidence)
         before = await self._context.snapshot()
 
         user_message = (
@@ -331,7 +364,11 @@ class SceneSupervisor:
         needs_verification = bool(delegated & _MUTATING_AGENTS) or _wants_mutation(transcript)
 
         await asyncio.sleep(_SCENE_SETTLE_S)
-        if needs_verification and not SceneContext.changes(before, await self._context.snapshot()):
+        latest = result
+        verify_no_change = needs_verification and not SceneContext.changes(
+            before, await self._context.snapshot()
+        )
+        if verify_no_change:
             if delegated & _MUTATING_AGENTS:
                 nudge = (
                     "Verified scene changes this turn: none. If the request needed a"
@@ -348,7 +385,7 @@ class SceneSupervisor:
                     " be done, say plainly that nothing was changed and why; never"
                     " reply that a change was made."
                 )
-            verification_messages = list(result.messages) + [
+            verification_messages = list(latest.messages) + [
                 ChatMessage(role="user", content=nudge),
             ]
             try:
@@ -359,7 +396,41 @@ class SceneSupervisor:
                 logger.warning("supervisor verification failed ({})", exc)
             else:
                 output = result2.content
+                latest = result2
             await asyncio.sleep(_SCENE_SETTLE_S)
+
+        perception_retried = False
+        if output and _claims_perception(output) and evidence.observed == 0:
+            logger.warning("perception claim without observation: {!r}", output[:80])
+            perception_retried = True
+            perception_nudge = (
+                "Your reply asserts what the user is holding, carrying, or"
+                " wearing, but no camera observation was made this turn."
+                " Delegate vision_agent now with that exact question and"
+                " answer only from its result; if it cannot see, say so."
+            )
+            perception_messages = list(latest.messages) + [
+                ChatMessage(role="user", content=perception_nudge),
+            ]
+            try:
+                perception_result = await run_tool_loop(
+                    perception_messages, self._toolset, _call_model, max_iterations=6
+                )
+            except ToolLoopError as exc:
+                logger.warning("perception retry failed ({})", exc)
+                output = ""
+            else:
+                output = perception_result.content
+            await asyncio.sleep(_SCENE_SETTLE_S)
+
+        # One text policy over the final reply, whichever loop produced it.
+        # Perception replaces before the mutation gate appends, so a turn that
+        # trips both keeps the no-change fact.
+        if evidence.observed == 0 and (
+            (perception_retried and not output) or (output and _claims_perception(output))
+        ):
+            output = _UNOBSERVED_REPLY
+        if verify_no_change:
             # Success is evidence-backed: a completion claim may stand only
             # when a scene write was applied (or the requested state already
             # held), never on the model's wording alone. A claim-free

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor.py
@@ -69,6 +69,11 @@ _TRUNCATED_ASK = "I think I missed the end of that."
 
 _UNOBSERVED_REPLY = "I haven't been able to observe that, so I can't say."
 
+_RECORDED_ONLY_REPLY = (
+    "I could only check a recorded frame, not your current view, so I can't"
+    " say what you're holding right now."
+)
+
 _CANCEL_PHRASES = frozenset({
     "never mind", "nevermind", "forget it", "forget that", "cancel", "cancel that", "no", "stop",
 })
@@ -138,12 +143,20 @@ _PERCEPTION_HEDGES = re.compile(
 )
 
 
+# A hedge exempts only its own clause: "I can't see clearly, but you are
+# holding a camera" still claims.
+_CLAUSE_SPLIT = re.compile(
+    r"[,;:]|\bbut\b|\band\b|\bhowever\b|\byet\b|\balthough\b|—|–|\s-\s",
+    re.IGNORECASE,
+)
+
+
 def _claims_perception(text: str) -> bool:
     return any(
-        _PERCEPTION_CLAIMS.search(sentence)
-        and not _is_question(sentence)
-        and not _PERCEPTION_HEDGES.search(sentence)
+        _PERCEPTION_CLAIMS.search(clause) and not _PERCEPTION_HEDGES.search(clause)
         for sentence in _SENTENCE_SPLIT.split(text)
+        if not _is_question(sentence)
+        for clause in _CLAUSE_SPLIT.split(sentence)
     )
 
 
@@ -400,15 +413,28 @@ class SceneSupervisor:
             await asyncio.sleep(_SCENE_SETTLE_S)
 
         perception_retried = False
-        if output and _claims_perception(output) and evidence.observed == 0:
-            logger.warning("perception claim without observation: {!r}", output[:80])
-            perception_retried = True
-            perception_nudge = (
-                "Your reply asserts what the user is holding, carrying, or"
-                " wearing, but no camera observation was made this turn."
-                " Delegate vision_agent now with that exact question and"
-                " answer only from its result; if it cannot see, say so."
+        if output and evidence.observed == 0 and _claims_perception(output):
+            logger.warning(
+                "perception claim without live observation"
+                " (observed_recorded={}): {!r}",
+                evidence.observed_recorded, output[:80],
             )
+            perception_retried = True
+            if evidence.observed_recorded > 0:
+                perception_nudge = (
+                    "Your reply asserts what the user is holding, carrying, or"
+                    " wearing right now, but this turn only consulted a"
+                    " recorded frame. Restate your answer explicitly about"
+                    " that recorded moment in past tense, or delegate"
+                    " vision_agent to look at the current view first."
+                )
+            else:
+                perception_nudge = (
+                    "Your reply asserts what the user is holding, carrying, or"
+                    " wearing, but no camera observation was made this turn."
+                    " Delegate vision_agent now with that exact question and"
+                    " answer only from its result; if it cannot see, say so."
+                )
             perception_messages = list(latest.messages) + [
                 ChatMessage(role="user", content=perception_nudge),
             ]
@@ -429,7 +455,14 @@ class SceneSupervisor:
         if evidence.observed == 0 and (
             (perception_retried and not output) or (output and _claims_perception(output))
         ):
-            output = _UNOBSERVED_REPLY
+            logger.warning(
+                "unobserved perception claim persisted"
+                " (observed_recorded={}); replacing reply {!r}",
+                evidence.observed_recorded, (output or "")[:80],
+            )
+            output = (
+                _RECORDED_ONLY_REPLY if evidence.observed_recorded > 0 else _UNOBSERVED_REPLY
+            )
         if verify_no_change:
             # Success is evidence-backed: a completion claim may stand only
             # when a scene write was applied (or the requested state already

--- a/docs/source/reference/xr-render-demo.md
+++ b/docs/source/reference/xr-render-demo.md
@@ -253,14 +253,17 @@ services. On each accepted `xr-render.user-query` event:
    completion claim is replaced with a fixed honest no-change sentence and
    any other non-question reply gets the no-change fact appended. Evidence
    is counted per turn, not per delegated task.
-4. **Perception gate** — on every turn, not just mutating ones. A sentence
+4. **Perception gate** — on every turn, not just mutating ones. A clause
    in the reply asserting what the user is holding, carrying, wearing, or
    gripping needs a live camera observation this turn (`look_at_current_frame`
-   or `resolve_physical_color`; a recorded frame does not count). Without
-   one, the supervisor is sent back to look once, and a still-unobserved
-   claim is replaced, never appended to, with a fixed honest can't-say
-   sentence. Questions and hedged sentences ("I can't tell what you're
-   holding") are left alone.
+   or `resolve_physical_color`; a recorded frame never licenses a
+   present-tense claim). Without one, the supervisor is sent back once —
+   steered to restate the answer about the recorded moment in past tense
+   when only `look_at_past_frame` ran this turn, to look otherwise — and a
+   still-unobserved claim is replaced, never appended to, with a fixed
+   honest sentence saying what could not be seen. Questions and hedged
+   clauses ("I can't tell what you're holding") are left alone; a hedge
+   exempts only its own clause.
 5. **Conversation history persisted** — the user utterance and agent reply
    are written to `TextMemoryTools` under `{participant_id}:user` and
    `{participant_id}:agent` source keys.

--- a/docs/source/reference/xr-render-demo.md
+++ b/docs/source/reference/xr-render-demo.md
@@ -253,10 +253,18 @@ services. On each accepted `xr-render.user-query` event:
    completion claim is replaced with a fixed honest no-change sentence and
    any other non-question reply gets the no-change fact appended. Evidence
    is counted per turn, not per delegated task.
-4. **Conversation history persisted** — the user utterance and agent reply
+4. **Perception gate** — on every turn, not just mutating ones. A sentence
+   in the reply asserting what the user is holding, carrying, wearing, or
+   gripping needs a live camera observation this turn (`look_at_current_frame`
+   or `resolve_physical_color`; a recorded frame does not count). Without
+   one, the supervisor is sent back to look once, and a still-unobserved
+   claim is replaced, never appended to, with a fixed honest can't-say
+   sentence. Questions and hedged sentences ("I can't tell what you're
+   holding") are left alone.
+5. **Conversation history persisted** — the user utterance and agent reply
    are written to `TextMemoryTools` under `{participant_id}:user` and
    `{participant_id}:agent` source keys.
-5. **Final response** published as one complete `voice.output` message for
+6. **Final response** published as one complete `voice.output` message for
    the voice subscriber and TTS.
 
 Mutation intent is read from the supervisor loop's own tool-call record

--- a/tests/test_render_physical_color.py
+++ b/tests/test_render_physical_color.py
@@ -85,6 +85,29 @@ async def test_resolver_returns_typed_color() -> None:
     assert (resolved.r, resolved.g, resolved.b) == (0.0, 0.4, 1.0)
 
 
+async def test_resolver_records_observation_evidence_only_on_success() -> None:
+    """Only a parsed VISIBLE answer counts as a camera observation; an outage
+    or an unparseable reply leaves the supervisor's perception gate unbacked."""
+    from xr_render_demo_worker._trace import TurnEvidence, current_turn_evidence
+
+    evidence = TurnEvidence()
+    token = current_turn_evidence.set(evidence)
+    try:
+        tool = make_physical_color_tool(_frame_tool(), _query_tool("VISIBLE 0.0 0.4 1.0"))
+        await tool.execute(ResolvePhysicalColorRequest(source_words="the lid"))
+        assert evidence.observed == 1
+
+        tool = make_physical_color_tool(_frame_tool(), _query_tool("no signal", available=False))
+        await _expect_rejection(tool, "the lid", "cannot currently see")
+        assert evidence.observed == 1
+
+        tool = make_physical_color_tool(_frame_tool(), _query_tool("UNKNOWN"))
+        await _expect_rejection(tool, "my shirt", "did not yield an observation")
+        assert evidence.observed == 1
+    finally:
+        current_turn_evidence.reset(token)
+
+
 async def test_resolver_caches_within_turn() -> None:
     query = _query_tool("VISIBLE 0.0 0.4 1.0")
     tool = make_physical_color_tool(_frame_tool(), query)

--- a/tests/test_render_spatial_ops.py
+++ b/tests/test_render_spatial_ops.py
@@ -324,13 +324,13 @@ async def test_empty_value_required_for_non_literal_kinds():
 
 
 async def test_recolor_records_applied_and_satisfied_evidence():
-    from xr_render_demo_worker._trace import MutationEvidence, current_mutation_evidence
+    from xr_render_demo_worker._trace import TurnEvidence, current_turn_evidence
     from xr_render_demo_worker.spatial_ops import _RecolorRequest, make_appearance_tools
 
     fake = _FakeScene([_obj("cone-0", "cone", (0, 0.8, 0))])
     tools = {tool.name: tool for tool in make_appearance_tools(_FakeSceneTools(fake))}
-    evidence = MutationEvidence()
-    token = current_mutation_evidence.set(evidence)
+    evidence = TurnEvidence()
+    token = current_turn_evidence.set(evidence)
     try:
         await tools["recolor"].execute(_RecolorRequest(
             object_words="cone-0", color_kind="literal", color_value="green"))
@@ -340,4 +340,4 @@ async def test_recolor_records_applied_and_satisfied_evidence():
             object_words="cone-0", color_kind="literal", color_value="red"))
         assert (evidence.applied, evidence.satisfied) == (1, 1)
     finally:
-        current_mutation_evidence.reset(token)
+        current_turn_evidence.reset(token)

--- a/tests/test_xr_render_demo_supervisor.py
+++ b/tests/test_xr_render_demo_supervisor.py
@@ -204,12 +204,12 @@ def test_status_questions_are_not_mutation_intent() -> None:
 async def test_already_satisfied_reply_stands_on_evidence(monkeypatch) -> None:
     """A recolor that found the requested state already holding records
     satisfied evidence; the model's reply stands despite no scene diff."""
-    from xr_render_demo_worker._trace import current_mutation_evidence
+    from xr_render_demo_worker._trace import current_turn_evidence
 
     supervisor, _fake = _make_supervisor()
 
     async def fake_loop(messages, toolset, call_model, max_iterations=12):
-        current_mutation_evidence.get().satisfied += 1
+        current_turn_evidence.get().satisfied += 1
         return SimpleNamespace(
             content="The sphere is already green.",
             messages=list(messages),
@@ -281,6 +281,204 @@ async def test_verification_offers_repeat_after_mutating_delegation(monkeypatch)
         transcript="Paint the sphere crimson.", participant_id="alice"))
     assert len(nudges) == 1
     assert "repeat your final answer" in nudges[0]
+
+
+def test_perception_claim_patterns() -> None:
+    """The gate fires on the model's dominant hands-and-body register and
+    stays off questions, hedges, memory recall, and look-at answers."""
+    from xr_render_demo_worker.supervisor import _claims_perception
+
+    assert _claims_perception("You are holding a camera.")
+    assert _claims_perception("You're wearing a red scarf.")
+    assert _claims_perception("You’re holding a camera.")
+    assert _claims_perception("You are currently holding a camera.")
+    assert _claims_perception("You are still holding a camera.")
+    assert _claims_perception("You appear to be holding a camera.")
+    assert _claims_perception("You seem to be carrying a canvas bag.")
+    assert _claims_perception("The bottle in your hand is green.")
+    assert _claims_perception("It looks like a camera is in your right hand.")
+    assert _claims_perception("You have a stapler in your grasp.")
+    assert _claims_perception("You are holding a camera. Want me to recolor it?")
+
+    assert not _claims_perception("You are holding a camera?")
+    assert not _claims_perception("What are you holding?")
+    assert not _claims_perception("I can't tell what you're holding.")
+    assert not _claims_perception("I cannot see what you are holding right now.")
+    assert not _claims_perception("I don't know what you are wearing.")
+    assert not _claims_perception("The camera is unavailable, so you are holding something I can't name.")
+    assert not _claims_perception("You were holding a green mug.")
+    assert not _claims_perception("You are looking at the red cube.")
+    assert not _claims_perception("You are pointing at the sphere I created.")
+    assert not _claims_perception("The sphere is in front of you.")
+    assert not _claims_perception("I looked at the camera feed.")
+
+
+async def test_unobserved_claim_is_retried_then_replaced(monkeypatch) -> None:
+    """A hands claim with no camera observation is sent back to look once,
+    then replaced with the honest can't-say sentence."""
+    from xr_render_demo_worker.supervisor import _UNOBSERVED_REPLY
+
+    supervisor, _fake = _make_supervisor()
+    nudges: list[str] = []
+    iterations: list[int] = []
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        iterations.append(max_iterations)
+        nudges.extend(m.content for m in messages
+                      if m.role == "user" and "no camera observation" in m.content)
+        return SimpleNamespace(
+            content="You are holding a camera.",
+            messages=list(messages),
+            tool_calls=(),
+        )
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    reply = await supervisor.handle(SceneRequest(
+        transcript="What am I holding?", participant_id="alice"))
+    assert len(nudges) == 1
+    assert iterations == [12, 6]
+    assert reply.response == _UNOBSERVED_REPLY
+
+
+async def test_observed_claim_stands(monkeypatch) -> None:
+    """A camera observation this turn backs the claim, so the reply stands
+    and no retry runs."""
+    from xr_render_demo_worker._trace import current_turn_evidence
+
+    supervisor, _fake = _make_supervisor()
+    calls = 0
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        nonlocal calls
+        calls += 1
+        current_turn_evidence.get().observed += 1
+        return SimpleNamespace(
+            content="You are holding a green mug.",
+            messages=list(messages),
+            tool_calls=(),
+        )
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    reply = await supervisor.handle(SceneRequest(
+        transcript="What am I holding?", participant_id="alice"))
+    assert reply.response == "You are holding a green mug."
+    assert calls == 1
+
+
+async def test_retry_with_observation_stands(monkeypatch) -> None:
+    """The forced look supplies the missing evidence, so the retry's answer
+    replaces the guess and survives the gate."""
+    from xr_render_demo_worker._trace import current_turn_evidence
+
+    supervisor, _fake = _make_supervisor()
+    calls = 0
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return SimpleNamespace(
+                content="You are holding a camera.",
+                messages=list(messages),
+                tool_calls=(),
+            )
+        current_turn_evidence.get().observed += 1
+        return SimpleNamespace(
+            content="You are holding a boba milk.",
+            messages=list(messages),
+            tool_calls=(),
+        )
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    reply = await supervisor.handle(SceneRequest(
+        transcript="What am I holding?", participant_id="alice"))
+    assert reply.response == "You are holding a boba milk."
+    assert calls == 2
+
+
+async def test_both_gates_apply_to_final_text(monkeypatch) -> None:
+    """A turn that trips the mutation gate and the perception gate keeps
+    both verdicts, and the perception retry threads from the latest loop."""
+    from xr_render_demo_worker.supervisor import _UNOBSERVED_REPLY
+
+    supervisor, _fake = _make_supervisor()
+    calls = 0
+    perception_context: list[list[str]] = []
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        nonlocal calls
+        calls += 1
+        asks = [m.content for m in messages if m.role == "user"]
+        if any("no camera observation" in ask for ask in asks):
+            perception_context.append(asks)
+        return SimpleNamespace(
+            content="Recolored the box to match what you are holding.",
+            messages=list(messages),
+            tool_calls=(SimpleNamespace(call=SimpleNamespace(name="appearance_agent")),),
+        )
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    reply = await supervisor.handle(SceneRequest(
+        transcript="Make the box the color of the thing I'm holding.", participant_id="alice"))
+    assert calls == 3
+    assert reply.response == f"{_UNOBSERVED_REPLY} Nothing in the scene was changed."
+    assert any("Verified scene changes this turn" in ask for ask in perception_context[0])
+
+
+async def test_perception_retry_failure_falls_back(monkeypatch) -> None:
+    """A retry that never completes still fails honestly rather than
+    shipping the unbacked claim."""
+    from xr_ai_tools.tool_calling import ToolLoopError
+    from xr_render_demo_worker.supervisor import _UNOBSERVED_REPLY
+
+    supervisor, _fake = _make_supervisor()
+    calls = 0
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return SimpleNamespace(
+                content="You are holding a camera.",
+                messages=list(messages),
+                tool_calls=(),
+            )
+        raise ToolLoopError(
+            "vision unreachable", messages=(), tool_calls=(), iterations=6
+        )
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    reply = await supervisor.handle(SceneRequest(
+        transcript="What am I holding?", participant_id="alice"))
+    assert reply.response == _UNOBSERVED_REPLY
+
+
+async def test_empty_perception_retry_falls_back(monkeypatch) -> None:
+    """An empty retry reply must not degrade to the generic "Done."."""
+    from xr_render_demo_worker.supervisor import _UNOBSERVED_REPLY
+
+    supervisor, _fake = _make_supervisor()
+    calls = 0
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        nonlocal calls
+        calls += 1
+        return SimpleNamespace(
+            content="You are holding a camera." if calls == 1 else "",
+            messages=list(messages),
+            tool_calls=(),
+        )
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    reply = await supervisor.handle(SceneRequest(
+        transcript="What am I holding?", participant_id="alice"))
+    assert reply.response == _UNOBSERVED_REPLY
 
 
 async def test_turn_tasks_run_in_forked_relay_context(monkeypatch) -> None:

--- a/tests/test_xr_render_demo_supervisor.py
+++ b/tests/test_xr_render_demo_supervisor.py
@@ -311,6 +311,109 @@ def test_perception_claim_patterns() -> None:
     assert not _claims_perception("You are pointing at the sphere I created.")
     assert not _claims_perception("The sphere is in front of you.")
     assert not _claims_perception("I looked at the camera feed.")
+    assert not _claims_perception("")
+
+    assert _claims_perception("I can't see clearly, but you are holding a camera.")
+    assert _claims_perception("I can't see the color, you are holding a camera.")
+    assert _claims_perception("I can't see the feed and you are holding a camera.")
+    assert _claims_perception("I can't see clearly — you are holding a camera.")
+    assert _claims_perception("Here's what I found: you are holding a camera.")
+    assert _claims_perception("I can't be certain; however you are holding a camera.")
+    assert _claims_perception("I can't be sure, yet you are holding a camera.")
+    assert _claims_perception("Although I can't see well, you are holding a camera.")
+    assert _claims_perception("You are holding a camera, not sure of the color.")
+
+    # Historic-present recorded phrasing still counts as a claim; the gate
+    # steers it toward past tense instead of exempting it.
+    assert _claims_perception("In the recorded frame, you are holding a purple mug.")
+    assert _claims_perception("A moment ago you were near the desk; you are holding a mug.")
+
+
+async def test_recorded_only_claim_is_steered_then_replaced(monkeypatch) -> None:
+    """With only a recorded-frame observation, a present-tense claim gets the
+    recorded-moment nudge, and a persisting claim is replaced with the honest
+    recorded-only sentence."""
+    from xr_render_demo_worker._trace import current_turn_evidence
+    from xr_render_demo_worker.supervisor import _RECORDED_ONLY_REPLY
+
+    supervisor, _fake = _make_supervisor()
+    nudges: list[str] = []
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        current_turn_evidence.get().observed_recorded = 1
+        nudges.extend(m.content for m in messages
+                      if m.role == "user" and "past tense" in m.content)
+        return SimpleNamespace(
+            content="In the recorded frame, you are holding a purple mug.",
+            messages=list(messages),
+            tool_calls=(),
+        )
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    reply = await supervisor.handle(SceneRequest(
+        transcript="What was I holding ten seconds ago?", participant_id="alice"))
+    assert len(nudges) == 1
+    assert reply.response == _RECORDED_ONLY_REPLY
+
+
+async def test_recorded_claim_rephrased_stands(monkeypatch) -> None:
+    """The recorded-moment nudge that yields a past-tense answer ships."""
+    from xr_render_demo_worker._trace import current_turn_evidence
+
+    supervisor, _fake = _make_supervisor()
+    calls = 0
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        nonlocal calls
+        calls += 1
+        current_turn_evidence.get().observed_recorded = 1
+        if calls == 1:
+            return SimpleNamespace(
+                content="In the recorded frame, you are holding a purple mug.",
+                messages=list(messages),
+                tool_calls=(),
+            )
+        return SimpleNamespace(
+            content="Ten seconds ago you were holding a purple mug.",
+            messages=list(messages),
+            tool_calls=(),
+        )
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    reply = await supervisor.handle(SceneRequest(
+        transcript="What was I holding ten seconds ago?", participant_id="alice"))
+    assert reply.response == "Ten seconds ago you were holding a purple mug."
+    assert calls == 2
+
+
+async def test_observed_empty_retry_keeps_done(monkeypatch) -> None:
+    """A retry that observes but returns no text must not be replaced with
+    the can't-say sentence; the observation happened."""
+    from xr_render_demo_worker._trace import current_turn_evidence
+
+    supervisor, _fake = _make_supervisor()
+    calls = 0
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return SimpleNamespace(
+                content="You are holding a camera.",
+                messages=list(messages),
+                tool_calls=(),
+            )
+        current_turn_evidence.get().observed += 1
+        return SimpleNamespace(content="", messages=list(messages), tool_calls=())
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    reply = await supervisor.handle(SceneRequest(
+        transcript="What am I holding?", participant_id="alice"))
+    assert calls == 2
+    assert reply.response == "Done."
 
 
 async def test_unobserved_claim_is_retried_then_replaced(monkeypatch) -> None:

--- a/tests/test_xr_render_demo_wire.py
+++ b/tests/test_xr_render_demo_wire.py
@@ -120,7 +120,7 @@ def test_eval_case_filter_rejects_unknown_names_in_mixed_selection() -> None:
 def test_eval_utterances_alias_selects_the_complete_battery() -> None:
     from xr_render_demo_eval import harness
 
-    assert len(harness.UTTERANCES) == 35
+    assert len(harness.UTTERANCES) == 36
     assert harness._resolve_case_names(["utterances"]) == {
         case.name for case in harness.UTTERANCES
     }


### PR DESCRIPTION
Follow-up to #416, extending evidence-backed success from mutations to perception. Live, "What am I holding?" was answered "You are holding a camera." in 0.4 s with no vision call, while the user held a mouse.

- `TurnEvidence` counts camera observations by kind: a successful live `look_at_current_frame` or `resolve_physical_color` records `observed`; `look_at_past_frame` records `observed_recorded`. Only a live observation licenses a present-tense claim.
- A reply asserting the user's physical state (present-tense hold/carry/wear/grip, "in your hand") with no live observation this turn gets one nudged retry, then an honest fallback. When only a recorded frame was consulted, the nudge steers the answer into past tense about the recorded moment, and the fallback sentence says the recorded-only situation plainly. The check runs per clause over the agent's own reply and skips questions; a hedge exempts only its own clause.

Test plan: unit 1360/1360 (`-m "not gpu"`), ruff and prompt audit clean, system prompt unchanged (retry nudge text reworked); regression tests for clause-scoped hedges and recorded-frame turns; eval cases `basics_bare_holding_question` and `historical_vision`; live manip 13/13; offline tiers (subagents 48/49, delegation 20/23, utterances 33/36) verified unchanged from the pre-PR base on the same stack.
