### PR TITLE
fix(services): migrate Hugging Face transfers to Xet

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -238,7 +238,8 @@ change, even when an individual dependency publishes newer Python wheels.
 - Runtime dependencies:
   - `vllm>=0.14.0`
   - `pyyaml>=6.0`
-  - `hf-transfer>=0.1.4`
+  - `huggingface-hub>=0.32.0`
+  - `hf-xet>=1.1.2,<2.0.0`
   - `xr-ai-logging` → [`xr-ai-logging`](utils/xr-ai-logging/) (local, editable)
   - `xr-ai-vllm` → [`xr-ai-vllm`](utils/xr-ai-vllm/) (local, editable)
 - Optional dependency groups: none
@@ -253,7 +254,8 @@ change, even when an individual dependency publishes newer Python wheels.
 - Runtime dependencies:
   - `vllm>=0.12.0`
   - `pyyaml>=6.0`
-  - `hf-transfer>=0.1.4`
+  - `huggingface-hub>=0.32.0`
+  - `hf-xet>=1.1.2,<2.0.0`
   - `xr-ai-logging` → [`xr-ai-logging`](utils/xr-ai-logging/) (local, editable)
   - `xr-ai-vllm` → [`xr-ai-vllm`](utils/xr-ai-vllm/) (local, editable)
 - Optional dependency groups: none
@@ -272,7 +274,8 @@ change, even when an individual dependency publishes newer Python wheels.
   - `numpy>=1.24`
   - `fastapi>=0.111`
   - `uvicorn[standard]>=0.29`
-  - `hf-transfer>=0.1.4`
+  - `huggingface-hub>=0.32.0`
+  - `hf-xet>=1.1.2,<2.0.0`
   - `pyyaml>=6.0`
   - `xr-ai-logging` → [`xr-ai-logging`](utils/xr-ai-logging/) (local, editable)
 - Optional dependency groups: none
@@ -287,7 +290,8 @@ change, even when an individual dependency publishes newer Python wheels.
 - Runtime dependencies:
   - `vllm>=0.12.0`
   - `pyyaml>=6.0`
-  - `hf-transfer>=0.1.4`
+  - `huggingface-hub>=0.32.0`
+  - `hf-xet>=1.1.2,<2.0.0`
   - `xr-ai-logging` → [`xr-ai-logging`](utils/xr-ai-logging/) (local, editable)
   - `xr-ai-vllm` → [`xr-ai-vllm`](utils/xr-ai-vllm/) (local, editable)
 - Optional dependency groups: none
@@ -302,7 +306,8 @@ change, even when an individual dependency publishes newer Python wheels.
 - Runtime dependencies:
   - `vllm>=0.12.0`
   - `pyyaml>=6.0`
-  - `hf-transfer>=0.1.4`
+  - `huggingface-hub>=0.32.0`
+  - `hf-xet>=1.1.2,<2.0.0`
   - `xr-ai-logging` → [`xr-ai-logging`](utils/xr-ai-logging/) (local, editable)
   - `xr-ai-vllm` → [`xr-ai-vllm`](utils/xr-ai-vllm/) (local, editable)
 - Optional dependency groups: none
@@ -344,7 +349,8 @@ change, even when an individual dependency publishes newer Python wheels.
   - `hatchling`
 - Runtime dependencies:
   - `piper-tts>=1.4.0`
-  - `huggingface-hub>=0.22`
+  - `huggingface-hub>=0.32.0`
+  - `hf-xet>=1.1.2,<2.0.0`
   - `fastapi>=0.111`
   - `uvicorn[standard]>=0.29`
   - `pyyaml>=6.0`
@@ -379,6 +385,8 @@ change, even when an individual dependency publishes newer Python wheels.
   - `fastapi>=0.111`
   - `uvicorn[standard]>=0.29`
   - `python-multipart>=0.0.9`
+  - `huggingface-hub>=0.32.0`
+  - `hf-xet>=1.1.2,<2.0.0`
   - `pyyaml>=6.0`
   - `xr-ai-logging` → [`xr-ai-logging`](utils/xr-ai-logging/) (local, editable)
 - Optional dependency groups: none
@@ -409,7 +417,8 @@ change, even when an individual dependency publishes newer Python wheels.
 - Runtime dependencies:
   - `vllm>=0.23.0`
   - `pyyaml>=6.0`
-  - `hf-transfer>=0.1.4`
+  - `huggingface-hub>=0.32.0`
+  - `hf-xet>=1.1.2,<2.0.0`
   - `xr-ai-logging` → [`xr-ai-logging`](utils/xr-ai-logging/) (local, editable)
   - `xr-ai-vllm` → [`xr-ai-vllm`](utils/xr-ai-vllm/) (local, editable)
 - Optional dependency groups: none

--- a/docs/source/components/ai-services.md
+++ b/docs/source/components/ai-services.md
@@ -50,6 +50,8 @@ two separate trees under the service's resolved `model_cache`:
 | STT and Magpie TTS (NeMo host processes) | `<model_cache>/huggingface/` | `<model_cache>/huggingface/hub/` |
 
 (The NeMo servers additionally cache non-HF artifacts under `<model_cache>/nemo/`.)
+Piper TTS passes `<model_cache>/piper/` directly as its Hub cache and defaults
+`HF_XET_CACHE` to `<model_cache>/piper/xet/` for its Xet cache.
 
 `model_cache` itself is set per YAML and resolved relative to the YAML file.
 Both the model-servers profiles and the standalone service YAMLs resolve it to
@@ -404,6 +406,28 @@ Existing `~/.docker/config.json` entries take priority and are not overwritten.
 - The host `model_cache` is bind-mounted at the same path inside the
   container and `HF_HOME` is set to it, so weights cached by pip mode are
   reused by docker mode and vice versa.
+- Before `vllm serve` starts, the wrapper verifies that the image's Hub exposes
+  its Xet download path and has `hf-xet>=1.1.2,<2.0.0`. It repairs a missing or
+  incompatible `hf-xet` wheel and checks the complete integration again; an
+  unavailable accelerator therefore fails startup instead of silently falling
+  back to plain HTTPS.
+- `HF_XET_HIGH_PERFORMANCE=1` is the default in pip and docker modes. Setting
+  it to `0` disables high-performance tuning, not Xet itself. Set
+  `HF_HUB_DISABLE_XET=1` to disable Xet. To use legacy `hf_transfer` with a
+  compatible Hub version, install the `hf_transfer` package and set both
+  `HF_HUB_DISABLE_XET=1` and `HF_HUB_ENABLE_HF_TRANSFER=1`; Xet-backed files
+  continue to use Xet when it remains enabled. These values are preserved,
+  forwarded, and included in the container fingerprint, so changing one
+  recreates a persistent container.
+
+The shipped image pins were qualified with these in-container versions:
+
+| Image | `huggingface-hub` | `hf-xet` |
+|---|---:|---:|
+| `nvcr.io/nvidia/vllm:26.04-py3` | 0.36.2 | 1.4.3 |
+| `nvcr.io/nvidia/vllm:26.07-py3` | 1.24.0 | 1.5.2 |
+| `vllm/vllm-openai:v0.20.0` | 1.12.0 | 1.4.3 |
+
 - Container name is deterministic per service: `xr-ai-vllm-vlm-server`,
   `xr-ai-vllm-llama-nemotron-llm-server`,
   `xr-ai-vllm-nemotron3-nano-llm-server`,

--- a/services/embedding-server/pyproject.toml
+++ b/services/embedding-server/pyproject.toml
@@ -12,7 +12,8 @@ requires-python = ">=3.11,<3.13"
 dependencies = [
     "vllm>=0.14.0",
     "pyyaml>=6.0",
-    "hf-transfer>=0.1.4",
+    "huggingface-hub>=0.32.0",
+    "hf-xet>=1.1.2,<2.0.0",
     "xr-ai-logging",
     "xr-ai-vllm",
 ]

--- a/services/llama-nemotron-llm/pyproject.toml
+++ b/services/llama-nemotron-llm/pyproject.toml
@@ -12,7 +12,8 @@ requires-python = ">=3.11,<3.13"
 dependencies = [
     "vllm>=0.12.0",
     "pyyaml>=6.0",
-    "hf-transfer>=0.1.4",
+    "huggingface-hub>=0.32.0",
+    "hf-xet>=1.1.2,<2.0.0",
     "xr-ai-logging",
     "xr-ai-vllm",
 ]

--- a/services/magpie-tts/magpie_tts_server/__main__.py
+++ b/services/magpie-tts/magpie_tts_server/__main__.py
@@ -194,7 +194,7 @@ async def _run(cfg: dict, yaml_dir: Path, ready_file: Path | None = None) -> Non
 
     os.environ["NEMO_CACHE_DIR"] = str(model_cache / "nemo")
     os.environ["HF_HOME"]        = str(model_cache / "huggingface")
-    os.environ.setdefault("HF_HUB_ENABLE_HF_TRANSFER", "1")
+    os.environ.setdefault("HF_XET_HIGH_PERFORMANCE", "1")
 
     port = int(cfg.get("port", _DEFAULT_PORT))
     host = cfg.get("host", "0.0.0.0")

--- a/services/magpie-tts/pyproject.toml
+++ b/services/magpie-tts/pyproject.toml
@@ -19,7 +19,8 @@ dependencies = [
     "numpy>=1.24",
     "fastapi>=0.111",
     "uvicorn[standard]>=0.29",
-    "hf-transfer>=0.1.4",
+    "huggingface-hub>=0.32.0",
+    "hf-xet>=1.1.2,<2.0.0",
     "pyyaml>=6.0",
     "xr-ai-logging",
 ]

--- a/services/nemotron-omni-llm/pyproject.toml
+++ b/services/nemotron-omni-llm/pyproject.toml
@@ -12,7 +12,8 @@ requires-python = ">=3.11,<3.13"
 dependencies = [
     "vllm>=0.12.0",
     "pyyaml>=6.0",
-    "hf-transfer>=0.1.4",
+    "huggingface-hub>=0.32.0",
+    "hf-xet>=1.1.2,<2.0.0",
     "xr-ai-logging",
     "xr-ai-vllm",
 ]

--- a/services/nemotron3-nano-llm/pyproject.toml
+++ b/services/nemotron3-nano-llm/pyproject.toml
@@ -16,8 +16,9 @@ dependencies = [
     # card (nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4) calls for.
     "vllm>=0.12.0",
     "pyyaml>=6.0",
-    # hf-transfer speeds up weight download on first run.
-    "hf-transfer>=0.1.4",
+    # Xet speeds up weight download on first run.
+    "huggingface-hub>=0.32.0",
+    "hf-xet>=1.1.2,<2.0.0",
     "xr-ai-logging",
     "xr-ai-vllm",
 ]

--- a/services/piper-tts/piper_tts_server/__main__.py
+++ b/services/piper-tts/piper_tts_server/__main__.py
@@ -328,6 +328,8 @@ async def _run(cfg: dict, yaml_dir: Path) -> None:
         sys.exit(1)
 
     model_cache = _resolve_model_cache(cfg, yaml_dir)
+    os.environ.setdefault("HF_XET_HIGH_PERFORMANCE", "1")
+    os.environ.setdefault("HF_XET_CACHE", str(model_cache / "piper" / "xet"))
     port = int(cfg.get("port", _DEFAULT_PORT))
     host = cfg.get("host", "0.0.0.0")
 

--- a/services/piper-tts/pyproject.toml
+++ b/services/piper-tts/pyproject.toml
@@ -11,7 +11,8 @@ version = "0.1.0"
 requires-python = ">=3.11,<3.13"
 dependencies = [
     "piper-tts>=1.4.0",
-    "huggingface-hub>=0.22",
+    "huggingface-hub>=0.32.0",
+    "hf-xet>=1.1.2,<2.0.0",
     "fastapi>=0.111",
     "uvicorn[standard]>=0.29",
     "pyyaml>=6.0",

--- a/services/stt-server/pyproject.toml
+++ b/services/stt-server/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
     "fastapi>=0.111",
     "uvicorn[standard]>=0.29",
     "python-multipart>=0.0.9",
+    "huggingface-hub>=0.32.0",
+    "hf-xet>=1.1.2,<2.0.0",
     "pyyaml>=6.0",
     "xr-ai-logging",
 ]

--- a/services/stt-server/stt_server/__main__.py
+++ b/services/stt-server/stt_server/__main__.py
@@ -232,7 +232,7 @@ async def _run(cfg: dict, yaml_dir: Path, ready_file: Path | None = None) -> Non
     # Direct NeMo and HuggingFace to the shared model directory.
     os.environ["NEMO_CACHE_DIR"] = str(model_cache / "nemo")
     os.environ["HF_HOME"]        = str(model_cache / "huggingface")
-    os.environ.setdefault("HF_HUB_ENABLE_HF_TRANSFER", "1")
+    os.environ.setdefault("HF_XET_HIGH_PERFORMANCE", "1")
 
     port = int(cfg.get("port", _DEFAULT_PORT))
     host = cfg.get("host", "0.0.0.0")

--- a/services/vlm-server/pyproject.toml
+++ b/services/vlm-server/pyproject.toml
@@ -12,7 +12,8 @@ requires-python = ">=3.11,<3.13"
 dependencies = [
     "vllm>=0.23.0",
     "pyyaml>=6.0",
-    "hf-transfer>=0.1.4",
+    "huggingface-hub>=0.32.0",
+    "hf-xet>=1.1.2,<2.0.0",
     "xr-ai-logging",
     "xr-ai-vllm",
 ]

--- a/tests/test_piper_tts.py
+++ b/tests/test_piper_tts.py
@@ -80,6 +80,31 @@ async def test_piper_config_rejects_unknown_use_cuda_string() -> None:
         module._parse_config_bool("sometimes", "use_cuda")
 
 
+async def test_piper_scopes_xet_cache_to_model_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_piper_main_module()
+    model_cache = tmp_path / "models"
+    monkeypatch.delenv("HF_XET_CACHE", raising=False)
+    monkeypatch.delenv("HF_XET_HIGH_PERFORMANCE", raising=False)
+    monkeypatch.setitem(module.sys.modules, "uvicorn", Mock())
+
+    def check_environment(_cfg: dict, resolved_cache: Path) -> None:
+        assert resolved_cache == model_cache
+        assert os.environ["HF_XET_CACHE"] == str(model_cache / "piper" / "xet")
+        assert os.environ["HF_XET_HIGH_PERFORMANCE"] == "1"
+        raise RuntimeError("environment checked")
+
+    monkeypatch.setattr(module, "_build_app", check_environment)
+
+    with pytest.raises(RuntimeError, match="environment checked"):
+        await module._run(
+            {"voice": "en_US-lessac-medium", "model_cache": str(model_cache)},
+            tmp_path,
+        )
+
+
 @pytest.mark.parametrize("config_path", _PIPER_CONFIGS)
 async def test_piper_configs_allow_cold_start(config_path: Path) -> None:
     module = _load_piper_main_module()

--- a/tests/test_vllm_docker.py
+++ b/tests/test_vllm_docker.py
@@ -22,7 +22,6 @@ from xr_ai_vllm._docker import (
     container_exists,
     container_label,
     container_running,
-    launch_fingerprint,
     pid_on_port,
     run,
 )
@@ -128,7 +127,10 @@ class TestBuildRunArgv:
     ):
         kwargs = self._base_kwargs(tmp_path)
         first = build_run_argv(**kwargs)
-        monkeypatch.setattr("xr_ai_vllm._docker._LAUNCH_CONTRACT_VERSION", 2)
+        monkeypatch.setattr(
+            "xr_ai_vllm._docker._LAUNCH_CONTRACT_VERSION",
+            _docker._LAUNCH_CONTRACT_VERSION + 1,
+        )
         second = build_run_argv(**kwargs)
 
         def fingerprint(argv):
@@ -200,6 +202,68 @@ class TestBuildRunArgv:
         env_flags = [argv[i + 1] for i, a in enumerate(argv) if a == "-e"]
         assert any(f == "MY_VAR=my_val" for f in env_flags)
 
+    def test_xet_high_performance_enabled_by_default(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("HF_XET_HIGH_PERFORMANCE", raising=False)
+        monkeypatch.delenv("HF_HUB_DISABLE_XET", raising=False)
+        monkeypatch.delenv("HF_HUB_ENABLE_HF_TRANSFER", raising=False)
+        argv = build_run_argv(**self._base_kwargs(tmp_path))
+        env_flags = [argv[i + 1] for i, a in enumerate(argv) if a == "-e"]
+        assert "HF_XET_HIGH_PERFORMANCE=1" in env_flags
+        assert not any("HF_HUB_ENABLE_HF_TRANSFER" in flag for flag in env_flags)
+
+    def test_xet_high_performance_forwards_host_override(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HF_XET_HIGH_PERFORMANCE", "0")
+        argv = build_run_argv(**self._base_kwargs(tmp_path))
+        env_flags = [argv[i + 1] for i, a in enumerate(argv) if a == "-e"]
+        assert "HF_XET_HIGH_PERFORMANCE=0" in env_flags
+
+    @pytest.mark.parametrize(
+        ("name", "value"),
+        [
+            ("HF_HUB_DISABLE_XET", "1"),
+            ("HF_HUB_ENABLE_HF_TRANSFER", "1"),
+        ],
+    )
+    def test_forwards_host_download_override(
+        self, tmp_path, monkeypatch, name, value
+    ):
+        monkeypatch.setenv(name, value)
+        argv = build_run_argv(**self._base_kwargs(tmp_path))
+        env_flags = [argv[i + 1] for i, a in enumerate(argv) if a == "-e"]
+        assert f"{name}={value}" in env_flags
+
+    def test_extra_env_overrides_host_download_setting(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HF_XET_HIGH_PERFORMANCE", "1")
+        kwargs = self._base_kwargs(tmp_path)
+        kwargs["extra_env"] = {"HF_XET_HIGH_PERFORMANCE": "0"}
+        argv = build_run_argv(**kwargs)
+        env_flags = [argv[i + 1] for i, a in enumerate(argv) if a == "-e"]
+        assert "HF_XET_HIGH_PERFORMANCE=0" in env_flags
+        assert "HF_XET_HIGH_PERFORMANCE=1" not in env_flags
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "HF_XET_HIGH_PERFORMANCE",
+            "HF_HUB_DISABLE_XET",
+            "HF_HUB_ENABLE_HF_TRANSFER",
+        ],
+    )
+    def test_download_override_changes_configuration_fingerprint(
+        self, tmp_path, monkeypatch, name
+    ):
+        monkeypatch.setenv(name, "0")
+        first = _fingerprint_from_argv(
+            build_run_argv(**self._base_kwargs(tmp_path))
+        )
+        monkeypatch.setenv(name, "1")
+        second = _fingerprint_from_argv(
+            build_run_argv(**self._base_kwargs(tmp_path))
+        )
+        assert first != second
+
     def test_model_cache_volume_mounted(self, tmp_path):
         kwargs = self._base_kwargs(tmp_path)
         argv = build_run_argv(**kwargs)
@@ -221,14 +285,26 @@ class TestBuildRunArgv:
         assert argv[image_index - 2 : image_index] == ["--entrypoint", "/bin/bash"]
         assert argv[image_index + 1] == "-c"
 
-    def test_no_extra_pip_runs_only_hf_transfer_install(self, tmp_path):
+    def test_bootstraps_xet_stack_before_starting_vllm(self, tmp_path):
         argv = build_run_argv(**self._base_kwargs(tmp_path))
-        # /bin/bash -c "<install>... && vllm serve ..." — the install is the last
-        # argv entry; with no extra_pip there must be exactly one pip line.
         bash_cmd = argv[-1]
-        assert bash_cmd.count("pip install ") == 1
-        assert "hf_transfer" in bash_cmd
-        assert "--no-build-isolation" not in bash_cmd
+        assert bash_cmd.count("import hf_xet") == 2
+        assert "huggingface_hub.file_download import xet_get" in bash_cmd
+        assert "python3 -m pip install -q" in bash_cmd
+        assert _docker._HF_XET_REQUIREMENT in bash_cmd
+        assert "huggingface-hub>=" not in bash_cmd
+        assert bash_cmd.endswith("vllm serve my-model --host 0.0.0.0 --port 8100")
+
+    def test_skips_xet_bootstrap_when_disabled_in_extra_env(self, tmp_path):
+        kwargs = self._base_kwargs(tmp_path)
+        kwargs["extra_env"] = {"HF_HUB_DISABLE_XET": "1"}
+        argv = build_run_argv(**kwargs)
+        env_flags = [argv[i + 1] for i, arg in enumerate(argv) if arg == "-e"]
+        bash_cmd = argv[-1]
+        assert "HF_HUB_DISABLE_XET=1" in env_flags
+        assert "import hf_xet" not in bash_cmd
+        assert _docker._HF_XET_REQUIREMENT not in bash_cmd
+        assert bash_cmd == "vllm serve my-model --host 0.0.0.0 --port 8100"
 
     def test_extra_pip_uses_no_build_isolation(self, tmp_path):
         # mamba-ssm and causal-conv1d both `import torch` from setup.py at
@@ -239,8 +315,11 @@ class TestBuildRunArgv:
         kwargs["extra_pip"] = ["mamba-ssm", "causal-conv1d"]
         argv = build_run_argv(**kwargs)
         bash_cmd = argv[-1]
-        assert "pip install -q hf_transfer" in bash_cmd
+        assert "python3 -m pip install -q" in bash_cmd
         assert "pip install -q --no-build-isolation mamba-ssm causal-conv1d" in bash_cmd
+        assert bash_cmd.index("python3 -m pip install -q") < bash_cmd.index(
+            "pip install -q --no-build-isolation"
+        )
 
 
 class _FakeLogProc:
@@ -418,18 +497,6 @@ def _fingerprint_from_argv(argv):
     labels = [argv[i + 1] for i, v in enumerate(argv) if v == "--label"]
     tagged = next(x for x in labels if x.startswith(f"{_CONFIG_LABEL}="))
     return tagged.split("=", 1)[1]
-
-
-def _expected_fingerprint(kwargs):
-    return launch_fingerprint({
-        "image": kwargs["image"],
-        "port": kwargs["port"],
-        "model_cache": str(kwargs["model_cache"]),
-        "cuda_visible_devices": kwargs["cuda_visible_devices"],
-        "extra_env": kwargs["extra_env"] or {},
-        "extra_pip": kwargs["extra_pip"] or [],
-        "vllm_argv": kwargs["vllm_argv"],
-    })
 
 
 class TestRun:

--- a/tests/test_vllm_lifecycle.py
+++ b/tests/test_vllm_lifecycle.py
@@ -1,14 +1,15 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for xr_ai_vllm._lifecycle pure helpers."""
+"""Unit tests for xr_ai_vllm configuration and lifecycle helpers."""
 from __future__ import annotations
 
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from xr_ai_vllm._config import parse_config_bool
+from xr_ai_vllm._config import parse_config_bool, setup_hf_env
 from xr_ai_vllm._lifecycle import health_ok, health_url, wait_until_healthy
 
 
@@ -35,6 +36,43 @@ class TestParseConfigBool:
     def test_rejects_other_values(self, value):
         with pytest.raises(ValueError, match="enforce_eager"):
             parse_config_bool(value, "enforce_eager")
+
+
+class TestSetupHfEnv:
+    @pytest.fixture(autouse=True)
+    def _guard_hf_environment(self, monkeypatch):
+        for key in (
+            "HF_XET_HIGH_PERFORMANCE",
+            "HF_HUB_DISABLE_XET",
+            "HF_HUB_ENABLE_HF_TRANSFER",
+            "HF_HOME",
+            "TRANSFORMERS_CACHE",
+        ):
+            monkeypatch.delenv(key, raising=False)
+
+    def test_preserves_legacy_transfer_opt_in(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HF_HUB_ENABLE_HF_TRANSFER", "1")
+
+        setup_hf_env({}, tmp_path)
+
+        assert os.environ["HF_XET_HIGH_PERFORMANCE"] == "1"
+        assert os.environ["HF_HUB_ENABLE_HF_TRANSFER"] == "1"
+        assert os.environ["HF_HOME"] == str(tmp_path)
+        assert os.environ["TRANSFORMERS_CACHE"] == str(tmp_path)
+
+    def test_preserves_xet_high_performance_override(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HF_XET_HIGH_PERFORMANCE", "0")
+
+        setup_hf_env({}, tmp_path)
+
+        assert os.environ["HF_XET_HIGH_PERFORMANCE"] == "0"
+
+    def test_preserves_xet_disable_override(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HF_HUB_DISABLE_XET", "1")
+
+        setup_hf_env({}, tmp_path)
+
+        assert os.environ["HF_HUB_DISABLE_XET"] == "1"
 
 
 class TestHealthUrl:

--- a/utils/xr-ai-vllm/xr_ai_vllm/__init__.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/__init__.py
@@ -105,13 +105,13 @@ def serve(
     service-specific name (e.g. ``xr-ai-vllm-<entry-point>``) so the stop
     helper can find it.
 
-    *extra_pip* is docker-mode only: a list of pip-installable package
-    specs that get installed into the container right before ``vllm
-    serve`` runs (same shell line that already installs ``hf_transfer``).
-    Use it for models whose architecture imports a wheel the NGC image
-    doesn't bundle — e.g. ``["mamba-ssm", "causal-conv1d"]`` for
-    Nemotron-Omni's hybrid SSM backbone. Silently ignored in pip mode
-    (deps belong in the wrapper's pyproject.toml there).
+    Docker mode verifies a Xet-capable Hub inside the container and repairs a
+    missing or incompatible ``hf-xet`` wheel. *extra_pip* is an additional
+    docker-only list of pip-installable package specs for model architectures
+    whose wheels the image doesn't bundle — e.g.
+    ``["mamba-ssm", "causal-conv1d"]`` for Nemotron-Omni's hybrid SSM
+    backbone. Silently ignored in pip mode (deps belong in the wrapper's
+    pyproject.toml there).
     """
     vllm_argv: list[str] = [
         "vllm", "serve", model,
@@ -188,10 +188,10 @@ def stop_persistent_servers(
                 # argv — stale --limit-mm-per-prompt, extra_pip, etc.).
                 #
                 # Tradeoff acknowledged: `_docker.run`'s start-on-existing path
-                # skipped `pip install` (hf_transfer, plus any extra_pip like
-                # mamba-ssm / causal-conv1d for Nemotron-Omni). Forcing rm means
-                # those reinstall on every restart — a few-second extra cost on
-                # warm cache, in exchange for config edits actually applying.
+                # skipped bootstrap installs, including any extra_pip such as
+                # mamba-ssm / causal-conv1d for Nemotron-Omni. Forcing rm means
+                # those rerun on every restart — a small extra cost on warm
+                # caches, in exchange for config edits actually applying.
                 # Acceptable: persistent-servers exists to skip MODEL reloads,
                 # not pip reinstalls.
                 if _docker.remove_container(container_name):

--- a/utils/xr-ai-vllm/xr_ai_vllm/_config.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/_config.py
@@ -81,11 +81,15 @@ def setup_hf_env(cfg: dict, model_cache: Path) -> str | None:
     """Apply the shared HuggingFace / CUDA env block.
 
     Sets ``CUDA_VISIBLE_DEVICES`` (when configured), ``HF_TOKEN`` (when
-    provided), ``HF_HUB_ENABLE_HF_TRANSFER``, ``HF_HOME``, and
+    provided), ``HF_XET_HIGH_PERFORMANCE``, ``HF_HOME``, and
     ``TRANSFORMERS_CACHE``.
 
-    Both ``HF_HOME`` and ``TRANSFORMERS_CACHE`` are set via ``setdefault``, so
-    an externally-set value wins over the YAML default. This intentionally
+    The Xet setting uses ``setdefault`` so callers can disable high-performance
+    mode explicitly. ``HF_HUB_DISABLE_XET`` is the separate Xet off switch.
+    A deliberate ``HF_HUB_ENABLE_HF_TRANSFER`` opt-in is preserved for
+    environments where the operator installed ``hf_transfer`` as a fallback.
+    Both ``HF_HOME`` and ``TRANSFORMERS_CACHE`` also use ``setdefault``, so an
+    externally-set value wins over the YAML default. This intentionally
     differs from the pre-consolidation per-server code where the LLM wrappers
     used an unconditional assignment for ``HF_HOME``; callers that need the
     YAML value to take priority must unset the env var before calling.
@@ -105,7 +109,7 @@ def setup_hf_env(cfg: dict, model_cache: Path) -> str | None:
     hf_token = cfg.get("hf_token") or os.environ.get("HF_TOKEN", "")
     if hf_token:
         os.environ["HF_TOKEN"] = hf_token
-    os.environ.setdefault("HF_HUB_ENABLE_HF_TRANSFER", "1")
+    os.environ.setdefault("HF_XET_HIGH_PERFORMANCE", "1")
     os.environ.setdefault("HF_HOME", str(model_cache))
     os.environ.setdefault("TRANSFORMERS_CACHE", str(model_cache))
 

--- a/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
+++ b/utils/xr-ai-vllm/xr_ai_vllm/_docker.py
@@ -39,7 +39,21 @@ log = logging.getLogger(__name__)
 _DOCKER_CONFIG = Path.home() / ".docker" / "config.json"
 _LOGIN_DONE: set[str] = set()
 _CONFIG_LABEL = "xr-ai-vllm.config"
-_LAUNCH_CONTRACT_VERSION = 1
+_LAUNCH_CONTRACT_VERSION = 2
+_HF_DOWNLOAD_ENV_KEYS = (
+    "HF_XET_HIGH_PERFORMANCE",
+    "HF_HUB_DISABLE_XET",
+    "HF_HUB_ENABLE_HF_TRANSFER",
+)
+_HF_XET_VERSION_SPEC = ">=1.1.2,<2.0.0"
+_HF_XET_REQUIREMENT = f"hf-xet{_HF_XET_VERSION_SPEC}"
+_HF_XET_IMPORT_CHECK = (
+    "import hf_xet; "
+    "from huggingface_hub.file_download import xet_get; "
+    "from importlib.metadata import version; "
+    "from packaging.specifiers import SpecifierSet; "
+    f"assert SpecifierSet({_HF_XET_VERSION_SPEC!r}).contains(version('hf-xet'))"
+)
 
 
 # ── docker run argv builder ──────────────────────────────────────────────────
@@ -95,6 +109,18 @@ def build_run_argv(
     as pip-mode vLLM.  With --network host the vLLM process is visible to
     ss(8) on the host, so no docker-specific stop logic is needed.
     """
+    env_vars: dict[str, str] = {
+        "HF_HOME": str(model_cache),
+        "HF_XET_HIGH_PERFORMANCE": os.environ.get(
+            "HF_XET_HIGH_PERFORMANCE", "1"
+        ),
+    }
+    for key in _HF_DOWNLOAD_ENV_KEYS[1:]:
+        if key in os.environ:
+            env_vars[key] = os.environ[key]
+    if extra_env:
+        env_vars.update(extra_env)
+
     argv: list[str] = ["docker", "run"]
     argv += ["--name", container_name]
     # Label lets container_on_port find this container by port without the
@@ -106,7 +132,7 @@ def build_run_argv(
         "port": port,
         "model_cache": str(model_cache),
         "cuda_visible_devices": cuda_visible_devices,
-        "extra_env": extra_env or {},
+        "env_vars": env_vars,
         "extra_pip": extra_pip or [],
         "vllm_argv": vllm_argv,
     }
@@ -137,28 +163,36 @@ def build_run_argv(
     # non-NGC image (or one with a narrower default) still gets CUDA compute.
     argv += ["-e", "NVIDIA_DRIVER_CAPABILITIES=compute,utility"]
 
-    env_vars: dict[str, str] = {
-        "HF_HOME": str(model_cache),
-        "HF_HUB_ENABLE_HF_TRANSFER": "1",
-    }
     if hf_token:
         # Name-only passthrough keeps the token off the ps-visible argv;
         # docker reads the value from this process's environment (run()
         # exports it before spawning).
         argv += ["-e", "HF_TOKEN"]
-    if extra_env:
-        env_vars.update(extra_env)
     for key, val in env_vars.items():
         argv += ["-e", f"{key}={val}"]
 
     argv += ["-v", f"{model_cache}:{model_cache}"]
 
     # Some vLLM images default to `vllm serve`; override the entrypoint so
-    # setup installs run in a shell before the server starts.
+    # dependency checks and optional setup installs run before the server.
     argv += ["--entrypoint", "/bin/bash", image]
-    # Install hf_transfer before starting vLLM — the NGC image doesn't ship it
-    # but HF_HUB_ENABLE_HF_TRANSFER=1 will error if it's missing.
-    install_cmds = ["pip install -q hf_transfer"]
+    xet_check = shlex.join(["python3", "-c", _HF_XET_IMPORT_CHECK])
+    xet_install = shlex.join(
+        ["python3", "-m", "pip", "install", "-q", _HF_XET_REQUIREMENT]
+    )
+    commands: list[str] = []
+    xet_disabled = env_vars.get("HF_HUB_DISABLE_XET", "").upper() in {
+        "1",
+        "ON",
+        "YES",
+        "TRUE",
+    }
+    if not xet_disabled:
+        # Images vary in their Hub/Xet stack. Repair a missing or incompatible
+        # hf-xet wheel, then re-check the complete Hub integration so an
+        # incapable Hub or install failure stops startup instead of falling
+        # back to HTTPS.
+        commands.extend([f"( {xet_check} || {xet_install} )", xet_check])
     if extra_pip:
         # extra_pip is the seam for models whose architecture needs a wheel
         # the NGC image doesn't bundle (e.g. mamba-ssm for Nemotron-Omni's
@@ -166,11 +200,11 @@ def build_run_argv(
         # can see the container's pre-installed torch — mamba-ssm and its
         # causal_conv1d peer both `import torch` from setup.py at config
         # time, and pip's default isolated build env doesn't have it.
-        install_cmds.append(
+        commands.append(
             f"pip install -q --no-build-isolation {shlex.join(extra_pip)}"
         )
-    install_cmds.append(shlex.join(vllm_argv))
-    argv += ["-c", " && ".join(install_cmds)]
+    commands.append(shlex.join(vllm_argv))
+    argv += ["-c", " && ".join(commands)]
     return argv
 
 


### PR DESCRIPTION
## Summary

  - migrate Hugging Face downloads from the deprecated `HF_HUB_ENABLE_HF_TRANSFER` path to Xet high-performance mode across vLLM, STT, Magpie TTS, and Piper TTS
  - update the Hugging Face dependencies in eight service `pyproject.toml` files
  - forward effective Xet settings into vLLM containers and include them in the launch fingerprint
  - remove the unconditional `hf_transfer` installation from Docker startup
  - validate the in-container Xet stack and conditionally install a compatible `hf-xet` version when validation fails
  - honor `HF_HUB_DISABLE_XET` after `extra_env` overrides by skipping Xet validation and repair

  ## Why

  The existing Docker startup path unconditionally installs the deprecated `hf_transfer` helper from PyPI before starting vLLM. This makes startup depend on live
  package access and can fail in restricted or offline deployments.

  This change uses the supported Xet path instead. Docker mode validates the image’s Xet stack, conditionally repairs it when necessary, and fails clearly if the
  integration remains incompatible. Operators can set `HF_HUB_DISABLE_XET=1` to disable Xet and skip bootstrap validation and installation entirely.

  Because the launch contract changes, existing persistent vLLM containers are recreated once on their next launch.

  ## Testing

  - 95 focused vLLM Docker and lifecycle tests passed
  - 1,368 non-GPU full-suite tests passed
  - all three shipped vLLM image stacks were validated on dual Ada
  - all eight affected service lockfiles resolved successfully
  - dependency-map and whitespace checks passed
