### PR TITLE
Redact stale perception answers from inline context

### DIFF
--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/harness.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/harness.py
@@ -14,8 +14,11 @@ from xr_ai_tools import Tool
 from xr_ai_tools.text_memory import (
     AddTranscriptRequest,
     ConversationEntry,
+    QueryTranscriptsRequest,
+    QueryTranscriptsResult,
     RecallConversationRequest,
     RecallConversationResult,
+    TranscriptSegment,
 )
 from xr_ai_tools.types import SpatialFrame, Vector3
 from xr_render_demo_worker.config import load_config
@@ -73,23 +76,54 @@ class _FakeTrackingTools:
         self.get_user_frame = Tool("get_user_frame", "User frame.", EmptyRequest, SpatialFrame, lambda _: pose)
 
 
+def _history_timestamps(index: int) -> tuple[int, int]:
+    """Fabricated (user, agent) timestamps for seeded history pair ``index``."""
+    return (index + 1) * 1_000_000, (index + 1) * 1_000_000 + 1
+
+
 class _FakeTextMemoryTools:
     def __init__(self, fake: "FakeScene") -> None:
         async def recall(req: RecallConversationRequest) -> RecallConversationResult:
             fake.calls.append(("recall_conversation", req.model_dump()))
             entries: list[ConversationEntry] = []
             for i, (user_text, agent_text) in enumerate(fake.history):
-                entries.append(ConversationEntry(timestamp_us=(i + 1) * 1_000_000, role="user", text=user_text))
-                entries.append(ConversationEntry(timestamp_us=(i + 1) * 1_000_000 + 1, role="agent", text=agent_text))
+                user_ts, agent_ts = _history_timestamps(i)
+                entries.append(ConversationEntry(timestamp_us=user_ts, role="user", text=user_text))
+                entries.append(ConversationEntry(timestamp_us=agent_ts, role="agent", text=agent_text))
             if fake.memory_answer:
                 entries.append(ConversationEntry(timestamp_us=1, role="agent", text=fake.memory_answer))
+            entries.sort(key=lambda entry: entry.timestamp_us)
             return RecallConversationResult(entries=entries)
 
         self.recall_conversation = Tool(
             "recall_conversation", "Recall.", RecallConversationRequest, RecallConversationResult, recall)
-        async def _noop_transcript(req: AddTranscriptRequest) -> None:
-            return None
-        self.add_transcript = Tool("add_transcript", "Add.", AddTranscriptRequest, None, _noop_transcript)
+        stored: list[AddTranscriptRequest] = []
+
+        async def _add_transcript(req: AddTranscriptRequest) -> None:
+            stored.append(req)
+
+        async def _query(req: QueryTranscriptsRequest) -> QueryTranscriptsResult:
+            fake.calls.append(("query_transcripts", req.model_dump()))
+            segments = [
+                TranscriptSegment(timestamp_us=r.timestamp_us, text=r.text)
+                for r in stored
+                if r.source_id == req.source_id
+                and req.start_us <= r.timestamp_us <= req.end_us
+            ]
+            if req.source_id.endswith(":agent-vision"):
+                segments.extend(
+                    TranscriptSegment(
+                        timestamp_us=_history_timestamps(i)[1],
+                        text=fake.history[i][1],
+                    )
+                    for i in fake.history_sightings
+                    if req.start_us <= _history_timestamps(i)[1] <= req.end_us
+                )
+            return QueryTranscriptsResult(segments=segments)
+
+        self.add_transcript = Tool("add_transcript", "Add.", AddTranscriptRequest, None, _add_transcript)
+        self.query_transcripts = Tool(
+            "query_transcripts", "Query.", QueryTranscriptsRequest, QueryTranscriptsResult, _query)
 
 
 class _FakeCurrentFrameTool:
@@ -206,7 +240,9 @@ class Case:
     expected_positions: tuple[tuple[str, tuple[float, float, float]], ...] = ()
     memory: str = ""
     history: tuple[tuple[str, str], ...] = ()
+    history_sightings: tuple[int, ...] = ()
     reply_contains: str = ""
+    reply_excludes: str = ""
     camera_error: str = ""
     physical_expect_source: str = ""
 
@@ -310,8 +346,30 @@ CASES = (
         expected_call_counts=(("recall_conversation", 1),),
     ),
     Case(
-        name="durable_memory",
-        request="What object did we discuss in the earlier session?",
+        name="stale_holding_fresh_look",
+        # A repeat ask must trigger a fresh look and track the changed world;
+        # the redacted prior sighting in history is the lure.
+        request="What am I holding now?",
+        history=(("What am I holding?", "You are holding a red notebook."),),
+        history_sightings=(0,),
+        vision="The user is holding a blue ceramic mug.",
+        required_tools=frozenset({"look_at_current_frame"}),
+        reply_contains="mug",
+        reply_excludes="notebook",
+    ),
+    Case(
+        name="recall_prior_sighting",
+        # The companion boundary: a transcript question is a memory answer,
+        # not a forced look ("what you saw" would be video, not transcript).
+        request="What did you tell me I was holding earlier?",
+        history=(("What am I holding?", "You are holding a red notebook."),),
+        history_sightings=(0,),
+        forbidden_tools=frozenset({"look_at_current_frame"}),
+        reply_contains="notebook",
+    ),
+    Case(
+        name="recall_prior_discussion",
+        request="What object did we discuss earlier?",
         memory="We discussed a small cyan sphere.",
         required_tools=frozenset({"recall_conversation"}),
     ),
@@ -450,6 +508,7 @@ class FakeScene:
     vision_error: str
     memory_answer: str
     history: tuple[tuple[str, str], ...] = ()
+    history_sightings: tuple[int, ...] = ()
     camera_error: str = ""
     physical_answer: str = ""
     physical_expect_source: str = ""
@@ -466,6 +525,7 @@ class FakeScene:
             case.vision_error,
             case.memory,
             case.history,
+            history_sightings=case.history_sightings,
             camera_error=case.camera_error,
             physical_expect_source=case.physical_expect_source,
         )
@@ -1149,6 +1209,8 @@ async def run_case(case: Case) -> bool:
     }
     wrong_reply = bool(
         case.reply_contains and case.reply_contains.lower() not in response.lower()
+    ) or bool(
+        case.reply_excludes and case.reply_excludes.lower() in response.lower()
     )
     passed = (
         not errored

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/subagents.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/subagents.py
@@ -554,6 +554,16 @@ CASES = (
         answer_contains="blue",
     ),
     SubagentCase(
+        # Pins the relay of a not-visible VLM answer; whether the VLM
+        # produces one is live-only behavior the fixture cannot score.
+        name="holding_question_relays_not_visible",
+        agent="vision",
+        instruction="Identify the object in the user's hand.",
+        vision_answer="The user's hands are not visible in the image.",
+        required_tools=("look_at_current_frame",),
+        answer_contains="not visible",
+    ),
+    SubagentCase(
         name="camera_transport_failure_degrades",
         agent="vision",
         instruction="Describe the real surface just left of the user.",

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/vision/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/vision/agent.py
@@ -52,7 +52,9 @@ def make_vision_agent(
                 frame = await current_frame.execute(CurrentFrameRequest(participant_id=participant_id))
             except Exception as error:
                 reraise_unavailable(error, "the current camera view")
-            return await image_query.execute(ImageQueryRequest(image=frame.image, query=req.question))
+            result = await image_query.execute(ImageQueryRequest(image=frame.image, query=req.question))
+            logger.debug("look result available={} text={!r}", result.available, result.text[:120])
+            return result
 
         tools = [
             Tool(
@@ -75,7 +77,9 @@ def make_vision_agent(
                     )
                 except Exception as error:
                     reraise_unavailable(error, "recorded video")
-                return await image_query.execute(ImageQueryRequest(image=frame.image, query=req.question))
+                result = await image_query.execute(ImageQueryRequest(image=frame.image, query=req.question))
+                logger.debug("look_past result available={} text={!r}", result.available, result.text[:120])
+                return result
 
             tools.append(Tool(
                 "look_at_past_frame",

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/app.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/app.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import shutil
 from pathlib import Path
 
 from loguru import logger
@@ -30,6 +29,17 @@ from .agent import (
 from .config import WorkerConfig
 from .supervisor import SceneSupervisor
 from .xr_session import XRSessionController
+
+
+def _clear_transcript_artifacts(store_dir: Path) -> None:
+    """Remove the transcript store's own files so recalled conversation never
+    outlives the run; anything else in the directory is left alone."""
+    if not store_dir.is_dir():
+        return
+    for artifact in (*store_dir.glob("*.jsonl"), *store_dir.glob("*.identity")):
+        artifact.unlink(missing_ok=True)
+
+
 
 
 async def run_app(
@@ -72,9 +82,7 @@ async def run_app(
     transport = HubVoiceTransport()
     scene = SceneTools(config.scene_endpoint)
     tracking = TrackingTools(config.openxr_endpoint)
-    shutil.rmtree(config.text_memory_dir, ignore_errors=True)
-    if any(Path(config.text_memory_dir).glob("*")):
-        logger.warning("stale transcripts survived the startup wipe in {}", config.text_memory_dir)
+    _clear_transcript_artifacts(Path(config.text_memory_dir))
     text_memory = TextMemoryTools(config.text_memory_dir)
     video = VideoMemoryTools(config.video_memory_endpoint)
     images = ImageRegistry(allow_external=True)

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/app.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/app.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 
 from loguru import logger
@@ -71,6 +72,9 @@ async def run_app(
     transport = HubVoiceTransport()
     scene = SceneTools(config.scene_endpoint)
     tracking = TrackingTools(config.openxr_endpoint)
+    shutil.rmtree(config.text_memory_dir, ignore_errors=True)
+    if any(Path(config.text_memory_dir).glob("*")):
+        logger.warning("stale transcripts survived the startup wipe in {}", config.text_memory_dir)
     text_memory = TextMemoryTools(config.text_memory_dir)
     video = VideoMemoryTools(config.video_memory_endpoint)
     images = ImageRegistry(allow_external=True)

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/config.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/config.py
@@ -38,7 +38,7 @@ def load_config(path: pathlib.Path | None) -> WorkerConfig:
         scene_endpoint = data.get("scene_endpoint", "tcp://127.0.0.1:8320"),
         openxr_endpoint = data.get("openxr_endpoint", "tcp://127.0.0.1:8330"),
         video_memory_endpoint = data.get("video_memory_endpoint", "tcp://127.0.0.1:8310"),
-        text_memory_dir = data.get("text_memory_dir", "/dev/shm/xr-ai/text-memory"),
+        text_memory_dir = str(_resolve(path, str(data.get("text_memory_dir", "/dev/shm/xr-ai/text-memory")))),
         silence_duration  = float(data.get("silence_duration",  0.8)),
         min_speech        = float(data.get("min_speech",        0.15)),
         silero_threshold  = float(data.get("silero_threshold",  0.5)),

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor.py
@@ -18,6 +18,7 @@ from xr_ai_tools.current_frame import CurrentFrameTool
 from xr_ai_tools.image import ImageRegistry
 from xr_ai_tools.text_memory import (
     AddTranscriptRequest,
+    ConversationEntry,
     QueryTranscriptsRequest,
     RecallConversationRequest,
     TextMemoryTools,
@@ -262,17 +263,23 @@ class SceneSupervisor:
             )
             perception_stamps = {segment.timestamp_us for segment in tagged.segments}
         except Exception as error:
-            logger.warning("perception tag lookup failed ({})", error)
-            perception_stamps = set()
+            # Fail closed: with provenance unknown, every agent entry could
+            # be a stale sighting.
+            logger.warning("perception tag lookup failed; redacting agent history ({})", error)
+            perception_stamps = None
+
+        def _redact(entry: ConversationEntry) -> bool:
+            return entry.role == "agent" and (
+                perception_stamps is None or entry.timestamp_us in perception_stamps
+            )
+
         lines = [
             "  Agent: [reported what the camera showed at that moment]"
-            if e.role == "agent" and e.timestamp_us in perception_stamps
+            if _redact(e)
             else f"  {'User' if e.role == 'user' else 'Agent'}: {e.text}"
             for e in entries
         ]
-        redacted = sum(
-            1 for e in entries if e.role == "agent" and e.timestamp_us in perception_stamps
-        )
+        redacted = sum(1 for e in entries if _redact(e))
         logger.debug("inline context: {} entries, {} redacted", len(entries), redacted)
         block = (
             "[Recent conversation] (already handled; never a source of new work)\n"
@@ -294,15 +301,10 @@ class SceneSupervisor:
                 )
             )
             agent_timestamp_us = time.time_ns() // 1_000
-            await self._text_memory.add_transcript.execute(
-                AddTranscriptRequest(
-                    source_id=f"{request.participant_id}:agent",
-                    timestamp_us=agent_timestamp_us,
-                    text=reply_text,
-                )
-            )
             if vision:
-                # Shadow source recall_conversation never surfaces.
+                # Shadow source recall_conversation never surfaces, written
+                # before the reply so a failed tag skips the reply write and
+                # an untagged sighting can never reach recall.
                 await self._text_memory.add_transcript.execute(
                     AddTranscriptRequest(
                         source_id=f"{request.participant_id}:agent-vision",
@@ -310,6 +312,13 @@ class SceneSupervisor:
                         text=reply_text,
                     )
                 )
+            await self._text_memory.add_transcript.execute(
+                AddTranscriptRequest(
+                    source_id=f"{request.participant_id}:agent",
+                    timestamp_us=agent_timestamp_us,
+                    text=reply_text,
+                )
+            )
         except Exception as error:
             logger.warning("transcript persist failed ({})", error)
 
@@ -382,8 +391,7 @@ class SceneSupervisor:
         # was delegated, or the utterance itself requests a change (which
         # also catches mixed requests where only vision or memory ran).
         delegated = {record.call.name for record in result.tool_calls}
-        vision_ran = bool(delegated & _PERCEPTION_AGENTS)
-        mutation_ran = bool(delegated & _MUTATING_AGENTS)
+        delegates = set(delegated)
         rewritten = False
         needs_verification = bool(delegated & _MUTATING_AGENTS) or _wants_mutation(transcript)
 
@@ -416,9 +424,7 @@ class SceneSupervisor:
                 logger.warning("supervisor verification failed ({})", exc)
             else:
                 output = result2.content
-                retry_names = {record.call.name for record in result2.tool_calls}
-                vision_ran = vision_ran or bool(retry_names & _PERCEPTION_AGENTS)
-                mutation_ran = mutation_ran or bool(retry_names & _MUTATING_AGENTS)
+                delegates |= {record.call.name for record in result2.tool_calls}
             await asyncio.sleep(_SCENE_SETTLE_S)
             # Success is evidence-backed: a completion claim may stand only
             # when a scene write was applied (or the requested state already
@@ -439,10 +445,15 @@ class SceneSupervisor:
 
         await self._context.record_moves(request.participant_id, before)
         reply_text = output or "Done."
-        # A mixed turn's reply also carries the mutation confirmation later
-        # turns resolve references against, so only pure perception turns are
-        # tagged for redaction.
-        vision_reply = vision_ran and not mutation_ran and not rewritten and bool(output)
+        # A mixed turn's reply also carries confirmations and recalled facts
+        # later turns resolve references against, so only pure perception
+        # turns are tagged for redaction.
+        vision_reply = (
+            bool(delegates)
+            and delegates <= _PERCEPTION_AGENTS
+            and not rewritten
+            and bool(output)
+        )
         await self._persist_turn(request, transcript, reply_text, vision=vision_reply)
         return SceneReply(response=reply_text)
 

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor.py
@@ -16,7 +16,12 @@ from xr_ai_models import ChatMessage, LLMService, VLMService
 from xr_ai_tools import Tool, ToolSet
 from xr_ai_tools.current_frame import CurrentFrameTool
 from xr_ai_tools.image import ImageRegistry
-from xr_ai_tools.text_memory import AddTranscriptRequest, RecallConversationRequest, TextMemoryTools
+from xr_ai_tools.text_memory import (
+    AddTranscriptRequest,
+    QueryTranscriptsRequest,
+    RecallConversationRequest,
+    TextMemoryTools,
+)
 from xr_ai_tools.tool_calling import ToolLoopError, run_tool_loop
 from xr_ai_tools.tracking import TrackingTools
 from xr_ai_tools.video_memory import VideoMemoryTools
@@ -79,6 +84,7 @@ _ACTION_VERBS = frozenset(
 
 
 _MUTATING_AGENTS = frozenset({"placement_agent", "appearance_agent", "object_agent"})
+_PERCEPTION_AGENTS = frozenset({"vision_agent"})
 
 # Seconds to let a scene RPC propagate before diffing snapshots.
 _SCENE_SETTLE_S = 0.15
@@ -193,7 +199,11 @@ class SceneSupervisor:
             image_query = ImageQueryTool(
                 images=images,
                 vlm=vlm,
-                system_prompt="Answer directly from the visible camera image in one short plain-English sentence.",
+                system_prompt=(
+                    "Answer directly from the visible camera image in one short"
+                    " plain-English sentence. If what the question asks about is"
+                    " not visible in the image, say exactly that; never guess."
+                ),
             )
 
             physical_color = make_physical_color_tool(
@@ -217,7 +227,9 @@ class SceneSupervisor:
         self._scene_lock: asyncio.Lock = asyncio.Lock()
 
     def forget_participant(self, participant_id: str) -> None:
-        """Drop per-participant state after departure; a reconnecting id starts clean."""
+        """Drop per-participant in-process state after departure.
+
+        Transcript history persists in the store for the run's lifetime."""
         self._participant_locks.pop(participant_id, None)
         self._context.forget_participant(participant_id)
 
@@ -236,28 +248,70 @@ class SceneSupervisor:
             and entries[-2].role == "user"
         ):
             pending = entries[-2].text
-        lines = [f"  {'User' if e.role == 'user' else 'Agent'}: {e.text}" for e in entries]
+        # A perception answer goes stale the moment the user moves, and
+        # leaving it inline invites answering the next look question from
+        # recall. A failed lookup costs one turn of unredacted history,
+        # never the turn.
+        try:
+            tagged = await self._text_memory.query_transcripts.execute(
+                QueryTranscriptsRequest(
+                    source_id=f"{participant_id}:agent-vision",
+                    start_us=entries[0].timestamp_us,
+                    end_us=entries[-1].timestamp_us,
+                )
+            )
+            perception_stamps = {segment.timestamp_us for segment in tagged.segments}
+        except Exception as error:
+            logger.warning("perception tag lookup failed ({})", error)
+            perception_stamps = set()
+        lines = [
+            "  Agent: [reported what the camera showed at that moment]"
+            if e.role == "agent" and e.timestamp_us in perception_stamps
+            else f"  {'User' if e.role == 'user' else 'Agent'}: {e.text}"
+            for e in entries
+        ]
+        redacted = sum(
+            1 for e in entries if e.role == "agent" and e.timestamp_us in perception_stamps
+        )
+        logger.debug("inline context: {} entries, {} redacted", len(entries), redacted)
         block = (
             "[Recent conversation] (already handled; never a source of new work)\n"
             + "\n".join(lines) + "\n\n"
         )
         return block, pending
 
-    async def _persist_turn(self, request: SceneRequest, user_text: str, reply_text: str) -> None:
-        await self._text_memory.add_transcript.execute(
-            AddTranscriptRequest(
-                source_id=f"{request.participant_id}:user",
-                timestamp_us=request.timestamp_us,
-                text=user_text,
+    async def _persist_turn(
+        self, request: SceneRequest, user_text: str, reply_text: str, *, vision: bool = False
+    ) -> None:
+        # Best-effort as a unit: the reply is already final, so a store
+        # failure costs memory of this turn, never the turn itself.
+        try:
+            await self._text_memory.add_transcript.execute(
+                AddTranscriptRequest(
+                    source_id=f"{request.participant_id}:user",
+                    timestamp_us=request.timestamp_us,
+                    text=user_text,
+                )
             )
-        )
-        await self._text_memory.add_transcript.execute(
-            AddTranscriptRequest(
-                source_id=f"{request.participant_id}:agent",
-                timestamp_us=time.time_ns() // 1_000,
-                text=reply_text,
+            agent_timestamp_us = time.time_ns() // 1_000
+            await self._text_memory.add_transcript.execute(
+                AddTranscriptRequest(
+                    source_id=f"{request.participant_id}:agent",
+                    timestamp_us=agent_timestamp_us,
+                    text=reply_text,
+                )
             )
-        )
+            if vision:
+                # Shadow source recall_conversation never surfaces.
+                await self._text_memory.add_transcript.execute(
+                    AddTranscriptRequest(
+                        source_id=f"{request.participant_id}:agent-vision",
+                        timestamp_us=agent_timestamp_us,
+                        text=reply_text,
+                    )
+                )
+        except Exception as error:
+            logger.warning("transcript persist failed ({})", error)
 
     async def handle(self, request: SceneRequest) -> SceneReply:
         current_trace_id.set(request.trace_id)
@@ -328,6 +382,9 @@ class SceneSupervisor:
         # was delegated, or the utterance itself requests a change (which
         # also catches mixed requests where only vision or memory ran).
         delegated = {record.call.name for record in result.tool_calls}
+        vision_ran = bool(delegated & _PERCEPTION_AGENTS)
+        mutation_ran = bool(delegated & _MUTATING_AGENTS)
+        rewritten = False
         needs_verification = bool(delegated & _MUTATING_AGENTS) or _wants_mutation(transcript)
 
         await asyncio.sleep(_SCENE_SETTLE_S)
@@ -359,6 +416,9 @@ class SceneSupervisor:
                 logger.warning("supervisor verification failed ({})", exc)
             else:
                 output = result2.content
+                retry_names = {record.call.name for record in result2.tool_calls}
+                vision_ran = vision_ran or bool(retry_names & _PERCEPTION_AGENTS)
+                mutation_ran = mutation_ran or bool(retry_names & _MUTATING_AGENTS)
             await asyncio.sleep(_SCENE_SETTLE_S)
             # Success is evidence-backed: a completion claim may stand only
             # when a scene write was applied (or the requested state already
@@ -372,12 +432,18 @@ class SceneSupervisor:
             if no_evidence and (not output or _claims_completion(output)):
                 logger.warning("no mutation evidence; replacing reply {!r}", (output or "")[:80])
                 output = "I couldn't make that change; nothing in the scene was changed."
+                rewritten = True
             elif no_evidence and not _is_question(output):
                 output = output.rstrip() + " Nothing in the scene was changed."
+                rewritten = True
 
         await self._context.record_moves(request.participant_id, before)
         reply_text = output or "Done."
-        await self._persist_turn(request, transcript, reply_text)
+        # A mixed turn's reply also carries the mutation confirmation later
+        # turns resolve references against, so only pure perception turns are
+        # tagged for redaction.
+        vision_reply = vision_ran and not mutation_ran and not rewritten and bool(output)
+        await self._persist_turn(request, transcript, reply_text, vision=vision_reply)
         return SceneReply(response=reply_text)
 
 

--- a/docs/source/reference/xr-render-demo.md
+++ b/docs/source/reference/xr-render-demo.md
@@ -239,6 +239,8 @@ services. On each accepted `xr-render.user-query` event:
 
 1. **Recent conversation** is recalled from `TextMemoryTools` and injected
    as context so the model understands references like "fix that" or "undo".
+   Replies from vision turns appear as a fixed placeholder rather than
+   their text; the original stays in text memory for explicit recall.
 2. **Supervisor loop** (`run_tool_loop`, up to 12 iterations) — Nemotron-Omni
    :8108 routes the request to one or more subagent tools. Each subagent
    runs its own inner `run_tool_loop` (up to 4 iterations) against the
@@ -255,7 +257,12 @@ services. On each accepted `xr-render.user-query` event:
    is counted per turn, not per delegated task.
 4. **Conversation history persisted** — the user utterance and agent reply
    are written to `TextMemoryTools` under `{participant_id}:user` and
-   `{participant_id}:agent` source keys.
+   `{participant_id}:agent` source keys. A vision turn's reply is also
+   written under `{participant_id}:agent-vision`, a shadow source
+   `recall_conversation` never returns; its timestamps mark which recalled
+   replies to redact, surviving voice-pipeline recycles. The store is
+   cleared at worker startup, so recalled conversation never outlives the
+   run that produced it.
 5. **Final response** published as one complete `voice.output` message for
    the voice subscriber and TTS.
 

--- a/tests/test_xr_render_demo_supervisor.py
+++ b/tests/test_xr_render_demo_supervisor.py
@@ -668,3 +668,96 @@ async def test_same_participant_duplicate_text_not_cross_redacted(monkeypatch) -
     final_context = contexts[-1]
     assert final_context.count("You are holding a red notebook.") == 1
     assert final_context.count("[reported what the camera showed at that moment]") == 1
+
+
+async def test_vision_plus_memory_reply_stays_inline(monkeypatch) -> None:
+    """A turn that also recalled memory keeps its reply verbatim; redaction
+    would erase stable recalled facts along with the sighting."""
+    memory = _RecordingMemory()
+    supervisor, _fake = _make_supervisor(memory)
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        return SimpleNamespace(
+            content="You asked for a mug earlier; you are holding one now.",
+            messages=list(messages),
+            tool_calls=(
+                SimpleNamespace(call=SimpleNamespace(name="vision_agent")),
+                SimpleNamespace(call=SimpleNamespace(name="memory_agent")),
+            ),
+        )
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    await supervisor.handle(SceneRequest(
+        transcript="Am I holding what I asked for?", participant_id="alice"))
+    assert not any(r.source_id == "alice:agent-vision" for r in memory.records)
+
+
+async def test_tag_lookup_failure_redacts_all_agent_history(monkeypatch) -> None:
+    """With provenance unknown, every agent entry is treated as a possible
+    stale sighting."""
+    memory = _RecordingMemory()
+    supervisor, _fake = _make_supervisor(memory)
+    contexts: list[str] = []
+
+    async def failing_query(req):
+        raise RuntimeError("store offline")
+
+    memory.query_transcripts = Tool(
+        "query_transcripts", "Query.", QueryTranscriptsRequest,
+        QueryTranscriptsResult, failing_query)
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        contexts.append(messages[1].content)
+        return SimpleNamespace(content="Hello there.", messages=list(messages), tool_calls=())
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    await supervisor.handle(SceneRequest(transcript="Hi.", participant_id="alice"))
+    await supervisor.handle(SceneRequest(transcript="Hi again.", participant_id="alice"))
+
+    assert "Hello there." not in contexts[1]
+    assert "[reported what the camera showed at that moment]" in contexts[1]
+    assert "Hi." in contexts[1]
+
+
+async def test_failed_tag_write_skips_reply_persist(monkeypatch) -> None:
+    """A sighting whose tag write fails is dropped from recall entirely; an
+    untagged sighting must never land in the :agent source."""
+    memory = _RecordingMemory()
+    original_add = memory._add
+
+    async def add(req: AddTranscriptRequest) -> None:
+        if req.source_id.endswith(":agent-vision"):
+            raise RuntimeError("store offline")
+        await original_add(req)
+
+    memory.add_transcript = Tool("add_transcript", "Store.", AddTranscriptRequest, None, add)
+    supervisor, _fake = _make_supervisor(memory)
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        return SimpleNamespace(
+            content="You are holding a mug.",
+            messages=list(messages),
+            tool_calls=(SimpleNamespace(call=SimpleNamespace(name="vision_agent")),),
+        )
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    reply = await supervisor.handle(SceneRequest(
+        transcript="What am I holding?", participant_id="alice"))
+    assert reply.response == "You are holding a mug."
+    assert [r.source_id for r in memory.records] == ["alice:user"]
+
+
+def test_clear_transcript_artifacts_leaves_unrelated_files(tmp_path) -> None:
+    """Startup cleanup removes only the store's own files."""
+    from xr_render_demo_worker.app import _clear_transcript_artifacts
+
+    (tmp_path / "alice_agent.jsonl").write_text("{}")
+    (tmp_path / "alice_agent.identity").write_text("alice:agent")
+    (tmp_path / "notes.txt").write_text("keep me")
+    _clear_transcript_artifacts(tmp_path)
+    assert not (tmp_path / "alice_agent.jsonl").exists()
+    assert not (tmp_path / "alice_agent.identity").exists()
+    assert (tmp_path / "notes.txt").read_text() == "keep me"

--- a/tests/test_xr_render_demo_supervisor.py
+++ b/tests/test_xr_render_demo_supervisor.py
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Supervisor turn-lifecycle tests: scene-lock serialization, failure
-publishing, and two-turn memory persistence — all over fakes, no LLM."""
+publishing, memory persistence, and vision-reply redaction, all over fakes
+(plus the real transcript store for restart survival), no LLM."""
 from __future__ import annotations
 
 import asyncio
@@ -12,8 +13,11 @@ from xr_ai_tools import Tool
 from xr_ai_tools.text_memory import (
     AddTranscriptRequest,
     ConversationEntry,
+    QueryTranscriptsRequest,
+    QueryTranscriptsResult,
     RecallConversationRequest,
     RecallConversationResult,
+    TranscriptSegment,
 )
 from xr_ai_voice import UserQuery
 from xr_render_demo_eval import harness
@@ -32,21 +36,36 @@ class _RecordingMemory:
         self.recall_conversation = Tool(
             "recall_conversation", "Recall.", RecallConversationRequest,
             RecallConversationResult, self._recall)
+        self.query_transcripts = Tool(
+            "query_transcripts", "Query.", QueryTranscriptsRequest,
+            QueryTranscriptsResult, self._query)
 
     async def _add(self, req: AddTranscriptRequest) -> None:
         self.records.append(req)
 
     async def _recall(self, req: RecallConversationRequest) -> RecallConversationResult:
+        # Mirrors the real text_memory._recall contract: exactly the :user
+        # and :agent sources with stored timestamps; append order is
+        # chronological here.
         entries = [
             ConversationEntry(
-                timestamp_us=index,
+                timestamp_us=record.timestamp_us,
                 role=record.source_id.rsplit(":", 1)[1],
                 text=record.text,
             )
-            for index, record in enumerate(self.records)
-            if record.source_id.startswith(f"{req.participant_id}:")
+            for record in self.records
+            if record.source_id in (f"{req.participant_id}:user", f"{req.participant_id}:agent")
         ]
         return RecallConversationResult(entries=entries)
+
+    async def _query(self, req: QueryTranscriptsRequest) -> QueryTranscriptsResult:
+        segments = [
+            TranscriptSegment(timestamp_us=record.timestamp_us, text=record.text)
+            for record in self.records
+            if record.source_id == req.source_id
+            and req.start_us <= record.timestamp_us <= req.end_us
+        ]
+        return QueryTranscriptsResult(segments=segments)
 
 
 def _make_supervisor(memory: _RecordingMemory | None = None) -> tuple[SceneSupervisor, harness.FakeScene]:
@@ -362,3 +381,290 @@ async def test_failing_supervisor_publishes_failure_notice() -> None:
     assert published[0].text == "Something went wrong. Please try again."
     assert published[0].final is True
     assert published[0].response_id == "trace-1"
+
+
+async def test_vision_reply_redacted_from_inline_context(monkeypatch) -> None:
+    """A vision turn's reply is redacted from the next turn's inline history
+    while text memory keeps the original for explicit recall."""
+    memory = _RecordingMemory()
+    supervisor, _fake = _make_supervisor(memory)
+    contexts: list[str] = []
+    turn = 0
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        nonlocal turn
+        turn += 1
+        contexts.append(messages[1].content)
+        if turn == 1:
+            return SimpleNamespace(
+                content="You are holding a red notebook.",
+                messages=list(messages),
+                tool_calls=(SimpleNamespace(call=SimpleNamespace(name="vision_agent")),),
+            )
+        return SimpleNamespace(
+            content="You are holding a blue mug.",
+            messages=list(messages),
+            tool_calls=(SimpleNamespace(call=SimpleNamespace(name="vision_agent")),),
+        )
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    await supervisor.handle(SceneRequest(
+        transcript="What am I holding?", participant_id="alice"))
+    reply = await supervisor.handle(SceneRequest(
+        transcript="What am I holding now?", participant_id="alice"))
+
+    assert "notebook" not in contexts[1]
+    assert "[reported what the camera showed at that moment]" in contexts[1]
+    assert reply.response == "You are holding a blue mug."
+    recalled = await memory.recall_conversation.execute(
+        RecallConversationRequest(participant_id="alice"))
+    assert any(
+        entry.role == "agent" and "notebook" in entry.text for entry in recalled.entries
+    )
+
+
+async def test_vision_redaction_survives_supervisor_restart(monkeypatch, tmp_path) -> None:
+    """Provenance lives in the transcript store, so a recycled worker still
+    redacts sightings recorded by its predecessor."""
+    from xr_ai_tools.text_memory import TextMemoryTools
+
+    memory = TextMemoryTools(tmp_path)
+    first, _fake1 = _make_supervisor(memory)
+    contexts: list[str] = []
+    turn = 0
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        nonlocal turn
+        turn += 1
+        contexts.append(messages[1].content)
+        if turn == 1:
+            return SimpleNamespace(
+                content="You are holding a red notebook.",
+                messages=list(messages),
+                tool_calls=(SimpleNamespace(call=SimpleNamespace(name="vision_agent")),),
+            )
+        return SimpleNamespace(
+            content="You are holding a blue mug.",
+            messages=list(messages),
+            tool_calls=(SimpleNamespace(call=SimpleNamespace(name="vision_agent")),),
+        )
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    await first.handle(SceneRequest(
+        transcript="What am I holding?", participant_id="alice", timestamp_us=1_000_000))
+
+    second, _fake2 = _make_supervisor(memory)
+    reply = await second.handle(SceneRequest(
+        transcript="What am I holding now?", participant_id="alice", timestamp_us=2_000_000))
+
+    assert "notebook" not in contexts[1]
+    assert "[reported what the camera showed at that moment]" in contexts[1]
+    assert reply.response == "You are holding a blue mug."
+
+
+async def test_non_vision_replies_survive_redaction(monkeypatch) -> None:
+    """Only vision turns are redacted: a non-vision reply shows verbatim in
+    later inline history, and one participant's sightings never touch
+    another's entries."""
+    memory = _RecordingMemory()
+    supervisor, _fake = _make_supervisor(memory)
+    contexts: list[str] = []
+    scripted = [
+        ("You are holding a red notebook.", True),
+        ("The scene has one sphere.", False),
+        ("You are holding a red notebook.", False),
+        ("Okay.", False),
+        ("Okay.", False),
+    ]
+    turn = 0
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        nonlocal turn
+        contexts.append(messages[1].content)
+        content, vision = scripted[turn]
+        turn += 1
+        calls = (SimpleNamespace(call=SimpleNamespace(name="vision_agent")),) if vision else ()
+        return SimpleNamespace(content=content, messages=list(messages), tool_calls=calls)
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    await supervisor.handle(SceneRequest(
+        transcript="What am I holding?", participant_id="alice"))
+    await supervisor.handle(SceneRequest(
+        transcript="Describe the scene.", participant_id="alice"))
+    await supervisor.handle(SceneRequest(
+        transcript="Guess what I am holding.", participant_id="bob"))
+    await supervisor.handle(SceneRequest(
+        transcript="Thanks.", participant_id="alice"))
+    await supervisor.handle(SceneRequest(
+        transcript="Thanks.", participant_id="bob"))
+
+    alice_context = contexts[3]
+    assert "[reported what the camera showed at that moment]" in alice_context
+    assert "The scene has one sphere." in alice_context
+    assert "notebook" not in alice_context
+    # bob's identical reply was produced without a look: alice's tag must not
+    # redact it in bob's history.
+    bob_context = contexts[4]
+    assert "You are holding a red notebook." in bob_context
+
+
+async def test_untagged_legacy_history_does_not_break_turns(monkeypatch, tmp_path) -> None:
+    """An agent-vision tag whose timestamp matches no agent entry leaves
+    that history inline unredacted; the turn itself proceeds normally."""
+    from xr_ai_tools.text_memory import TextMemoryTools
+
+    memory = TextMemoryTools(tmp_path)
+    await memory.add_transcript.execute(AddTranscriptRequest(
+        source_id="alice:user", timestamp_us=1_000_000, text="What am I holding?"))
+    await memory.add_transcript.execute(AddTranscriptRequest(
+        source_id="alice:agent", timestamp_us=2_000_000,
+        text="You are holding a red notebook."))
+    await memory.add_transcript.execute(AddTranscriptRequest(
+        source_id="alice:agent-vision", timestamp_us=1_000_000,
+        text="You are holding a red notebook."))
+
+    supervisor, _fake = _make_supervisor(memory)
+    contexts: list[str] = []
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        contexts.append(messages[1].content)
+        return SimpleNamespace(
+            content="You are holding a blue mug.",
+            messages=list(messages),
+            tool_calls=(SimpleNamespace(call=SimpleNamespace(name="vision_agent")),),
+        )
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    reply = await supervisor.handle(SceneRequest(
+        transcript="What am I holding now?", participant_id="alice", timestamp_us=3_000_000))
+
+    assert reply.response == "You are holding a blue mug."
+    assert "You are holding a red notebook." in contexts[0]
+    assert "What am I holding?" in contexts[0]
+
+
+async def test_retry_loop_vision_reply_is_tagged(monkeypatch) -> None:
+    """A sighting produced by the verification retry is tagged like one from
+    the first loop."""
+    from xr_render_demo_worker._trace import current_mutation_evidence
+
+    memory = _RecordingMemory()
+    supervisor, _fake = _make_supervisor(memory)
+    calls = 0
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return SimpleNamespace(content="Checking.", messages=list(messages), tool_calls=())
+        current_mutation_evidence.get().satisfied += 1
+        return SimpleNamespace(
+            content="You are holding a mug.",
+            messages=list(messages),
+            tool_calls=(SimpleNamespace(call=SimpleNamespace(name="vision_agent")),),
+        )
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    await supervisor.handle(SceneRequest(
+        transcript="Change the wall and tell me what I am holding.", participant_id="alice"))
+    assert calls == 2
+    assert any(r.source_id == "alice:agent-vision" for r in memory.records)
+
+
+async def test_replaced_reply_is_not_tagged(monkeypatch) -> None:
+    """A canned no-change replacement is not a sighting, even when vision ran;
+    it must show verbatim in the next turn's history."""
+    memory = _RecordingMemory()
+    supervisor, _fake = _make_supervisor(memory)
+    contexts: list[str] = []
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        contexts.append(messages[1].content)
+        return SimpleNamespace(
+            content="Recolored the wall to match what you are holding.",
+            messages=list(messages),
+            tool_calls=(SimpleNamespace(call=SimpleNamespace(name="vision_agent")),),
+        )
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    await supervisor.handle(SceneRequest(
+        transcript="Recolor the wall to match my mug.", participant_id="alice"))
+    assert not any(r.source_id == "alice:agent-vision" for r in memory.records)
+
+    await supervisor.handle(SceneRequest(
+        transcript="Did anything change?", participant_id="alice"))
+    assert "I couldn't make that change" in contexts[-1]
+
+
+async def test_mixed_vision_and_mutation_reply_stays_inline(monkeypatch) -> None:
+    """A turn that both looked and mutated keeps its reply verbatim in
+    history; redacting it would erase the confirmation later turns resolve
+    references against."""
+    from xr_render_demo_worker._trace import current_mutation_evidence
+
+    memory = _RecordingMemory()
+    supervisor, _fake = _make_supervisor(memory)
+    contexts: list[str] = []
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        contexts.append(messages[1].content)
+        current_mutation_evidence.get().satisfied += 1
+        return SimpleNamespace(
+            content="Added a cone; you are holding a mug.",
+            messages=list(messages),
+            tool_calls=(
+                SimpleNamespace(call=SimpleNamespace(name="vision_agent")),
+                SimpleNamespace(call=SimpleNamespace(name="object_agent")),
+            ),
+        )
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    await supervisor.handle(SceneRequest(
+        transcript="Add a cone and tell me what I am holding.", participant_id="alice"))
+    assert not any(r.source_id == "alice:agent-vision" for r in memory.records)
+
+    await supervisor.handle(SceneRequest(
+        transcript="Make it bigger.", participant_id="alice"))
+    assert "Added a cone; you are holding a mug." in contexts[-1]
+
+
+async def test_same_participant_duplicate_text_not_cross_redacted(monkeypatch) -> None:
+    """Timestamp keying: a later non-vision reply with text identical to a
+    tagged sighting stays inline verbatim."""
+    memory = _RecordingMemory()
+    supervisor, _fake = _make_supervisor(memory)
+    contexts: list[str] = []
+    scripted = [
+        ("You are holding a red notebook.", True),
+        ("You are holding a red notebook.", False),
+        ("Okay.", False),
+    ]
+    turn = 0
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        nonlocal turn
+        contexts.append(messages[1].content)
+        content, vision = scripted[turn]
+        turn += 1
+        calls = (SimpleNamespace(call=SimpleNamespace(name="vision_agent")),) if vision else ()
+        return SimpleNamespace(content=content, messages=list(messages), tool_calls=calls)
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    await supervisor.handle(SceneRequest(
+        transcript="What am I holding?", participant_id="alice"))
+    await supervisor.handle(SceneRequest(
+        transcript="Say that again.", participant_id="alice"))
+    await supervisor.handle(SceneRequest(
+        transcript="Thanks.", participant_id="alice"))
+
+    final_context = contexts[-1]
+    assert final_context.count("You are holding a red notebook.") == 1
+    assert final_context.count("[reported what the camera showed at that moment]") == 1


### PR DESCRIPTION
Repeat "What am I holding?" asks were answered from the prior sighting in history instead of a fresh look. Supersedes the gate in #432.

Vision-turn replies show in inline history as a placeholder (tagged via a shadow transcript source recall never returns), so answering a perception question requires looking again. The store is cleared at worker startup so memory never outlives the run, and the VLM is told to say when the subject isn't visible instead of guessing.

Test plan: vision tier 10/10, offline tiers at baseline, new eval + restart-survival regressions, live headset testing across object changes, empty hands, and idle recycles.
