### PR TITLE
build: freeze dependency qualification by upload date

### DIFF
--- a/.github/workflows/lock-check.yml
+++ b/.github/workflows/lock-check.yml
@@ -9,9 +9,11 @@ name: lock-check
 # so a single `uv lock` per project covers every supported interpreter
 # without needing a Python-version matrix here.
 #
-# This is the repo-wide check on Python-version + dependency consistency:
-# a project bumping `requires-python` (or pinning a dep that drops a
-# Python version) only passes if the constraints stay jointly satisfiable.
+# The root uv.toml limits package-index candidates to the last repository-wide
+# qualification point. This is the repo-wide check on Python-version +
+# dependency consistency: a project bumping `requires-python`, advancing that
+# cutoff, or pinning a dependency that drops a Python version only passes if
+# the constraints stay jointly satisfiable.
 
 on:
   push:
@@ -21,6 +23,9 @@ on:
 concurrency:
   group: lock-check-${{ github.ref }}
   cancel-in-progress: true
+
+env:
+  UV_CONFIG_FILE: ${{ github.workspace }}/uv.toml
 
 jobs:
   dependency-map:
@@ -53,9 +58,10 @@ jobs:
           enable-cache: true
           # Lockfiles are gitignored repo-wide, so the default `**/uv.lock`
           # cache-dependency-glob matches nothing in CI. Key the cache off
-          # every committed pyproject.toml instead.
+          # every committed pyproject.toml and the shared resolution policy.
           cache-dependency-glob: |
             **/pyproject.toml
+            uv.toml
 
       - name: Resolve every pyproject.toml
         run: |

--- a/.github/workflows/lock-check.yml
+++ b/.github/workflows/lock-check.yml
@@ -52,6 +52,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Validate dependency cutoff
+        run: |
+          cutoff=$(sed -nE 's/^exclude-newer = "([^"]+)"$/\1/p' uv.toml)
+          if [[ -z "$cutoff" ]] || ! cutoff_epoch=$(date -u -d "$cutoff" +%s); then
+            echo "::error file=uv.toml::exclude-newer must be a valid timestamp"
+            exit 1
+          fi
+          if (( cutoff_epoch > $(date -u +%s) )); then
+            echo "::error file=uv.toml::exclude-newer is in the future: $cutoff"
+            exit 1
+          fi
+
       - name: Install uv
         uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3.2.4
         with:

--- a/.github/workflows/nightly-xr-ai-test.yml
+++ b/.github/workflows/nightly-xr-ai-test.yml
@@ -3,6 +3,9 @@
 
 name: nightly XR AI test
 
+env:
+  UV_CONFIG_FILE: ${{ github.workspace }}/uv.toml
+
 # Runs the `gpu`-marked pytest suite on a self-hosted GPU runner — these
 # tests need real GPU / Docker / NVENC hardware, so they're filtered out of
 # the default `tests` workflow (ubuntu-latest). Mirrors the local
@@ -91,8 +94,8 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: |
+            uv.toml
             tests/pyproject.toml
-            tests/uv.lock
             agent-sdk/xr-ai-hub/pyproject.toml
             services/device-io-hub/pyproject.toml
 

--- a/.github/workflows/nightly-xr-ai-test.yml
+++ b/.github/workflows/nightly-xr-ai-test.yml
@@ -25,6 +25,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/nightly-xr-ai-test.yml
+      - uv.toml
 
 # Queue overlapping runs instead of cancelling; the previous nightly
 # may still be running when the next cron fires on a busy GPU host.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,9 @@
 
 name: tests
 
+env:
+  UV_CONFIG_FILE: ${{ github.workspace }}/uv.toml
+
 # Runs the IPC + multi-client / multi-agent suite under tests/.
 # The suite is hub-on-loopback only — it does not need Docker, LiveKit,
 # or NVENC, so it runs cleanly on a stock ubuntu-latest runner.
@@ -43,8 +46,8 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: |
+            uv.toml
             tests/pyproject.toml
-            tests/uv.lock
             agent-sdk/xr-ai-hub/pyproject.toml
             services/device-io-hub/pyproject.toml
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,12 @@ Refer to [Adding a sample](docs/source/guides/adding-a-sample.md) and the
   normally regenerates the Python inventory automatically and CI rejects drift.
   Do not hand-edit the generated section in `DEPENDENCIES.md`. Regenerate the
   affected project's gitignored `uv.lock` locally to verify resolution.
+- The root `uv.toml` limits registry artifacts to the last dependency
+  qualification timestamp. Advance it only in a dedicated dependency refresh,
+  resolve every project's gitignored `uv.lock` with
+  `uv --config-file uv.toml lock --project <directory>` from the repository
+  root, and run the full test suite. Standalone nested projects do not inherit
+  the root config implicitly. Do not commit generated lockfiles.
 - Never put API keys or tokens in source files. Use environment variables or
   the credential store documented in `docs/source/getting_started/credentials.md`.
 - Do not add an abstraction until two concrete use cases need it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,9 +114,11 @@ Refer to [Adding a sample](docs/source/guides/adding-a-sample.md) and the
 - The root `uv.toml` limits registry artifacts to the last dependency
   qualification timestamp. Advance it only in a dedicated dependency refresh,
   resolve every project's gitignored `uv.lock` with
-  `uv --config-file uv.toml lock --project <directory>` from the repository
-  root, and run the full test suite. Standalone nested projects do not inherit
-  the root config implicitly. Do not commit generated lockfiles.
+  `uv --config-file uv.toml lock --upgrade --project <directory>` from the
+  repository root, and run the full test suite. uv stops upward config discovery
+  at a nearer `[tool.uv]` table; most nested projects define one through
+  `[tool.uv.sources]`, so pass the root config explicitly. Do not commit
+  generated lockfiles.
 - Never put API keys or tokens in source files. Use environment variables or
   the credential store documented in `docs/source/getting_started/credentials.md`.
 - Do not add an abstraction until two concrete use cases need it.

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -39,12 +39,14 @@ without publishing repository policy as artificial upper bounds in library
 metadata. Fresh CI runs therefore resolve the same qualified package set
 instead of silently admitting newly published artifacts.
 
-Advance the timestamp only in a dedicated dependency refresh. Resolve every
-project from the repository root with
-`uv --config-file uv.toml lock --project <directory>`, inspect the version
-changes, and run the full test suite. Standalone nested projects do not inherit
-the root config implicitly. All generated `uv.lock` files remain gitignored
-validation artifacts; do not commit them.
+Advance the timestamp only in a dedicated dependency refresh; it never updates
+automatically. Set `exclude-newer` to the current UTC value from
+`date -u +%Y-%m-%dT%H:%M:%SZ`, then resolve every project from the repository
+root with `uv --config-file uv.toml lock --project <directory>`. Inspect the
+resolved version changes and run the full CPU and GPU test suites before
+merging. Standalone nested projects do not inherit the root config implicitly.
+All generated `uv.lock` files remain gitignored validation artifacts; do not
+commit them.
 
 ## Generated Python project inventory
 

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -30,6 +30,22 @@ The pytest matrix in `.github/workflows/tests.yml` covers Python 3.11 and 3.12.
 Loosening the repository-wide upper bound requires a coordinated qualification
 change, even when an individual dependency publishes newer Python wheels.
 
+## Dependency qualification
+
+The root `uv.toml` limits package-index candidates to artifacts uploaded by the
+last repository-wide qualification timestamp. Repository CI supplies that file
+to every uv command. This applies to direct, transitive, and build dependencies
+without publishing repository policy as artificial upper bounds in library
+metadata. Fresh CI runs therefore resolve the same qualified package set
+instead of silently admitting newly published artifacts.
+
+Advance the timestamp only in a dedicated dependency refresh. Resolve every
+project from the repository root with
+`uv --config-file uv.toml lock --project <directory>`, inspect the version
+changes, and run the full test suite. Standalone nested projects do not inherit
+the root config implicitly. All generated `uv.lock` files remain gitignored
+validation artifacts; do not commit them.
+
 ## Generated Python project inventory
 
 <!-- BEGIN GENERATED PYTHON DEPENDENCY MAP -->

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -42,11 +42,12 @@ instead of silently admitting newly published artifacts.
 Advance the timestamp only in a dedicated dependency refresh; it never updates
 automatically. Set `exclude-newer` to the current UTC value from
 `date -u +%Y-%m-%dT%H:%M:%SZ`, then resolve every project from the repository
-root with `uv --config-file uv.toml lock --project <directory>`. Inspect the
-resolved version changes and run the full CPU and GPU test suites before
-merging. Standalone nested projects do not inherit the root config implicitly.
-All generated `uv.lock` files remain gitignored validation artifacts; do not
-commit them.
+root with `uv --config-file uv.toml lock --upgrade --project <directory>`.
+Inspect the resolved version changes and run the full CPU and GPU test suites
+before merging. uv stops upward config discovery at a nearer `[tool.uv]` table;
+most nested projects define one through `[tool.uv.sources]`, so pass the root
+config explicitly. All generated `uv.lock` files remain gitignored validation
+artifacts; do not commit them.
 
 ## Generated Python project inventory
 

--- a/docs/source/guides/contributing-and-conventions.md
+++ b/docs/source/guides/contributing-and-conventions.md
@@ -57,7 +57,10 @@ The root `uv.toml` records the repository's dependency qualification cutoff.
 Repository CI passes it explicitly to uv, so fresh resolutions ignore
 package-index artifacts uploaded after that timestamp while normal
 compatibility ranges stay in package metadata. Standalone nested projects do
-not inherit the root file implicitly; run uv from the repository root with
-`--config-file uv.toml` as shown above. To qualify newer dependencies, advance
-the cutoff in a dedicated change, resolve every project, and run the full test
-suite. The generated lockfiles are validation artifacts and remain gitignored.
+not always inherit the root file: uv stops upward config discovery at a nearer
+`[tool.uv]` table, and most projects define `[tool.uv.sources]`. Run uv from the
+repository root with `--config-file uv.toml` as shown above. To qualify newer
+dependencies, advance the cutoff in a dedicated change, resolve every project
+with `uv --config-file uv.toml lock --upgrade --project <directory>`, and run
+the full test suite. The generated lockfiles are validation artifacts and remain
+gitignored.

--- a/docs/source/guides/contributing-and-conventions.md
+++ b/docs/source/guides/contributing-and-conventions.md
@@ -18,8 +18,8 @@ for the package dependency map.
 For a Python change:
 
 ```bash
-uv sync --project <affected-project>
-uv run --project tests pytest <affected-test-files>
+uv --config-file uv.toml sync --project <affected-project>
+uv --config-file uv.toml run --project tests pytest <affected-test-files>
 uv tool run ruff check <changed-python-files>
 ```
 
@@ -52,3 +52,12 @@ normally regenerates the Python inventory in `DEPENDENCIES.md` automatically,
 and CI rejects drift. Do not edit that generated section by hand. Regenerate the
 affected project's gitignored `uv.lock` locally. New source files require an
 SPDX header; refer to {doc}`SPDX headers <spdx-headers>`.
+
+The root `uv.toml` records the repository's dependency qualification cutoff.
+Repository CI passes it explicitly to uv, so fresh resolutions ignore
+package-index artifacts uploaded after that timestamp while normal
+compatibility ranges stay in package metadata. Standalone nested projects do
+not inherit the root file implicitly; run uv from the repository root with
+`--config-file uv.toml` as shown above. To qualify newer dependencies, advance
+the cutoff in a dedicated change, resolve every project, and run the full test
+suite. The generated lockfiles are validation artifacts and remain gitignored.

--- a/docs/source/guides/testing.md
+++ b/docs/source/guides/testing.md
@@ -15,14 +15,15 @@ required for the browser camera tests.
 From the repository root:
 
 ```bash
-uv sync --project tests
-uv run --project tests pytest -v
+uv --config-file uv.toml sync --project tests
+uv --config-file uv.toml run --project tests pytest -v
 ```
 
 CI runs the same project on Python 3.11 and 3.12 with:
 
 ```bash
-uv run pytest -v --tb=short --color=yes -m "not gpu"
+uv --config-file uv.toml run --project tests \
+  pytest -v --tb=short --color=yes -m "not gpu"
 ```
 
 Tests marked `integration` may start real CPU subprocesses and still run in CI.
@@ -30,7 +31,7 @@ Tests that require a real GPU, Docker, or NVENC use the `gpu` marker and run
 only on a suitably configured developer host:
 
 ```bash
-bash run_local_gpu_tests.sh
+bash tests/run_local_gpu_tests.sh
 ```
 
 Pass extra pytest arguments after the script name to select a file or test.

--- a/docs/source/guides/testing.md
+++ b/docs/source/guides/testing.md
@@ -19,7 +19,9 @@ uv --config-file uv.toml sync --project tests
 uv --config-file uv.toml run --project tests pytest -v
 ```
 
-CI runs the same project on Python 3.11 and 3.12 with:
+CI runs the same selection on Python 3.11 and 3.12 from `tests/`, with the
+project environment at the repository root for nltk compatibility. The
+equivalent repository-root command is:
 
 ```bash
 uv --config-file uv.toml run --project tests \

--- a/tests/README.md
+++ b/tests/README.md
@@ -10,8 +10,8 @@ and multi-client and multi-agent routing.
 
 ```bash
 cd tests
-uv sync
-uv run pytest -v
+uv --config-file ../uv.toml sync
+uv --config-file ../uv.toml run pytest -v
 ```
 
 GPU-, Docker-, and NVENC-dependent tests are excluded from CI and can be run

--- a/tests/run_local_gpu_tests.sh
+++ b/tests/run_local_gpu_tests.sh
@@ -7,5 +7,5 @@
 
 set -euo pipefail
 cd "$(dirname "$0")"
-uv sync
-uv run pytest -v --tb=short --color=yes -m gpu "$@"
+uv --config-file ../uv.toml sync
+uv --config-file ../uv.toml run pytest -v --tb=short --color=yes -m gpu "$@"

--- a/uv.toml
+++ b/uv.toml
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Advance only as part of a repository-wide dependency qualification change.
+exclude-newer = "2026-08-27T17:15:48Z"


### PR DESCRIPTION
## Summary

- Add a repository-wide uv cutoff for package artifacts uploaded after `2026-08-27T17:15:48Z`.
- Apply that policy explicitly to lock-check, CPU test, and nightly GPU workflows, and include it in their cache keys.
- Document the intentional dependency-refresh process while keeping every generated `uv.lock` gitignored.

## Why

PR #433 showed that a fresh CI resolution can fail without any repository change when Pipecat publishes a new release. Adding exact upper bounds to every direct dependency would miss transitive/build dependencies, duplicate policy across 37 standalone projects, and leak repository qualification state into published library metadata. uv's `exclude-newer` setting provides one reviewable qualification point for the whole package-index graph instead.

Nested standalone projects do not inherit a parent uv config automatically, so CI exports `UV_CONFIG_FILE` explicitly and the contributor guidance uses `--config-file uv.toml`.

## Validation

- `uv lock` under the shared config: 37/37 projects resolved, 0 failures
- `xr-ai-voice` resolved Pipecat 1.8.1, uploaded before the cutoff
- Generated dependency map is current
- Focused dependency-map tests: 11 passed
- All workflow YAML parsed successfully
- No `uv.lock` is tracked or included in this PR