### PR TITLE
fix(tea): ground idle visual questions

### DIFF
--- a/agent-samples/tea-making-sample/eval/cases.yaml
+++ b/agent-samples/tea-making-sample/eval/cases.yaml
@@ -13,7 +13,7 @@
   expected_tool: current_view
   forbidden_response: I can only help with the active tea guide right now.
 - name: idle-routes-open-ended-scene-question
-  query: What do you see?
+  query: Describe my surroundings.
   expected_tool: current_view
 - name: idle-routes-visual-reference
   query: What is this?

--- a/agent-samples/tea-making-sample/eval/cases.yaml
+++ b/agent-samples/tea-making-sample/eval/cases.yaml
@@ -12,6 +12,15 @@
   query: What color is the shirt?
   expected_tool: current_view
   forbidden_response: I can only help with the active tea guide right now.
+- name: idle-routes-open-ended-scene-question
+  query: What do you see?
+  expected_tool: current_view
+- name: idle-routes-visual-reference
+  query: What is this?
+  expected_tool: current_view
+- name: idle-routes-visible-background
+  query: What is in the background?
+  expected_tool: current_view
 - name: start-tea-guide
   query: Help me make a cup of tea.
   expected_tool: workflow__start

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/foreground.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/foreground.py
@@ -324,7 +324,7 @@ class ForegroundAgent(Agent):
 
         return Tool(
             "current_view",
-            "Inspect this participant's current camera frame for a specific visible fact.",
+            "Inspect this participant's current camera frame to answer a question about the current scene.",
             CurrentViewRequest,
             ImageQueryResult,
             inspect,

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/foreground_idle.txt
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/foreground_idle.txt
@@ -1,3 +1,6 @@
 The tea guide is idle. Act as a general-purpose assistant and answer unrelated
-questions normally. Start tea guidance only when the user explicitly asks to
-make or start tea. Do not apply restrictions that belong to an active guide.
+questions normally. Questions about the current scene, surroundings, or a
+visual reference are in scope. You cannot see the scene without calling
+current_view, so call it before answering such a request. Start tea guidance
+only when the user explicitly asks to make or start tea. Do not apply
+restrictions that belong to an active guide.

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/foreground_idle.txt
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/foreground_idle.txt
@@ -1,6 +1,6 @@
 The tea guide is idle. Act as a general-purpose assistant and answer unrelated
 questions normally. Questions about the current scene, surroundings, or a
-visual reference are in scope. You cannot see the scene without calling
-current_view, so call it before answering such a request. Start tea guidance
-only when the user explicitly asks to make or start tea. Do not apply
-restrictions that belong to an active guide.
+reference to something currently visible are in scope. You cannot see the scene
+without calling current_view, so call it before answering such a request. Start
+tea guidance only when the user explicitly asks to make or start tea. Do not
+apply restrictions that belong to an active guide.

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/foreground_prompt.txt
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/foreground_prompt.txt
@@ -1,8 +1,8 @@
-Route each request to the smallest matching tool. The current camera view is
-inherent conversation context. Any broad or specific request about the current
-scene or a visual reference must call current_view before any response. Never
-describe, disclaim, or promise a visual check without that call.
-Answer general knowledge directly. Use rag_lookup for tea or hot-water facts.
-Use application_context__query only when explicitly asked about recorded or
-past background observations. Use named controls for background applications.
+Route each request to the smallest matching tool. Use current_view only for
+questions about the current camera scene. Answer general-knowledge questions
+directly without calling current_view. Use rag_lookup for tea or hot-water
+facts.
+Use application_context__query to recall observations recorded by a background
+application. Start, stop, or query a background application only through its
+named controls. Never claim to see the scene without calling a visual tool.
 Answer briefly for voice.

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/foreground_prompt.txt
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/prompts/foreground_prompt.txt
@@ -1,7 +1,8 @@
-Route each request to the smallest matching tool. Use current_view only for a
-question about a visible fact in the current camera scene. Answer
-general-knowledge questions directly without calling current_view. Use
-rag_lookup for tea or hot-water facts.
-Use application_context__query for recent background observations. Start, stop,
-or query a background application only through its named controls. Never claim
-to see the scene without calling a visual tool. Answer briefly for voice.
+Route each request to the smallest matching tool. The current camera view is
+inherent conversation context. Any broad or specific request about the current
+scene or a visual reference must call current_view before any response. Never
+describe, disclaim, or promise a visual check without that call.
+Answer general knowledge directly. Use rag_lookup for tea or hot-water facts.
+Use application_context__query only when explicitly asked about recorded or
+past background observations. Use named controls for background applications.
+Answer briefly for voice.

--- a/agent-samples/tea-making-sample/worker/tea_making_worker/workflow_tools.py
+++ b/agent-samples/tea-making-sample/worker/tea_making_worker/workflow_tools.py
@@ -148,7 +148,7 @@ def participant_current_view_tool(
 
     return Tool(
         "current_view",
-        "Inspect this participant's current camera frame for a specific visible fact.",
+        "Inspect this participant's current camera frame to answer a question about the current scene.",
         CurrentViewRequest,
         ImageQueryResult,
         inspect,


### PR DESCRIPTION
## Summary

- scope current-scene routing to idle turns without changing active-guide behavior
- require `current_view` before answering questions about the current scene, surroundings, or something currently visible
- align both private `current_view` tool descriptions with broad and specific scene questions
- distinguish current spatial context from observations recorded by background applications
- add routing evals for open scene, current visual-reference, and visible-background questions

## Motivation

In an idle-state run, the foreground model sometimes promised a visual check without calling `current_view`, and sometimes routed a question about the visible background to recorded application context. The foreground LLM receives the camera image only through `current_view`, so the idle prompt now states that current-scene questions are in scope while requiring the tool before answering.

The change does not claim general past-scene memory. `application_context__query` can retrieve only textual facts produced by active background applications.

## Validation

- `5 passed` — focused tea foreground tests
- `27 passed` — live-model routing eval against the local Omni endpoint
- Ruff passed
- `git diff --check` passed
