### PR TITLE
fix(voice): preserve final intent after stop probe

### DIFF
--- a/agent-samples/simple-vlm-example/yaml/voice_gate.yaml
+++ b/agent-samples/simple-vlm-example/yaml/voice_gate.yaml
@@ -8,7 +8,9 @@
 # with one of these or contain one after '.', '?', or '!' followed by
 # whitespace or a closing quote. Matching is case-insensitive. Text through
 # the matched phrase is stripped before the agent sees the query; commas and
-# other mid-sentence mentions do not match.
+# other mid-sentence mentions do not match. The same stripped tail is used for
+# early global-STOP detection; the complete final transcript still determines
+# whether a stop-like opening is a global stop or a scoped agent command.
 magic_phrases:
   - "agent"
   - "hey agent"

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_pipeline.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_pipeline.py
@@ -78,7 +78,7 @@ def _build_voice_pipeline(
         vad_cfg=vad_cfg,
         on_partial_transcript=(
             voice_gate_proc.handle_partial_transcript
-            if voice_gate_proc.early_wake_ack_enabled
+            if voice_gate_cfg.magic_phrases
             else None
         ),
         on_final_transcript=on_final_transcript,

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_processors/vad_stt.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_processors/vad_stt.py
@@ -46,7 +46,7 @@ from xr_ai_voicegate._phrases import STOP_RE
 from .._frames import ParticipantLeftFrame
 
 
-# True means the gate handled the partial; False requests another bounded probe.
+# True means the gate matched STOP; False requests another bounded probe.
 PartialTranscriptHandler = Callable[[str, str], Awaitable[bool]]
 FinalTranscriptHandler = Callable[[str, str, int], Awaitable[None]]
 _MAX_PARTIAL_PROBES = 3
@@ -64,8 +64,9 @@ class VadConfig:
     ``stop_probe_after_s`` — cadence in seconds for up to three STT probes of
     the partial audio buffer. This gives STOP commands a fast interruption path
     without replacing final transcription, and lets a configured wake phrase
-    be acknowledged before the utterance ends. Set to ``0`` or negative to
-    disable probes.
+    be acknowledged before the utterance ends. A phrase-gated utterance can
+    make up to three partial STT requests plus the final request. Set to ``0``
+    or negative to disable probes.
     """
     silence_duration:   float = 0.8
     """Seconds of silence that finalize an utterance."""
@@ -339,7 +340,8 @@ class VadSttProcessor(FrameProcessor):
                         logger.exception("partial-transcript handler failed pid={!r}", pid)
                         return
                     if decision is True:
-                        logger.info("early partial transcript handled pid={!r}", pid)
+                        logger.info("gate-aware partial STOP matched pid={!r}", pid)
+                        await self._emit_early_interruption(pid, text)
                         return
             finally:
                 self._probe_inflight.discard(pid)

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_processors/vad_stt.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_processors/vad_stt.py
@@ -53,15 +53,6 @@ _PARTIAL_PROBE_TAIL_S = 0.12
 _PARTIAL_PROBE_FINISH_GRACE_S = 0.15
 
 
-def _is_unambiguous_partial_stop(text: str) -> bool:
-    """Reserve an ambiguous bare STOP for final-transcript routing."""
-
-    if not STOP_RE.match(text):
-        return False
-    words = text.rstrip(" \t\r\n.!?").casefold().split()
-    return not (words[-1] == "stop" and words.count("stop") == 1)
-
-
 @dataclass(frozen=True)
 class VadConfig:
     """Tuning knobs for the Silero-VAD utterance detector.
@@ -121,19 +112,13 @@ class VadSttProcessor(FrameProcessor):
         self._current_pid: str | None = None
         # Per-pid mutable audio buffer for the early STOP probe — present
         # only while an utterance is in flight. ``on_speech_start`` opens
-        # the entry; ``on_utterance`` (and the probe itself, after firing)
-        # close it.
+        # the entry and ``on_utterance`` closes it.
         self._probe_buffer:   dict[str, bytearray] = {}
         self._probe_sr:       dict[str, int]       = {}
         # One probe task per pid, so a fresh speech_start can cancel a
         # lingering task before scheduling the next.
         self._probe_task:     dict[str, asyncio.Task] = {}
         self._probe_inflight: set[str] = set()
-        # Pids whose probe has already pushed a STOP for the current
-        # utterance — suppresses the duplicate that would fire when VAD
-        # eventually finalizes the same speech run. Cleared on the next
-        # ``on_speech_start`` for the pid.
-        self._stop_fired_for_current_utterance: set[str] = set()
         # Presentation timestamp (ns) of the most recent audio frame per pid, and
         # the one captured at speech onset. The onset value anchors the resulting
         # transcript to when the participant started speaking rather than to when
@@ -152,9 +137,9 @@ class VadSttProcessor(FrameProcessor):
 
         if isinstance(frame, (EndFrame, CancelFrame)):
             # Pipeline shutdown: tear down every pending probe task so a probe
-            # cannot push a transcript (and trigger a turn) after the session has
-            # ended. The frame is still forwarded so the rest of the pipeline
-            # stops normally.
+            # cannot emit an interruption or wake acknowledgement after the
+            # session has ended. The frame is still forwarded so the rest of
+            # the pipeline stops normally.
             for pid in list(self._probe_task):
                 await self._cancel_probe_task(pid)
             await self.push_frame(frame, direction)
@@ -182,7 +167,6 @@ class VadSttProcessor(FrameProcessor):
             self._current_pid = pid
             # Await the cancelled task before scheduling the next probe so
             # the two tasks never overlap mid-push_frame.
-            self._stop_fired_for_current_utterance.discard(pid)
             onset_pts = self._last_frame_pts.get(pid)
             if onset_pts is not None:
                 self._utterance_pts[pid] = onset_pts
@@ -218,23 +202,6 @@ class VadSttProcessor(FrameProcessor):
 
             dur_s = (len(audio_bytes) // 2) / max(sample_rate, 1)
             logger.info("utterance finalize pid={!r} dur={:.2f}s", pid, dur_s)
-
-            # If the probe already pushed STOP for this utterance, the
-            # frames downstream (InterruptionFrame + TranscriptionFrame
-            # to the gate + UserStoppedSpeakingFrame) have already done
-            # their job. Re-firing UserStoppedSpeakingFrame + a fresh
-            # TranscriptionFrame (gate sees STOP again → re-fires the ack
-            # TTS) would double the stop-ack. Suppress.
-            if pid in self._stop_fired_for_current_utterance:
-                self._stop_fired_for_current_utterance.discard(pid)
-                logger.info(
-                    "suppressed duplicate utterance after probe STOP pid={!r}", pid,
-                )
-                logger.debug(
-                    "VadSttProcessor suppressing duplicate VAD-finalize "
-                    "STOP pid={!r} (probe already fired)", pid,
-                )
-                return
 
             # Order matters: pipecat consumers expect "user stopped speaking"
             # before the transcript so they can finalize turn state.
@@ -306,8 +273,8 @@ class VadSttProcessor(FrameProcessor):
 
         # Accumulate audio for the probe only while speech is active —
         # the dict entry is opened in on_speech_start and closed in
-        # on_utterance (or by the probe itself after firing STOP). Append
-        # AFTER ``feed`` so the chunk that synchronously triggered
+        # on_utterance. Append AFTER ``feed`` so the chunk that synchronously
+        # triggered
         # on_speech_start lands in the buffer. (In production
         # on_speech_start runs as a task and may not have created the
         # entry yet — at most we lose ~20-30ms of audio, which is fine
@@ -351,14 +318,14 @@ class VadSttProcessor(FrameProcessor):
                     logger.exception("partial-probe stt transcribe failed pid={!r}", pid)
                     return
 
-                stop_matched = bool(text and _is_unambiguous_partial_stop(text))
+                stop_matched = bool(text and STOP_RE.match(text))
                 logger.info(
                     "early transcript probe fired pid={!r} attempt={} latency_ms={} stop_matched={}",
                     pid, attempt, round((time.monotonic() - before) * 1000),
                     stop_matched,
                 )
                 if stop_matched:
-                    await self._emit_early_stop(pid, text)
+                    await self._emit_early_interruption(pid, text)
                     return
 
                 if text and self._on_partial_transcript is not None:
@@ -413,8 +380,8 @@ class VadSttProcessor(FrameProcessor):
             )
             return text
 
-    async def _emit_early_stop(self, pid: str, text: str) -> None:
-        """Emit the interrupt sequence for a STOP matched by a partial probe."""
+    async def _emit_early_interruption(self, pid: str, text: str) -> None:
+        """Cancel active output without treating partial STT as final intent."""
 
         # Race guard: if on_utterance already closed the buffer between
         # the STT await returning and this check, the cancellation simply
@@ -424,44 +391,13 @@ class VadSttProcessor(FrameProcessor):
             return
 
         logger.debug(
-            "VadSttProcessor early-probe STOP match pid={!r}",
+            "VadSttProcessor early-probe interruption pid={!r} text={!r}",
             pid,
+            text,
         )
-
-        # Mark before pushing so the suppression flag is set if the VAD
-        # racing-finalize lands while frames are still queueing downstream.
-        self._stop_fired_for_current_utterance.add(pid)
-
-        # Close the probe buffer now — on_utterance will see the empty
-        # entry and skip its own buffering work, but the suppression flag
-        # is what actually gates the duplicate frame emission.
-        self._probe_buffer.pop(pid, None)
-        self._probe_sr.pop(pid, None)
-
-        # Frame order intentionally differs from ``on_utterance``'s
-        # USSF-first convention: the probe is a fast-path interruption,
-        # not a clean end-of-turn. InterruptionFrame goes first so the
-        # assistant cancels any in-flight reasoning before the gate sees the
-        # STOP transcript and re-issues its own InterruptionFrame +
-        # canned ack. UserStoppedSpeakingFrame tails as a hint to
-        # downstream turn-state consumers that the partial-audio turn
-        # has ended.
         f = InterruptionFrame()
         f.transport_source = pid
         await self.push_frame(f)
-        tf = TranscriptionFrame(
-            text      = text,
-            user_id   = pid,
-            timestamp = _now_iso(),
-        )
-        tf.transport_source = pid
-        # Same onset anchor as the final-utterance path. Kept (not popped) so a
-        # subsequent VAD finalize for the same run still carries it.
-        tf.pts = self._utterance_pts.get(pid)
-        await self.push_frame(tf)
-        ssf = UserStoppedSpeakingFrame()
-        ssf.transport_source = pid
-        await self.push_frame(ssf)
 
     async def _evict_participant(self, pid: str) -> None:
         """Drop all per-pid state when a participant leaves.
@@ -476,7 +412,6 @@ class VadSttProcessor(FrameProcessor):
         self._detectors.pop(pid, None)
         self._probe_buffer.pop(pid, None)
         self._probe_sr.pop(pid, None)
-        self._stop_fired_for_current_utterance.discard(pid)
         self._last_frame_pts.pop(pid, None)
         self._utterance_pts.pop(pid, None)
         if self._current_pid == pid:

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_processors/vad_stt.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_processors/vad_stt.py
@@ -12,10 +12,11 @@ VAD start/stop edges are forwarded as pipecat's built-in
 ``UserStartedSpeakingFrame`` / ``UserStoppedSpeakingFrame`` so the assistant
 can cancel in-flight work on the moment speech starts.
 
-Also runs bounded early STT probes shortly after speech-start. Brief STOP
-utterances interrupt without waiting for VAD finalization, while an optional
-partial-transcript callback can acknowledge a wake phrase before the user
-finishes the command. Normal query dispatch still uses the final transcript.
+Also runs bounded early STT probes shortly after speech-start. A stop-like
+partial interrupts without waiting for VAD finalization but does not commit the
+user's intent; final STT still decides between a global stop and an application
+query. An optional partial-transcript callback can apply configured wake-phrase
+rules and acknowledge a wake phrase before the user finishes the command.
 """
 from __future__ import annotations
 
@@ -45,7 +46,7 @@ from xr_ai_voicegate._phrases import STOP_RE
 from .._frames import ParticipantLeftFrame
 
 
-# True acknowledges and False requests another bounded probe.
+# True means the gate handled the partial; False requests another bounded probe.
 PartialTranscriptHandler = Callable[[str, str], Awaitable[bool]]
 FinalTranscriptHandler = Callable[[str, str, int], Awaitable[None]]
 _MAX_PARTIAL_PROBES = 3
@@ -61,9 +62,10 @@ class VadConfig:
     values match the in-tree samples' current behavior.
 
     ``stop_probe_after_s`` — cadence in seconds for up to three STT probes of
-    the partial audio buffer. This gives STOP commands a fast interrupt path
-    and lets a configured wake phrase be acknowledged before the utterance
-    ends. Set to ``0`` or negative to disable probes.
+    the partial audio buffer. This gives STOP commands a fast interruption path
+    without replacing final transcription, and lets a configured wake phrase
+    be acknowledged before the utterance ends. Set to ``0`` or negative to
+    disable probes.
     """
     silence_duration:   float = 0.8
     """Seconds of silence that finalize an utterance."""
@@ -337,7 +339,7 @@ class VadSttProcessor(FrameProcessor):
                         logger.exception("partial-transcript handler failed pid={!r}", pid)
                         return
                     if decision is True:
-                        logger.info("early wake phrase acknowledged pid={!r}", pid)
+                        logger.info("early partial transcript handled pid={!r}", pid)
                         return
             finally:
                 self._probe_inflight.discard(pid)

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_processors/voice_gate.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_processors/voice_gate.py
@@ -104,22 +104,16 @@ class VoiceGateProcessor(FrameProcessor):
         self._tts_response_active = probe
 
     async def handle_partial_transcript(self, pid: str, text: str) -> bool:
-        """Handle a gate-aware STOP or acknowledge a complete wake phrase.
+        """Return whether a partial contains a gate-aware STOP.
 
-        True means the partial was handled and False means the probe needs more
-        audio. A STOP only interrupts active output; the final transcript still
-        decides whether the utterance is a global stop or an application query.
-        A later sentence can introduce a wake phrase even when the current
-        partial transcript is not a phrase prefix.
+        Wake acknowledgement may emit the optional chime but never ends bounded
+        probing. The caller owns interruption; final STT still decides whether
+        the utterance is a global stop or an application query.
         """
         if self._gate._matches_partial_stop(text):
-            frame = InterruptionFrame()
-            frame.transport_source = pid
-            await self.push_frame(frame)
             return True
         if self._gate.matches_magic_phrase(text):
             await self._emit_chime(pid, early=True)
-            return True
         return False
 
     # ── AudioSink ─────────────────────────────────────────────────────────────

--- a/agent-sdk/xr-ai-voice/xr_ai_voice/_processors/voice_gate.py
+++ b/agent-sdk/xr-ai-voice/xr_ai_voice/_processors/voice_gate.py
@@ -13,7 +13,8 @@ Maps gate events to frames:
 
 The processor also acts as the gate's ``AudioSink`` so the chime and
 stop-ack play out via the same audio path as TTS. Partial transcripts can
-acknowledge a wake phrase before the complete command is available.
+interrupt on a gate-aware STOP or acknowledge a wake phrase before the
+complete command is available.
 """
 from __future__ import annotations
 
@@ -95,11 +96,6 @@ class VoiceGateProcessor(FrameProcessor):
         :class:`StreamingTtsProcessor` for ``observe_tts_wav`` callbacks."""
         return self._gate
 
-    @property
-    def early_wake_ack_enabled(self) -> bool:
-        """Whether partial STT should probe for an early wake acknowledgement."""
-        return self._gate.wake_ack_enabled
-
     def set_tts_response_active_probe(
         self,
         probe: Callable[[str], bool],
@@ -108,12 +104,19 @@ class VoiceGateProcessor(FrameProcessor):
         self._tts_response_active = probe
 
     async def handle_partial_transcript(self, pid: str, text: str) -> bool:
-        """Handle a partial transcript and acknowledge a complete wake phrase.
+        """Handle a gate-aware STOP or acknowledge a complete wake phrase.
 
-        True means acknowledged and False means the probe needs more audio.
+        True means the partial was handled and False means the probe needs more
+        audio. A STOP only interrupts active output; the final transcript still
+        decides whether the utterance is a global stop or an application query.
         A later sentence can introduce a wake phrase even when the current
         partial transcript is not a phrase prefix.
         """
+        if self._gate._matches_partial_stop(text):
+            frame = InterruptionFrame()
+            frame.transport_source = pid
+            await self.push_frame(frame)
+            return True
         if self._gate.matches_magic_phrase(text):
             await self._emit_chime(pid, early=True)
             return True

--- a/docs/source/reference/agent-sdk-voice.md
+++ b/docs/source/reference/agent-sdk-voice.md
@@ -130,6 +130,9 @@ audio includes a silent tail so offline STT can finalize a phrase. A partial
 global-STOP match interrupts active output immediately, but it does not commit
 the user's intent: final STT remains authoritative for global-stop versus query
 routing. A slow probe receives a short grace period and is then cancelled.
+With wake phrases configured, one utterance can make up to three bounded partial
+STT requests plus the authoritative final request. Set `stop_probe_after_s` to
+zero to disable the additional requests and early interruption path.
 
 A wake phrase is accepted at the beginning of a transcript or after
 sentence-final `.`, `?`, or `!` punctuation followed by whitespace or a closing
@@ -148,7 +151,9 @@ stop?`), reported speech (`you said stop`), unconfigured arbitrary prefixes,
 and scoped or multi-action commands (`stop monitoring xyz`) are not global
 stops. They follow the ordinary gate rules.
 
-The early path emits only an interruption, not a chime or stop acknowledgement.
+A partial STOP match emits only an interruption, not a chime or stop
+acknowledgement. Wake recognition may independently emit the optional chime,
+but chime configuration, initialization, or playback does not control probing.
 If the final transcript remains a global stop, normal stop handling emits the
 acknowledgement. If STT revises partial `hey agent stop` to final `hey agent stop
 monitoring xyz`, the final transcript instead dispatches `stop monitoring xyz`

--- a/docs/source/reference/agent-sdk-voice.md
+++ b/docs/source/reference/agent-sdk-voice.md
@@ -125,16 +125,34 @@ release or shutdown.
 
 ## Voice gating and early probes
 
-When wake phrases and a listening chime are enabled, VAD and STT probe the opening
-audio while the user is still speaking. Probe audio includes a silent tail so
-offline STT can finalize a phrase. Only the final transcript is dispatched as a
-query; a slow probe receives a short grace period and is then cancelled.
+VAD and STT probe the opening audio while the user is still speaking. Probe
+audio includes a silent tail so offline STT can finalize a phrase. A partial
+global-STOP match interrupts active output immediately, but it does not commit
+the user's intent: final STT remains authoritative for global-stop versus query
+routing. A slow probe receives a short grace period and is then cancelled.
 
 A wake phrase is accepted at the beginning of a transcript or after
 sentence-final `.`, `?`, or `!` punctuation followed by whitespace or a closing
 quote. Text before the boundary and the phrase are removed. A phrase after a
-comma, semicolon, or inside ordinary prose does not activate the gate. STOP
-commands use the same early-probe path for prompt interruption.
+comma, semicolon, or inside ordinary prose does not activate the gate. Partial
+STOP classification checks both raw text and the tail after a configured wake
+phrase, so `stop` and `hey agent stop` interrupt equally early.
+
+Global STOP uses a closed imperative grammar for direct requests such as
+`stop`, `stop it`, `stop talking`, `be quiet`, and `shut up`, with a bounded set
+of conversational prefixes and punctuation. Up to two prefixes may be drawn
+from `please`, `hey`, `okay`, `ok`, `uh`, `um`, `wait`, `no`, `just`,
+`alright`, `sorry`, `whoa`, `hang on`, `I said`, or `can`, `could`, `would`,
+or `will` followed by `you`. Negations (`don't stop`), questions (`should I
+stop?`), reported speech (`you said stop`), unconfigured arbitrary prefixes,
+and scoped or multi-action commands (`stop monitoring xyz`) are not global
+stops. They follow the ordinary gate rules.
+
+The early path emits only an interruption, not a chime or stop acknowledgement.
+If the final transcript remains a global stop, normal stop handling emits the
+acknowledgement. If STT revises partial `hey agent stop` to final `hey agent stop
+monitoring xyz`, the final transcript instead dispatches `stop monitoring xyz`
+to the agent; the latency-saving interruption is not undone.
 
 ## Relay telemetry
 

--- a/tests/test_voice_pipeline.py
+++ b/tests/test_voice_pipeline.py
@@ -558,29 +558,46 @@ async def test_vad_stt_retries_partial_probe_after_background_sentence(monkeypat
 
 @pytest.mark.asyncio
 async def test_vad_stt_stop_probe_emits_interruption_on_stop_match(monkeypatch):
-    """When the probe's partial transcript is an unambiguous STOP the
-    processor pushes ``InterruptionFrame`` + the matched
-    ``TranscriptionFrame`` + ``UserStoppedSpeakingFrame`` downstream
-    immediately — without waiting for VAD's silence-window finalize."""
+    """A stop-like partial cancels output without committing user intent."""
     _StagedVad.instances.clear()
+    monkeypatch.setattr("pipecat.pipeline.worker.warm_deferred_imports", lambda: None)
     stt = _StagedStt(texts=["stop it"])
     monkeypatch.setattr("xr_ai_voice._processors.vad_stt.VadDetector", _StagedVad)
     proc = VadSttProcessor(stt=stt, vad_cfg=VadConfig(stop_probe_after_s=0.05))
 
     frame = InputAudioRawFrame(audio=b"\x00\x00" * 320, sample_rate=16000, num_channels=1)
     frame.transport_source = "web-client"
-    sink = await _run_chain(proc, sends=[frame], settle_s=0.2)
+
+    class _SignalSink(_CaptureSink):
+        def __init__(self) -> None:
+            super().__init__()
+            self.interrupted = asyncio.Event()
+
+        async def process_frame(self, item: Frame, direction: FrameDirection) -> None:
+            await super().process_frame(item, direction)
+            if isinstance(item, InterruptionFrame):
+                self.interrupted.set()
+
+    sink = _SignalSink()
+    worker = PipelineWorker(
+        Pipeline([proc, sink]),
+        cancel_on_idle_timeout=False,
+        enable_rtvi=False,
+    )
+    runner = WorkerRunner()
+    await runner.add_workers(worker)
+
+    async def drive() -> None:
+        await worker.queue_frame(frame)
+        await asyncio.wait_for(sink.interrupted.wait(), timeout=1.0)
+        await worker.queue_frame(EndFrame())
+
+    await asyncio.gather(runner.run(), drive())
 
     kinds = [type(f).__name__ for f in sink.frames]
-    assert "InterruptionFrame"        in kinds
-    assert "UserStoppedSpeakingFrame" in kinds
-    transcripts = [f for f in sink.frames if isinstance(f, TranscriptionFrame)]
-    assert [t.text for t in transcripts] == ["stop it"]
-    # InterruptionFrame must arrive before the TranscriptionFrame so any
-    # in-flight reasoning is cancelled before the gate sees STOP.
-    int_idx = next(i for i, f in enumerate(sink.frames) if isinstance(f, InterruptionFrame))
-    tf_idx  = next(i for i, f in enumerate(sink.frames) if isinstance(f, TranscriptionFrame))
-    assert int_idx < tf_idx
+    assert "InterruptionFrame" in kinds
+    assert "UserStoppedSpeakingFrame" not in kinds
+    assert not any(isinstance(f, TranscriptionFrame) for f in sink.frames)
 
 
 @pytest.mark.asyncio
@@ -602,7 +619,7 @@ async def test_vad_stt_stop_probe_silent_on_non_stop_match(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_vad_stt_bare_partial_stop_preserves_scoped_final_command(
+async def test_vad_stt_bare_partial_stop_interrupts_and_preserves_scoped_final_command(
     monkeypatch,
 ):
     _StagedVad.instances.clear()
@@ -662,7 +679,7 @@ async def test_vad_stt_bare_partial_stop_preserves_scoped_final_command(
 
     await asyncio.gather(runner.run(), drive())
 
-    assert not any(isinstance(item, InterruptionFrame) for item in sink.frames)
+    assert sum(isinstance(item, InterruptionFrame) for item in sink.frames) == 1
     transcripts = [
         item for item in sink.frames if isinstance(item, TranscriptionFrame)
     ]
@@ -849,16 +866,45 @@ async def test_vad_stt_final_transcription_cancels_stalled_probe(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_vad_stt_stop_probe_suppresses_duplicate_vad_finalize(monkeypatch):
-    """After the probe fires STOP, the eventual VAD-finalize for the
-    same utterance must NOT re-emit ``UserStoppedSpeakingFrame`` + a
-    second ``TranscriptionFrame`` — otherwise the gate would re-fire
-    its canned "Okay, I will stop." ack TTS."""
+@pytest.mark.parametrize(("partial", "final"), [
+    ("stop it", "stop it from monitoring the kettle"),
+    ("stop talking", "stop talking about the timer and start monitoring"),
+    ("stop now", "stop now and start the change watcher"),
+    ("stop, stop", "stop, stop visual monitoring"),
+])
+async def test_vad_stt_stop_probe_preserves_revised_final_transcript(
+    monkeypatch,
+    partial: str,
+    final: str,
+):
+    """A revisable stop-like partial must never replace the final transcript."""
     _StagedVad.instances.clear()
-    # Probe call returns "stop it"; the eventual on_utterance call (if
-    # the suppression failed) would return "stop now" — we must not see
-    # that downstream.
-    stt = _StagedStt(texts=["stop it", "stop now"])
+    monkeypatch.setattr("pipecat.pipeline.worker.warm_deferred_imports", lambda: None)
+
+    class _SignaledStt(_StagedStt):
+        def __init__(self) -> None:
+            super().__init__(texts=[partial, final])
+            self.first_completed = asyncio.Event()
+
+        async def transcribe(
+            self,
+            audio: bytes,
+            *,
+            sample_rate: int | None = None,
+            channels: int = 1,
+            timeout: float | None = None,
+        ) -> str:
+            text = await super().transcribe(
+                audio,
+                sample_rate=sample_rate,
+                channels=channels,
+                timeout=timeout,
+            )
+            if len(self.calls) == 1:
+                self.first_completed.set()
+            return text
+
+    stt = _SignaledStt()
     monkeypatch.setattr("xr_ai_voice._processors.vad_stt.VadDetector", _StagedVad)
     proc = VadSttProcessor(stt=stt, vad_cfg=VadConfig(stop_probe_after_s=0.05))
 
@@ -872,32 +918,20 @@ async def test_vad_stt_stop_probe_suppresses_duplicate_vad_finalize(monkeypatch)
     await runner.add_workers(worker)
 
     async def drive() -> None:
-        await asyncio.sleep(0.05)
         await worker.queue_frame(frame)
-        # Wait for the probe to fire (>= stop_probe_after_s).
-        await asyncio.sleep(0.2)
-        # VAD now finalizes after silence — would normally push a fresh
-        # UserStoppedSpeakingFrame + TranscriptionFrame.
+        await asyncio.wait_for(stt.first_completed.wait(), timeout=1.0)
         assert _StagedVad.instances
         await _StagedVad.instances[-1].trigger_utterance()
-        await asyncio.sleep(0.1)
         await worker.queue_frame(EndFrame())
 
     await asyncio.gather(runner.run(), drive())
 
     transcripts = [f for f in sink.frames if isinstance(f, TranscriptionFrame)]
-    assert [t.text for t in transcripts] == ["stop it"], (
-        "duplicate transcription from VAD-finalize must be suppressed "
-        "after the probe already fired STOP"
-    )
-    # The probe's stop-emit ends with UserStoppedSpeakingFrame; VAD's
-    # finalize would re-push one. With suppression we should see exactly
-    # one of each.
+    assert [t.text for t in transcripts] == [final]
     stops = [f for f in sink.frames if isinstance(f, UserStoppedSpeakingFrame)]
     assert len(stops) == 1
-    # Only the probe-side STT call should have happened — the on_utterance
-    # path bailed before its own STT call.
-    assert len(stt.calls) == 1
+    assert sum(isinstance(f, InterruptionFrame) for f in sink.frames) == 1
+    assert len(stt.calls) == 2
 
 
 @pytest.mark.asyncio
@@ -1244,7 +1278,23 @@ async def test_voice_gate_processor_synthetic_query_chimes_after_empty_speech_tu
 
 
 @pytest.mark.asyncio
-async def test_voice_gate_processor_chimes_on_partial_wake_without_dispatching_early():
+@pytest.mark.parametrize(("partial", "final", "expected_query"), [
+    (
+        "hey agent place a blue sphere",
+        "hey agent place a blue sphere",
+        "place a blue sphere",
+    ),
+    (
+        "hey agent stop",
+        "hey agent stop monitoring xyz",
+        "stop monitoring xyz",
+    ),
+])
+async def test_voice_gate_processor_chimes_on_partial_wake_without_dispatching_early(
+    partial: str,
+    final: str,
+    expected_query: str,
+):
     cfg = VoiceGateConfig(
         magic_phrases=("agent", "hey agent"),
         listening_chime=True,
@@ -1267,18 +1317,20 @@ async def test_voice_gate_processor_chimes_on_partial_wake_without_dispatching_e
         nonlocal early_audio_count
         await asyncio.sleep(0.05)
         acknowledged = await proc.handle_partial_transcript(
-            "pid-1", "hey agent place a blue sphere",
+            "pid-1", partial,
         )
         assert acknowledged is True
         early_audio_count = sum(
             isinstance(frame, OutputAudioRawFrame) for frame in sink.frames
         )
         assert not any(isinstance(frame, GatedQueryFrame) for frame in sink.frames)
-        await worker.queue_frame(TranscriptionFrame(
-            text="hey agent place a blue sphere",
+        transcript = TranscriptionFrame(
+            text=final,
             user_id="pid-1",
             timestamp="t",
-        ))
+        )
+        transcript.transport_source = "pid-1"
+        await worker.queue_frame(transcript)
         await asyncio.sleep(0.05)
         await worker.queue_frame(EndFrame())
 
@@ -1290,7 +1342,8 @@ async def test_voice_gate_processor_chimes_on_partial_wake_without_dispatching_e
     queries = [frame for frame in sink.frames if isinstance(frame, GatedQueryFrame)]
     assert early_audio_count > 0
     assert audio_count == early_audio_count
-    assert [query.text for query in queries] == ["place a blue sphere"]
+    assert [query.text for query in queries] == [expected_query]
+    assert not any(isinstance(frame, InterruptionFrame) for frame in sink.frames)
 
 
 @pytest.mark.asyncio

--- a/tests/test_voice_pipeline.py
+++ b/tests/test_voice_pipeline.py
@@ -495,14 +495,14 @@ async def test_vad_stt_stop_probe_schedules_on_speech_start(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_vad_stt_retries_partial_probe_until_wake_phrase_is_recognized(monkeypatch):
+async def test_vad_stt_retries_partial_probe_until_gate_aware_stop_matches(monkeypatch):
     _StagedVad.instances.clear()
-    stt = _StagedStt(texts=["hey", "hey agent place a cube"])
+    stt = _StagedStt(texts=["hey", "hey agent stop"])
     partials: list[tuple[str, str]] = []
 
     async def on_partial(pid: str, text: str) -> bool:
         partials.append((pid, text))
-        return text.startswith("hey agent")
+        return text == "hey agent stop"
 
     monkeypatch.setattr("xr_ai_voice._processors.vad_stt.VadDetector", _StagedVad)
     proc = VadSttProcessor(
@@ -521,7 +521,7 @@ async def test_vad_stt_retries_partial_probe_until_wake_phrase_is_recognized(mon
 
     assert partials == [
         ("web-client", "hey"),
-        ("web-client", "hey agent place a cube"),
+        ("web-client", "hey agent stop"),
     ]
     assert len(stt.calls) == 2
 
@@ -553,7 +553,8 @@ async def test_vad_stt_retries_partial_probe_after_background_sentence(monkeypat
 
     await _run_chain(proc, sends=[frame], settle_s=0.25)
 
-    assert len(stt.calls) == 2
+    # Wake acknowledgement does not end the bounded probe sequence.
+    assert len(stt.calls) == 3
 
 
 @pytest.mark.asyncio
@@ -687,19 +688,23 @@ async def test_vad_stt_bare_partial_stop_interrupts_and_preserves_scoped_final_c
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(("partial", "final", "expected_query", "chime"), [
-    ("agent stop", "agent stop", None, False),
-    ("hey agent stop", "hey agent stop", None, True),
+@pytest.mark.parametrize(("partials", "final", "expected_query", "chime"), [
+    (("agent stop",), "agent stop", None, False),
+    (("hey agent stop",), "hey agent stop", None, True),
     (
-        "hey agent stop",
+        ("hey agent stop",),
         "hey agent stop monitoring xyz",
         "stop monitoring xyz",
         True,
     ),
+    (("hey agent", "hey agent stop"), "hey agent stop", None, True),
+    (("hey agent", "hey agent stop"), "hey agent stop", None, False),
+    (("hey agent st", "hey agent stop"), "hey agent stop", None, True),
+    (("hey agent st", "hey agent stop"), "hey agent stop", None, False),
 ])
 async def test_vad_stt_gate_aware_stop_probe_preserves_final_intent(
     monkeypatch,
-    partial: str,
+    partials: tuple[str, ...],
     final: str,
     expected_query: str | None,
     chime: bool,
@@ -710,7 +715,7 @@ async def test_vad_stt_gate_aware_stop_probe_preserves_final_intent(
 
     class _SignaledStt(_StagedStt):
         def __init__(self) -> None:
-            super().__init__(texts=[partial, final])
+            super().__init__(texts=[*partials, final])
             self.first_completed = asyncio.Event()
 
         async def transcribe(
@@ -797,7 +802,7 @@ async def test_vad_stt_gate_aware_stop_probe_preserves_final_intent(
         if isinstance(item, TextFrame) and item.text == "Okay, I will stop."
     ]
     assert stop_acks == (["Okay, I will stop."] if expected_query is None else [])
-    assert len(stt.calls) == 2
+    assert len(stt.calls) == len(partials) + 1
 
 
 @pytest.mark.asyncio
@@ -1410,10 +1415,10 @@ async def test_voice_gate_processor_chimes_on_partial_wake_without_dispatching_e
     async def drive() -> None:
         nonlocal early_audio_count
         await asyncio.sleep(0.05)
-        acknowledged = await proc.handle_partial_transcript(
+        stop_matched = await proc.handle_partial_transcript(
             "pid-1", "hey agent place a blue sphere",
         )
-        assert acknowledged is True
+        assert stop_matched is False
         early_audio_count = sum(
             isinstance(frame, OutputAudioRawFrame) for frame in sink.frames
         )
@@ -1449,6 +1454,8 @@ async def test_voice_gate_processor_keeps_partial_wake_probes_open():
     proc = VoiceGateProcessor(cfg=cfg, tts=_FakeTts())
 
     assert await proc.handle_partial_transcript("pid-1", "hey") is False
+    assert await proc.handle_partial_transcript("pid-1", "hey agent") is False
+    assert await proc.handle_partial_transcript("pid-1", "hey agent st") is False
     assert await proc.handle_partial_transcript("pid-1", "room conversation") is False
     assert await proc.handle_partial_transcript("pid-1", "background.") is False
 

--- a/tests/test_voice_pipeline.py
+++ b/tests/test_voice_pipeline.py
@@ -687,6 +687,120 @@ async def test_vad_stt_bare_partial_stop_interrupts_and_preserves_scoped_final_c
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(("partial", "final", "expected_query", "chime"), [
+    ("agent stop", "agent stop", None, False),
+    ("hey agent stop", "hey agent stop", None, True),
+    (
+        "hey agent stop",
+        "hey agent stop monitoring xyz",
+        "stop monitoring xyz",
+        True,
+    ),
+])
+async def test_vad_stt_gate_aware_stop_probe_preserves_final_intent(
+    monkeypatch,
+    partial: str,
+    final: str,
+    expected_query: str | None,
+    chime: bool,
+):
+    """Wake-prefixed STOP interrupts early; final STT remains authoritative."""
+    _StagedVad.instances.clear()
+    monkeypatch.setattr("pipecat.pipeline.worker.warm_deferred_imports", lambda: None)
+
+    class _SignaledStt(_StagedStt):
+        def __init__(self) -> None:
+            super().__init__(texts=[partial, final])
+            self.first_completed = asyncio.Event()
+
+        async def transcribe(
+            self,
+            audio: bytes,
+            *,
+            sample_rate: int | None = None,
+            channels: int = 1,
+            timeout: float | None = None,
+        ) -> str:
+            text = await super().transcribe(
+                audio,
+                sample_rate=sample_rate,
+                channels=channels,
+                timeout=timeout,
+            )
+            if len(self.calls) == 1:
+                self.first_completed.set()
+            return text
+
+    class _SignalSink(_CaptureSink):
+        def __init__(self) -> None:
+            super().__init__()
+            self.interrupted = asyncio.Event()
+
+        async def process_frame(self, item: Frame, direction: FrameDirection) -> None:
+            await super().process_frame(item, direction)
+            if isinstance(item, InterruptionFrame):
+                self.interrupted.set()
+
+    stt = _SignaledStt()
+    gate = VoiceGateProcessor(
+        cfg=VoiceGateConfig(
+            magic_phrases=("agent", "hey agent"),
+            listening_chime=chime,
+        ),
+        tts=_FakeTts(),
+    )
+    monkeypatch.setattr("xr_ai_voice._processors.vad_stt.VadDetector", _StagedVad)
+    vad_stt = VadSttProcessor(
+        stt=stt,
+        vad_cfg=VadConfig(stop_probe_after_s=0.05),
+        on_partial_transcript=gate.handle_partial_transcript,
+    )
+    frame = InputAudioRawFrame(
+        audio=b"\x00\x00" * 320,
+        sample_rate=16000,
+        num_channels=1,
+    )
+    frame.transport_source = "web-client"
+    sink = _SignalSink()
+    worker = PipelineWorker(
+        Pipeline([vad_stt, gate, sink]),
+        cancel_on_idle_timeout=False,
+        enable_rtvi=False,
+    )
+    runner = WorkerRunner()
+    await runner.add_workers(worker)
+
+    async def drive() -> None:
+        await worker.queue_frame(frame)
+        await asyncio.wait_for(stt.first_completed.wait(), timeout=1.0)
+        await asyncio.wait_for(sink.interrupted.wait(), timeout=1.0)
+        assert not any(
+            isinstance(item, UserStoppedSpeakingFrame) for item in sink.frames
+        )
+        assert not any(isinstance(item, OutputAudioRawFrame) for item in sink.frames)
+        assert _StagedVad.instances
+        await _StagedVad.instances[-1].trigger_utterance()
+        await worker.queue_frame(EndFrame())
+
+    await asyncio.gather(runner.run(), drive())
+
+    queries = [item for item in sink.frames if isinstance(item, GatedQueryFrame)]
+    assert [item.text for item in queries] == (
+        [] if expected_query is None else [expected_query]
+    )
+    interruptions = sum(
+        isinstance(item, InterruptionFrame) for item in sink.frames
+    )
+    assert interruptions == (2 if expected_query is None else 1)
+    stop_acks = [
+        item.text for item in sink.frames
+        if isinstance(item, TextFrame) and item.text == "Okay, I will stop."
+    ]
+    assert stop_acks == (["Okay, I will stop."] if expected_query is None else [])
+    assert len(stt.calls) == 2
+
+
+@pytest.mark.asyncio
 async def test_vad_stt_stop_probe_cancelled_when_vad_finalizes_first(monkeypatch):
     """If VAD finalizes the utterance before the probe timer fires, the
     pending probe task is cancelled — STT is called exactly once (by
@@ -970,12 +1084,8 @@ async def test_vad_stt_stop_probe_disabled_when_setting_zero(monkeypatch):
     assert len(stt.calls) == 1
     transcripts = [f for f in sink.frames if isinstance(f, TranscriptionFrame)]
     assert [t.text for t in transcripts] == ["stop"]
-    # The discriminating signal: with the probe disabled, the
-    # InterruptionFrame the probe normally pushes on STOP-match must NOT
-    # appear. (Without this assertion, the call-count check above would
-    # pass even if the probe ran — its STT call and the on_utterance one
-    # would either way total exactly one because the suppression flag
-    # would gate out the duplicate.)
+    # With the probe disabled, final STT still routes "stop" normally but no
+    # early InterruptionFrame can appear.
     assert not any(isinstance(f, InterruptionFrame) for f in sink.frames), (
         "probe must not push InterruptionFrame when stop_probe_after_s=0"
     )
@@ -996,7 +1106,7 @@ async def test_vad_stt_stop_probe_no_unawaited_coroutine_under_finalize_race(mon
     finalizer fires before the assertion runs.
     """
     _StagedVad.instances.clear()
-    # Probe sees STOP; finalize would see "stop now" if suppression failed.
+    # Probe sees STOP; finalization intentionally transcribes the utterance again.
     stt = _StagedStt(texts=["stop it", "stop now"])
     monkeypatch.setattr("xr_ai_voice._processors.vad_stt.VadDetector", _StagedVad)
     proc = VadSttProcessor(stt=stt, vad_cfg=VadConfig(stop_probe_after_s=0.05))
@@ -1278,23 +1388,7 @@ async def test_voice_gate_processor_synthetic_query_chimes_after_empty_speech_tu
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(("partial", "final", "expected_query"), [
-    (
-        "hey agent place a blue sphere",
-        "hey agent place a blue sphere",
-        "place a blue sphere",
-    ),
-    (
-        "hey agent stop",
-        "hey agent stop monitoring xyz",
-        "stop monitoring xyz",
-    ),
-])
-async def test_voice_gate_processor_chimes_on_partial_wake_without_dispatching_early(
-    partial: str,
-    final: str,
-    expected_query: str,
-):
+async def test_voice_gate_processor_chimes_on_partial_wake_without_dispatching_early():
     cfg = VoiceGateConfig(
         magic_phrases=("agent", "hey agent"),
         listening_chime=True,
@@ -1317,7 +1411,7 @@ async def test_voice_gate_processor_chimes_on_partial_wake_without_dispatching_e
         nonlocal early_audio_count
         await asyncio.sleep(0.05)
         acknowledged = await proc.handle_partial_transcript(
-            "pid-1", partial,
+            "pid-1", "hey agent place a blue sphere",
         )
         assert acknowledged is True
         early_audio_count = sum(
@@ -1325,7 +1419,7 @@ async def test_voice_gate_processor_chimes_on_partial_wake_without_dispatching_e
         )
         assert not any(isinstance(frame, GatedQueryFrame) for frame in sink.frames)
         transcript = TranscriptionFrame(
-            text=final,
+            text="hey agent place a blue sphere",
             user_id="pid-1",
             timestamp="t",
         )
@@ -1342,7 +1436,7 @@ async def test_voice_gate_processor_chimes_on_partial_wake_without_dispatching_e
     queries = [frame for frame in sink.frames if isinstance(frame, GatedQueryFrame)]
     assert early_audio_count > 0
     assert audio_count == early_audio_count
-    assert [query.text for query in queries] == [expected_query]
+    assert [query.text for query in queries] == ["place a blue sphere"]
     assert not any(isinstance(frame, InterruptionFrame) for frame in sink.frames)
 
 
@@ -3006,7 +3100,7 @@ async def test_private_pipeline_assembly_connects_audio_in_to_audio_out(monkeypa
     assert tts.calls == ["echo hi pipeline."]
 
 
-def test_private_pipeline_assembly_wires_early_wake_ack_for_chime_config():
+def test_private_pipeline_assembly_wires_partial_handler_for_magic_phrases():
     from xr_ai_voice._transport import HubVoiceTransport
 
     transport = HubVoiceTransport()
@@ -3019,7 +3113,7 @@ def test_private_pipeline_assembly_wires_early_wake_ack_for_chime_config():
             vad_cfg=VadConfig(),
             voice_gate_cfg=VoiceGateConfig(
                 magic_phrases=("hey agent",),
-                listening_chime=True,
+                listening_chime=False,
             ),
         )
         vad_stt = next(

--- a/tests/test_xr_ai_voicegate.py
+++ b/tests/test_xr_ai_voicegate.py
@@ -239,6 +239,8 @@ def test_phrase_only_utterance_strips_to_empty_string():
     "stop doing that",
     "stop for now",
     "stop, stop",
+    "I said, stop",
+    "can you, stop",
 ])
 def test_stop_regex_canonical_forms_match(text: str):
     """Case 9: all the canonical interruption phrases match."""

--- a/tests/test_xr_ai_voicegate.py
+++ b/tests/test_xr_ai_voicegate.py
@@ -235,6 +235,10 @@ def test_phrase_only_utterance_strips_to_empty_string():
     "sorry, stop",
     "whoa stop",
     "hang on stop",
+    "stop right now",
+    "stop doing that",
+    "stop for now",
+    "stop, stop",
 ])
 def test_stop_regex_canonical_forms_match(text: str):
     """Case 9: all the canonical interruption phrases match."""
@@ -242,12 +246,7 @@ def test_stop_regex_canonical_forms_match(text: str):
 
 
 def test_stop_regex_suffix_with_too_much_filler_does_not_match():
-    """Case 10 (locked to actual behavior): 'the agent told me to stop'
-    has 4 filler words before 'stop'; the regex allows {0,2} filler
-    words, so this does NOT match.
-
-    The original brief speculated this would match as a "suffix STOP" —
-    the impl says no. We lock the impl's behavior in as the contract."""
+    """Reported speech is not an imperative interruption."""
     assert STOP_RE.match("the agent told me to stop") is None
 
 
@@ -255,6 +254,25 @@ def test_stop_regex_mid_sentence_real_question_does_not_match():
     """Case 11: 'what should we stop doing about climate change' is a
     genuine question that mentions 'stop' mid-sentence; must not trigger."""
     assert STOP_RE.match("what should we stop doing about climate change") is None
+
+
+@pytest.mark.parametrize("text", [
+    "don't stop",
+    "do not stop",
+    "never stop",
+    "please don't stop",
+    "should I stop",
+    "we should stop",
+    "you said stop",
+    "the word stop",
+    "say stop",
+    "don't shut up",
+    "do not be quiet",
+    "not quiet",
+])
+def test_stop_regex_negations_and_questions_do_not_match(text: str):
+    """Agent requests mentioning STOP must not become global interruptions."""
+    assert STOP_RE.match(text) is None
 
 
 @pytest.mark.parametrize("text", [
@@ -544,6 +562,7 @@ async def test_feed_stop_matched_on_magic_stripped_tail():
 @pytest.mark.asyncio
 @pytest.mark.parametrize("phrases,text", [
     (("hey agent",), "hey agent stop visual monitoring."),
+    (("hey agent",), "hey agent stop monitoring xyz"),
     ((), "stop visual monitoring."),
 ])
 async def test_feed_application_stop_command_dispatches_to_agent(
@@ -556,7 +575,22 @@ async def test_feed_application_stop_command_dispatches_to_agent(
 
     await gate.feed("p1", text)
 
-    assert events == [("query", "p1", "stop visual monitoring.", True)]
+    expected = text.removeprefix("hey agent ")
+    assert events == [("query", "p1", expected, True)]
+
+
+@pytest.mark.asyncio
+async def test_feed_stop_mention_in_followup_dispatches_as_query():
+    gate, _, _ = _gate(phrases=("agent",), followup_grace_s=5.0)
+    events = _recording_handlers(gate)
+
+    await gate.feed("p1", "agent")
+    await gate.feed("p1", "don't stop")
+
+    assert events == [
+        ("phrase_only", "p1"),
+        ("query", "p1", "don't stop", False),
+    ]
 
 
 @pytest.mark.asyncio

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/_phrases.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/_phrases.py
@@ -9,8 +9,8 @@ from typing import Sequence
 
 
 # Speech-interruption phrases matching this pattern bypass the magic-phrase
-# gate so the user can interrupt a response mid-flight without starting with
-# the configured phrase. Scoped application commands such as "stop recording"
+# gate. Classification tests raw text and, when a phrase is configured, its
+# wake-stripped tail. Scoped application commands such as "stop recording"
 # must not match: they need to reach the agent and its lifecycle tools.
 STOP_RE: re.Pattern = re.compile(
     r"""
@@ -18,8 +18,8 @@ STOP_RE: re.Pattern = re.compile(
     (?:
         (?:please|hey|okay|ok|uh|um|wait|no|just|alright|sorry|whoa)[,\s]+
         |hang\s+on[,\s]+
-        |i\s+said\s+
-        |(?:can|could|would|will)\s+you\s+
+        |i\s+said[,\s]+
+        |(?:can|could|would|will)\s+you[,\s]+
     ){0,2}
     (?:
         stop

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/_phrases.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/_phrases.py
@@ -15,15 +15,21 @@ from typing import Sequence
 STOP_RE: re.Pattern = re.compile(
     r"""
     ^\s*
-    (?:\S+[,\s]+){0,2}
+    (?:
+        (?:please|hey|okay|ok|uh|um|wait|no|just|alright|sorry|whoa)[,\s]+
+        |hang\s+on[,\s]+
+        |i\s+said\s+
+        |(?:can|could|would|will)\s+you\s+
+    ){0,2}
     (?:
         stop
         (?:
-            (?:\s+stop)+(?:\s+(?:please|now))?
-            |\s+(?:it|that|this|already)(?:\s+(?:please|now))?
-            |\s+(?:please|now)
-            |\s+(?:talking|speaking)(?:\s+(?:please|now))?
+            (?:[,\s]+stop)+
+            |[,\s]+(?:it|that|this)
+            |[,\s]+doing[,\s]+(?:it|that|this)
+            |[,\s]+(?:talking|speaking)
         )?
+        (?:[,\s]+(?:please|already|now|right\s+now|for\s+now)){0,2}
         |be\s+quiet(?:\s+please)?
         |quiet(?:\s+please)?
         |shut\s+up(?:\s+please)?

--- a/utils/xr-ai-voicegate/xr_ai_voicegate/gate.py
+++ b/utils/xr-ai-voicegate/xr_ai_voicegate/gate.py
@@ -63,6 +63,13 @@ class VoiceGate:
     are inert in this mode — they only make sense once a phrase exists
     to gate against.
 
+    STOP is a closed imperative grammar: direct requests such as ``stop``,
+    ``stop it``, ``stop talking``, ``be quiet``, and ``shut up`` may use a
+    bounded set of conversational prefixes and punctuation. Negations,
+    questions, reported speech, unconfigured arbitrary prefixes, and scoped or
+    multi-action commands such as ``stop monitoring`` are ordinary queries,
+    not global stops.
+
     Handler exceptions are logged and swallowed so one bad handler does
     not kill the gate.
     """
@@ -172,6 +179,12 @@ class VoiceGate:
     def matches_magic_phrase(self, text: str) -> bool:
         """Return whether *text* has a phrase at a sentence boundary."""
         return self._magic_re is not None and strip_magic(self._magic_re, text) is not None
+
+    def _matches_partial_stop(self, text: str) -> bool:
+        """Match a partial STOP on raw text or its wake-stripped tail."""
+        stripped = strip_magic(self._magic_re, text)
+        candidate = stripped if stripped else text
+        return STOP_RE.match(candidate) is not None
 
     def could_match_magic_phrase(self, text: str) -> bool:
         """Return whether the current partial sentence can become a match."""


### PR DESCRIPTION
## Summary

- treat a stop-like partial STT result only as an early output interruption
- classify partial STOP on raw text and on the tail after a configured wake phrase, even when the listening chime is disabled
- keep bounded probing after wake acknowledgement so later partial STT can revise `hey agent` or `hey agent st` to `hey agent stop`
- keep chime playback presentation-only; STOP classification alone terminates probing and `VadSttProcessor` alone emits early interruption
- keep the completed transcript authoritative for global-stop versus scoped-command routing
- keep a closed global-STOP grammar while accepting punctuation in approved forms such as `I said, stop` and `can you, stop`
- document the exact partial/final routing boundary and cover it through the VAD-to-gate pipeline

## Intent boundary

Direct imperatives such as `stop`, `stop it`, `stop talking`, `be quiet`, and wake-prefixed equivalents such as `hey agent stop` interrupt active output early. Negations, questions, reported speech, unconfigured arbitrary prefixes, and scoped or multi-action commands such as `stop monitoring xyz` are not global stops.

A partial `hey agent stop` may interrupt playback immediately. If final STT revises it to `hey agent stop monitoring xyz`, the final transcript wins and dispatches `stop monitoring xyz` to the agent; the early interruption is not treated as committed intent.

## Why

Partial STT hypotheses are revisable. Treating a stop-like partial as the final command can discard the user's completed scoped request, while waiting for final STT makes genuine stop commands feel unresponsive. The split behavior preserves low-latency interruption without replacing final routing.

With wake phrases configured, the bounded probe can issue up to three partial STT requests and finalization issues the authoritative request. Chime configuration, initialization, and playback do not affect that control flow.

This follow-up is separate from merged #441: it corrects stop-probe routing and its gate-aware edge cases without redesigning the voice pipeline or expanding its public API.

## Validation

- `uv run --project tests pytest -q tests/test_voice_pipeline.py tests/test_xr_ai_voicegate.py` — 228 passed
- `uv run --project tests pytest -q tests/test_docs_versions.py tests/test_config_documentation.py tests/test_cli_documentation.py` — 26 passed
- `ruff 0.15.16 check .` — passed
- `git diff --check` — passed
