### PR TITLE
Gate DeviceIOHub startup readiness on shared-memory registration

### DIFF
--- a/agent-sdk/xr-ai-hub/xr_ai_hub/_shm.py
+++ b/agent-sdk/xr-ai-hub/xr_ai_hub/_shm.py
@@ -76,6 +76,10 @@ def _frame_size_error(
     )
 
 
+class _IncompatibleSharedMemoryError(RuntimeError):
+    """The named segment exists but is not a valid XR AI frame ring."""
+
+
 class SlotView(NamedTuple):
     """Zero-copy view into one ring-buffer slot's pixel data."""
     data:   memoryview
@@ -89,8 +93,9 @@ class ShmRingBuffer:
     """
     Shared-memory ring buffer for raw video frames.
 
-    Hub creates the buffer (create=True). Connector opens it (create=False) and
-    reads num_slots / max_frame_bytes from the global header automatically.
+    The connector creates the buffer (create=True). The hub opens it
+    (create=False) and reads num_slots / max_frame_bytes from the global header
+    automatically.
 
     The caller that uses read_slot() MUST call release_slot() before the next
     write_frame() for that slot can succeed. Both operations are O(1).
@@ -126,16 +131,66 @@ class ShmRingBuffer:
                 off = _GH_SIZE + i * slot_stride
                 _SH.pack_into(buffer, off, _MAGIC_SLOT, _STATE_FREE, 0, 0, 0, 0, 0, 0, 0)
         else:
-            self._shm                              = SharedMemory(name=name, create=False)
+            self._shm = SharedMemory(name=name, create=False)
             buffer = self._shm.buf
             assert buffer is not None
-            _, num_slots, max_frame_bytes, slot_stride = _GH.unpack_from(buffer, 0)
+            try:
+                num_slots, max_frame_bytes, slot_stride = self._validate_layout(buffer)
+            except Exception:
+                buffer.release()
+                self._shm.close()
+                raise
 
         self._buf            = buffer
         self._num_slots      = num_slots
         self._max_frame_bytes = max_frame_bytes
         self._slot_stride    = slot_stride
         self._write_pos      = 0  # local to producer; never shared
+
+    @staticmethod
+    def _validate_layout(buffer: memoryview) -> tuple[int, int, int]:
+        """Validate an attached segment before exposing it to the hub."""
+        if len(buffer) < _GH_SIZE:
+            raise _IncompatibleSharedMemoryError(
+                f"segment is too small for the global header ({len(buffer)} bytes)"
+            )
+        try:
+            magic, num_slots, max_frame_bytes, slot_stride = _GH.unpack_from(buffer, 0)
+        except struct.error as exc:
+            raise _IncompatibleSharedMemoryError("cannot read the global header") from exc
+        if magic != _MAGIC_GLOBAL:
+            raise _IncompatibleSharedMemoryError(
+                f"invalid global header magic 0x{magic:08x}"
+            )
+        if num_slots <= 0 or max_frame_bytes <= 0:
+            raise _IncompatibleSharedMemoryError(
+                "ring dimensions must be positive "
+                f"(num_slots={num_slots}, max_frame_bytes={max_frame_bytes})"
+            )
+        expected_stride = _SH_SIZE + max_frame_bytes
+        if slot_stride != expected_stride:
+            raise _IncompatibleSharedMemoryError(
+                f"invalid slot stride {slot_stride} (expected {expected_stride})"
+            )
+        expected_size = _GH_SIZE + num_slots * slot_stride
+        # Some POSIX implementations expose page-rounded mappings (macOS is a
+        # common example), so trailing capacity is valid but truncation is not.
+        if len(buffer) < expected_size:
+            raise _IncompatibleSharedMemoryError(
+                f"segment size {len(buffer)} is smaller than expected {expected_size}"
+            )
+        for slot in range(num_slots):
+            offset = _GH_SIZE + slot * slot_stride
+            slot_magic, state = _SH.unpack_from(buffer, offset)[:2]
+            if slot_magic != _MAGIC_SLOT:
+                raise _IncompatibleSharedMemoryError(
+                    f"slot {slot} has invalid header magic 0x{slot_magic:08x}"
+                )
+            if state not in (_STATE_FREE, _STATE_WRITING, _STATE_READY):
+                raise _IncompatibleSharedMemoryError(
+                    f"slot {slot} has invalid state {state}"
+                )
+        return num_slots, max_frame_bytes, slot_stride
 
     # ── producer ──────────────────────────────────────────────────────────────
 

--- a/agent-sdk/xr-ai-hub/xr_ai_hub/_shm.py
+++ b/agent-sdk/xr-ai-hub/xr_ai_hub/_shm.py
@@ -76,10 +76,6 @@ def _frame_size_error(
     )
 
 
-class _IncompatibleSharedMemoryError(RuntimeError):
-    """The named segment exists but is not a valid XR AI frame ring."""
-
-
 class SlotView(NamedTuple):
     """Zero-copy view into one ring-buffer slot's pixel data."""
     data:   memoryview
@@ -111,6 +107,13 @@ class ShmRingBuffer:
     create :
         Create and initialize the segment instead of attaching to an existing
         one. The creator is responsible for eventually calling :meth:`unlink`.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the named segment does not exist when attaching.
+    ValueError
+        If an existing segment has an invalid or incompatible ring layout.
     """
 
     def __init__(
@@ -151,43 +154,40 @@ class ShmRingBuffer:
     def _validate_layout(buffer: memoryview) -> tuple[int, int, int]:
         """Validate an attached segment before exposing it to the hub."""
         if len(buffer) < _GH_SIZE:
-            raise _IncompatibleSharedMemoryError(
+            raise ValueError(
                 f"segment is too small for the global header ({len(buffer)} bytes)"
             )
-        try:
-            magic, num_slots, max_frame_bytes, slot_stride = _GH.unpack_from(buffer, 0)
-        except struct.error as exc:
-            raise _IncompatibleSharedMemoryError("cannot read the global header") from exc
+        magic, num_slots, max_frame_bytes, slot_stride = _GH.unpack_from(buffer, 0)
         if magic != _MAGIC_GLOBAL:
-            raise _IncompatibleSharedMemoryError(
+            raise ValueError(
                 f"invalid global header magic 0x{magic:08x}"
             )
         if num_slots <= 0 or max_frame_bytes <= 0:
-            raise _IncompatibleSharedMemoryError(
+            raise ValueError(
                 "ring dimensions must be positive "
                 f"(num_slots={num_slots}, max_frame_bytes={max_frame_bytes})"
             )
         expected_stride = _SH_SIZE + max_frame_bytes
         if slot_stride != expected_stride:
-            raise _IncompatibleSharedMemoryError(
+            raise ValueError(
                 f"invalid slot stride {slot_stride} (expected {expected_stride})"
             )
         expected_size = _GH_SIZE + num_slots * slot_stride
         # Some POSIX implementations expose page-rounded mappings (macOS is a
         # common example), so trailing capacity is valid but truncation is not.
         if len(buffer) < expected_size:
-            raise _IncompatibleSharedMemoryError(
+            raise ValueError(
                 f"segment size {len(buffer)} is smaller than expected {expected_size}"
             )
         for slot in range(num_slots):
             offset = _GH_SIZE + slot * slot_stride
             slot_magic, state = _SH.unpack_from(buffer, offset)[:2]
             if slot_magic != _MAGIC_SLOT:
-                raise _IncompatibleSharedMemoryError(
+                raise ValueError(
                     f"slot {slot} has invalid header magic 0x{slot_magic:08x}"
                 )
             if state not in (_STATE_FREE, _STATE_WRITING, _STATE_READY):
-                raise _IncompatibleSharedMemoryError(
+                raise ValueError(
                     f"slot {slot} has invalid state {state}"
                 )
         return num_slots, max_frame_bytes, slot_stride

--- a/docs/source/components/server-runtime.md
+++ b/docs/source/components/server-runtime.md
@@ -34,11 +34,17 @@ The hub is one hub, many clients, many agents. A single instance fans the
 inbound media stream out to every connected agent and routes any return
 traffic back to the originating client only.
 
-On startup, `__main__.py` constructs a `HubEndpoint` (the IPC server),
-registers hub-local callbacks (`on_frame`, `on_audio`, `on_data`,
-`on_participant`), loads the configuration, and brings up the `LiveKitConnector`.
-The hub task and the connector task then run concurrently until `SIGINT` or
-`SIGTERM`. A periodic stats loop logs per-participant video, audio, and data
+On startup, `__main__.py` loads the configuration, constructs a `HubEndpoint`
+(the IPC server), registers hub-local callbacks (`on_frame`, `on_audio`,
+`on_data`, `on_participant`), and starts the hub receive loop before bringing
+up the `LiveKitConnector`. The connector waits for the hub to acknowledge
+shared-memory attachment and layout validation before connecting the LiveKit
+room. The ready file is created only after connector startup and the remaining
+startup configuration succeed.
+
+The hub task and connector task run concurrently, and the process waits for
+`SIGINT` or `SIGTERM` to shut down. Startup failures clean up the started
+components. A periodic stats loop logs per-participant video, audio, and data
 rates.
 
 ### Isolation contract
@@ -87,7 +93,8 @@ which transport carries the media.
    generated configuration does not restrict the signaling listener to
    loopback, so deployment firewalls must control direct access.
 2. Optionally starts the browser-facing web server and/or token server.
-3. Registers itself as a `ConnectorEndpoint` with the IPC layer.
+3. Creates its shared-memory ring and registers itself as a `ConnectorEndpoint`
+   with the IPC layer, waiting for the hub acknowledgement before proceeding.
 4. Connects a Python `RoomClient` to the LiveKit room. The room client is
    subscribe-only — it never publishes media of its own except per-participant
    return-audio tracks.
@@ -128,7 +135,9 @@ connector_N ──PUSH──┘    ↓ dispatch
 
 Each connector owns and creates its own shared-memory ring buffer and
 announces it to the hub with a `ConnectorRegistration` message; the hub opens
-that buffer on demand. Video frames travel zero-copy through the ring buffer:
+and validates that buffer before acknowledging registration. Duplicate
+registrations for the same connector and segment are acknowledged without
+replacing the mapping. Video frames travel zero-copy through the ring buffer:
 the connector writes pixels into a slot and pushes a lightweight
 `FRAME_SIGNAL` (metadata) at full frame rate; consumers that want the pixels
 issue a `FRAME_REQUEST`, and the hub replies with the held slot's

--- a/docs/source/components/server-runtime.md
+++ b/docs/source/components/server-runtime.md
@@ -43,9 +43,10 @@ room. The ready file is created only after connector startup and the remaining
 startup configuration succeed.
 
 The hub task and connector task run concurrently, and the process waits for
-`SIGINT` or `SIGTERM` to shut down. Startup failures clean up the started
-components. A periodic stats loop logs per-participant video, audio, and data
-rates.
+`SIGINT` or `SIGTERM` to shut down. Startup failures attempt cleanup of every
+owned component. Cleanup errors are logged without replacing the original
+startup failure. A periodic stats loop logs per-participant video, audio, and
+data rates.
 
 ### Isolation contract
 

--- a/docs/source/reference/migrations.md
+++ b/docs/source/reference/migrations.md
@@ -15,6 +15,11 @@ and command to `device_io_hub`. Rename `xr_media_hub.yaml` to
 
 ## Operator-visible runtime changes
 
+- DeviceIOHub now waits for the hub to acknowledge shared-memory attachment
+  before connecting the LiveKit room or creating its ready file. Missing
+  segments trigger bounded recreation; incompatible layouts and acknowledgement
+  timeouts fail startup. Check the registration error in the hub logs rather
+  than treating a running process as ready.
 - DeviceIOHub no longer falls back to embedded LiveKit development credentials.
   Set `api_key` and `api_secret` in `device_io_hub.yaml`, or inject
   `LIVEKIT_API_KEY` and `LIVEKIT_API_SECRET` through the environment.

--- a/services/device-io-hub/device_io_hub/__main__.py
+++ b/services/device-io-hub/device_io_hub/__main__.py
@@ -96,7 +96,16 @@ async def main(ready_file: Path | None = None) -> None:
     hub.on_participant(on_participant)
 
     connector = LiveKitConnector(cfg)
-    await connector.start()
+    hub_task = asyncio.create_task(hub.run(), name="hub")
+    await asyncio.sleep(0)
+    try:
+        await connector.start()
+    except BaseException:
+        hub.stop()
+        hub.close()
+        hub_task.cancel()
+        await asyncio.gather(hub_task, return_exceptions=True)
+        raise
 
     vr_cfg = cfg.video_recording or {}
     if vr_cfg.get("enabled"):
@@ -140,19 +149,37 @@ async def main(ready_file: Path | None = None) -> None:
         loop.add_signal_handler(sig, stop.set)
 
     logger.info("DeviceIOHub running — press Ctrl-C to exit")
-    hub_task   = asyncio.create_task(hub.run(),       name="hub")
     conn_task  = asyncio.create_task(connector.run(), name="connector")
     stats_task = asyncio.create_task(_stats_loop(),   name="stats")
+    stop_task  = asyncio.create_task(stop.wait(),     name="stop-signal")
 
-    await stop.wait()
+    done, _ = await asyncio.wait(
+        [stop_task, hub_task, conn_task],
+        return_when=asyncio.FIRST_COMPLETED,
+    )
+    failure: BaseException | None = None
+    if stop_task not in done:
+        failed_task = next(task for task in done if task is not stop_task)
+        if failed_task.cancelled():
+            failure = RuntimeError(f"{failed_task.get_name()} task was cancelled")
+        else:
+            failure = failed_task.exception()
+            failure = failure or RuntimeError(
+                f"{failed_task.get_name()} task exited unexpectedly"
+            )
+
     logger.info("Shutting down…")
-
+    stop_task.cancel()
     stats_task.cancel()
     hub.stop()
     hub.close()
     await connector.stop()
-
-    await asyncio.gather(hub_task, conn_task, stats_task, return_exceptions=True)
+    await asyncio.gather(
+        hub_task, conn_task, stats_task, stop_task,
+        return_exceptions=True,
+    )
+    if failure is not None:
+        raise RuntimeError(f"DeviceIOHub task failed: {failure}") from failure
 
 
 def run() -> None:

--- a/services/device-io-hub/device_io_hub/__main__.py
+++ b/services/device-io-hub/device_io_hub/__main__.py
@@ -167,7 +167,7 @@ async def main(ready_file: Path | None = None) -> None:
                 for task in tasks:
                     task.cancel()
                 await asyncio.gather(*tasks, return_exceptions=True)
-        except BaseException:
+        except (Exception, asyncio.CancelledError):
             if failure is None:
                 raise
             logger.exception("DeviceIOHub cleanup failed while handling an earlier failure")

--- a/services/device-io-hub/device_io_hub/__main__.py
+++ b/services/device-io-hub/device_io_hub/__main__.py
@@ -97,89 +97,72 @@ async def main(ready_file: Path | None = None) -> None:
 
     connector = LiveKitConnector(cfg)
     hub_task = asyncio.create_task(hub.run(), name="hub")
-    await asyncio.sleep(0)
-    try:
-        await connector.start()
-    except BaseException:
-        hub.stop()
-        hub.close()
-        hub_task.cancel()
-        await asyncio.gather(hub_task, return_exceptions=True)
-        raise
-
-    vr_cfg = cfg.video_recording or {}
-    if vr_cfg.get("enabled"):
-        from device_io_hub.video import VideoRecorder, VideoRecorderConfig
-        rc_defaults = VideoRecorderConfig()
-        rc = VideoRecorderConfig(
-            out_dir         = vr_cfg.get("out_dir",         rc_defaults.out_dir),
-            chunk_frames    = int(vr_cfg.get("chunk_frames",    rc_defaults.chunk_frames)),
-            max_total_bytes = int(vr_cfg.get("max_total_bytes", rc_defaults.max_total_bytes)),
-            sample_fps      = float(vr_cfg.get("sample_fps",    rc_defaults.sample_fps)),
-            bitrate         = int(vr_cfg.get("bitrate",         rc_defaults.bitrate)),
-            gpu_id          = int(vr_cfg.get("gpu_id",          rc_defaults.gpu_id)),
-        )
-        _recorder = VideoRecorder(rc)
-        logger.info("Video recording enabled  out_dir={}", rc.out_dir)
-
-    token = make_client_token(cfg, identity="ios-client")
-    web_scheme = "https" if cfg.web_server_tls else "http"
-    # External clients reach LiveKit via the web server's /rtc proxy;
-    # without that, LiveKit's native plain ws:// is the only path.
-    if cfg.enable_web_server:
-        lk_scheme   = "wss" if cfg.web_server_tls else "ws"
-        lk_url_port = cfg.web_server_port
-    else:
-        lk_scheme   = "ws"
-        lk_url_port = cfg.lk_port_ws
-    logger.info("LiveKit URL : {}://localhost:{}", lk_scheme, lk_url_port)
-    logger.info("Room        : {}", cfg.room_name)
-    logger.info("Token       : {}", token)
-    if cfg.enable_web_server:
-        logger.info("Web client  : {}://localhost:{}", web_scheme, cfg.web_server_port)
-    if _recorder is not None:
-        logger.info("Recording   : {}", rc.out_dir)
-
-    if ready_file:
-        ready_file.touch()
-
-    stop = asyncio.Event()
+    tasks = [hub_task]
+    connector_started = False
+    installed_signals = []
     loop = asyncio.get_running_loop()
-    for sig in (signal.SIGINT, signal.SIGTERM):
-        loop.add_signal_handler(sig, stop.set)
+    try:
+        await asyncio.sleep(0)
+        await connector.start()
+        connector_started = True
 
-    logger.info("DeviceIOHub running — press Ctrl-C to exit")
-    conn_task  = asyncio.create_task(connector.run(), name="connector")
-    stats_task = asyncio.create_task(_stats_loop(),   name="stats")
-    stop_task  = asyncio.create_task(stop.wait(),     name="stop-signal")
-
-    done, _ = await asyncio.wait(
-        [stop_task, hub_task, conn_task],
-        return_when=asyncio.FIRST_COMPLETED,
-    )
-    failure: BaseException | None = None
-    if stop_task not in done:
-        failed_task = next(task for task in done if task is not stop_task)
-        if failed_task.cancelled():
-            failure = RuntimeError(f"{failed_task.get_name()} task was cancelled")
-        else:
-            failure = failed_task.exception()
-            failure = failure or RuntimeError(
-                f"{failed_task.get_name()} task exited unexpectedly"
+        vr_cfg = cfg.video_recording or {}
+        if vr_cfg.get("enabled"):
+            from device_io_hub.video import VideoRecorder, VideoRecorderConfig
+            rc_defaults = VideoRecorderConfig()
+            rc = VideoRecorderConfig(
+                out_dir         = vr_cfg.get("out_dir",         rc_defaults.out_dir),
+                chunk_frames    = int(vr_cfg.get("chunk_frames",    rc_defaults.chunk_frames)),
+                max_total_bytes = int(vr_cfg.get("max_total_bytes", rc_defaults.max_total_bytes)),
+                sample_fps      = float(vr_cfg.get("sample_fps",    rc_defaults.sample_fps)),
+                bitrate         = int(vr_cfg.get("bitrate",         rc_defaults.bitrate)),
+                gpu_id          = int(vr_cfg.get("gpu_id",          rc_defaults.gpu_id)),
             )
+            _recorder = VideoRecorder(rc)
+            logger.info("Video recording enabled  out_dir={}", rc.out_dir)
 
-    logger.info("Shutting down…")
-    stop_task.cancel()
-    stats_task.cancel()
-    hub.stop()
-    hub.close()
-    await connector.stop()
-    await asyncio.gather(
-        hub_task, conn_task, stats_task, stop_task,
-        return_exceptions=True,
-    )
-    if failure is not None:
-        raise RuntimeError(f"DeviceIOHub task failed: {failure}") from failure
+        token = make_client_token(cfg, identity="ios-client")
+        web_scheme = "https" if cfg.web_server_tls else "http"
+        # External clients reach LiveKit via the web server's /rtc proxy;
+        # without that, LiveKit's native plain ws:// is the only path.
+        if cfg.enable_web_server:
+            lk_scheme   = "wss" if cfg.web_server_tls else "ws"
+            lk_url_port = cfg.web_server_port
+        else:
+            lk_scheme   = "ws"
+            lk_url_port = cfg.lk_port_ws
+        logger.info("LiveKit URL : {}://localhost:{}", lk_scheme, lk_url_port)
+        logger.info("Room        : {}", cfg.room_name)
+        logger.info("Token       : {}", token)
+        if cfg.enable_web_server:
+            logger.info("Web client  : {}://localhost:{}", web_scheme, cfg.web_server_port)
+        if _recorder is not None:
+            logger.info("Recording   : {}", rc.out_dir)
+
+        if ready_file:
+            ready_file.touch()
+
+        stop = asyncio.Event()
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            loop.add_signal_handler(sig, stop.set)
+            installed_signals.append(sig)
+
+        logger.info("DeviceIOHub running — press Ctrl-C to exit")
+        conn_task  = asyncio.create_task(connector.run(), name="connector")
+        stats_task = asyncio.create_task(_stats_loop(),   name="stats")
+        tasks.extend([conn_task, stats_task])
+        await stop.wait()
+    finally:
+        logger.info("Shutting down…")
+        for sig in installed_signals:
+            loop.remove_signal_handler(sig)
+        hub.stop()
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        hub.close()
+        if connector_started:
+            await connector.stop()
 
 
 def run() -> None:

--- a/services/device-io-hub/device_io_hub/__main__.py
+++ b/services/device-io-hub/device_io_hub/__main__.py
@@ -15,6 +15,7 @@ import collections
 import signal
 import sys
 import time
+from contextlib import AsyncExitStack
 from pathlib import Path
 
 from loguru import logger
@@ -154,15 +155,22 @@ async def main(ready_file: Path | None = None) -> None:
         await stop.wait()
     finally:
         logger.info("Shutting down…")
-        for sig in installed_signals:
-            loop.remove_signal_handler(sig)
-        hub.stop()
-        for task in tasks:
-            task.cancel()
-        await asyncio.gather(*tasks, return_exceptions=True)
-        hub.close()
-        if connector_started:
-            await connector.stop()
+        failure = sys.exception()
+        try:
+            async with AsyncExitStack() as cleanup:
+                if connector_started:
+                    cleanup.push_async_callback(connector.stop)
+                cleanup.callback(hub.close)
+                for sig in installed_signals:
+                    loop.remove_signal_handler(sig)
+                hub.stop()
+                for task in tasks:
+                    task.cancel()
+                await asyncio.gather(*tasks, return_exceptions=True)
+        except BaseException:
+            if failure is None:
+                raise
+            logger.exception("DeviceIOHub cleanup failed while handling an earlier failure")
 
 
 def run() -> None:

--- a/services/device-io-hub/device_io_hub/ipc/_connector.py
+++ b/services/device-io-hub/device_io_hub/ipc/_connector.py
@@ -21,17 +21,18 @@ The connector process only needs: pyzmq, msgpack (no CUDA, no GPU deps).
 """
 from __future__ import annotations
 
+import asyncio
 import uuid
 from collections import defaultdict
-from typing import Awaitable, Callable
+from typing import Any, Awaitable, Callable
 
 import zmq
 import zmq.asyncio
 from loguru import logger
 
-from xr_ai_hub import (AudioChunk, ConnectorRegistration, ControlMessage,
-                         DataMessage, FrameSignal, MsgType, ParticipantEvent, PixelFormat,
-                         ReturnAudioFlush, ShmRingBuffer, decode, encode)
+from xr_ai_hub import (AudioChunk, ConnectorRegistration, ControlMessage, DataMessage,
+                       FrameSignal, MsgType, ParticipantEvent, PixelFormat,
+                       ReturnAudioFlush, ShmRingBuffer, decode, encode)
 
 ReturnAudioCallback      = Callable[[AudioChunk],        Awaitable[None]]
 ReturnDataCallback       = Callable[[DataMessage],       Awaitable[None]]
@@ -39,6 +40,19 @@ ReturnAudioFlushCallback = Callable[[ReturnAudioFlush],  Awaitable[None]]
 
 _DEFAULT_NUM_SLOTS       = 16
 _DEFAULT_MAX_FRAME_BYTES = 12_441_600  # 4K NV12
+_DEFAULT_REGISTRATION_TIMEOUT_S = 3.0
+_DEFAULT_REGISTRATION_ATTEMPTS  = 3
+_REGISTRATION_RESEND_INTERVAL_S = 0.25
+_CONNECTOR_REGISTER_ACK_TOPIC = "_connector.registration_ack"
+
+
+class _ConnectorRegistrationError(RuntimeError):
+    """The hub did not acknowledge a usable shared-memory registration."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(f"{code}: {message}")
+        self.code = code
+        self.message = message
 
 
 class ConnectorEndpoint:
@@ -84,16 +98,14 @@ class ConnectorEndpoint:
         num_slots       : Ring buffer slot count (default 16).
         max_frame_bytes : Max bytes per slot (default 4K NV12 = 12 441 600).
         """
-        self._connector_id = connector_id or uuid.uuid4().hex
-        self._shm_name     = shm_name or f"xr_conn_{self._connector_id[:8]}"
-
-        # Each connector owns and creates its own ring buffer.
-        self._ring = ShmRingBuffer(
-            name=self._shm_name,
-            num_slots=num_slots,
-            max_frame_bytes=max_frame_bytes,
-            create=True,
-        )
+        self._connector_id  = connector_id or uuid.uuid4().hex
+        self._shm_base_name = shm_name or f"xr_conn_{self._connector_id[:8]}"
+        self._shm_name      = ""
+        self._num_slots = num_slots
+        self._max_frame_bytes = max_frame_bytes
+        self._ring: ShmRingBuffer | None = None
+        self._ring_generation = 0
+        self._registered = False
 
         ctx = zmq.asyncio.Context.instance()
 
@@ -102,7 +114,13 @@ class ConnectorEndpoint:
 
         self._sub: zmq.asyncio.Socket = ctx.socket(zmq.SUB)
         self._sub.connect(sub_addr)
-        # No subscriptions yet — added dynamically as participants join.
+        # Subscribe during construction, before expensive transport startup, so
+        # the PUB/SUB route is established by the time registration needs an ACK.
+        self._sub.setsockopt(
+            zmq.SUBSCRIBE,
+            f"connector.{self._connector_id}.".encode(),
+        )
+        # Participant return subscriptions are added dynamically on join.
 
         self._seq: dict[tuple[str, str], int] = defaultdict(int)
 
@@ -115,13 +133,110 @@ class ConnectorEndpoint:
 
     async def register(self) -> None:
         """
-        Announce this connector to the hub.
+        Create this connector's ring and register it with the hub.
 
-        Must be called once before pushing any media. The hub opens the
-        ring buffer upon receiving the registration message.
+        The method returns only after the hub has attached and validated the
+        ring. Missing shared memory causes bounded recreation with a fresh
+        name; incompatible rings and acknowledgement timeouts fail startup.
         """
-        reg = ConnectorRegistration(connector_id=self._connector_id, shm_name=self._shm_name)
-        await self._push.send(encode(MsgType.CONNECTOR_REGISTER, reg))
+        timeout = _DEFAULT_REGISTRATION_TIMEOUT_S
+        max_attempts = _DEFAULT_REGISTRATION_ATTEMPTS
+
+        for attempt in range(1, max_attempts + 1):
+            if self._ring is None:
+                self._create_ring()
+            reg = ConnectorRegistration(
+                connector_id=self._connector_id,
+                shm_name=self._shm_name,
+            )
+            ack = await self._request_registration(reg, timeout)
+            if ack["success"]:
+                self._registered = True
+                logger.info(
+                    "Connector {} registration acknowledged (shm={})",
+                    self._connector_id,
+                    self._shm_name,
+                )
+                return
+            if ack["error_code"] == "shm_not_found" and attempt < max_attempts:
+                logger.warning(
+                    "Hub could not attach connector {} shared memory {}; "
+                    "recreating ring ({}/{})",
+                    self._connector_id,
+                    self._shm_name,
+                    attempt,
+                    max_attempts,
+                )
+                self._destroy_ring()
+                continue
+            self._registered = False
+            raise _ConnectorRegistrationError(
+                str(ack["error_code"] or "registration_failed"),
+                str(ack["error_message"] or "hub rejected shared-memory registration"),
+            )
+
+    def _create_ring(self) -> None:
+        """Create a connector-owned ring immediately before registration."""
+        self._ring_generation += 1
+        self._shm_name = (
+            self._shm_base_name
+            if self._ring_generation == 1
+            else f"{self._shm_base_name}_{uuid.uuid4().hex[:8]}"
+        )
+        try:
+            self._ring = ShmRingBuffer(
+                name=self._shm_name,
+                num_slots=self._num_slots,
+                max_frame_bytes=self._max_frame_bytes,
+                create=True,
+            )
+        except Exception as exc:
+            raise _ConnectorRegistrationError(
+                "shm_create_failed",
+                f"could not create shared memory {self._shm_name!r}: {exc}",
+            ) from exc
+
+    async def _request_registration(
+        self,
+        reg: ConnectorRegistration,
+        timeout: float,
+    ) -> dict[str, Any]:
+        """Send until a correlated ACK arrives or the bounded timeout expires."""
+        async def exchange() -> dict[str, Any]:
+            while True:
+                await self._push.send(encode(MsgType.CONNECTOR_REGISTER, reg))
+                try:
+                    _topic, raw = await asyncio.wait_for(
+                        self._sub.recv_multipart(),
+                        timeout=_REGISTRATION_RESEND_INTERVAL_S,
+                    )
+                except TimeoutError:
+                    continue
+                type_id, ack = decode(raw)
+                if type_id == MsgType.CONTROL and ack.topic == _CONNECTOR_REGISTER_ACK_TOPIC:
+                    payload = ack.payload
+                    if (payload.get("connector_id"), payload.get("shm_name")) == (
+                        self._connector_id,
+                        reg.shm_name,
+                    ):
+                        return payload
+
+        try:
+            return await asyncio.wait_for(exchange(), timeout=timeout)
+        except TimeoutError:
+            self._registered = False
+            raise _ConnectorRegistrationError(
+                "registration_timeout",
+                f"hub did not acknowledge shared memory {reg.shm_name!r} within {timeout:g}s",
+            ) from None
+
+    def _require_registered_ring(self) -> ShmRingBuffer:
+        if not self._registered or self._ring is None:
+            raise _ConnectorRegistrationError(
+                "connector_not_registered",
+                "media cannot be accepted before shared-memory registration succeeds",
+            )
+        return self._ring
 
     # ── inbound media ─────────────────────────────────────────────────────────
 
@@ -140,11 +255,12 @@ class ConnectorEndpoint:
         the hub. Raises RuntimeError if all slots are occupied — caller should
         drop the frame and log a warning.
         """
+        ring = self._require_registered_ring()
         key = (participant_id, track_id)
         self._seq[key] += 1
         seq  = self._seq[key]
         data_size = data.nbytes if isinstance(data, memoryview) else len(data)
-        slot = self._ring.write_frame(data, width, height, fmt, pts_us, seq)
+        slot = ring.write_frame(data, width, height, fmt, pts_us, seq)
         sig  = FrameSignal(
             slot=slot, seq=seq, pts_us=pts_us,
             width=width, height=height, fmt=fmt, data_sz=data_size,
@@ -153,12 +269,15 @@ class ConnectorEndpoint:
         await self._push.send(encode(MsgType.FRAME_SIGNAL, sig))
 
     async def push_audio(self, chunk: AudioChunk) -> None:
+        self._require_registered_ring()
         await self._push.send(encode(MsgType.AUDIO_CHUNK, chunk))
 
     async def push_data(self, msg: DataMessage) -> None:
+        self._require_registered_ring()
         await self._push.send(encode(MsgType.DATA_MESSAGE, msg))
 
     async def send_control(self, msg: ControlMessage) -> None:
+        self._require_registered_ring()
         await self._push.send(encode(MsgType.CONTROL, msg))
 
     # ── participant lifecycle ─────────────────────────────────────────────────
@@ -171,6 +290,7 @@ class ConnectorEndpoint:
         The hub uses the embedded connector_id to maintain its participant →
         connector mapping.
         """
+        self._require_registered_ring()
         # Trailing "." terminates the pid segment so a subscription for `alice`
         # does not byte-prefix-match a topic addressed to `alice2`. The hub
         # publishes return topics with the same trailing delimiter (see
@@ -192,6 +312,7 @@ class ConnectorEndpoint:
         Unsubscribes from return traffic, cleans up sequence counters, and
         notifies the hub.
         """
+        self._require_registered_ring()
         self._sub.setsockopt(zmq.UNSUBSCRIBE, f"return_audio.{participant_id}.".encode())
         self._sub.setsockopt(zmq.UNSUBSCRIBE, f"return_audio_flush.{participant_id}.".encode())
         self._sub.setsockopt(zmq.UNSUBSCRIBE, f"return_data.{participant_id}.".encode())
@@ -239,6 +360,8 @@ class ConnectorEndpoint:
                 elif type_id == MsgType.RETURN_AUDIO_FLUSH:
                     for cb in self._return_audio_flush_cbs:
                         await cb(msg)
+                elif type_id == MsgType.CONTROL and msg.topic == _CONNECTOR_REGISTER_ACK_TOPIC:
+                    logger.debug("Ignoring stale connector registration ACK")
                 else:
                     logger.debug("Connector: unhandled return type {}", type_id)
             except Exception:
@@ -249,9 +372,17 @@ class ConnectorEndpoint:
     def stop(self) -> None:
         self._running = False
 
+    def _destroy_ring(self) -> None:
+        ring = self._ring
+        self._ring = None
+        self._registered = False
+        if ring is None:
+            return
+        ring.close()
+        ring.unlink()
+
     def close(self) -> None:
         """Close sockets and release the ring buffer. Unlinks the shm segment."""
         self._push.close(linger=0)
         self._sub.close(linger=0)
-        self._ring.close()
-        self._ring.unlink()
+        self._destroy_ring()

--- a/services/device-io-hub/device_io_hub/ipc/_connector.py
+++ b/services/device-io-hub/device_io_hub/ipc/_connector.py
@@ -34,6 +34,8 @@ from xr_ai_hub import (AudioChunk, ConnectorRegistration, ControlMessage, DataMe
                        FrameSignal, MsgType, ParticipantEvent, PixelFormat,
                        ReturnAudioFlush, ShmRingBuffer, decode, encode)
 
+from ._hub import _CONNECTOR_REGISTER_ACK_TOPIC
+
 ReturnAudioCallback      = Callable[[AudioChunk],        Awaitable[None]]
 ReturnDataCallback       = Callable[[DataMessage],       Awaitable[None]]
 ReturnAudioFlushCallback = Callable[[ReturnAudioFlush],  Awaitable[None]]
@@ -43,7 +45,6 @@ _DEFAULT_MAX_FRAME_BYTES = 12_441_600  # 4K NV12
 _DEFAULT_REGISTRATION_TIMEOUT_S = 3.0
 _DEFAULT_REGISTRATION_ATTEMPTS  = 3
 _REGISTRATION_RESEND_INTERVAL_S = 0.25
-_CONNECTOR_REGISTER_ACK_TOPIC = "_connector.registration_ack"
 
 
 class _ConnectorRegistrationError(RuntimeError):
@@ -51,8 +52,6 @@ class _ConnectorRegistrationError(RuntimeError):
 
     def __init__(self, code: str, message: str) -> None:
         super().__init__(f"{code}: {message}")
-        self.code = code
-        self.message = message
 
 
 class ConnectorEndpoint:
@@ -104,7 +103,6 @@ class ConnectorEndpoint:
         self._num_slots = num_slots
         self._max_frame_bytes = max_frame_bytes
         self._ring: ShmRingBuffer | None = None
-        self._ring_generation = 0
         self._registered = False
 
         ctx = zmq.asyncio.Context.instance()
@@ -177,10 +175,9 @@ class ConnectorEndpoint:
 
     def _create_ring(self) -> None:
         """Create a connector-owned ring immediately before registration."""
-        self._ring_generation += 1
         self._shm_name = (
             self._shm_base_name
-            if self._ring_generation == 1
+            if not self._shm_name
             else f"{self._shm_base_name}_{uuid.uuid4().hex[:8]}"
         )
         try:
@@ -202,27 +199,21 @@ class ConnectorEndpoint:
         timeout: float,
     ) -> dict[str, Any]:
         """Send until a correlated ACK arrives or the bounded timeout expires."""
-        async def exchange() -> dict[str, Any]:
-            while True:
-                await self._push.send(encode(MsgType.CONNECTOR_REGISTER, reg))
-                try:
-                    _topic, raw = await asyncio.wait_for(
-                        self._sub.recv_multipart(),
-                        timeout=_REGISTRATION_RESEND_INTERVAL_S,
-                    )
-                except TimeoutError:
-                    continue
-                type_id, ack = decode(raw)
-                if type_id == MsgType.CONTROL and ack.topic == _CONNECTOR_REGISTER_ACK_TOPIC:
-                    payload = ack.payload
-                    if (payload.get("connector_id"), payload.get("shm_name")) == (
-                        self._connector_id,
-                        reg.shm_name,
-                    ):
-                        return payload
-
         try:
-            return await asyncio.wait_for(exchange(), timeout=timeout)
+            async with asyncio.timeout(timeout):
+                while True:
+                    await self._push.send(encode(MsgType.CONNECTOR_REGISTER, reg))
+                    if not await self._sub.poll(timeout=_REGISTRATION_RESEND_INTERVAL_S * 1000):
+                        continue
+                    _topic, raw = await self._sub.recv_multipart()
+                    type_id, ack = decode(raw)
+                    if type_id == MsgType.CONTROL and ack.topic == _CONNECTOR_REGISTER_ACK_TOPIC:
+                        payload = ack.payload
+                        if (payload.get("connector_id"), payload.get("shm_name")) == (
+                            self._connector_id,
+                            reg.shm_name,
+                        ):
+                            return payload
         except TimeoutError:
             self._registered = False
             raise _ConnectorRegistrationError(
@@ -360,8 +351,6 @@ class ConnectorEndpoint:
                 elif type_id == MsgType.RETURN_AUDIO_FLUSH:
                     for cb in self._return_audio_flush_cbs:
                         await cb(msg)
-                elif type_id == MsgType.CONTROL and msg.topic == _CONNECTOR_REGISTER_ACK_TOPIC:
-                    logger.debug("Ignoring stale connector registration ACK")
                 else:
                     logger.debug("Connector: unhandled return type {}", type_id)
             except Exception:

--- a/services/device-io-hub/device_io_hub/ipc/_connector.py
+++ b/services/device-io-hub/device_io_hub/ipc/_connector.py
@@ -34,7 +34,7 @@ from xr_ai_hub import (AudioChunk, ConnectorRegistration, ControlMessage, DataMe
                        FrameSignal, MsgType, ParticipantEvent, PixelFormat,
                        ReturnAudioFlush, ShmRingBuffer, decode, encode)
 
-from ._hub import _CONNECTOR_REGISTER_ACK_TOPIC
+from ._registration import _CONNECTOR_REGISTER_ACK_TOPIC
 
 ReturnAudioCallback      = Callable[[AudioChunk],        Awaitable[None]]
 ReturnDataCallback       = Callable[[DataMessage],       Awaitable[None]]
@@ -61,6 +61,9 @@ class ConnectorEndpoint:
     Each instance owns a dedicated ring buffer so multiple connectors can
     write frames concurrently without any locking. The hub is agnostic to
     how many connectors exist or how many participants each carries.
+
+    Only video frames require successful shared-memory registration. Audio,
+    data, control messages, and participant events do not use the ring.
 
     Usage
     -----
@@ -136,6 +139,14 @@ class ConnectorEndpoint:
         The method returns only after the hub has attached and validated the
         ring. Missing shared memory causes bounded recreation with a fresh
         name; incompatible rings and acknowledgement timeouts fail startup.
+
+        Raises
+        ------
+        RuntimeError
+            If the ring cannot be created, the hub rejects attachment or layout
+            validation, or no matching acknowledgement arrives before the
+            timeout. Missing segments are retried a bounded number of times
+            before raising. Call :meth:`close` to release resources after failure.
         """
         timeout = _DEFAULT_REGISTRATION_TIMEOUT_S
         max_attempts = _DEFAULT_REGISTRATION_ATTEMPTS
@@ -221,14 +232,6 @@ class ConnectorEndpoint:
                 f"hub did not acknowledge shared memory {reg.shm_name!r} within {timeout:g}s",
             ) from None
 
-    def _require_registered_ring(self) -> ShmRingBuffer:
-        if not self._registered or self._ring is None:
-            raise _ConnectorRegistrationError(
-                "connector_not_registered",
-                "media cannot be accepted before shared-memory registration succeeds",
-            )
-        return self._ring
-
     # ── inbound media ─────────────────────────────────────────────────────────
 
     async def push_frame(
@@ -243,10 +246,23 @@ class ConnectorEndpoint:
     ) -> None:
         """
         Write a decoded CPU frame into this connector's ring buffer and signal
-        the hub. Raises RuntimeError if all slots are occupied — caller should
-        drop the frame and log a warning.
+        the hub.
+
+        Raises
+        ------
+        RuntimeError
+            If shared-memory registration has not succeeded, the ring has been
+            closed, or all slots are occupied. Drop the frame and log the reason.
+        ValueError
+            If the frame exceeds the slot capacity or its memoryview is not
+            contiguous.
         """
-        ring = self._require_registered_ring()
+        ring = self._ring
+        if not self._registered or ring is None:
+            raise _ConnectorRegistrationError(
+                "connector_not_registered",
+                "video cannot be accepted before shared-memory registration succeeds",
+            )
         key = (participant_id, track_id)
         self._seq[key] += 1
         seq  = self._seq[key]
@@ -260,15 +276,12 @@ class ConnectorEndpoint:
         await self._push.send(encode(MsgType.FRAME_SIGNAL, sig))
 
     async def push_audio(self, chunk: AudioChunk) -> None:
-        self._require_registered_ring()
         await self._push.send(encode(MsgType.AUDIO_CHUNK, chunk))
 
     async def push_data(self, msg: DataMessage) -> None:
-        self._require_registered_ring()
         await self._push.send(encode(MsgType.DATA_MESSAGE, msg))
 
     async def send_control(self, msg: ControlMessage) -> None:
-        self._require_registered_ring()
         await self._push.send(encode(MsgType.CONTROL, msg))
 
     # ── participant lifecycle ─────────────────────────────────────────────────
@@ -281,7 +294,6 @@ class ConnectorEndpoint:
         The hub uses the embedded connector_id to maintain its participant →
         connector mapping.
         """
-        self._require_registered_ring()
         # Trailing "." terminates the pid segment so a subscription for `alice`
         # does not byte-prefix-match a topic addressed to `alice2`. The hub
         # publishes return topics with the same trailing delimiter (see
@@ -303,7 +315,6 @@ class ConnectorEndpoint:
         Unsubscribes from return traffic, cleans up sequence counters, and
         notifies the hub.
         """
-        self._require_registered_ring()
         self._sub.setsockopt(zmq.UNSUBSCRIBE, f"return_audio.{participant_id}.".encode())
         self._sub.setsockopt(zmq.UNSUBSCRIBE, f"return_audio_flush.{participant_id}.".encode())
         self._sub.setsockopt(zmq.UNSUBSCRIBE, f"return_data.{participant_id}.".encode())

--- a/services/device-io-hub/device_io_hub/ipc/_hub.py
+++ b/services/device-io-hub/device_io_hub/ipc/_hub.py
@@ -46,9 +46,12 @@ import zmq
 import zmq.asyncio
 
 from xr_ai_hub import (AGENT_STATUS_TOPIC, AudioChunk, ConnectorRegistration,
-                       ControlMessage, DataMessage, FrameData, MsgType,
-                       ParticipantEvent, ReturnAudioFlush, ShmRingBuffer, SlotView,
-                       decode, encode)
+                       ControlMessage, DataMessage, FrameData,
+                       MsgType, ParticipantEvent,
+                       ReturnAudioFlush, ShmRingBuffer, SlotView, decode, encode)
+from xr_ai_hub._shm import _IncompatibleSharedMemoryError
+
+from ._connector import _CONNECTOR_REGISTER_ACK_TOPIC
 
 
 def _now_us() -> int:
@@ -106,6 +109,8 @@ class HubEndpoint:
 
         # connector_id → ShmRingBuffer (opened on CONNECTOR_REGISTER)
         self._ring_registry: dict[str, ShmRingBuffer] = {}
+        # Connector IDs whose missing ring forced hub shutdown.
+        self._unhealthy_connectors: set[str] = set()
         # participant_id → connector_id (updated on PARTICIPANT_EVENT)
         self._participant_connector: dict[str, str] = {}
         # (participant_id, track_id) → (ring, SlotView) of the latest frame.
@@ -314,7 +319,7 @@ class HubEndpoint:
 
     async def _dispatch(self, type_id: int, msg) -> None:
         if type_id == MsgType.CONNECTOR_REGISTER:
-            self._handle_registration(msg)
+            await self._handle_registration(msg)
 
         elif type_id == MsgType.FRAME_SIGNAL:
             connector_id = self._participant_connector.get(msg.participant_id)
@@ -323,7 +328,11 @@ class HubEndpoint:
                 return
             ring = self._ring_registry.get(connector_id)
             if ring is None:
-                logger.warning("Ring buffer for connector {} not found — dropped", connector_id)
+                self._mark_connector_unhealthy(
+                    connector_id,
+                    f"frame for participant {msg.participant_id!r} referenced a connector "
+                    "without a registered shared-memory ring",
+                )
                 return
 
             key = (msg.participant_id, msg.track_id)
@@ -532,34 +541,86 @@ class HubEndpoint:
                 b"participant", encode(MsgType.PARTICIPANT_EVENT, event),
             ])
 
-    def _handle_registration(self, reg: ConnectorRegistration) -> None:
-        if reg.connector_id in self._ring_registry:
-            logger.warning("Connector {} re-registered — replacing ring buffer", reg.connector_id)
-            old_ring = self._ring_registry.pop(reg.connector_id)
-            # Drop any frames still held in the old ring BEFORE closing it.
-            # A live SlotView keeps a sliced memoryview exported into the ring's
-            # mmap; closing with that outstanding makes ShmRingBuffer.close()'s
-            # self._buf.release() raise BufferError, and leaves _latest_slots
-            # referencing a half-closed ring whose slot the next FRAME_SIGNAL
-            # would write through (#197).
-            for key in [k for k, (ring, _) in self._latest_slots.items() if ring is old_ring]:
-                _, view = self._latest_slots.pop(key)
-                self._release_held_slot(
-                    old_ring,
-                    view,
-                    context=f"re-registration of {reg.connector_id}",
-                )
-            old_ring.close()
+    async def _acknowledge_registration(
+        self,
+        reg: ConnectorRegistration,
+        error_code: str = "",
+        error_message: str = "",
+    ) -> None:
+        ack = ControlMessage(
+            topic=_CONNECTOR_REGISTER_ACK_TOPIC,
+            payload={
+                "connector_id": reg.connector_id,
+                "shm_name": reg.shm_name,
+                "success": not error_code,
+                "error_code": error_code,
+                "error_message": error_message,
+            },
+        )
+        await self._pub.send_multipart([
+            f"connector.{reg.connector_id}.".encode(),
+            encode(MsgType.CONTROL, ack),
+        ])
+
+    def _mark_connector_unhealthy(
+        self,
+        connector_id: str,
+        error_message: str,
+    ) -> None:
+        self._unhealthy_connectors.add(connector_id)
+        logger.error("Connector {} unhealthy: {}", connector_id, error_message)
+        self.stop()
+
+    async def _handle_registration(self, reg: ConnectorRegistration) -> None:
         try:
-            self._ring_registry[reg.connector_id] = ShmRingBuffer(
-                name=reg.shm_name, create=False,
+            new_ring = ShmRingBuffer(name=reg.shm_name, create=False)
+        except FileNotFoundError:
+            error_code = "shm_not_found"
+            error_message = f"shared memory {reg.shm_name!r} does not exist"
+        except _IncompatibleSharedMemoryError as exc:
+            error_code = "shm_incompatible"
+            error_message = f"shared memory {reg.shm_name!r} is incompatible: {exc}"
+        except Exception as exc:
+            error_code = "shm_open_failed"
+            error_message = f"could not open shared memory {reg.shm_name!r}: {exc}"
+            logger.opt(exception=exc).error(
+                "Failed to register connector {} using shm {}",
+                reg.connector_id,
+                reg.shm_name,
             )
+        else:
+            old_ring = self._ring_registry.get(reg.connector_id)
+            if old_ring is not None:
+                logger.warning(
+                    "Connector {} re-registered — replacing ring buffer",
+                    reg.connector_id,
+                )
+                # Drop held frames before closing the old consumer mapping. A
+                # SlotView exports a memoryview into the mapping and would leave
+                # a half-closed ring behind if it survived replacement (#197).
+                for key in [
+                    k for k, (ring, _) in self._latest_slots.items()
+                    if ring is old_ring
+                ]:
+                    _, view = self._latest_slots.pop(key)
+                    self._release_held_slot(
+                        old_ring,
+                        view,
+                        context=f"re-registration of {reg.connector_id}",
+                    )
+                old_ring.close()
+            self._ring_registry[reg.connector_id] = new_ring
+            self._unhealthy_connectors.discard(reg.connector_id)
             logger.info("Connector {} registered (shm={})", reg.connector_id, reg.shm_name)
-        except Exception:
-            logger.exception(
-                "Failed to open shm {} for connector {}",
-                reg.shm_name, reg.connector_id,
-            )
+            await self._acknowledge_registration(reg)
+            return
+
+        logger.warning(
+            "Failed to register connector {}: {}",
+            reg.connector_id,
+            error_message,
+        )
+        await self._acknowledge_registration(reg, error_code, error_message)
 
     # ── lifecycle ─────────────────────────────────────────────────────────────
 
@@ -575,3 +636,4 @@ class HubEndpoint:
         for ring in self._ring_registry.values():
             ring.close()
         self._ring_registry.clear()
+        self._unhealthy_connectors.clear()

--- a/services/device-io-hub/device_io_hub/ipc/_hub.py
+++ b/services/device-io-hub/device_io_hub/ipc/_hub.py
@@ -46,12 +46,9 @@ import zmq
 import zmq.asyncio
 
 from xr_ai_hub import (AGENT_STATUS_TOPIC, AudioChunk, ConnectorRegistration,
-                       ControlMessage, DataMessage, FrameData,
-                       MsgType, ParticipantEvent,
-                       ReturnAudioFlush, ShmRingBuffer, SlotView, decode, encode)
-from xr_ai_hub._shm import _IncompatibleSharedMemoryError
-
-from ._connector import _CONNECTOR_REGISTER_ACK_TOPIC
+                       ControlMessage, DataMessage, FrameData, MsgType,
+                       ParticipantEvent, ReturnAudioFlush, ShmRingBuffer, SlotView,
+                       decode, encode)
 
 
 def _now_us() -> int:
@@ -86,6 +83,7 @@ TOPIC_CONTROL            = b"control"
 TOPIC_RETURN_AUDIO       = b"return_audio"
 TOPIC_RETURN_AUDIO_FLUSH = b"return_audio_flush"
 TOPIC_RETURN_DATA        = b"return_data"
+_CONNECTOR_REGISTER_ACK_TOPIC = "_connector.registration_ack"
 
 
 class HubEndpoint:
@@ -109,8 +107,7 @@ class HubEndpoint:
 
         # connector_id → ShmRingBuffer (opened on CONNECTOR_REGISTER)
         self._ring_registry: dict[str, ShmRingBuffer] = {}
-        # Connector IDs whose missing ring forced hub shutdown.
-        self._unhealthy_connectors: set[str] = set()
+        self._ring_names: dict[str, str] = {}
         # participant_id → connector_id (updated on PARTICIPANT_EVENT)
         self._participant_connector: dict[str, str] = {}
         # (participant_id, track_id) → (ring, SlotView) of the latest frame.
@@ -328,11 +325,7 @@ class HubEndpoint:
                 return
             ring = self._ring_registry.get(connector_id)
             if ring is None:
-                self._mark_connector_unhealthy(
-                    connector_id,
-                    f"frame for participant {msg.participant_id!r} referenced a connector "
-                    "without a registered shared-memory ring",
-                )
+                logger.warning("Ring buffer for connector {} not found — dropped", connector_id)
                 return
 
             key = (msg.participant_id, msg.track_id)
@@ -562,22 +555,16 @@ class HubEndpoint:
             encode(MsgType.CONTROL, ack),
         ])
 
-    def _mark_connector_unhealthy(
-        self,
-        connector_id: str,
-        error_message: str,
-    ) -> None:
-        self._unhealthy_connectors.add(connector_id)
-        logger.error("Connector {} unhealthy: {}", connector_id, error_message)
-        self.stop()
-
     async def _handle_registration(self, reg: ConnectorRegistration) -> None:
+        if self._ring_names.get(reg.connector_id) == reg.shm_name:
+            await self._acknowledge_registration(reg)
+            return
         try:
             new_ring = ShmRingBuffer(name=reg.shm_name, create=False)
         except FileNotFoundError:
             error_code = "shm_not_found"
             error_message = f"shared memory {reg.shm_name!r} does not exist"
-        except _IncompatibleSharedMemoryError as exc:
+        except ValueError as exc:
             error_code = "shm_incompatible"
             error_message = f"shared memory {reg.shm_name!r} is incompatible: {exc}"
         except Exception as exc:
@@ -610,7 +597,7 @@ class HubEndpoint:
                     )
                 old_ring.close()
             self._ring_registry[reg.connector_id] = new_ring
-            self._unhealthy_connectors.discard(reg.connector_id)
+            self._ring_names[reg.connector_id] = reg.shm_name
             logger.info("Connector {} registered (shm={})", reg.connector_id, reg.shm_name)
             await self._acknowledge_registration(reg)
             return
@@ -636,4 +623,4 @@ class HubEndpoint:
         for ring in self._ring_registry.values():
             ring.close()
         self._ring_registry.clear()
-        self._unhealthy_connectors.clear()
+        self._ring_names.clear()

--- a/services/device-io-hub/device_io_hub/ipc/_hub.py
+++ b/services/device-io-hub/device_io_hub/ipc/_hub.py
@@ -50,6 +50,8 @@ from xr_ai_hub import (AGENT_STATUS_TOPIC, AudioChunk, ConnectorRegistration,
                        ParticipantEvent, ReturnAudioFlush, ShmRingBuffer, SlotView,
                        decode, encode)
 
+from ._registration import _CONNECTOR_REGISTER_ACK_TOPIC
+
 
 def _now_us() -> int:
     return time.time_ns() // 1_000
@@ -83,7 +85,6 @@ TOPIC_CONTROL            = b"control"
 TOPIC_RETURN_AUDIO       = b"return_audio"
 TOPIC_RETURN_AUDIO_FLUSH = b"return_audio_flush"
 TOPIC_RETURN_DATA        = b"return_data"
-_CONNECTOR_REGISTER_ACK_TOPIC = "_connector.registration_ack"
 
 
 class HubEndpoint:

--- a/services/device-io-hub/device_io_hub/ipc/_registration.py
+++ b/services/device-io-hub/device_io_hub/ipc/_registration.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Private registration handshake shared by the producer and hub."""
+
+_CONNECTOR_REGISTER_ACK_TOPIC = "_connector.registration_ack"

--- a/services/device-io-hub/device_io_hub/transport/livekit/_room_client.py
+++ b/services/device-io-hub/device_io_hub/transport/livekit/_room_client.py
@@ -488,10 +488,10 @@ class RoomClient:
                         participant_id=identity,
                         track_id=track_id,
                     )
-                except RuntimeError:
+                except RuntimeError as exc:
                     logger.warning(
-                        "Ring buffer full — dropped frame from {!r}/{!r}",
-                        identity, track_id,
+                        "Frame from {!r}/{!r} dropped: {}",
+                        identity, track_id, exc,
                     )
                 except ValueError as exc:
                     logger.warning(

--- a/services/device-io-hub/device_io_hub/transport/livekit/connector.py
+++ b/services/device-io-hub/device_io_hub/transport/livekit/connector.py
@@ -37,7 +37,13 @@ from typing import Awaitable, Callable
 
 from loguru import logger
 
-from device_io_hub.ipc import AudioChunk, ConnectorEndpoint, DataMessage
+from device_io_hub._errors import StartupError
+from device_io_hub.ipc import (
+    AudioChunk,
+    ConnectorEndpoint,
+    DataMessage,
+)
+from device_io_hub.ipc._connector import _ConnectorRegistrationError
 
 from ._docker import LiveKitDocker
 from ._hwcodec import require_nvidia_video_codecs
@@ -63,6 +69,7 @@ class LiveKitConnector:
             max_frame_bytes=self._cfg.shm_max_frame_bytes,
         )
         self._room_client = RoomClient(self._cfg, self._ep)
+        self._room_connected = False
 
     # ── callback registration ─────────────────────────────────────────────────
 
@@ -78,14 +85,24 @@ class LiveKitConnector:
 
     async def start(self) -> None:
         """Start Docker, optional servers, register IPC endpoint, connect room client."""
-        require_nvidia_video_codecs()
-        await self._docker.start()
-        if self._token:
-            await self._token.start()
-        if self._web:
-            await self._web.start()
-        await self._ep.register()
-        await self._room_client.connect()
+        try:
+            require_nvidia_video_codecs()
+            await self._docker.start()
+            if self._token:
+                await self._token.start()
+            if self._web:
+                await self._web.start()
+            # Ring creation happens inside register(), after the expensive
+            # services above and immediately before the IPC handshake.
+            await self._ep.register()
+            await self._room_client.connect()
+            self._room_connected = True
+        except _ConnectorRegistrationError as exc:
+            await self.stop()
+            raise StartupError(
+                "DeviceIOHub video IPC registration failed; LiveKit media was not accepted.\n"
+                f"{exc}"
+            ) from exc
         self._ep.on_return_data(self._room_client.send_return_data)
         self._ep.on_return_audio(self._room_client.send_return_audio)
         self._ep.on_return_audio_flush(self._room_client.flush_return_audio)
@@ -127,7 +144,8 @@ class LiveKitConnector:
         docker_task = asyncio.create_task(self._docker.stop(), name="docker-stop")
         self._ep.stop()
         self._room_client.stop()
-        await self._room_client.disconnect()
+        if self._room_connected:
+            await self._room_client.disconnect()
         self._ep.close()
         if self._web:
             await self._web.stop()

--- a/services/device-io-hub/device_io_hub/transport/livekit/connector.py
+++ b/services/device-io-hub/device_io_hub/transport/livekit/connector.py
@@ -69,7 +69,7 @@ class LiveKitConnector:
             max_frame_bytes=self._cfg.shm_max_frame_bytes,
         )
         self._room_client = RoomClient(self._cfg, self._ep)
-        self._room_connected = False
+        self._room_connect_started = False
 
     # ── callback registration ─────────────────────────────────────────────────
 
@@ -95,18 +95,26 @@ class LiveKitConnector:
             # Ring creation happens inside register(), after the expensive
             # services above and immediately before the IPC handshake.
             await self._ep.register()
+            self._room_connect_started = True
             await self._room_client.connect()
-            self._room_connected = True
-        except _ConnectorRegistrationError as exc:
+            self._ep.on_return_data(self._room_client.send_return_data)
+            self._ep.on_return_audio(self._room_client.send_return_audio)
+            self._ep.on_return_audio_flush(self._room_client.flush_return_audio)
+            logger.info("LiveKitConnector started — room={!r}", self._cfg.room_name)
+        except BaseException as exc:
             await self.stop()
-            raise StartupError(
-                "DeviceIOHub video IPC registration failed; LiveKit media was not accepted.\n"
-                f"{exc}"
-            ) from exc
-        self._ep.on_return_data(self._room_client.send_return_data)
-        self._ep.on_return_audio(self._room_client.send_return_audio)
-        self._ep.on_return_audio_flush(self._room_client.flush_return_audio)
-        logger.info("LiveKitConnector started — room={!r}", self._cfg.room_name)
+            if isinstance(exc, _ConnectorRegistrationError):
+                banner = "━" * 56
+                raise StartupError("\n".join([
+                    "",
+                    banner,
+                    "  DeviceIOHub video IPC registration failed — refusing to start",
+                    banner,
+                    "  LiveKit media was not accepted.",
+                    f"  {exc}",
+                    banner,
+                ])) from exc
+            raise
 
     async def run(self) -> None:
         """
@@ -144,7 +152,8 @@ class LiveKitConnector:
         docker_task = asyncio.create_task(self._docker.stop(), name="docker-stop")
         self._ep.stop()
         self._room_client.stop()
-        if self._room_connected:
+        if self._room_connect_started:
+            self._room_connect_started = False
             await self._room_client.disconnect()
         self._ep.close()
         if self._web:

--- a/services/device-io-hub/device_io_hub/transport/livekit/connector.py
+++ b/services/device-io-hub/device_io_hub/transport/livekit/connector.py
@@ -33,6 +33,7 @@ Usage
 from __future__ import annotations
 
 import asyncio
+from contextlib import AsyncExitStack
 from typing import Awaitable, Callable
 
 from loguru import logger
@@ -84,7 +85,17 @@ class LiveKitConnector:
     # ── lifecycle ─────────────────────────────────────────────────────────────
 
     async def start(self) -> None:
-        """Start Docker, optional servers, register IPC endpoint, connect room client."""
+        """Start Docker, optional servers, register IPC endpoint, connect room client.
+
+        Any startup failure triggers cleanup of owned resources. Cleanup errors
+        are logged without replacing the startup failure.
+
+        Raises
+        ------
+        RuntimeError
+            If shared-memory registration fails or a startup prerequisite is
+            not met. Operator-facing failures include a diagnostic banner.
+        """
         try:
             require_nvidia_video_codecs()
             await self._docker.start()
@@ -102,7 +113,10 @@ class LiveKitConnector:
             self._ep.on_return_audio_flush(self._room_client.flush_return_audio)
             logger.info("LiveKitConnector started — room={!r}", self._cfg.room_name)
         except BaseException as exc:
-            await self.stop()
+            try:
+                await self.stop()
+            except BaseException:
+                logger.exception("LiveKitConnector cleanup failed after startup failure")
             if isinstance(exc, _ConnectorRegistrationError):
                 banner = "━" * 56
                 raise StartupError("\n".join([
@@ -145,20 +159,24 @@ class LiveKitConnector:
                 logger.error("Connector task {!r} raised: {}", t.get_name(), exc)
 
     async def stop(self) -> None:
-        """Gracefully shut down all components in reverse-start order."""
+        """Shut down all components, attempting every cleanup even if one fails.
+
+        Cleanup errors propagate after every cleanup step has been attempted.
+        """
         logger.info("LiveKitConnector stopping…")
         # Start Docker shutdown immediately so it runs in parallel with the
         # other cleanup steps — docker compose down can take several seconds.
         docker_task = asyncio.create_task(self._docker.stop(), name="docker-stop")
-        self._ep.stop()
-        self._room_client.stop()
-        if self._room_connect_started:
-            self._room_connect_started = False
-            await self._room_client.disconnect()
-        self._ep.close()
-        if self._web:
-            await self._web.stop()
-        if self._token:
-            await self._token.stop()
-        await docker_task
+        async with AsyncExitStack() as cleanup:
+            cleanup.push_async_callback(asyncio.gather, docker_task)
+            if self._token:
+                cleanup.push_async_callback(self._token.stop)
+            if self._web:
+                cleanup.push_async_callback(self._web.stop)
+            cleanup.callback(self._ep.close)
+            if self._room_connect_started:
+                self._room_connect_started = False
+                cleanup.push_async_callback(self._room_client.disconnect)
+            cleanup.callback(self._room_client.stop)
+            cleanup.callback(self._ep.stop)
         logger.info("LiveKitConnector stopped")

--- a/services/device-io-hub/device_io_hub/transport/livekit/connector.py
+++ b/services/device-io-hub/device_io_hub/transport/livekit/connector.py
@@ -115,7 +115,7 @@ class LiveKitConnector:
         except BaseException as exc:
             try:
                 await self.stop()
-            except BaseException:
+            except (Exception, asyncio.CancelledError):
                 logger.exception("LiveKitConnector cleanup failed after startup failure")
             if isinstance(exc, _ConnectorRegistrationError):
                 banner = "━" * 56

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ Fixtures
 ``hub``                 — a running :class:`HubEndpoint`.
 ``make_connector``      — factory yielding fresh :class:`ConnectorEndpoint`s
                           tied to ``hub_addrs`` (each represents one client
-                          on its own ring buffer).
+                          with a ring buffer created during registration).
 ``make_processor``      — factory yielding fresh :class:`ProcessorEndpoint`s
                           (each represents one agent / consumer).
 ``settle``              — small ``await asyncio.sleep`` that lets ZMQ
@@ -139,7 +139,8 @@ async def hub(hub_addrs) -> AsyncIterator[HubEndpoint]:
 async def make_connector(hub_addrs):
     """Factory creating client-side ``ConnectorEndpoint``s wired to the hub.
 
-    Each call yields a fresh connector with its own ring buffer / shm name.
+    Each call yields a fresh connector with a unique shared-memory name;
+    its ring buffer is created when registration begins.
     The fixture cleans up every connector it produced when the test exits.
     """
     pull, pub = hub_addrs

--- a/tests/test_connector_registration.py
+++ b/tests/test_connector_registration.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared-memory registration handshake and connector health regressions."""
+from __future__ import annotations
+
+import asyncio
+
+import device_io_hub.ipc._connector as connector_module
+import device_io_hub.ipc._hub as hub_module
+import pytest
+from device_io_hub.ipc import (
+    ConnectorEndpoint,
+)
+from xr_ai_hub import PixelFormat
+from xr_ai_hub._shm import _IncompatibleSharedMemoryError
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_ring_is_created_only_when_registration_begins(
+    hub,
+    make_connector,
+    settle,
+):
+    connector = make_connector()
+    assert connector._ring is None
+    assert connector._shm_name == ""
+
+    await settle()
+    await connector.register()
+
+    assert connector._ring is not None
+    assert connector._registered is True
+    assert hub._ring_registry[connector._connector_id] is not None
+
+
+async def test_missing_ring_is_recreated_with_unique_name(
+    hub,
+    make_connector,
+    settle,
+    monkeypatch,
+):
+    connector = make_connector()
+    real_ring = hub_module.ShmRingBuffer
+    missing_name: str | None = None
+    attempted_names: list[str] = []
+
+    def fail_first_name(*, name: str, create: bool):
+        nonlocal missing_name
+        attempted_names.append(name)
+        if missing_name is None:
+            missing_name = name
+        if name == missing_name:
+            raise FileNotFoundError(name)
+        return real_ring(name=name, create=create)
+
+    monkeypatch.setattr(hub_module, "ShmRingBuffer", fail_first_name)
+    await settle()
+
+    await connector.register()
+
+    assert connector._registered is True
+    assert attempted_names[0] != attempted_names[-1]
+    assert connector._shm_name == attempted_names[-1]
+    assert connector._shm_name.startswith(f"{connector._shm_base_name}_")
+
+
+async def test_incompatible_ring_fails_without_connecting_media(
+    hub,
+    make_connector,
+    settle,
+    monkeypatch,
+):
+    connector = make_connector()
+
+    def reject_ring(*, name: str, create: bool):
+        raise _IncompatibleSharedMemoryError(f"invalid layout in {name}")
+
+    monkeypatch.setattr(hub_module, "ShmRingBuffer", reject_ring)
+    await settle()
+
+    with pytest.raises(connector_module._ConnectorRegistrationError, match="shm_incompatible"):
+        await connector.register()
+
+    assert connector._registered is False
+    with pytest.raises(
+        connector_module._ConnectorRegistrationError,
+        match="before shared-memory registration",
+    ):
+        await connector.push_frame(b"ABCD", 1, 1, PixelFormat.RGBA, 1)
+
+
+async def test_registration_acknowledgement_has_bounded_timeout(
+    hub_addrs,
+    monkeypatch,
+):
+    pull, pub = hub_addrs
+    connector = ConnectorEndpoint(
+        push_addr=pull,
+        sub_addr=pub,
+        connector_id="no-hub",
+        shm_name="xr_test_no_hub",
+        num_slots=1,
+        max_frame_bytes=64,
+    )
+    monkeypatch.setattr(connector_module, "_DEFAULT_REGISTRATION_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(connector_module, "_DEFAULT_REGISTRATION_ATTEMPTS", 1)
+    try:
+        with pytest.raises(
+            connector_module._ConnectorRegistrationError,
+            match="registration_timeout",
+        ):
+            await asyncio.wait_for(
+                connector.register(),
+                timeout=0.5,
+            )
+        assert connector._registered is False
+    finally:
+        connector.close()
+
+
+async def test_ring_creation_failure_is_structured(
+    make_connector,
+    monkeypatch,
+):
+    connector = make_connector()
+
+    def fail_create(**_kwargs):
+        raise FileExistsError("stale shared-memory name")
+
+    monkeypatch.setattr(connector_module, "ShmRingBuffer", fail_create)
+
+    with pytest.raises(connector_module._ConnectorRegistrationError, match="shm_create_failed"):
+        await connector.register()
+
+    assert connector._registered is False
+    assert connector._ring is None
+
+
+async def test_frame_without_registered_ring_marks_connector_unhealthy(
+    hub,
+    make_connector,
+    settle,
+):
+    connector = make_connector()
+    await settle()
+    await connector.register()
+    await connector.notify_participant_joined("alice", pts_us=1)
+    await settle()
+
+    consumer_ring = hub._ring_registry.pop(connector._connector_id)
+    consumer_ring.close()
+    await connector.push_frame(
+        b"ABCD",
+        width=1,
+        height=1,
+        fmt=PixelFormat.RGBA,
+        pts_us=2,
+        participant_id="alice",
+        track_id="camera",
+    )
+    await settle()
+    assert connector._connector_id in hub._unhealthy_connectors
+    assert hub._running is False

--- a/tests/test_connector_registration.py
+++ b/tests/test_connector_registration.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shared-memory registration handshake and connector health regressions."""
+"""Shared-memory registration handshake and frame-routing regressions."""
 from __future__ import annotations
 
 import asyncio
@@ -9,11 +9,7 @@ import asyncio
 import device_io_hub.ipc._connector as connector_module
 import device_io_hub.ipc._hub as hub_module
 import pytest
-from device_io_hub.ipc import (
-    ConnectorEndpoint,
-)
-from xr_ai_hub import PixelFormat
-from xr_ai_hub._shm import _IncompatibleSharedMemoryError
+from xr_ai_hub import FrameSignal, MsgType, ParticipantEvent, PixelFormat, encode
 
 pytestmark = pytest.mark.asyncio
 
@@ -51,8 +47,7 @@ async def test_missing_ring_is_recreated_with_unique_name(
         attempted_names.append(name)
         if missing_name is None:
             missing_name = name
-        if name == missing_name:
-            raise FileNotFoundError(name)
+            connector._ring.unlink()
         return real_ring(name=name, create=create)
 
     monkeypatch.setattr(hub_module, "ShmRingBuffer", fail_first_name)
@@ -75,7 +70,7 @@ async def test_incompatible_ring_fails_without_connecting_media(
     connector = make_connector()
 
     def reject_ring(*, name: str, create: bool):
-        raise _IncompatibleSharedMemoryError(f"invalid layout in {name}")
+        raise ValueError(f"invalid layout in {name}")
 
     monkeypatch.setattr(hub_module, "ShmRingBuffer", reject_ring)
     await settle()
@@ -92,32 +87,28 @@ async def test_incompatible_ring_fails_without_connecting_media(
 
 
 async def test_registration_acknowledgement_has_bounded_timeout(
-    hub_addrs,
+    hub,
+    make_connector,
     monkeypatch,
 ):
-    pull, pub = hub_addrs
-    connector = ConnectorEndpoint(
-        push_addr=pull,
-        sub_addr=pub,
-        connector_id="no-hub",
-        shm_name="xr_test_no_hub",
-        num_slots=1,
-        max_frame_bytes=64,
-    )
-    monkeypatch.setattr(connector_module, "_DEFAULT_REGISTRATION_TIMEOUT_S", 0.05)
+    connector = make_connector()
+    registrations = []
+
+    async def withhold_ack(reg, *_args):
+        registrations.append(reg)
+
+    monkeypatch.setattr(hub, "_acknowledge_registration", withhold_ack)
+    monkeypatch.setattr(connector_module, "_REGISTRATION_RESEND_INTERVAL_S", 0.01)
+    monkeypatch.setattr(connector_module, "_DEFAULT_REGISTRATION_TIMEOUT_S", 0.1)
     monkeypatch.setattr(connector_module, "_DEFAULT_REGISTRATION_ATTEMPTS", 1)
-    try:
-        with pytest.raises(
-            connector_module._ConnectorRegistrationError,
-            match="registration_timeout",
-        ):
-            await asyncio.wait_for(
-                connector.register(),
-                timeout=0.5,
-            )
-        assert connector._registered is False
-    finally:
-        connector.close()
+    with pytest.raises(
+        connector_module._ConnectorRegistrationError,
+        match="registration_timeout",
+    ):
+        await asyncio.wait_for(connector.register(), timeout=1.0)
+    assert connector._registered is False
+    assert len(registrations) >= 2
+    assert {reg.shm_name for reg in registrations} == {connector._shm_name}
 
 
 async def test_ring_creation_failure_is_structured(
@@ -138,7 +129,7 @@ async def test_ring_creation_failure_is_structured(
     assert connector._ring is None
 
 
-async def test_frame_without_registered_ring_marks_connector_unhealthy(
+async def test_frame_without_registered_ring_does_not_stop_hub(
     hub,
     make_connector,
     settle,
@@ -149,8 +140,13 @@ async def test_frame_without_registered_ring_marks_connector_unhealthy(
     await connector.notify_participant_joined("alice", pts_us=1)
     await settle()
 
-    consumer_ring = hub._ring_registry.pop(connector._connector_id)
-    consumer_ring.close()
+    await connector._push.send(encode(MsgType.PARTICIPANT_EVENT, ParticipantEvent(
+        participant_id="foreign", joined=True, pts_us=1, connector_id="unregistered",
+    )))
+    await connector._push.send(encode(MsgType.FRAME_SIGNAL, FrameSignal(
+        slot=0, seq=1, pts_us=2, width=1, height=1, fmt=PixelFormat.RGBA,
+        data_sz=4, participant_id="foreign", track_id="camera",
+    )))
     await connector.push_frame(
         b"ABCD",
         width=1,
@@ -161,5 +157,47 @@ async def test_frame_without_registered_ring_marks_connector_unhealthy(
         track_id="camera",
     )
     await settle()
-    assert connector._connector_id in hub._unhealthy_connectors
-    assert hub._running is False
+    assert ("foreign", "camera") not in hub._latest_slots
+    assert bytes(hub._latest_slots[("alice", "camera")][1].data) == b"ABCD"
+    assert hub._running is True
+
+
+async def test_duplicate_registration_preserves_mapping_and_held_frame(
+    hub, make_connector, settle, monkeypatch,
+):
+    connector = make_connector()
+    await connector.register()
+    await connector.notify_participant_joined("alice", pts_us=1)
+    await connector.push_frame(b"ABCD", 1, 1, PixelFormat.RGBA, 2, "alice", "camera")
+    await settle()
+    ring = hub._ring_registry[connector._connector_id]
+    held = hub._latest_slots[("alice", "camera")]
+
+    def unexpected_attach(**_kwargs):
+        pytest.fail("duplicate registration must not reattach the segment")
+
+    monkeypatch.setattr(hub_module, "ShmRingBuffer", unexpected_attach)
+    await connector.register()
+
+    assert hub._ring_registry[connector._connector_id] is ring
+    assert hub._latest_slots[("alice", "camera")] is held
+    assert bytes(held[1].data) == b"ABCD"
+
+
+async def test_registration_resend_recovers_a_lost_ack(hub, make_connector, monkeypatch):
+    connector = make_connector()
+    acknowledge = hub._acknowledge_registration
+    registered_rings = []
+
+    async def drop_first_ack(reg, *args):
+        registered_rings.append(hub._ring_registry[reg.connector_id])
+        if len(registered_rings) > 1:
+            await acknowledge(reg, *args)
+
+    monkeypatch.setattr(hub, "_acknowledge_registration", drop_first_ack)
+    monkeypatch.setattr(connector_module, "_REGISTRATION_RESEND_INTERVAL_S", 0.01)
+    await asyncio.wait_for(connector.register(), timeout=1.0)
+
+    assert connector._registered is True
+    assert len(registered_rings) >= 2
+    assert all(ring is registered_rings[0] for ring in registered_rings)

--- a/tests/test_connector_registration.py
+++ b/tests/test_connector_registration.py
@@ -5,11 +5,21 @@
 from __future__ import annotations
 
 import asyncio
+from unittest.mock import AsyncMock
 
 import device_io_hub.ipc._connector as connector_module
 import device_io_hub.ipc._hub as hub_module
 import pytest
-from xr_ai_hub import FrameSignal, MsgType, ParticipantEvent, PixelFormat, encode
+from xr_ai_hub import (
+    AudioChunk,
+    ControlMessage,
+    DataMessage,
+    FrameSignal,
+    MsgType,
+    ParticipantEvent,
+    PixelFormat,
+    encode,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -75,12 +85,12 @@ async def test_incompatible_ring_fails_without_connecting_media(
     monkeypatch.setattr(hub_module, "ShmRingBuffer", reject_ring)
     await settle()
 
-    with pytest.raises(connector_module._ConnectorRegistrationError, match="shm_incompatible"):
+    with pytest.raises(RuntimeError, match="shm_incompatible"):
         await connector.register()
 
     assert connector._registered is False
     with pytest.raises(
-        connector_module._ConnectorRegistrationError,
+        RuntimeError,
         match="before shared-memory registration",
     ):
         await connector.push_frame(b"ABCD", 1, 1, PixelFormat.RGBA, 1)
@@ -102,7 +112,7 @@ async def test_registration_acknowledgement_has_bounded_timeout(
     monkeypatch.setattr(connector_module, "_DEFAULT_REGISTRATION_TIMEOUT_S", 0.1)
     monkeypatch.setattr(connector_module, "_DEFAULT_REGISTRATION_ATTEMPTS", 1)
     with pytest.raises(
-        connector_module._ConnectorRegistrationError,
+        RuntimeError,
         match="registration_timeout",
     ):
         await asyncio.wait_for(connector.register(), timeout=1.0)
@@ -122,11 +132,42 @@ async def test_ring_creation_failure_is_structured(
 
     monkeypatch.setattr(connector_module, "ShmRingBuffer", fail_create)
 
-    with pytest.raises(connector_module._ConnectorRegistrationError, match="shm_create_failed"):
+    with pytest.raises(RuntimeError, match="shm_create_failed"):
         await connector.register()
 
     assert connector._registered is False
     assert connector._ring is None
+
+
+async def test_non_video_messages_do_not_require_a_ring(hub, make_connector, settle):
+    connector = make_connector()
+    audio_received = AsyncMock()
+    data_received = AsyncMock()
+    control_received = AsyncMock()
+    participant_received = AsyncMock()
+    hub.on_audio(audio_received)
+    hub.on_data(data_received)
+    hub.on_control(control_received)
+    hub.on_participant(participant_received)
+    chunk = AudioChunk(pts_us=1, sample_rate=16000, channels=1, samples=1, data=b"\0" * 4)
+    data = DataMessage(participant_id="default", topic="chat", pts_us=1, data=b"hello")
+    control = ControlMessage(topic="test", payload={"enabled": True})
+
+    await connector.notify_participant_joined("default", pts_us=1)
+    await connector.push_audio(chunk)
+    await connector.push_data(data)
+    await connector.send_control(control)
+    await connector.notify_participant_left("default", pts_us=2)
+    await settle()
+
+    audio_received.assert_awaited_once_with(chunk)
+    data_received.assert_awaited_once_with(data)
+    control_received.assert_awaited_once_with(control)
+    assert [call.args[0].joined for call in participant_received.await_args_list] == [True, False]
+    assert connector._ring is None
+    assert not connector._registered
+    with pytest.raises(RuntimeError, match="before shared-memory registration"):
+        await connector.push_frame(b"ABCD", 1, 1, PixelFormat.RGBA, 1)
 
 
 async def test_frame_without_registered_ring_does_not_stop_hub(

--- a/tests/test_device_io_hub_startup.py
+++ b/tests/test_device_io_hub_startup.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DeviceIOHub startup ordering and readiness regressions."""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import device_io_hub.__main__ as hub_main
+import pytest
+from device_io_hub._errors import StartupError
+from device_io_hub.ipc._connector import _ConnectorRegistrationError
+from device_io_hub.transport.livekit import connector as connector_module
+
+
+@pytest.mark.asyncio
+async def test_registration_failure_never_creates_ready_file(
+    monkeypatch,
+    tmp_path,
+):
+    receive_started = asyncio.Event()
+
+    class FakeHub:
+        def on_frame(self, _callback): pass
+        def on_audio(self, _callback): pass
+        def on_data(self, _callback): pass
+        def on_participant(self, _callback): pass
+
+        async def run(self):
+            receive_started.set()
+            await asyncio.Event().wait()
+
+        def stop(self): pass
+        def close(self): pass
+
+    class FakeConnector:
+        async def start(self):
+            assert receive_started.is_set()
+            raise StartupError("registration failed")
+
+    connector = FakeConnector()
+    monkeypatch.setattr(hub_main, "setup_logging", lambda _name: None)
+    monkeypatch.setattr(
+        hub_main,
+        "load_config",
+        lambda: SimpleNamespace(
+            hub_push_addr="ipc://unused-in",
+            hub_sub_addr="ipc://unused-out",
+        ),
+    )
+    monkeypatch.setattr(hub_main, "HubEndpoint", lambda **_kwargs: FakeHub())
+    monkeypatch.setattr(hub_main, "LiveKitConnector", lambda _cfg: connector)
+    ready_file = tmp_path / "hub.ready"
+
+    with pytest.raises(StartupError, match="registration failed"):
+        await hub_main.main(ready_file=ready_file)
+
+    assert receive_started.is_set()
+    assert not ready_file.exists()
+
+
+@pytest.mark.asyncio
+async def test_livekit_room_is_not_connected_when_registration_fails(monkeypatch):
+    events: list[str] = []
+
+    class Service:
+        async def start(self):
+            events.append("service-start")
+
+        async def stop(self):
+            events.append("service-stop")
+
+    class Endpoint:
+        async def register(self):
+            events.append("register")
+            raise _ConnectorRegistrationError("shm_not_found", "segment disappeared")
+
+        def stop(self): pass
+        def close(self): events.append("endpoint-close")
+
+    class Room:
+        async def connect(self):
+            events.append("room-connect")
+
+        def stop(self): pass
+
+    connector = connector_module.LiveKitConnector.__new__(
+        connector_module.LiveKitConnector
+    )
+    connector._cfg = SimpleNamespace(room_name="test")
+    connector._docker = Service()
+    connector._token = Service()
+    connector._web = Service()
+    connector._ep = Endpoint()
+    connector._room_client = Room()
+    connector._room_connected = False
+    monkeypatch.setattr(connector_module, "require_nvidia_video_codecs", lambda: None)
+
+    with pytest.raises(StartupError, match="shm_not_found"):
+        await connector.start()
+
+    assert events[:4] == ["service-start", "service-start", "service-start", "register"]
+    assert "room-connect" not in events
+    assert "endpoint-close" in events

--- a/tests/test_device_io_hub_startup.py
+++ b/tests/test_device_io_hub_startup.py
@@ -30,23 +30,28 @@ async def test_registration_failure_never_creates_ready_file(main_runtime):
     assert all(task.done() for task in runtime.tasks)
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize("stage", ["docker", "token", "web", "register", "connect", "cancel-connect"])
-async def test_connector_start_failure_cleans_up_all_resources(
-    hub, make_connector, monkeypatch, stage,
-):
-    endpoint = make_connector()
+@pytest.fixture
+def livekit_connector(hub, make_connector, monkeypatch):
     connector = connector_module.LiveKitConnector.__new__(connector_module.LiveKitConnector)
     connector._cfg = SimpleNamespace(room_name="test")
     connector._docker = SimpleNamespace(start=AsyncMock(), stop=AsyncMock())
     connector._token = SimpleNamespace(start=AsyncMock(), stop=AsyncMock())
     connector._web = SimpleNamespace(start=AsyncMock(), stop=AsyncMock())
-    connector._ep = endpoint
+    connector._ep = make_connector()
     connector._room_connect_started = False
     connector._room_client = SimpleNamespace(
         connect=AsyncMock(), disconnect=AsyncMock(), stop=Mock(),
+        send_return_data=AsyncMock(), send_return_audio=AsyncMock(), flush_return_audio=AsyncMock(),
     )
     monkeypatch.setattr(connector_module, "require_nvidia_video_codecs", lambda: None)
+    return connector
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stage", ["docker", "token", "web", "register", "connect", "cancel-connect"])
+async def test_connector_start_failure_cleans_up_all_resources(livekit_connector, monkeypatch, stage):
+    connector = livekit_connector
+    endpoint = connector._ep
     failure = asyncio.CancelledError() if stage == "cancel-connect" else RuntimeError(stage)
     if stage == "register":
         failure = _ConnectorRegistrationError("shm_not_found", "segment disappeared")
@@ -77,6 +82,59 @@ async def test_connector_start_failure_cleans_up_all_resources(
     assert endpoint._sub.closed
     with pytest.raises(FileNotFoundError):
         SharedMemory(name=endpoint._shm_base_name, create=False)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("startup_fails", [True, False])
+@pytest.mark.parametrize(
+    "cleanup_step", ["disconnect", "endpoint-stop", "room-stop", "endpoint-close", "web", "token", "docker"],
+)
+async def test_cleanup_failure_does_not_skip_later_steps(
+    livekit_connector, monkeypatch, startup_fails, cleanup_step,
+):
+    connector = livekit_connector
+    endpoint = connector._ep
+    start_error = ValueError("room connection failed")
+    cleanup_error = RuntimeError(f"{cleanup_step} cleanup failed")
+    endpoint_stop = Mock(wraps=endpoint.stop)
+    endpoint_close = Mock(wraps=endpoint.close)
+    monkeypatch.setattr(endpoint, "stop", endpoint_stop)
+    monkeypatch.setattr(endpoint, "close", endpoint_close)
+    operation = {
+        "disconnect": connector._room_client.disconnect,
+        "endpoint-stop": endpoint_stop,
+        "room-stop": connector._room_client.stop,
+        "endpoint-close": endpoint_close,
+        "web": connector._web.stop,
+        "token": connector._token.stop,
+        "docker": connector._docker.stop,
+    }[cleanup_step]
+    operation.side_effect = cleanup_error
+    try:
+        if startup_fails:
+            connector._room_client.connect.side_effect = start_error
+            with pytest.raises(ValueError) as caught:
+                await connector.start()
+            assert caught.value is start_error
+        else:
+            await connector.start()
+            with pytest.raises(RuntimeError) as caught:
+                await connector.stop()
+            assert caught.value is cleanup_error
+
+        endpoint_stop.assert_called_once()
+        endpoint_close.assert_called_once()
+        connector._room_client.stop.assert_called_once()
+        connector._room_client.disconnect.assert_awaited_once()
+        connector._web.stop.assert_awaited_once()
+        connector._token.stop.assert_awaited_once()
+        connector._docker.stop.assert_awaited_once()
+        if cleanup_step != "endpoint-close":
+            assert endpoint._ring is None
+            assert endpoint._push.closed
+            assert endpoint._sub.closed
+    finally:
+        operation.side_effect = None
 
 
 @pytest.fixture
@@ -127,8 +185,15 @@ def main_runtime(monkeypatch, tmp_path):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("stage", ["token", "recorder"])
-async def test_failure_after_connector_start_cleans_up_before_ready(main_runtime, monkeypatch, stage):
+@pytest.mark.parametrize("cleanup_failure", [None, "hub", "connector"])
+async def test_failure_after_connector_start_cleans_up_before_ready(
+    main_runtime, monkeypatch, stage, cleanup_failure,
+):
     runtime = main_runtime
+    if cleanup_failure == "hub":
+        runtime.hub.close.side_effect = RuntimeError("hub cleanup failed")
+    elif cleanup_failure == "connector":
+        runtime.connector.stop.side_effect = RuntimeError("connector cleanup failed")
     if stage == "token":
         monkeypatch.setattr(hub_main, "make_client_token", Mock(side_effect=ValueError("bad token")))
     else:

--- a/tests/test_device_io_hub_startup.py
+++ b/tests/test_device_io_hub_startup.py
@@ -5,7 +5,9 @@
 from __future__ import annotations
 
 import asyncio
+from multiprocessing.shared_memory import SharedMemory
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
 
 import device_io_hub.__main__ as hub_main
 import pytest
@@ -15,91 +17,167 @@ from device_io_hub.transport.livekit import connector as connector_module
 
 
 @pytest.mark.asyncio
-async def test_registration_failure_never_creates_ready_file(
-    monkeypatch,
-    tmp_path,
-):
-    receive_started = asyncio.Event()
-
-    class FakeHub:
-        def on_frame(self, _callback): pass
-        def on_audio(self, _callback): pass
-        def on_data(self, _callback): pass
-        def on_participant(self, _callback): pass
-
-        async def run(self):
-            receive_started.set()
-            await asyncio.Event().wait()
-
-        def stop(self): pass
-        def close(self): pass
-
-    class FakeConnector:
-        async def start(self):
-            assert receive_started.is_set()
-            raise StartupError("registration failed")
-
-    connector = FakeConnector()
-    monkeypatch.setattr(hub_main, "setup_logging", lambda _name: None)
-    monkeypatch.setattr(
-        hub_main,
-        "load_config",
-        lambda: SimpleNamespace(
-            hub_push_addr="ipc://unused-in",
-            hub_sub_addr="ipc://unused-out",
-        ),
-    )
-    monkeypatch.setattr(hub_main, "HubEndpoint", lambda **_kwargs: FakeHub())
-    monkeypatch.setattr(hub_main, "LiveKitConnector", lambda _cfg: connector)
-    ready_file = tmp_path / "hub.ready"
+async def test_registration_failure_never_creates_ready_file(main_runtime):
+    runtime = main_runtime
+    runtime.connector.start.side_effect = StartupError("registration failed")
 
     with pytest.raises(StartupError, match="registration failed"):
-        await hub_main.main(ready_file=ready_file)
+        await hub_main.main(ready_file=runtime.ready_file)
 
-    assert receive_started.is_set()
-    assert not ready_file.exists()
+    assert runtime.hub_started.is_set()
+    assert not runtime.ready_file.exists()
+    runtime.hub.close.assert_called_once()
+    assert all(task.done() for task in runtime.tasks)
 
 
 @pytest.mark.asyncio
-async def test_livekit_room_is_not_connected_when_registration_fails(monkeypatch):
-    events: list[str] = []
-
-    class Service:
-        async def start(self):
-            events.append("service-start")
-
-        async def stop(self):
-            events.append("service-stop")
-
-    class Endpoint:
-        async def register(self):
-            events.append("register")
-            raise _ConnectorRegistrationError("shm_not_found", "segment disappeared")
-
-        def stop(self): pass
-        def close(self): events.append("endpoint-close")
-
-    class Room:
-        async def connect(self):
-            events.append("room-connect")
-
-        def stop(self): pass
-
-    connector = connector_module.LiveKitConnector.__new__(
-        connector_module.LiveKitConnector
-    )
+@pytest.mark.parametrize("stage", ["docker", "token", "web", "register", "connect", "cancel-connect"])
+async def test_connector_start_failure_cleans_up_all_resources(
+    hub, make_connector, monkeypatch, stage,
+):
+    endpoint = make_connector()
+    connector = connector_module.LiveKitConnector.__new__(connector_module.LiveKitConnector)
     connector._cfg = SimpleNamespace(room_name="test")
-    connector._docker = Service()
-    connector._token = Service()
-    connector._web = Service()
-    connector._ep = Endpoint()
-    connector._room_client = Room()
-    connector._room_connected = False
+    connector._docker = SimpleNamespace(start=AsyncMock(), stop=AsyncMock())
+    connector._token = SimpleNamespace(start=AsyncMock(), stop=AsyncMock())
+    connector._web = SimpleNamespace(start=AsyncMock(), stop=AsyncMock())
+    connector._ep = endpoint
+    connector._room_connect_started = False
+    connector._room_client = SimpleNamespace(
+        connect=AsyncMock(), disconnect=AsyncMock(), stop=Mock(),
+    )
     monkeypatch.setattr(connector_module, "require_nvidia_video_codecs", lambda: None)
+    failure = asyncio.CancelledError() if stage == "cancel-connect" else RuntimeError(stage)
+    if stage == "register":
+        failure = _ConnectorRegistrationError("shm_not_found", "segment disappeared")
+        monkeypatch.setattr(endpoint, "register", AsyncMock(side_effect=failure))
+    elif "connect" in stage:
+        connector._room_client.connect.side_effect = failure
+    else:
+        getattr(connector, f"_{stage}").start.side_effect = failure
 
-    with pytest.raises(StartupError, match="shm_not_found"):
+    with pytest.raises(StartupError if stage == "register" else type(failure)) as caught:
         await connector.start()
 
-    assert events[:4] == ["service-start", "service-start", "service-start", "register"]
-    assert "room-connect" not in events
-    assert "endpoint-close" in events
+    if stage == "register":
+        assert caught.value.__cause__ is failure
+        assert str(caught.value).startswith("\n" + "━" * 56 + "\n")
+    else:
+        assert caught.value is failure
+    connector._docker.stop.assert_awaited_once()
+    connector._token.stop.assert_awaited_once()
+    connector._web.stop.assert_awaited_once()
+    if "connect" in stage:
+        connector._room_client.disconnect.assert_awaited_once()
+    else:
+        connector._room_client.connect.assert_not_awaited()
+        connector._room_client.disconnect.assert_not_awaited()
+    assert endpoint._ring is None
+    assert endpoint._push.closed
+    assert endpoint._sub.closed
+    with pytest.raises(FileNotFoundError):
+        SharedMemory(name=endpoint._shm_base_name, create=False)
+
+
+@pytest.fixture
+def main_runtime(monkeypatch, tmp_path):
+    hub_started = asyncio.Event()
+    runtime_started = asyncio.Event()
+    running_tasks = []
+    ready_file = tmp_path / "hub.ready"
+
+    async def run_hub():
+        running_tasks.append(asyncio.current_task())
+        hub_started.set()
+        await asyncio.Event().wait()
+
+    async def start_connector():
+        assert hub_started.is_set()
+
+    async def run_connector():
+        running_tasks.append(asyncio.current_task())
+        assert ready_file.exists()
+        runtime_started.set()
+        await asyncio.Event().wait()
+
+    hub = SimpleNamespace(
+        on_frame=Mock(), on_audio=Mock(), on_data=Mock(), on_participant=Mock(),
+        run=AsyncMock(side_effect=run_hub), stop=Mock(), close=Mock(),
+    )
+    connector = SimpleNamespace(
+        start=AsyncMock(side_effect=start_connector),
+        run=AsyncMock(side_effect=run_connector), stop=AsyncMock(),
+    )
+    config = SimpleNamespace(
+        hub_push_addr="ipc://unused-in", hub_sub_addr="ipc://unused-out",
+        video_recording={}, web_server_tls=False, enable_web_server=False,
+        lk_port_ws=7880, room_name="test",
+    )
+    monkeypatch.setattr(hub_main, "setup_logging", lambda _name: None)
+    monkeypatch.setattr(hub_main, "load_config", lambda: config)
+    monkeypatch.setattr(hub_main, "HubEndpoint", lambda **_kwargs: hub)
+    monkeypatch.setattr(hub_main, "LiveKitConnector", lambda _cfg: connector)
+    monkeypatch.setattr(hub_main, "make_client_token", Mock(return_value="test-token"))
+    monkeypatch.setattr(hub_main, "_recorder", None)
+    return SimpleNamespace(
+        hub=hub, connector=connector, config=config, hub_started=hub_started,
+        runtime_started=runtime_started, tasks=running_tasks, ready_file=ready_file,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stage", ["token", "recorder"])
+async def test_failure_after_connector_start_cleans_up_before_ready(main_runtime, monkeypatch, stage):
+    runtime = main_runtime
+    if stage == "token":
+        monkeypatch.setattr(hub_main, "make_client_token", Mock(side_effect=ValueError("bad token")))
+    else:
+        runtime.config.video_recording = {"enabled": True, "chunk_frames": "not-an-integer"}
+
+    with pytest.raises(ValueError):
+        await asyncio.wait_for(hub_main.main(ready_file=runtime.ready_file), timeout=1.0)
+
+    assert not runtime.ready_file.exists()
+    runtime.connector.stop.assert_awaited_once()
+    runtime.hub.stop.assert_called_once()
+    runtime.hub.close.assert_called_once()
+    assert all(task.done() for task in runtime.tasks)
+
+
+@pytest.mark.asyncio
+async def test_main_cancellation_after_ready_cleans_up(main_runtime):
+    runtime = main_runtime
+    main_task = asyncio.create_task(hub_main.main(ready_file=runtime.ready_file))
+    try:
+        await asyncio.wait_for(runtime.runtime_started.wait(), timeout=1.0)
+    finally:
+        main_task.cancel()
+        await asyncio.gather(main_task, return_exceptions=True)
+
+    assert main_task.cancelled()
+    runtime.connector.stop.assert_awaited_once()
+    runtime.hub.close.assert_called_once()
+    assert all(task.done() for task in runtime.tasks)
+
+
+@pytest.mark.asyncio
+async def test_shutdown_signal_after_ready_exits_cleanly(main_runtime, monkeypatch):
+    runtime = main_runtime
+    loop = asyncio.get_running_loop()
+    handlers = {}
+    monkeypatch.setattr(loop, "add_signal_handler", lambda sig, callback: handlers.update({sig: callback}))
+    remove_handler = Mock()
+    monkeypatch.setattr(loop, "remove_signal_handler", remove_handler)
+    main_task = asyncio.create_task(hub_main.main(ready_file=runtime.ready_file))
+    try:
+        await asyncio.wait_for(runtime.runtime_started.wait(), timeout=1.0)
+        handlers[hub_main.signal.SIGTERM]()
+        await asyncio.wait_for(main_task, timeout=1.0)
+    finally:
+        main_task.cancel()
+        await asyncio.gather(main_task, return_exceptions=True)
+
+    runtime.connector.stop.assert_awaited_once()
+    runtime.hub.close.assert_called_once()
+    assert remove_handler.call_count == 2
+    assert all(task.done() for task in runtime.tasks)

--- a/tests/test_device_io_hub_startup.py
+++ b/tests/test_device_io_hub_startup.py
@@ -210,6 +210,29 @@ async def test_failure_after_connector_start_cleans_up_before_ready(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("cleanup_error_type", [asyncio.CancelledError, KeyboardInterrupt, SystemExit])
+@pytest.mark.parametrize("owner", ["main", "connector"])
+async def test_cleanup_preserves_failure_without_swallowing_process_exit(
+    main_runtime, livekit_connector, monkeypatch, cleanup_error_type, owner,
+):
+    startup_error = ValueError("startup failed")
+    cleanup_error = cleanup_error_type("cleanup interrupted")
+    if owner == "main":
+        monkeypatch.setattr(hub_main, "make_client_token", Mock(side_effect=startup_error))
+        main_runtime.connector.stop.side_effect = cleanup_error
+        operation = hub_main.main(ready_file=main_runtime.ready_file)
+    else:
+        livekit_connector._room_client.connect.side_effect = startup_error
+        livekit_connector._room_client.disconnect.side_effect = cleanup_error
+        operation = livekit_connector.start()
+
+    expected = startup_error if cleanup_error_type is asyncio.CancelledError else cleanup_error
+    with pytest.raises(type(expected)) as caught:
+        await operation
+    assert caught.value is expected
+
+
+@pytest.mark.asyncio
 async def test_main_cancellation_after_ready_cleans_up(main_runtime):
     runtime = main_runtime
     main_task = asyncio.create_task(hub_main.main(ready_file=runtime.ready_file))

--- a/tests/test_participant_events.py
+++ b/tests/test_participant_events.py
@@ -15,6 +15,7 @@ from types import SimpleNamespace
 
 import pytest
 import device_io_hub.ipc._hub as hub_module
+from device_io_hub.ipc._connector import _CONNECTOR_REGISTER_ACK_TOPIC
 
 from xr_ai_hub import (
     ConnectorRegistration,
@@ -22,6 +23,7 @@ from xr_ai_hub import (
     MsgType,
     ParticipantEvent,
     PixelFormat,
+    decode,
 )
 
 pytestmark = pytest.mark.asyncio
@@ -172,8 +174,8 @@ async def test_connector_reregistration_releases_held_slots(hub, make_connector,
     assert ("alice", "cam") in hub._latest_slots
 
 
-async def test_connector_reregistration_open_failure_drops_stale_ring(monkeypatch):
-    """A failed replacement must not retain the closed old ring."""
+async def test_connector_reregistration_open_failure_preserves_healthy_ring(monkeypatch):
+    """A failed replacement must not destroy the existing healthy mapping."""
 
     class CloseTrackingRing:
         def __init__(self) -> None:
@@ -189,6 +191,13 @@ async def test_connector_reregistration_open_failure_drops_stale_ring(monkeypatc
     def fail_open(*, name: str, create: bool):
         raise RuntimeError(f"cannot open {name} create={create}")
 
+    class FakePublisher:
+        def __init__(self) -> None:
+            self.messages = []
+
+        async def send_multipart(self, parts) -> None:
+            self.messages.append(parts)
+
     hub = hub_module.HubEndpoint.__new__(hub_module.HubEndpoint)
     old_ring = CloseTrackingRing()
     held_data = memoryview(b"held")
@@ -198,18 +207,27 @@ async def test_connector_reregistration_open_failure_drops_stale_ring(monkeypatc
     )
     hub._latest_slots = {("alice", "cam"): (old_ring, held_view)}
     hub._ring_registry = {"conn": old_ring}
+    hub._unhealthy_connectors = set()
+    hub._pub = FakePublisher()
     monkeypatch.setattr(hub_module, "ShmRingBuffer", fail_open)
 
-    hub._handle_registration(
-        ConnectorRegistration(connector_id="conn", shm_name="missing")
+    await hub._handle_registration(
+        ConnectorRegistration(
+            connector_id="conn",
+            shm_name="missing",
+        )
     )
 
-    assert old_ring.closed is True
-    assert old_ring.released_slots == [2]
-    assert hub._latest_slots == {}
-    with pytest.raises(ValueError, match="released memoryview"):
-        held_data.tobytes()
-    assert "conn" not in hub._ring_registry
+    assert old_ring.closed is False
+    assert old_ring.released_slots == []
+    assert hub._latest_slots == {("alice", "cam"): (old_ring, held_view)}
+    assert held_data.tobytes() == b"held"
+    assert hub._ring_registry == {"conn": old_ring}
+    type_id, ack = decode(hub._pub.messages[0][1])
+    assert type_id == MsgType.CONTROL
+    assert ack.topic == _CONNECTOR_REGISTER_ACK_TOPIC
+    assert ack.payload["success"] is False
+    assert ack.payload["error_code"] == "shm_open_failed"
 
 
 async def test_rejected_frame_signal_releases_new_ring_slot(

--- a/tests/test_participant_events.py
+++ b/tests/test_participant_events.py
@@ -15,7 +15,7 @@ from types import SimpleNamespace
 
 import pytest
 import device_io_hub.ipc._hub as hub_module
-from device_io_hub.ipc._connector import _CONNECTOR_REGISTER_ACK_TOPIC
+from device_io_hub.ipc._hub import _CONNECTOR_REGISTER_ACK_TOPIC
 
 from xr_ai_hub import (
     ConnectorRegistration,
@@ -157,10 +157,7 @@ async def test_connector_reregistration_releases_held_slots(hub, make_connector,
     await settle()
     assert ("alice", "cam") in hub._latest_slots  # frame held in the ring
 
-    # Re-register the same connector (crash/reconnect while a frame is held).
-    # Pre-fix: the held slot is left dangling and close() raises BufferError
-    # (swallowed by the run loop), so the stale entry survives. Post-fix: the
-    # held slot is released and dropped before the old ring is closed.
+    conn._destroy_ring()
     await conn.register()
     await settle()
     assert ("alice", "cam") not in hub._latest_slots
@@ -207,7 +204,7 @@ async def test_connector_reregistration_open_failure_preserves_healthy_ring(monk
     )
     hub._latest_slots = {("alice", "cam"): (old_ring, held_view)}
     hub._ring_registry = {"conn": old_ring}
-    hub._unhealthy_connectors = set()
+    hub._ring_names = {"conn": "original"}
     hub._pub = FakePublisher()
     monkeypatch.setattr(hub_module, "ShmRingBuffer", fail_open)
 
@@ -223,6 +220,7 @@ async def test_connector_reregistration_open_failure_preserves_healthy_ring(monk
     assert hub._latest_slots == {("alice", "cam"): (old_ring, held_view)}
     assert held_data.tobytes() == b"held"
     assert hub._ring_registry == {"conn": old_ring}
+    assert hub._ring_names == {"conn": "original"}
     type_id, ack = decode(hub._pub.messages[0][1])
     assert type_id == MsgType.CONTROL
     assert ack.topic == _CONNECTOR_REGISTER_ACK_TOPIC

--- a/tests/test_participant_events.py
+++ b/tests/test_participant_events.py
@@ -15,7 +15,7 @@ from types import SimpleNamespace
 
 import pytest
 import device_io_hub.ipc._hub as hub_module
-from device_io_hub.ipc._hub import _CONNECTOR_REGISTER_ACK_TOPIC
+from device_io_hub.ipc._registration import _CONNECTOR_REGISTER_ACK_TOPIC
 
 from xr_ai_hub import (
     ConnectorRegistration,

--- a/tests/test_shm_ring_buffer.py
+++ b/tests/test_shm_ring_buffer.py
@@ -10,7 +10,13 @@ from dataclasses import replace
 
 import pytest
 from xr_ai_hub import FrameSignal, PixelFormat, ShmRingBuffer
-from xr_ai_hub._shm import _GH_SIZE, _SH, _SH_SIZE
+from xr_ai_hub._shm import (
+    _GH,
+    _GH_SIZE,
+    _SH,
+    _SH_SIZE,
+    _IncompatibleSharedMemoryError,
+)
 
 
 @pytest.fixture
@@ -58,6 +64,36 @@ def test_unlink_tolerates_repeated_same_process_cleanup():
     ) as ring:
         ring.unlink()
         ring.unlink()
+
+
+def test_attach_rejects_invalid_global_header():
+    name = f"xr_test_{uuid.uuid4().hex[:12]}"
+    owner = ShmRingBuffer(name=name, num_slots=1, max_frame_bytes=64, create=True)
+    try:
+        header = list(_GH.unpack_from(owner._buf, 0))
+        header[0] = 0
+        _GH.pack_into(owner._buf, 0, *header)
+
+        with pytest.raises(_IncompatibleSharedMemoryError, match="global header magic"):
+            ShmRingBuffer(name=name, create=False)
+    finally:
+        owner.close()
+        owner.unlink()
+
+
+def test_attach_rejects_invalid_slot_header():
+    name = f"xr_test_{uuid.uuid4().hex[:12]}"
+    owner = ShmRingBuffer(name=name, num_slots=1, max_frame_bytes=64, create=True)
+    try:
+        slot_header = list(_SH.unpack_from(owner._buf, _GH_SIZE))
+        slot_header[0] = 0
+        _SH.pack_into(owner._buf, _GH_SIZE, *slot_header)
+
+        with pytest.raises(_IncompatibleSharedMemoryError, match="slot 0.*header magic"):
+            ShmRingBuffer(name=name, create=False)
+    finally:
+        owner.close()
+        owner.unlink()
 
 
 def test_write_frame_rejects_oversized_frame_before_claiming_slot(ring):

--- a/tests/test_shm_ring_buffer.py
+++ b/tests/test_shm_ring_buffer.py
@@ -15,7 +15,6 @@ from xr_ai_hub._shm import (
     _GH_SIZE,
     _SH,
     _SH_SIZE,
-    _IncompatibleSharedMemoryError,
 )
 
 
@@ -74,7 +73,7 @@ def test_attach_rejects_invalid_global_header():
         header[0] = 0
         _GH.pack_into(owner._buf, 0, *header)
 
-        with pytest.raises(_IncompatibleSharedMemoryError, match="global header magic"):
+        with pytest.raises(ValueError, match="global header magic"):
             ShmRingBuffer(name=name, create=False)
     finally:
         owner.close()
@@ -89,7 +88,7 @@ def test_attach_rejects_invalid_slot_header():
         slot_header[0] = 0
         _SH.pack_into(owner._buf, _GH_SIZE, *slot_header)
 
-        with pytest.raises(_IncompatibleSharedMemoryError, match="slot 0.*header magic"):
+        with pytest.raises(ValueError, match="slot 0.*header magic"):
             ShmRingBuffer(name=name, create=False)
     finally:
         owner.close()


### PR DESCRIPTION
## Why

The reported failure on commit 5f8251ba was that the hub could not open the shared-memory name created by the connector: attachment raised FileNotFoundError. The hub nevertheless created its ready file. LiveKit decoded video while the hub dropped frame signals, the producer ring filled, and workers reported no camera frame.

The actor that removed the name, and the trigger for that removal, have not been identified. This change hardens startup against a missing segment; unique-name recreation is a bounded mitigation, not a diagnosis or fix of the original unlinking cause.

## Summary

- Start the hub receive loop before connector startup and create the connector-owned ring immediately before registration.
- Require a correlated acknowledgement after attachment and layout validation before connecting the LiveKit room or creating the ready file.
- Poll for acknowledgement availability before receiving; resend within a bounded deadline and re-acknowledge duplicate connector/segment registrations without replacing mappings or held frames.
- Recreate missing segments with fresh names within a bounded attempt count; fail startup on incompatible layouts or acknowledgement timeouts.
- Attempt every owned cleanup step after failed connector startup, including partial room connection and cancellation, and after failures during subsequent recorder or token setup. Log cleanup failures without replacing the original startup error.
- Require a registered ring only for video frames. Audio, data, control messages, and participant events remain independent of shared memory.
- Preserve drop-and-log handling for frames referencing an unregistered connector; do not add unhealthy-connector tracking or a runtime shutdown policy.
- Document operator-visible readiness changes and public RuntimeError behavior, use ValueError for incompatible layouts, and share the private acknowledgement topic through an internal registration module.

## Scope

The handshake remains internal, using the existing CONTROL message without a new wire enum, public data shape, or exported error type. The connector creator owns unlinking; the hub only closes its mappings. Runtime task supervision is outside this startup-readiness change: the process retains its existing signal-based shutdown behavior. This is not runtime ring-loss detection: unlinking a segment does not invalidate an existing mapping.

## Validation

Regression coverage includes actual unlinking through the connector's own handle before attachment, bounded resend timeouts with unique names, lost-ack recovery, duplicate registration preserving held frames, unregistered-frame isolation, non-video traffic without a ring, partial startup cleanup, failures in individual cleanup steps, main cancellation, and normal signal shutdown.

- 158 focused CPU IPC, routing, lifecycle, configuration, and API documentation tests passed on Python 3.12.
- Ruff 0.15.16, diff whitespace checks, and SPDX header checks passed.

GPU and live Docker/LiveKit integration require a configured host and were not exercised by these CPU tests.
