### PR TITLE
Move XR render routing rules from supervisor prompt to tool descriptions

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -583,6 +583,7 @@ artifacts; do not commit them.
   - `xr_render_demo_live_explore` → `xr_render_demo_eval.live_explore:run`
   - `xr_render_demo_live_garble` → `xr_render_demo_eval.live_garble:run`
   - `xr_render_demo_live_manip` → `xr_render_demo_eval.live_manip:run`
+  - `xr_render_demo_live_perception` → `xr_render_demo_eval.live_perception:run`
   - `xr_render_demo_live_pose_matrix` → `xr_render_demo_eval.live_pose_matrix:run`
   - `xr_render_demo_live_smoke` → `xr_render_demo_eval.live_smoke:run`
 

--- a/agent-samples/xr-render-demo/eval/README.md
+++ b/agent-samples/xr-render-demo/eval/README.md
@@ -23,6 +23,7 @@ uv run xr_render_demo_live_pose_matrix
 uv run xr_render_demo_live_manip
 uv run xr_render_demo_live_garble
 uv run xr_render_demo_live_explore
+uv run xr_render_demo_live_perception
 ```
 
 <!-- Compatibility anchors for headings consolidated into the documentation. -->

--- a/agent-samples/xr-render-demo/eval/pyproject.toml
+++ b/agent-samples/xr-render-demo/eval/pyproject.toml
@@ -32,6 +32,7 @@ xr_render_demo_live_pose_matrix = "xr_render_demo_eval.live_pose_matrix:run"
 xr_render_demo_live_manip = "xr_render_demo_eval.live_manip:run"
 xr_render_demo_live_garble = "xr_render_demo_eval.live_garble:run"
 xr_render_demo_live_explore = "xr_render_demo_eval.live_explore:run"
+xr_render_demo_live_perception = "xr_render_demo_eval.live_perception:run"
 
 [tool.hatch.build.targets.wheel]
 packages = ["xr_render_demo_eval"]

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/harness.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/harness.py
@@ -800,6 +800,57 @@ UTTERANCES = (
         expected_colors=(("sphere-0", (0.0, 0.4, 1.0)),),
     ),
     Case(
+        name="basics_describe_view_is_camera",
+        # A describe-the-view request means the physical world; reciting
+        # SCENE OBJECTS is never the answer.
+        request="Describe what you can see.",
+        scene=(
+            {"id": "sphere-0", "type": "sphere",
+             "position": {"x": 0.0, "y": 1.6, "z": -1.5},
+             "color": {"r": 0, "g": 0.8, "b": 0}, "size": 0.1},
+            {"id": "box-0", "type": "box",
+             "position": {"x": 0.5, "y": 1.4, "z": -1.2},
+             "color": {"r": 1, "g": 0.5, "b": 0}, "size": 0.1},
+        ),
+        vision="A cluttered desk with a laptop and a coffee mug.",
+        required_tools=frozenset({"look_at_current_frame"}),
+        forbidden_tools=_FORBID_MUTATIONS,
+        reply_contains="desk",
+    ),
+    Case(
+        name="basics_use_the_camera_imperative",
+        # Telling the agent to consult the camera re-enters the pending
+        # question; the literal words are never the delegation.
+        request="Use the camera.",
+        vision="A bookshelf against a white wall.",
+        history=(
+            ("What's behind me right now?",
+             "Could you say more about what you mean?"),
+        ),
+        required_tools=frozenset({"look_at_current_frame"}),
+        forbidden_tools=_FORBID_MUTATIONS,
+        reply_contains="bookshelf",
+    ),
+    Case(
+        name="basics_holding_after_scene_work",
+        # A perception question right after ordinary scene work is fresh;
+        # neither SCENE OBJECTS nor the transcript holds the answer.
+        request="What's in my hand right now?",
+        scene=(
+            {"id": "box-1", "type": "box",
+             "position": {"x": -0.5, "y": 1.6, "z": -1.5},
+             "color": {"r": 0, "g": 0.8, "b": 0}, "size": 0.1},
+        ),
+        history=(
+            ("Make a green box.", "Created a green box in front of you."),
+            ("Move it left.", "Moved the box to your left."),
+        ),
+        vision="A phone in the user's hand.",
+        required_tools=frozenset({"look_at_current_frame"}),
+        forbidden_tools=_FORBID_MUTATIONS,
+        reply_contains="phone",
+    ),
+    Case(
         name="basics_physical_source_camera_down",
         # The camera outage must degrade to an honest no-change reply: the
         # resolver was attempted, nothing mutated, no invented color.

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/harness.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/harness.py
@@ -851,6 +851,15 @@ UTTERANCES = (
         reply_contains="phone",
     ),
     Case(
+        name="basics_compound_one_part_blocked",
+        # One blocked part of a compound turn never blocks the others: the
+        # creation still lands while the perception part reports the outage.
+        request="Create a purple ring, then tell me what is printed on my shirt.",
+        camera_error="RPCError: camera feed unavailable",
+        required_tools=frozenset({"add_primitive"}),
+        expected_colors=(("ring-0", (0.6, 0.0, 1.0)),),
+    ),
+    Case(
         name="basics_physical_source_camera_down",
         # The camera outage must degrade to an honest no-change reply: the
         # resolver was attempted, nothing mutated, no invented color.
@@ -1241,7 +1250,8 @@ def audit_prompts() -> None:
     # Model-visible text lives in the prompt files and in the tool field
     # descriptions of spatial_ops.py; both shape the model's templates.
     prompts = (sorted(worker.rglob("*prompt*.txt"))
-               + [worker / "spatial_ops.py", worker / "_physical_color.py"]
+               + [worker / "spatial_ops.py", worker / "_physical_color.py",
+                  worker / "supervisor.py"]
                + sorted(worker.glob("agents/*/agent.py")))
     utterances = [case["user"] for case in CORPUS_CASES if case.get("user")]
     utterances += [case.request for case in (*CASES, *UTTERANCES)]
@@ -1289,6 +1299,21 @@ def audit_prompts() -> None:
             for text in turn
         ]
         fixture_ids |= {item["id"] for case in eval_supervisor.CASES for item in case.scene}
+    try:
+        from . import live_perception
+    except ImportError:
+        pass
+    else:
+        utterances += [case["prompt"] for case in live_perception.CASES]
+        utterances += [
+            turn for case in live_perception.CASES for turn in case.get("history", ())
+        ]
+        utterances += [case["pending"] for case in live_perception.CASES if "pending" in case]
+        eval_texts += [
+            text
+            for case in live_perception.CASES
+            for _role, text in case.get("poisoned", ())
+        ]
     for prompt_path in prompts:
         label = str(prompt_path.relative_to(worker))
         text = prompt_path.read_text(encoding="utf-8")

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/harness.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/harness.py
@@ -77,10 +77,15 @@ class _FakeTextMemoryTools:
     def __init__(self, fake: "FakeScene") -> None:
         async def recall(req: RecallConversationRequest) -> RecallConversationResult:
             fake.calls.append(("recall_conversation", req.model_dump()))
+            # History ends seconds before the case's request timestamp, so
+            # the recency window (and the pending-ask window, for truncation
+            # cases) treats it as part of this session.
+            base_us = EVAL_REFERENCE_US - 4_000_000 - max(len(fake.history) - 1, 0) * 2_000_000
             entries: list[ConversationEntry] = []
             for i, (user_text, agent_text) in enumerate(fake.history):
-                entries.append(ConversationEntry(timestamp_us=(i + 1) * 1_000_000, role="user", text=user_text))
-                entries.append(ConversationEntry(timestamp_us=(i + 1) * 1_000_000 + 1, role="agent", text=agent_text))
+                turn_us = base_us + i * 2_000_000
+                entries.append(ConversationEntry(timestamp_us=turn_us, role="user", text=user_text))
+                entries.append(ConversationEntry(timestamp_us=turn_us + 1, role="agent", text=agent_text))
             if fake.memory_answer:
                 entries.append(ConversationEntry(timestamp_us=1, role="agent", text=fake.memory_answer))
             return RecallConversationResult(entries=entries)
@@ -189,6 +194,10 @@ class _FakeImageQueryTool:
         )
 
 
+# One clock for eval requests and the fake recall entries windowed against them.
+EVAL_REFERENCE_US = 1_700_000_000_000_000
+
+
 @dataclass(frozen=True)
 class Case:
     name: str
@@ -207,6 +216,7 @@ class Case:
     memory: str = ""
     history: tuple[tuple[str, str], ...] = ()
     reply_contains: str = ""
+    reply_excludes: str = ""
     camera_error: str = ""
     physical_expect_source: str = ""
 
@@ -313,7 +323,10 @@ CASES = (
         name="durable_memory",
         request="What object did we discuss in the earlier session?",
         memory="We discussed a small cyan sphere.",
-        required_tools=frozenset({"recall_conversation"}),
+        # The supervisor's own block recall is call one; memory_agent's
+        # recall is the second.
+        expected_call_counts=(("recall_conversation", 2),),
+        reply_contains="cyan",
     ),
     Case(
         name="placement_despite_camera_off",
@@ -693,7 +706,7 @@ async def run_corpus_case(case: dict[str, Any]) -> bool:
                 SceneRequest(
                     transcript=case["user"],
                     participant_id=_PARTICIPANT,
-                    timestamp_us=1_700_000_000_000_000,
+                    timestamp_us=EVAL_REFERENCE_US,
                 )
             )
             response = reply.response
@@ -872,6 +885,19 @@ UTTERANCES = (
         camera_error="RPCError: camera feed unavailable",
         required_tools=frozenset({"current_frame"}),
         forbidden_tools=_FORBID_MUTATIONS,
+    ),
+    Case(
+        name="basics_stale_held_object_not_renamed",
+        # The user swapped objects between turns: the reply describes what
+        # this turn's camera read, never the object a recalled turn named.
+        # A guard for the supervisor prompt's reply rule; offline
+        # composition does not reproduce the failure, so this cannot catch
+        # the rule's removal.
+        request="Make a cube the color of what I'm holding.",
+        history=(("What am I holding?", "You are holding a red soda can."),),
+        vision="The item in the user's hand is gray.",
+        expected_colors=(("box-0", (0.5, 0.5, 0.5)),),
+        reply_excludes="soda",
     ),
     Case(
         name="basics_holding_color_with_history",
@@ -1162,7 +1188,7 @@ async def run_case(case: Case) -> bool:
                 SceneRequest(
                     transcript=case.request,
                     participant_id=_PARTICIPANT,
-                    timestamp_us=1_700_000_000_000_000,
+                    timestamp_us=EVAL_REFERENCE_US,
                 )
             )
             response = reply.response
@@ -1209,6 +1235,8 @@ async def run_case(case: Case) -> bool:
     }
     wrong_reply = bool(
         case.reply_contains and case.reply_contains.lower() not in response.lower()
+    ) or bool(
+        case.reply_excludes and case.reply_excludes.lower() in response.lower()
     )
     passed = (
         not errored

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/live_perception.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/live_perception.py
@@ -8,7 +8,9 @@ perception turn must come back as an honest inability report from
 vision_agent. That invariant catches the misses the offline tiers cannot
 reproduce (their [Recent conversation] is far shorter than a live one):
 a perception question answered from the transcript, or a describe-the-view
-request answered by reciting SCENE OBJECTS.
+request answered by reciting SCENE OBJECTS. Same-session turns inside the
+supervisor's recall window are out of scope here; diagnose those from the
+worker log and the transcript store.
 
 Run subsets: `live_perception.py [case-name ...]`.
 """
@@ -55,6 +57,8 @@ INABILITY_MARKERS = (
 # Words that appear in a reply only when the model recites the XR scene.
 SCENE_RECITAL_WORDS = ("cube", "box", "sphere", "ball", "cone", "capsule", "cylinder", "pyramid")
 
+_WORD_TYPES = {"cube": "box", "ball": "sphere", "donut": "torus"}
+
 # Each case: history prompts that must change the scene (real turns that
 # fill [Recent conversation]), then one perception prompt judged on the
 # reply text and on the scene staying unchanged.
@@ -97,7 +101,9 @@ CASES = [
 
 
 async def _inject_poisoned(memory, participant, turns):
-    base_us = time.time_ns() // 1_000 - 120_000_000
+    # Two hours old: unambiguously cross-session, the condition this eval
+    # reproduces.
+    base_us = time.time_ns() // 1_000 - 7_200_000_000
     for offset, (role, text) in enumerate(turns):
         await memory.add_transcript.execute(AddTranscriptRequest(
             source_id=f"{participant}:{role}",
@@ -137,13 +143,15 @@ async def _send_and_wait_reply(endpoint, memory, participant, prompt, timeout_s=
     return ""
 
 
-def _judge(reply, scene_unchanged):
+def _judge(reply, scene_unchanged, asked_words=()):
     lowered = reply.lower().replace("’", "'")
     if not reply:
         return False, "no reply within timeout"
     if not scene_unchanged:
         return False, "scene changed on a perception turn"
-    recited = [w for w in SCENE_RECITAL_WORDS if w in lowered]
+    # A shape word the case's own utterances used is the request echoed,
+    # not the scene recited.
+    recited = [w for w in SCENE_RECITAL_WORDS if w in lowered and w not in asked_words]
     if recited:
         return False, f"reply recites scene objects {recited}: {reply!r}"
     if not any(marker in lowered for marker in INABILITY_MARKERS):
@@ -194,7 +202,16 @@ async def main() -> None:
                     before = {i.id: i for i in (await scene.get_scene_state(EmptyRequest())).objects}
                     reply = await _send_and_wait_reply(endpoint, memory, participant, case["prompt"])
                     after = {i.id: i for i in (await scene.get_scene_state(EmptyRequest())).objects}
-                    ok, detail = _judge(reply, before == after)
+                    # Only the judged turn's own words are exempt, and only
+                    # while no scene object of that type exists; history
+                    # words must still count as recital.
+                    asked = f"{case['prompt']} {case.get('pending', '')}".lower()
+                    scene_types = {item.type for item in before.values()}
+                    asked_words = tuple(
+                        w for w in SCENE_RECITAL_WORDS
+                        if w in asked and _WORD_TYPES.get(w, w) not in scene_types
+                    )
+                    ok, detail = _judge(reply, before == after, asked_words)
             print(f"{'PASS' if ok else 'FAIL'} {case['name']:28s} {detail[:220]}", flush=True)
             passed += ok
             failed += not ok

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/live_perception.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/live_perception.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from xr_ai_hub import DataMessage
 from xr_ai_tools.rpc import RPCClient
 from xr_ai_tools.text_memory import AddTranscriptRequest, RecallConversationRequest, TextMemoryTools
+from xr_render_demo_worker.config import load_config
 from xr_render_scene import AddPrimitiveRequest, EmptyRequest, RemovePrimitiveRequest, SceneClient
 
 from ._live_endpoint import LiveEvalEndpoint, live_participant
@@ -35,13 +36,7 @@ CANONICAL = {"position": {"x": 0, "y": 1.6, "z": 0}, "forward": {"x": 0, "y": 0,
 def _text_memory_dir() -> str:
     """The driver reads the same transcript store the worker writes."""
     yaml_path = Path(__file__).resolve().parents[2] / "yaml" / "xr_render_demo_worker.yaml"
-    try:
-        for line in yaml_path.read_text(encoding="utf-8").splitlines():
-            if line.strip().startswith("text_memory_dir:"):
-                return line.split(":", 1)[1].strip()
-    except OSError:
-        pass
-    return "/dev/shm/xr-ai/text-memory"
+    return load_config(yaml_path).text_memory_dir
 
 
 # Bare "camera"/"vision" are excluded: a confabulated answer may mention the
@@ -176,6 +171,9 @@ async def main() -> None:
         raise SystemExit(2) from None
     try:
         wanted = set(sys.argv[1:])
+        unknown = wanted - {case["name"] for case in CASES}
+        if unknown:
+            raise SystemExit(f"unknown cases: {sorted(unknown)}")
         passed = failed = 0
         for index, case in enumerate(CASES):
             if wanted and case["name"] not in wanted:

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/live_perception.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/live_perception.py
@@ -1,0 +1,219 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Live perception-routing tests: real conversation history, reply-text verdict.
+
+The live eval stack publishes no camera track, so a correctly routed
+perception turn must come back as an honest inability report from
+vision_agent. That invariant catches the misses the offline tiers cannot
+reproduce (their [Recent conversation] is far shorter than a live one):
+a perception question answered from the transcript, or a describe-the-view
+request answered by reciting SCENE OBJECTS.
+
+Run subsets: `live_perception.py [case-name ...]`.
+"""
+
+import asyncio
+import os
+import sys
+import time
+from pathlib import Path
+
+from xr_ai_hub import DataMessage
+from xr_ai_tools.rpc import RPCClient
+from xr_ai_tools.text_memory import AddTranscriptRequest, RecallConversationRequest, TextMemoryTools
+from xr_render_scene import AddPrimitiveRequest, EmptyRequest, RemovePrimitiveRequest, SceneClient
+
+from ._live_endpoint import LiveEvalEndpoint, live_participant
+
+CANONICAL = {"position": {"x": 0, "y": 1.6, "z": 0}, "forward": {"x": 0, "y": 0, "z": -1},
+             "right": {"x": 1, "y": 0, "z": 0}, "up": {"x": 0, "y": 1, "z": 0},
+             "yaw_deg": 0.0, "pitch_deg": 0.0, "ts": 1}
+
+def _text_memory_dir() -> str:
+    """The driver reads the same transcript store the worker writes."""
+    yaml_path = Path(__file__).resolve().parents[2] / "yaml" / "xr_render_demo_worker.yaml"
+    try:
+        for line in yaml_path.read_text(encoding="utf-8").splitlines():
+            if line.strip().startswith("text_memory_dir:"):
+                return line.split(":", 1)[1].strip()
+    except OSError:
+        pass
+    return "/dev/shm/xr-ai/text-memory"
+
+
+# Bare "camera"/"vision" are excluded: a confabulated answer may mention the
+# camera while still claiming to see.
+INABILITY_MARKERS = (
+    "can't see", "cannot see", "couldn't see", "can not see",
+    "unable", "not able", "no camera", "no view",
+    "unavailable", "not available", "can't access", "cannot access",
+    "don't have", "do not have", "can't tell", "cannot tell",
+    "can't check", "cannot check", "couldn't check",
+)
+
+# Words that appear in a reply only when the model recites the XR scene.
+SCENE_RECITAL_WORDS = ("cube", "box", "sphere", "ball", "cone", "capsule", "cylinder", "pyramid")
+
+# Each case: history prompts that must change the scene (real turns that
+# fill [Recent conversation]), then one perception prompt judged on the
+# reply text and on the scene staying unchanged.
+CASES = [
+    {
+        "name": "holding_mid_conversation",
+        "history": ["Make a green cube.", "Move it to the left."],
+        "prompt": "What is the thing in my hand?",
+    },
+    {
+        "name": "describe_view_not_scene",
+        "history": ["Make a green cube.", "Add a blue ball next to it."],
+        "prompt": "Tell me what everything around me looks like.",
+    },
+    {
+        "name": "camera_imperative_pending",
+        "history": ["Make a green cube."],
+        "pending": "Make a ball the color of the item in my hand.",
+        "prompt": "Go ahead and look.",
+    },
+    {
+        # The transcript store persists across sessions, so [Recent
+        # conversation] can carry old turns where perception questions were
+        # answered without the camera. Those replies are few-shot poison:
+        # the supervisor must still delegate vision, never imitate them.
+        "name": "holding_after_poisoned_history",
+        "fixtures": [("box", 0.0, 1.6, -1.5, 1, 0, 0, 0.1)],
+        "poisoned": [
+            ("user", "What do you see?"),
+            ("agent", "I see a red box located at position x=0.0, y=1.6, z=-1.5."),
+            ("user", "Look at the camera and describe what you see."),
+            ("agent", "The camera shows a red cube (id: box-0) positioned at "
+                      "coordinates (0.0, 1.6, -1.5) in the scene."),
+            ("user", "What is in my hand?"),
+            ("agent", "You are not holding anything."),
+        ],
+        "prompt": "What am I holding?",
+    },
+]
+
+
+async def _inject_poisoned(memory, participant, turns):
+    base_us = time.time_ns() // 1_000 - 120_000_000
+    for offset, (role, text) in enumerate(turns):
+        await memory.add_transcript.execute(AddTranscriptRequest(
+            source_id=f"{participant}:{role}",
+            timestamp_us=base_us + offset * 5_000_000,
+            text=text,
+        ))
+
+
+async def clear_scene(scene):
+    state = await scene.get_scene_state(EmptyRequest())
+    for item in state.objects:
+        await scene.remove_primitive(RemovePrimitiveRequest(obj_id=item.id))
+
+
+async def _agent_replies_since(memory, participant, after_us):
+    recalled = await memory.recall_conversation.execute(
+        RecallConversationRequest(participant_id=participant))
+    return [
+        entry.text
+        for entry in recalled.entries
+        if entry.role == "agent" and entry.timestamp_us >= after_us
+    ]
+
+
+async def _send_and_wait_reply(endpoint, memory, participant, prompt, timeout_s=75):
+    # Correlating by timestamp keeps a straggler reply to the previous
+    # prompt from being judged as this one's.
+    sent_us = time.time_ns() // 1_000
+    await endpoint.inject_data(DataMessage(
+        participant_id=participant, topic="", pts_us=sent_us, data=prompt.encode()))
+    deadline = asyncio.get_running_loop().time() + timeout_s
+    while asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(2)
+        replies = await _agent_replies_since(memory, participant, sent_us)
+        if replies:
+            return replies[0]
+    return ""
+
+
+def _judge(reply, scene_unchanged):
+    lowered = reply.lower().replace("’", "'")
+    if not reply:
+        return False, "no reply within timeout"
+    if not scene_unchanged:
+        return False, "scene changed on a perception turn"
+    recited = [w for w in SCENE_RECITAL_WORDS if w in lowered]
+    if recited:
+        return False, f"reply recites scene objects {recited}: {reply!r}"
+    if not any(marker in lowered for marker in INABILITY_MARKERS):
+        return False, f"reply claims an answer with no camera: {reply!r}"
+    return True, reply
+
+
+async def main() -> None:
+    scene = SceneClient("tcp://127.0.0.1:8320")
+    memory = TextMemoryTools(_text_memory_dir())
+    tracking = RPCClient("tcp://127.0.0.1:8330", timeout_s=10.0)
+    endpoint = LiveEvalEndpoint()
+    await asyncio.sleep(0.5)
+    try:
+        await tracking.call("set_sim_pose", CANONICAL)
+    except Exception as error:
+        print(f"openxr service refused set_sim_pose ({error}); set allow_sim_pose: true in "
+              "../yaml/openxr_service.yaml and restart the stack")
+        await scene.close()
+        await tracking.close()
+        await endpoint.close()
+        raise SystemExit(2) from None
+    try:
+        wanted = set(sys.argv[1:])
+        passed = failed = 0
+        for index, case in enumerate(CASES):
+            if wanted and case["name"] not in wanted:
+                continue
+            participant = f"live-perception-{os.getpid()}-{int(time.time())}-{index}"
+            async with live_participant(endpoint, participant):
+                await clear_scene(scene)
+                ok, detail = True, ""
+                for prim_type, x, y, z, r, g, b, size in case.get("fixtures", ()):
+                    await scene.add_primitive(AddPrimitiveRequest(
+                        prim_type=prim_type, x=x, y=y, z=z, r=r, g=g, b=b, size=size))
+                if "poisoned" in case:
+                    await _inject_poisoned(memory, participant, case["poisoned"])
+                for turn in case.get("history", ()):
+                    before = {i.id: i for i in (await scene.get_scene_state(EmptyRequest())).objects}
+                    await _send_and_wait_reply(endpoint, memory, participant, turn)
+                    after = {i.id: i for i in (await scene.get_scene_state(EmptyRequest())).objects}
+                    if before == after:
+                        ok, detail = False, f"history turn made no scene change: {turn!r}"
+                        break
+                if ok and "pending" in case:
+                    await _send_and_wait_reply(endpoint, memory, participant, case["pending"])
+                if ok:
+                    before = {i.id: i for i in (await scene.get_scene_state(EmptyRequest())).objects}
+                    reply = await _send_and_wait_reply(endpoint, memory, participant, case["prompt"])
+                    after = {i.id: i for i in (await scene.get_scene_state(EmptyRequest())).objects}
+                    ok, detail = _judge(reply, before == after)
+            print(f"{'PASS' if ok else 'FAIL'} {case['name']:28s} {detail[:220]}", flush=True)
+            passed += ok
+            failed += not ok
+        print(f"\nlive perception: {passed} passed, {failed} failed", flush=True)
+    finally:
+        try:
+            await tracking.call("clear_sim_pose", {})
+        except Exception:
+            # Best-effort cleanup; the stack may already be gone.
+            pass
+        await scene.close()
+        await tracking.close()
+        await endpoint.close()
+    sys.exit(1 if failed else 0)
+
+
+def run() -> None:
+    asyncio.run(main())
+
+
+if __name__ == "__main__":
+    run()

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/subagents.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/subagents.py
@@ -500,6 +500,13 @@ CASES = (
         forbid_tools=("add_primitive", "update_primitive", "remove_primitive"),
         answer_contains="recolor",
     ),
+    # Known limitation, deliberately untested here: a MIXED instruction that
+    # pairs a recolor with owned work ("make it pink and twice as big")
+    # cannot be handled reliably by this agent at temperature zero; every
+    # contract tried (execute owned parts, or refuse whole) reshaped the
+    # object or dropped the report. The supervisor's compound-splitting rule
+    # is the guarantee such instructions never reach this agent; it is
+    # covered end to end by three_actions_compound.
     SubagentCase(
         name="recolor_explicit_rgb",
         agent="appearance",

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/subagents.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/subagents.py
@@ -500,13 +500,10 @@ CASES = (
         forbid_tools=("add_primitive", "update_primitive", "remove_primitive"),
         answer_contains="recolor",
     ),
-    # Known limitation, deliberately untested here: a MIXED instruction that
-    # pairs a recolor with owned work ("make it pink and twice as big")
-    # cannot be handled reliably by this agent at temperature zero; every
-    # contract tried (execute owned parts, or refuse whole) reshaped the
-    # object or dropped the report. The supervisor's compound-splitting rule
-    # is the guarantee such instructions never reach this agent; it is
-    # covered end to end by three_actions_compound.
+    # Mixed instructions pairing a recolor with owned work ("make it pink
+    # and twice as big") are deliberately untested: the supervisor's
+    # compound-splitting rule guarantees they never reach this agent, and
+    # that rule is covered end to end by three_actions_compound.
     SubagentCase(
         name="recolor_explicit_rgb",
         agent="appearance",
@@ -745,7 +742,7 @@ async def run_case(case: SubagentCase) -> bool:
             physical_color=make_fake_physical_color(scene),
         )
         current_participant_id.set(_PARTICIPANT)
-        current_reference_time_us.set(1_700_000_000_000_000)
+        current_reference_time_us.set(harness.EVAL_REFERENCE_US)
         errored = False
         try:
             reply = await agent.execute(SubagentTask(instruction=case.instruction))

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/subagents.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/subagents.py
@@ -493,6 +493,14 @@ CASES = (
         ),
     ),
     SubagentCase(
+        name="recolor_reports_back",
+        agent="object",
+        instruction="Make cone-0 pink.",
+        scene=(_CONE,),
+        forbid_tools=("add_primitive", "update_primitive", "remove_primitive"),
+        answer_contains="recolor",
+    ),
+    SubagentCase(
         name="recolor_explicit_rgb",
         agent="appearance",
         instruction="Set cone-0 to the observed wall color: normalized RGB (1.0, 0.5, 0.0).",

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/supervisor.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/supervisor.py
@@ -284,7 +284,7 @@ async def run_case(case: RoutingCase) -> bool:
                 SceneRequest(
                     transcript=case.request,
                     participant_id="eval-user",
-                    timestamp_us=1_700_000_000_000_000,
+                    timestamp_us=harness.EVAL_REFERENCE_US,
                 )
             )
         except Exception as exc:

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/appearance/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/appearance/agent.py
@@ -21,10 +21,10 @@ from ...spatial_ops import TurnGuard, make_appearance_tools
 _PROMPT = Path(__file__).with_name("prompt.txt")
 DESCRIPTION = (
     "Change only the color of existing XR objects: every recolor of an existing object is this "
-    "agent, whatever the verb, never object_agent. The instruction keeps the user's color source "
-    "words verbatim: a color word, an XR object to copy ('same as capsule-8'), or a physical-"
-    "world phrase ('match my jacket') whose color this agent reads from the camera itself; never "
-    "guess a physical color and never send vision_agent to look one up."
+    "agent, whatever the verb, never object_agent. The instruction keeps the user's color "
+    "source words verbatim: a color word, an XR object to copy (\"same as capsule-8\"), or a "
+    "physical-world phrase (\"match my jacket\") whose color this agent reads from the camera "
+    "itself; never guess a physical color and never send vision_agent to look one up."
 )
 
 

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/appearance/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/appearance/agent.py
@@ -19,7 +19,13 @@ from ...scene import SceneContext
 from ...spatial_ops import TurnGuard, make_appearance_tools
 
 _PROMPT = Path(__file__).with_name("prompt.txt")
-DESCRIPTION = "Change only the color of existing XR objects."
+DESCRIPTION = (
+    "Change only the color of existing XR objects: every recolor of an existing object is this "
+    "agent, whatever the verb, never object_agent. The instruction keeps the user's color source "
+    "words verbatim: a color word, an XR object to copy ('same as capsule-8'), or a physical-"
+    "world phrase ('match my jacket') whose color this agent reads from the camera itself; never "
+    "guess a physical color and never send vision_agent to look one up."
+)
 
 
 _prompt_text = _PROMPT.read_text(encoding="utf-8").strip()

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/memory/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/memory/agent.py
@@ -23,12 +23,12 @@ from ...models import SubagentResult, SubagentTask
 _PROMPT = Path(__file__).with_name("prompt.txt")
 DESCRIPTION = (
     "Recall what was said, asked, or done in earlier conversation turns, including objects and "
-    "colors mentioned there. Every history question ('which shape did I request first?', 'what "
-    "did I ask you to build?') routes here, even when [Recent conversation] "
-    "seems to contain the answer; that block only resolves references, and guessing a history "
-    "answer is always wrong. Never a source for present-day or physical-world facts, and what "
-    "the camera saw earlier belongs to vision_agent: the camera's past lives in recorded video, "
-    "the conversation's past in the transcript."
+    "colors mentioned there. Every history question (\"which shape did I request first?\", "
+    "\"what did I ask you to build?\") routes here, even when [Recent conversation] seems to "
+    "contain the answer; that block only resolves references, and guessing a history answer is "
+    "always wrong. Never a source for present-day or physical-world facts, and what the camera "
+    "saw earlier belongs to vision_agent: the camera's past lives in recorded video, the "
+    "conversation's past in the transcript."
 )
 
 _MAX_END_US = RecallConversationRequest.model_fields["end_us"].default

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/memory/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/memory/agent.py
@@ -21,9 +21,15 @@ from ..._trace import current_participant_id, current_reference_time_us, current
 from ...models import SubagentResult, SubagentTask
 
 _PROMPT = Path(__file__).with_name("prompt.txt")
-DESCRIPTION = ("Recall what was said in earlier conversation turns, including objects and "
-               "colors mentioned there; never a source for present-day or physical-world "
-               "facts like the color of a real surface.")
+DESCRIPTION = (
+    "Recall what was said, asked, or done in earlier conversation turns, including objects and "
+    "colors mentioned there. Every history question ('which shape did I request first?', 'what "
+    "did I ask you to build?') routes here, even when [Recent conversation] "
+    "seems to contain the answer; that block only resolves references, and guessing a history "
+    "answer is always wrong. Never a source for present-day or physical-world facts, and what "
+    "the camera saw earlier belongs to vision_agent: the camera's past lives in recorded video, "
+    "the conversation's past in the transcript."
+)
 
 _MAX_END_US = RecallConversationRequest.model_fields["end_us"].default
 

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/memory/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/memory/agent.py
@@ -27,8 +27,8 @@ DESCRIPTION = (
     "\"what did I ask you to build?\") routes here, even when [Recent conversation] seems to "
     "contain the answer; that block only resolves references, and guessing a history answer is "
     "always wrong. Never a source for present-day or physical-world facts, and what the camera "
-    "saw earlier belongs to vision_agent: the camera's past lives in recorded video, the "
-    "conversation's past in the transcript."
+    "saw earlier belongs to vision_agent, not memory: only the conversation's own turns live "
+    "in the transcript."
 )
 
 _MAX_END_US = RecallConversationRequest.model_fields["end_us"].default

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/object/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/object/agent.py
@@ -20,8 +20,8 @@ from ...scene import SceneContext
 from ...spatial_ops import CreationLedger, TurnGuard, make_object_tools
 
 _PROMPT = Path(__file__).with_name("prompt.txt")
-# The creation-always-new rule deliberately restates a supervisor_prompt.txt rule:
-# tool descriptions alone are under-weighted mid-loop, so both copies are load-bearing.
+# The creation-always-new rule intentionally duplicates supervisor_prompt.txt; see
+# docs/source/reference/xr-render-demo.md ("stated in both places on purpose").
 DESCRIPTION = (
     "Create new XR objects at their requested initial positions, and remove, resize, duplicate, "
     "or reshape existing ones; never moves or recolors an existing object. Moving includes "

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/object/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/object/agent.py
@@ -20,20 +20,23 @@ from ...scene import SceneContext
 from ...spatial_ops import CreationLedger, TurnGuard, make_object_tools
 
 _PROMPT = Path(__file__).with_name("prompt.txt")
+# The creation-always-new rule deliberately restates a supervisor_prompt.txt rule:
+# tool descriptions alone are under-weighted mid-loop, so both copies are load-bearing.
 DESCRIPTION = (
     "Create new XR objects at their requested initial positions, and remove, resize, duplicate, "
     "or reshape existing ones; never moves or recolors an existing object. Moving includes "
     "putting one in, on, or next to another, and any color change of an existing object belongs "
     "to appearance_agent. A creation request always makes a new object, even when SCENE OBJECTS "
-    "already lists an identical one. Creation carries its position in the same single call, whether user-"
-    "relative, anchored on scene objects, or between two of them; this agent resolves tracking "
-    "and anchor geometry itself. Phrase creation as: Create <count, when more than one> <color> "
-    "<shape>(s) <the user's own spatial words>, with the user's color words verbatim (a color "
-    "word, 'same as capsule-8', or a physical phrase like 'the color of my apron') and every "
-    "requested copy in the one instruction; when the user named no position at all, end with "
-    "'no position stated', and never invent a position. Removal words with a side ('the X on "
-    "the left') stay a removal; a resize instruction carries the resolved id ('Resize capsule-8 "
-    "to half its current size')."
+    "already lists an identical one. Creation carries its position in the same single call, "
+    "whether user-relative, anchored on scene objects, or between two of them; this agent "
+    "resolves tracking and anchor geometry itself. Phrase creation as: Create <count, when more "
+    "than one> <color> <shape>(s) <the user's own spatial words>, with the user's color words "
+    "verbatim (a color word, \"same as capsule-8\", or a physical phrase like \"the color of my "
+    "apron\") and every requested copy in the one instruction. When the user named no position "
+    "at all, end with \"no position stated\"; never add that phrase when spatial words are "
+    "present, and never invent a position. Removal words with a side (\"the X on the left\") "
+    "stay a removal; a resize instruction carries the resolved id (\"Resize capsule-8 to half "
+    "its current size\")."
 )
 
 

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/object/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/object/agent.py
@@ -21,8 +21,19 @@ from ...spatial_ops import CreationLedger, TurnGuard, make_object_tools
 
 _PROMPT = Path(__file__).with_name("prompt.txt")
 DESCRIPTION = (
-    "Create new XR objects at their requested initial positions, and remove, resize, duplicate, or "
-    "reshape existing ones; never moves an existing object, including putting one in, on, or next to another."
+    "Create new XR objects at their requested initial positions, and remove, resize, duplicate, "
+    "or reshape existing ones; never moves or recolors an existing object. Moving includes "
+    "putting one in, on, or next to another, and any color change of an existing object belongs "
+    "to appearance_agent. A creation request always makes a new object, even when SCENE OBJECTS "
+    "already lists an identical one. Creation carries its position in the same single call, whether user-"
+    "relative, anchored on scene objects, or between two of them; this agent resolves tracking "
+    "and anchor geometry itself. Phrase creation as: Create <count, when more than one> <color> "
+    "<shape>(s) <the user's own spatial words>, with the user's color words verbatim (a color "
+    "word, 'same as capsule-8', or a physical phrase like 'the color of my apron') and every "
+    "requested copy in the one instruction; when the user named no position at all, end with "
+    "'no position stated', and never invent a position. Removal words with a side ('the X on "
+    "the left') stay a removal; a resize instruction carries the resolved id ('Resize capsule-8 "
+    "to half its current size')."
 )
 
 

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/object/prompt.txt
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/object/prompt.txt
@@ -10,7 +10,10 @@ id or tool argument.
 
 Handle creation, including a new object's initial position, plus deletion,
 shape changes, resizing, and duplication. Do not change color or move an
-existing object; the supervisor will invoke appearance or placement separately.
+existing object; the supervisor will invoke appearance or placement
+separately. An instruction that names an existing object and a color while
+changing nothing else is a recolor, never a creation, and never a removal
+followed by recreation in the new color.
 
 Quote the instruction's own shape word as prim_type, mangled spellings
 included; the tools map it to a renderer shape themselves. A shape word you
@@ -90,8 +93,11 @@ factor 3.
 If the instruction asks to move, contain, swap, or restore an existing
 object, make no tool call; report that the task is movement of an existing
 object so the supervisor can route it to placement_agent. If it asks to
-change an existing object's color, make no tool call; report that the task
-is a recolor so the supervisor can route it to appearance_agent.
+change an existing object's color, never alter that color by any means,
+including removing and recreating the object: complete only the non-color
+parts of the instruction, if any, and report that the color part is a
+recolor so the supervisor can route it to appearance_agent. A pure recolor
+instruction gets no tool call at all.
 
 Tool calls must use their declared schemas. Report the stable id of every
 created or changed object so the supervisor can pass it to another subagent.

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/object/prompt.txt
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/object/prompt.txt
@@ -89,7 +89,9 @@ factor 3.
 
 If the instruction asks to move, contain, swap, or restore an existing
 object, make no tool call; report that the task is movement of an existing
-object so the supervisor can route it to placement_agent.
+object so the supervisor can route it to placement_agent. If it asks to
+change an existing object's color, make no tool call; report that the task
+is a recolor so the supervisor can route it to appearance_agent.
 
 Tool calls must use their declared schemas. Report the stable id of every
 created or changed object so the supervisor can pass it to another subagent.

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/placement/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/placement/agent.py
@@ -21,8 +21,10 @@ from ...spatial_ops import TurnGuard, make_placement_tools
 
 _PROMPT = Path(__file__).with_name("prompt.txt")
 DESCRIPTION = (
-    "Move, swap, contain, stack, or restore existing XR objects; "
-    "never creates, recolors, or removes them."
+    "Move, swap, contain, stack, or restore existing XR objects; never creates, recolors, or "
+    "removes them. Only an object already listed in SCENE OBJECTS can move: 'put the X in/on/"
+    "inside the Y' with X listed is a move for this agent, while placing an X not yet in the "
+    "scene is a creation for object_agent, initial position included."
 )
 
 

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/placement/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/placement/agent.py
@@ -22,9 +22,9 @@ from ...spatial_ops import TurnGuard, make_placement_tools
 _PROMPT = Path(__file__).with_name("prompt.txt")
 DESCRIPTION = (
     "Move, swap, contain, stack, or restore existing XR objects; never creates, recolors, or "
-    "removes them. Only an object already listed in SCENE OBJECTS can move: 'put the X in/on/"
-    "inside the Y' with X listed is a move for this agent, while placing an X not yet in the "
-    "scene is a creation for object_agent, initial position included."
+    "removes them. Only an object already listed in SCENE OBJECTS can move: \"put the X "
+    "in/on/inside the Y\" with X listed is a move for this agent, while placing an X not yet "
+    "in the scene is a creation for object_agent, initial position included."
 )
 
 

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/vision/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/vision/agent.py
@@ -20,16 +20,19 @@ from ...models import SubagentResult, SubagentTask
 from ...scene import SceneContext
 
 _PROMPT = Path(__file__).with_name("prompt.txt")
-# The SCENE OBJECTS sentence deliberately restates a supervisor_prompt.txt rule:
-# tool descriptions alone are under-weighted mid-loop, so both copies are load-bearing.
+# The SCENE OBJECTS sentence intentionally duplicates supervisor_prompt.txt; see
+# docs/source/reference/xr-render-demo.md ("stated in both places on purpose").
+# _SHARED_RULES ends mid-sentence: each description completes it differently.
 _SHARED_RULES = (
-    "A user statement about the camera itself is not a perception request. Never for facts "
-    "about XR objects: SCENE OBJECTS is always current and complete, tracking resolves "
-    "user-relative placement, and the mutating agents read the camera themselves for physical "
-    "color sources. A new question about what the user holds, wears, or sees is always a fresh "
-    "delegation, whatever earlier turns said about cameras; \"check the camera\" as an answer "
-    "to a clarifying question means delegating the original pending question. If live vision "
-    "is unavailable this agent reports so"
+    "Any request to describe or survey what is visible also means the physical view, never a "
+    "recital of the XR scene. A user statement about the camera itself is not a perception "
+    "request. Never for facts about XR objects: SCENE OBJECTS is always current and complete, "
+    "tracking resolves user-relative placement, and the mutating agents read the camera "
+    "themselves for physical color sources. A new question about what the user holds, wears, "
+    "or sees is always a fresh delegation, every time it is asked, whatever earlier turns said "
+    "about cameras or showed as replies; \"check the camera\" or any telling you to look or "
+    "observe, as an answer to a clarifying question, means delegating the original pending "
+    "question, never those literal words. If live vision is unavailable this agent reports so"
 )
 
 DESCRIPTION = (

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/vision/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/vision/agent.py
@@ -20,17 +20,31 @@ from ...models import SubagentResult, SubagentTask
 from ...scene import SceneContext
 
 _PROMPT = Path(__file__).with_name("prompt.txt")
+# The SCENE OBJECTS sentence deliberately restates a supervisor_prompt.txt rule:
+# tool descriptions alone are under-weighted mid-loop, so both copies are load-bearing.
+_SHARED_RULES = (
+    "A user statement about the camera itself is not a perception request. Never for facts "
+    "about XR objects: SCENE OBJECTS is always current and complete, tracking resolves "
+    "user-relative placement, and the mutating agents read the camera themselves for physical "
+    "color sources. A new question about what the user holds, wears, or sees is always a fresh "
+    "delegation, whatever earlier turns said about cameras; \"check the camera\" as an answer "
+    "to a clarifying question means delegating the original pending question. If live vision "
+    "is unavailable this agent reports so"
+)
+
 DESCRIPTION = (
     "Answer a question about the user's physical surroundings from the live camera, or from "
-    "recorded video when the question is about a past moment: 'what am I looking at?' and 'what "
-    "was I holding a moment ago?' are always this agent, never answered from your own impression "
-    "of the camera. Never for facts about XR objects: "
-    "SCENE OBJECTS is always current and complete, tracking resolves user-relative placement, and "
-    "the mutating agents read the camera themselves for physical color sources. A new question "
-    "about what the user holds, wears, or sees is always a fresh delegation, whatever earlier "
-    "turns said about cameras; 'check the camera' as an answer to a clarifying question means "
-    "delegating the original pending question. If live vision is unavailable the agent reports "
-    "so; never redelegate with historical video substituted for the present."
+    "recorded video when the question is about a past moment: \"what am I looking at?\" and "
+    "\"what was I holding a moment ago?\" are always this agent, never answered without "
+    "delegating here. " + _SHARED_RULES + "; never redelegate with historical video "
+    "substituted for the present."
+)
+
+_LIVE_ONLY_DESCRIPTION = (
+    "Answer a question about the user's present physical surroundings from the live camera: "
+    "\"what am I looking at?\" is always this agent, never answered without delegating here. "
+    "Recorded video is not available, so a question about a past moment cannot be answered; "
+    "say so plainly. " + _SHARED_RULES + "."
 )
 
 
@@ -111,7 +125,8 @@ def make_vision_agent(
             return SubagentResult(result="I couldn't complete that. Please try again.")
         return SubagentResult(result=loop_result.content or "Done.")
 
-    return Tool(name="vision_agent", description=DESCRIPTION,
+    description = DESCRIPTION if video is not None else _LIVE_ONLY_DESCRIPTION
+    return Tool(name="vision_agent", description=description,
                 request_model=SubagentTask, result_model=SubagentResult, handler=handle)
 
 

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/vision/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/vision/agent.py
@@ -21,8 +21,16 @@ from ...scene import SceneContext
 
 _PROMPT = Path(__file__).with_name("prompt.txt")
 DESCRIPTION = (
-    "Answer a question about the physical world from the live or recorded camera; "
-    "never for XR scene state or placement."
+    "Answer a question about the user's physical surroundings from the live camera, or from "
+    "recorded video when the question is about a past moment: 'what am I looking at?' and 'what "
+    "was I holding a moment ago?' are always this agent, never answered from your own impression "
+    "of the camera. Never for facts about XR objects: "
+    "SCENE OBJECTS is always current and complete, tracking resolves user-relative placement, and "
+    "the mutating agents read the camera themselves for physical color sources. A new question "
+    "about what the user holds, wears, or sees is always a fresh delegation, whatever earlier "
+    "turns said about cameras; 'check the camera' as an answer to a clarifying question means "
+    "delegating the original pending question. If live vision is unavailable the agent reports "
+    "so; never redelegate with historical video substituted for the present."
 )
 
 

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/vision/prompt.txt
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/vision/prompt.txt
@@ -7,8 +7,12 @@ supervisor. When SCENE OBJECTS is present, it lists every XR object;
 contrast: "Is there a magenta cone currently in the scene?": answer directly
 from SCENE OBJECTS with the ids and positions it shows, no tool call. "What
 color is the mug the user is holding?": a physical-world fact, call
-look_at_current_frame with that question. Call look_at_current_frame with a
-specific question only for the present physical view. Never guess a real-
+look_at_current_frame with that question. "Describe the visible
+surroundings.": a physical-world instruction even though SCENE OBJECTS
+lists XR objects, so call look_at_current_frame with it; never answer a
+describe-the-view instruction by listing SCENE OBJECTS. Call
+look_at_current_frame with a specific question only for the present
+physical view. Never guess a real-
 world object, color, shape, or text, and never reply that you cannot see
 something without calling look_at_current_frame first: only the tool's own
 result can establish that the view is unavailable. Anyone claiming you

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/app.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/app.py
@@ -144,6 +144,13 @@ async def run_app(
                 await render.stop()
         logger.info("xr-render-demo worker stopped")
     finally:
-        await scene.client.close()
-        await tracking.close()
+        await close_clients(scene, tracking, video)
+
+
+async def close_clients(
+    scene: SceneTools, tracking: TrackingTools, video: VideoMemoryTools | None
+) -> None:
+    await scene.client.close()
+    await tracking.close()
+    if video is not None:
         await video.close()

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/app.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/app.py
@@ -72,7 +72,7 @@ async def run_app(
     scene = SceneTools(config.scene_endpoint)
     tracking = TrackingTools(config.openxr_endpoint)
     text_memory = TextMemoryTools(config.text_memory_dir)
-    video = VideoMemoryTools(config.video_memory_endpoint)
+    video = VideoMemoryTools(config.video_memory_endpoint) if config.video_history_enabled else None
     images = ImageRegistry(allow_external=True)
     current_frame = CurrentFrameTool(
         endpoint=transport.endpoint,

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/config.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/config.py
@@ -18,6 +18,7 @@ class WorkerConfig:
     scene_endpoint: str
     openxr_endpoint: str
     video_memory_endpoint: str
+    video_history_enabled: bool
     text_memory_dir: str
 
     silence_duration:  float
@@ -38,6 +39,7 @@ def load_config(path: pathlib.Path | None) -> WorkerConfig:
         scene_endpoint = data.get("scene_endpoint", "tcp://127.0.0.1:8320"),
         openxr_endpoint = data.get("openxr_endpoint", "tcp://127.0.0.1:8330"),
         video_memory_endpoint = data.get("video_memory_endpoint", "tcp://127.0.0.1:8310"),
+        video_history_enabled = bool(data.get("video_history_enabled", False)),
         text_memory_dir = data.get("text_memory_dir", "/dev/shm/xr-ai/text-memory"),
         silence_duration  = float(data.get("silence_duration",  0.8)),
         min_speech        = float(data.get("min_speech",        0.15)),

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/config.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/config.py
@@ -32,6 +32,9 @@ class WorkerConfig:
 def load_config(path: pathlib.Path | None) -> WorkerConfig:
     data = _read_yaml(path)
     idle_timeout = data.get("idle_timeout_secs")
+    video_history = data.get("video_history_enabled", False)
+    if not isinstance(video_history, bool):
+        raise ValueError(f"video_history_enabled must be a YAML boolean, got {video_history!r}")
 
     return WorkerConfig(
         models_config = _resolve(path, "models.json"),
@@ -39,7 +42,7 @@ def load_config(path: pathlib.Path | None) -> WorkerConfig:
         scene_endpoint = data.get("scene_endpoint", "tcp://127.0.0.1:8320"),
         openxr_endpoint = data.get("openxr_endpoint", "tcp://127.0.0.1:8330"),
         video_memory_endpoint = data.get("video_memory_endpoint", "tcp://127.0.0.1:8310"),
-        video_history_enabled = bool(data.get("video_history_enabled", False)),
+        video_history_enabled = video_history,
         text_memory_dir = data.get("text_memory_dir", "/dev/shm/xr-ai/text-memory"),
         silence_duration  = float(data.get("silence_duration",  0.8)),
         min_speech        = float(data.get("min_speech",        0.15)),

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/spatial_ops.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/spatial_ops.py
@@ -249,6 +249,12 @@ class _Leaves:
             if word in _SHAPE_WORDS:
                 return _SHAPE_WORDS[word]
         for word in words:
+            if word in _COLOR_WORDS:
+                raise ValueError(
+                    f"{word!r} is a color, not a shape. Do not change the shape; "
+                    "report the color change back as a recolor for appearance_agent."
+                )
+        for word in words:
             close = difflib.get_close_matches(word, _SHAPE_WORDS, n=1, cutoff=0.6)
             if close:
                 logger.debug("shape words resolved {!r} -> {}", shape_words, _SHAPE_WORDS[close[0]])

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor.py
@@ -228,7 +228,11 @@ class SceneSupervisor:
         """Drop per-participant state after departure; a reconnecting id starts clean."""
         self._participant_locks.pop(participant_id, None)
         self._context.forget_participant(participant_id)
-        self._left_at_us[participant_id] = time.time_ns() // 1_000
+        now_us = time.time_ns() // 1_000
+        expired = [p for p, t in self._left_at_us.items() if t < now_us - _RECENT_WINDOW_US]
+        for p in expired:
+            del self._left_at_us[p]
+        self._left_at_us[participant_id] = now_us
 
     async def _recent_conversation(
         self, participant_id: str, reference_us: int
@@ -236,10 +240,13 @@ class SceneSupervisor:
         recalled = await self._text_memory.recall_conversation.execute(
             RecallConversationRequest(participant_id=participant_id)
         )
-        # A clipped utterance is completed within seconds or not at all; an
-        # older ask never splices into a new session's first words.
+        # A departure ends the session: turns before the last leave neither
+        # re-enter the block nor complete a clipped ask, however recent.
+        left_us = self._left_at_us.get(participant_id, 0)
+        session = [e for e in recalled.entries if e.timestamp_us >= left_us]
+        # A clipped utterance is completed within seconds or not at all.
         pending = ""
-        tail = recalled.entries[-2:]
+        tail = session[-2:]
         if (
             len(tail) == 2
             and tail[1].role == "agent"
@@ -249,15 +256,10 @@ class SceneSupervisor:
         ):
             pending = tail[0].text
         # User turns carry the hub's clock, agent turns the worker's; the
-        # window assumes both are wall-clock microseconds. A departure ends
-        # the session: turns before the last leave never re-enter the block,
-        # however recent; the age window covers worker restarts, which leave
-        # no departure record.
-        cutoff_us = max(
-            reference_us - _RECENT_WINDOW_US,
-            self._left_at_us.get(participant_id, 0),
-        )
-        entries = [e for e in recalled.entries if e.timestamp_us >= cutoff_us][-8:]
+        # window assumes both are wall-clock microseconds. The age window
+        # covers worker restarts, which leave no departure record.
+        cutoff_us = reference_us - _RECENT_WINDOW_US
+        entries = [e for e in session if e.timestamp_us >= cutoff_us][-8:]
         if not entries:
             return "", pending
         lines = [f"  {'User' if e.role == 'user' else 'Agent'}: {e.text}" for e in entries]

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import re
 import time
 from collections import defaultdict
@@ -112,6 +113,41 @@ def _claims_completion(text: str) -> bool:
 
 def _is_question(text: str) -> bool:
     return text.rstrip().rstrip("\"'”’)").rstrip().endswith("?")
+
+
+def _normalize(text: str) -> str:
+    return " ".join(text.replace("’", "'").lower().split())
+
+
+def _is_parrot(reply: str, transcript: str, recalled: dict[str, frozenset[str]]) -> bool:
+    """A non-question reply repeating a recalled agent turn that answered a
+    DIFFERENT utterance is [Recent conversation] parroted as an answer; the
+    same question re-asked may honestly earn the same reply. Verbatim match
+    only: paraphrased parroting is a known residual gap.
+    """
+    if not reply or _is_question(reply):
+        return False
+    askers = recalled.get(_normalize(reply))
+    return askers is not None and _normalize(transcript) not in askers
+
+
+def _last_subagent_result(loop_result) -> str:
+    """Result text of the loop's final tool call, empty when absent."""
+    records = loop_result.tool_calls
+    if not records:
+        return ""
+    try:
+        payload = json.loads(records[-1].message.content or "")
+    except ValueError:
+        return ""
+    text = payload.get("result", "") if isinstance(payload, dict) else ""
+    return text.strip() if isinstance(text, str) else ""
+
+
+def _tts_safe(text: str) -> bool:
+    """Subagent results may carry ids and RGB numbers the spoken reply
+    contract forbids; digits mark them."""
+    return bool(text) and not any(ch.isdigit() for ch in text)
 
 
 def _is_truncated(transcript: str) -> bool:
@@ -221,13 +257,15 @@ class SceneSupervisor:
         self._participant_locks.pop(participant_id, None)
         self._context.forget_participant(participant_id)
 
-    async def _recent_conversation(self, participant_id: str) -> tuple[str, str]:
+    async def _recent_conversation(
+        self, participant_id: str
+    ) -> tuple[str, str, dict[str, frozenset[str]]]:
         recalled = await self._text_memory.recall_conversation.execute(
             RecallConversationRequest(participant_id=participant_id)
         )
         entries = recalled.entries[-8:]
         if not entries:
-            return "", ""
+            return "", "", {}
         pending = ""
         if (
             len(entries) >= 2
@@ -241,7 +279,17 @@ class SceneSupervisor:
             "[Recent conversation] (already handled; never a source of new work)\n"
             + "\n".join(lines) + "\n\n"
         )
-        return block, pending
+        # Each agent reply keyed to the user turns it answered, so the parrot
+        # guard can exempt an identical question honestly re-answered.
+        replies: dict[str, set[str]] = {}
+        last_user = ""
+        for entry in entries:
+            if entry.role == "user":
+                last_user = _normalize(entry.text)
+            else:
+                replies.setdefault(_normalize(entry.text), set()).add(last_user)
+        pairs = {reply: frozenset(askers) for reply, askers in replies.items()}
+        return block, pending, pairs
 
     async def _persist_turn(self, request: SceneRequest, user_text: str, reply_text: str) -> None:
         await self._text_memory.add_transcript.execute(
@@ -278,7 +326,9 @@ class SceneSupervisor:
             "supervisor turn participant={} trace={} transcript={!r}",
             request.participant_id, request.trace_id, request.transcript[:80],
         )
-        conversation, pending_truncation = await self._recent_conversation(request.participant_id)
+        conversation, pending_truncation, recalled_replies = await self._recent_conversation(
+            request.participant_id
+        )
         transcript = request.transcript
         if pending_truncation:
             resolved = _resolve_truncation_reply(pending_truncation, transcript)
@@ -289,11 +339,16 @@ class SceneSupervisor:
             transcript = resolved
 
         async with self._scene_lock:
-            return await self._handle_scene(request, transcript, conversation)
+            return await self._handle_scene(request, transcript, conversation, recalled_replies)
 
     async def _handle_scene(
-        self, request: SceneRequest, transcript: str, conversation: str
+        self,
+        request: SceneRequest,
+        transcript: str,
+        conversation: str,
+        recalled_replies: dict[str, frozenset[str]] | None = None,
     ) -> SceneReply:
+        recalled_replies = recalled_replies or {}
         evidence = MutationEvidence()
         current_mutation_evidence.set(evidence)
         before = await self._context.snapshot()
@@ -323,6 +378,37 @@ class SceneSupervisor:
             await self._persist_turn(request, transcript, reply)
             return SceneReply(response=reply)
         output = result.content
+
+        # Stale cross-session transcripts made parroting the top live failure
+        # mode; _is_parrot documents the trigger and its residual gap. The
+        # nudge deliberately mirrors vision_agent's DESCRIPTION wording.
+        if not result.tool_calls and _is_parrot(output, transcript, recalled_replies):
+            logger.warning("parroted recalled reply; renudging {!r}", output[:80])
+            nudge = (
+                "That reply repeats an earlier turn from [Recent conversation]"
+                " verbatim, so it is not grounded in this turn. Handle the new"
+                " request itself: delegate the right subagent now (a question"
+                " about what the user holds, wears, or sees goes to"
+                " vision_agent), or answer only from this turn's own results."
+            )
+            retry_messages = list(result.messages) + [ChatMessage(role="user", content=nudge)]
+            try:
+                retry = await run_tool_loop(retry_messages, self._toolset, _call_model, max_iterations=6)
+            except ToolLoopError as exc:
+                logger.warning("parrot retry failed ({})", exc)
+            else:
+                result = retry
+                output = retry.content
+                if _is_parrot(output, transcript, recalled_replies):
+                    # A second parrot means the model will not ground itself:
+                    # answer from the retry's own subagent result, spoken only
+                    # when free of the ids and numbers TTS forbids.
+                    subagent_evidence = _last_subagent_result(retry)
+                    if _tts_safe(subagent_evidence):
+                        output = subagent_evidence
+                    else:
+                        output = "I can't check that right now."
+                    logger.warning("parrot persisted; replying {!r}", output[:80])
 
         # Verify only turns with actual mutation intent: a mutating subagent
         # was delegated, or the utterance itself requests a change (which
@@ -358,7 +444,10 @@ class SceneSupervisor:
             except ToolLoopError as exc:
                 logger.warning("supervisor verification failed ({})", exc)
             else:
-                output = result2.content
+                if _is_parrot(result2.content, transcript, recalled_replies):
+                    logger.warning("verification reply parrots; keeping prior reply")
+                else:
+                    output = result2.content
             await asyncio.sleep(_SCENE_SETTLE_S)
             # Success is evidence-backed: a completion claim may stand only
             # when a scene write was applied (or the requested state already

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import re
 import time
 from collections import defaultdict
@@ -84,6 +83,13 @@ _MUTATING_AGENTS = frozenset({"placement_agent", "appearance_agent", "object_age
 # Seconds to let a scene RPC propagate before diffing snapshots.
 _SCENE_SETTLE_S = 0.15
 
+# [Recent conversation] means this conversation: the transcript store
+# persists across sessions, and older turns read as answers to new
+# questions. History beyond the window is memory_agent's to recall.
+_RECENT_WINDOW_US = 10 * 60 * 1_000_000
+
+_PENDING_ASK_WINDOW_US = 8 * 1_000_000
+
 
 # Leading words that mark a status question about past work ("Did you move
 # the cube?"); unlike can/could/will, they cannot open a polite command.
@@ -113,41 +119,6 @@ def _claims_completion(text: str) -> bool:
 
 def _is_question(text: str) -> bool:
     return text.rstrip().rstrip("\"'”’)").rstrip().endswith("?")
-
-
-def _normalize(text: str) -> str:
-    return " ".join(text.replace("’", "'").lower().split())
-
-
-def _is_parrot(reply: str, transcript: str, recalled: dict[str, frozenset[str]]) -> bool:
-    """A non-question reply repeating a recalled agent turn that answered a
-    DIFFERENT utterance is [Recent conversation] parroted as an answer; the
-    same question re-asked may honestly earn the same reply. Verbatim match
-    only: paraphrased parroting is a known residual gap.
-    """
-    if not reply or _is_question(reply):
-        return False
-    askers = recalled.get(_normalize(reply))
-    return askers is not None and _normalize(transcript) not in askers
-
-
-def _last_subagent_result(loop_result) -> str:
-    """Result text of the loop's final tool call, empty when absent."""
-    records = loop_result.tool_calls
-    if not records:
-        return ""
-    try:
-        payload = json.loads(records[-1].message.content or "")
-    except ValueError:
-        return ""
-    text = payload.get("result", "") if isinstance(payload, dict) else ""
-    return text.strip() if isinstance(text, str) else ""
-
-
-def _tts_safe(text: str) -> bool:
-    """Subagent results may carry ids and RGB numbers the spoken reply
-    contract forbids; digits mark them."""
-    return bool(text) and not any(ch.isdigit() for ch in text)
 
 
 def _is_truncated(transcript: str) -> bool:
@@ -251,45 +222,50 @@ class SceneSupervisor:
         self._prompt = _PROMPT.read_text(encoding="utf-8").strip()
         self._participant_locks: defaultdict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
         self._scene_lock: asyncio.Lock = asyncio.Lock()
+        self._left_at_us: dict[str, int] = {}
 
     def forget_participant(self, participant_id: str) -> None:
         """Drop per-participant state after departure; a reconnecting id starts clean."""
         self._participant_locks.pop(participant_id, None)
         self._context.forget_participant(participant_id)
+        self._left_at_us[participant_id] = time.time_ns() // 1_000
 
     async def _recent_conversation(
-        self, participant_id: str
-    ) -> tuple[str, str, dict[str, frozenset[str]]]:
+        self, participant_id: str, reference_us: int
+    ) -> tuple[str, str]:
         recalled = await self._text_memory.recall_conversation.execute(
             RecallConversationRequest(participant_id=participant_id)
         )
-        entries = recalled.entries[-8:]
-        if not entries:
-            return "", "", {}
+        # A clipped utterance is completed within seconds or not at all; an
+        # older ask never splices into a new session's first words.
         pending = ""
+        tail = recalled.entries[-2:]
         if (
-            len(entries) >= 2
-            and entries[-1].role == "agent"
-            and entries[-1].text.startswith(_TRUNCATED_ASK)
-            and entries[-2].role == "user"
+            len(tail) == 2
+            and tail[1].role == "agent"
+            and tail[1].text.startswith(_TRUNCATED_ASK)
+            and tail[1].timestamp_us >= reference_us - _PENDING_ASK_WINDOW_US
+            and tail[0].role == "user"
         ):
-            pending = entries[-2].text
+            pending = tail[0].text
+        # User turns carry the hub's clock, agent turns the worker's; the
+        # window assumes both are wall-clock microseconds. A departure ends
+        # the session: turns before the last leave never re-enter the block,
+        # however recent; the age window covers worker restarts, which leave
+        # no departure record.
+        cutoff_us = max(
+            reference_us - _RECENT_WINDOW_US,
+            self._left_at_us.get(participant_id, 0),
+        )
+        entries = [e for e in recalled.entries if e.timestamp_us >= cutoff_us][-8:]
+        if not entries:
+            return "", pending
         lines = [f"  {'User' if e.role == 'user' else 'Agent'}: {e.text}" for e in entries]
         block = (
             "[Recent conversation] (already handled; never a source of new work)\n"
             + "\n".join(lines) + "\n\n"
         )
-        # Each agent reply keyed to the user turns it answered, so the parrot
-        # guard can exempt an identical question honestly re-answered.
-        replies: dict[str, set[str]] = {}
-        last_user = ""
-        for entry in entries:
-            if entry.role == "user":
-                last_user = _normalize(entry.text)
-            else:
-                replies.setdefault(_normalize(entry.text), set()).add(last_user)
-        pairs = {reply: frozenset(askers) for reply, askers in replies.items()}
-        return block, pending, pairs
+        return block, pending
 
     async def _persist_turn(self, request: SceneRequest, user_text: str, reply_text: str) -> None:
         await self._text_memory.add_transcript.execute(
@@ -308,6 +284,9 @@ class SceneSupervisor:
         )
 
     async def handle(self, request: SceneRequest) -> SceneReply:
+        if request.timestamp_us <= 0:
+            # An unset timestamp would disable the recall recency window.
+            request = request.model_copy(update={"timestamp_us": time.time_ns() // 1_000})
         current_trace_id.set(request.trace_id)
         current_participant_id.set(request.participant_id)
         current_reference_time_us.set(request.timestamp_us)
@@ -326,8 +305,8 @@ class SceneSupervisor:
             "supervisor turn participant={} trace={} transcript={!r}",
             request.participant_id, request.trace_id, request.transcript[:80],
         )
-        conversation, pending_truncation, recalled_replies = await self._recent_conversation(
-            request.participant_id
+        conversation, pending_truncation = await self._recent_conversation(
+            request.participant_id, request.timestamp_us
         )
         transcript = request.transcript
         if pending_truncation:
@@ -339,16 +318,11 @@ class SceneSupervisor:
             transcript = resolved
 
         async with self._scene_lock:
-            return await self._handle_scene(request, transcript, conversation, recalled_replies)
+            return await self._handle_scene(request, transcript, conversation)
 
     async def _handle_scene(
-        self,
-        request: SceneRequest,
-        transcript: str,
-        conversation: str,
-        recalled_replies: dict[str, frozenset[str]] | None = None,
+        self, request: SceneRequest, transcript: str, conversation: str
     ) -> SceneReply:
-        recalled_replies = recalled_replies or {}
         evidence = MutationEvidence()
         current_mutation_evidence.set(evidence)
         before = await self._context.snapshot()
@@ -378,37 +352,6 @@ class SceneSupervisor:
             await self._persist_turn(request, transcript, reply)
             return SceneReply(response=reply)
         output = result.content
-
-        # Stale cross-session transcripts made parroting the top live failure
-        # mode; _is_parrot documents the trigger and its residual gap. The
-        # nudge deliberately mirrors vision_agent's DESCRIPTION wording.
-        if not result.tool_calls and _is_parrot(output, transcript, recalled_replies):
-            logger.warning("parroted recalled reply; renudging {!r}", output[:80])
-            nudge = (
-                "That reply repeats an earlier turn from [Recent conversation]"
-                " verbatim, so it is not grounded in this turn. Handle the new"
-                " request itself: delegate the right subagent now (a question"
-                " about what the user holds, wears, or sees goes to"
-                " vision_agent), or answer only from this turn's own results."
-            )
-            retry_messages = list(result.messages) + [ChatMessage(role="user", content=nudge)]
-            try:
-                retry = await run_tool_loop(retry_messages, self._toolset, _call_model, max_iterations=6)
-            except ToolLoopError as exc:
-                logger.warning("parrot retry failed ({})", exc)
-            else:
-                result = retry
-                output = retry.content
-                if _is_parrot(output, transcript, recalled_replies):
-                    # A second parrot means the model will not ground itself:
-                    # answer from the retry's own subagent result, spoken only
-                    # when free of the ids and numbers TTS forbids.
-                    subagent_evidence = _last_subagent_result(retry)
-                    if _tts_safe(subagent_evidence):
-                        output = subagent_evidence
-                    else:
-                        output = "I can't check that right now."
-                    logger.warning("parrot persisted; replying {!r}", output[:80])
 
         # Verify only turns with actual mutation intent: a mutating subagent
         # was delegated, or the utterance itself requests a change (which
@@ -444,10 +387,7 @@ class SceneSupervisor:
             except ToolLoopError as exc:
                 logger.warning("supervisor verification failed ({})", exc)
             else:
-                if _is_parrot(result2.content, transcript, recalled_replies):
-                    logger.warning("verification reply parrots; keeping prior reply")
-                else:
-                    output = result2.content
+                output = result2.content
             await asyncio.sleep(_SCENE_SETTLE_S)
             # Success is evidence-backed: a completion claim may stand only
             # when a scene write was applied (or the requested state already

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor_prompt.txt
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor_prompt.txt
@@ -1,146 +1,29 @@
 You are the supervisor for an XR scene assistant. Satisfy the complete user
-request by invoking the focused subagents available as tools. You may call no
-subagent for ordinary conversation, one subagent for a focused request, or
-several subagents in sequence for a compound request.
-
-Delegate only self-contained tasks. Include the relevant stable XR object ids
-when they are known. After each result, decide whether the request is
-complete or whether another focused task is required. Call at most one subagent
-in each model response and wait for its result before selecting the next. Never
-ask one subagent to perform work owned by another.
-
-vision_agent answers questions about the PHYSICAL world only: what the user
-holds, wears, points at, or what a real wall or room looks like. Every fact
-about XR objects, positions, and empty space is already in SCENE OBJECTS, and
-the subagents resolve user-relative placement ("ahead of me", "at my feet",
-"on the left") through tracking. A mutation whose color comes from the
-physical world does not need vision_agent: pass the user's phrase to the
-mutating agent, whose tools read the camera themselves. If present-time
-vision is unavailable, never retry or substitute historical video; when the
-request truly depends on the missing visual fact, tell the user, and
-otherwise continue satisfying the request without vision. A user statement
-about the camera itself is not a perception request, but a new question
-about what the user holds, wears, or sees always is, no matter what [Recent
-conversation] says about cameras or earlier looks: delegate vision_agent
-again fresh each time. When the user answers a clarifying question of yours
-by telling you to observe instead of answering ("check the camera", "use
-your eyes", or similar), delegate vision_agent with the original pending
-question, never those literal words.
-Never call vision_agent to look up, confirm, or verify the color, shape,
-position, or existence of any object already listed in SCENE OBJECTS; that
-data is always current and complete. Read those values directly from SCENE
-OBJECTS and pass them in the subagent instruction. If an utterance is incomplete,
-self-corrected, commenting on the interaction, or a fragment that does not
-itself request anything ("Creative.", "Okay.", a cut-off phrase), reply
-conversationally or ask one short question; never call a subagent, and never
-re-execute a request from [Recent conversation] that the current utterance
-does not restate.
-
-memory_agent answers questions about the conversation itself. Route every
-question about what was said, asked, or done earlier ("which shape did I
-request first?", "what did I ask you to build?") to memory_agent
-once, even when [Recent conversation] seems to contain the answer; that
-block exists to resolve references, never to answer history questions from,
-and guessing a history answer is always wrong. But questions about what the
-camera saw earlier ("what color was the thing in my hand a while ago?") are
-vision_agent with the past-time question, never memory_agent: the camera's
-past lives in recorded video, the conversation's past in the transcript.
-Present-day facts about the user's clothing, body, or surroundings are
-never memory either; they are perception.
-
-appearance_agent changes only color. placement_agent moves objects that
-already exist, including swaps, containment, stacking, and undo; those are
-moves, never creation. object_agent creates new objects and also removes,
-resizes, duplicates, or changes object shape.
-Use multiple subagents when a request spans those responsibilities, even when a
-single lower-level render function could technically modify several fields.
-
-Routing examples:
-- "Creative." / "Okay." / a cut-off fragment after earlier requests: no
-  subagent call; reply with one short question like "What would you like me
-  to do?" even though [Recent conversation] shows completed work.
-- "That's the wrong capsule" / "no, not that one", right after a change:
-  the intended target is unknown, so nothing can be fixed, created, or
-  removed yet; the whole turn is one short question: "Which capsule should
-  it sit above?"
-- "Put/place the X in/on/inside the Y", X already in SCENE OBJECTS: a move,
-  placement_agent, never object_agent.
-- "Add/create an X inside the Y": a creation, object_agent.
-- "Put/place a lavender cone above the teal capsule" and SCENE OBJECTS in
-  this message lists no lavender cone: a creation with an anchor,
-  object_agent in one call, never placement_agent; only an X that already
-  exists can move. SCENE OBJECTS already states what exists and where;
-  vision_agent never answers either question.
-- "Put an ivory pyramid above the teal capsule" and the capsule appears in
-  SCENE OBJECTS: one object_agent call with the anchor name. Never call
-  vision_agent first to find where the capsule is; its position is in
-  SCENE OBJECTS and object_agent resolves the geometry itself.
-- "Put a teal cone between the ivory capsule and the lavender cylinder" and
-  both appear in SCENE OBJECTS: one object_agent call naming both anchors.
-  The positions are in SCENE OBJECTS; never call vision_agent to find them.
-- "Make the navy cylinder the same color as the teal capsule" and both
-  appear in SCENE OBJECTS: read the teal color directly from SCENE OBJECTS,
-  then call appearance_agent once with that value. Never call vision_agent
-  to look up the color of either object.
-- "Make a lavender cone two meters ahead of me" (or any position relative
-  to the user's body): object_agent directly in one call; never
-  vision_agent first, and never a vision check afterwards — tracking
-  already knows where the user stands and faces, camera or no camera.
-- "Create a cone matching my jacket" / "Make the capsule the same color
-  as the curtains" / "Recolor the torus to match my sweater": a physical
-  color source (a real-world thing, including the user's clothing) goes
-  straight to the mutating agent with the user's own words ("Create a cone the color of my jacket,
-  no position stated"); its tools read the camera themselves. What is
-  never fine is guessing: brands and typical looks are not observations.
-  An anchor that names an XR object, whatever its color or shape:
-  object_agent alone, never vision.
-- "What am I looking at?" / "Describe what you can see": the user means
-  their physical view; one vision_agent question about what is in front
-  of the user.
-- "What color is the mug on my table?": the mug is physical (not in SCENE
-  OBJECTS), so vision_agent once with that question; never answer from the
-  XR scene that no such object exists.
-- "What's in my hand?", even right after turns discussing the camera or a
-  clarifying question you asked: one vision_agent question ("What is the
-  user holding?"). Nothing in [Recent conversation] makes a fresh
-  perception question rhetorical.
-- "What was I holding a moment ago?" or any question about what the camera
-  saw at an earlier time: vision_agent once with the past-time question; it
-  consults the recorded video.
-- "What was the first thing I asked you to create?" / "What did I ask you
-  to build earlier?": memory_agent once with the question. The transcript
-  store is the only reliable history; answering from [Recent conversation]
-  or from your own impression invents facts.
-- "Remove/delete the X on the left": removal, object_agent; the side words
-  only select which X, never a move.
-- "Double it / make the X half the size": resize, object_agent, and the
-  instruction carries the id resolved from SCENE OBJECTS or [Recent
-  conversation]: "Resize capsule-8 to half its current size".
-
-Phrase every creation instruction as: Create <count, when more than one>
-<color> <shape>(s) <the user's own spatial words>. The color slot carries
-the user's color words verbatim: a color word, an XR object to copy
-("same as capsule-8"), or the user's physical phrase ("the color of my
-apron"); the mutating agent resolves them. If the user named no
-position at all, end with "no position stated" in place of spatial words;
-never add "no position stated" when spatial words are present. Use that
-exact phrasing whatever verb the user chose (add, make, spawn, put up), and
-keep every requested copy in the one instruction: "Create three teal cones
-in a row, no position stated", never one call per cone. Never invent a
-position the user did not say. A task an agent reports back keeps
-every word: re-delegate the same instruction to the right agent, never a
-reduced one. Do not split initial placement into a later
-placement_agent call. Use placement_agent only when an object that already
-exists must move.
-
-Do not repeat a completed mutation, and never report a change you did not
-delegate this turn: a request like "triple its size" always requires a
-subagent call now, even when [Recent conversation] shows related earlier
-work. An existing object never satisfies a new creation request: "make a
-cone" with a cone already in SCENE OBJECTS still creates another one;
-never answer that the user already has one. When all required work is complete, respond
-with one short plain-English sentence. That sentence is spoken aloud through
-text-to-speech: never include numeric coordinates, object ids, or unit
-symbols; describe positions in everyday words, like "just below the teal
-capsule" or "in front of you". Never expose tool syntax, intermediate
-instructions, JSON, or private reasoning.
+request by routing focused, self-contained tasks to the subagent tools; each
+tool's description states the work it owns and how to phrase its
+instructions. Call no subagent for ordinary conversation, one for a focused
+request, or several in sequence for a compound request, at most one per
+model response, and include the relevant stable XR object ids when they are
+known. In a compound request, route each part to the agent that owns it,
+never to whichever agent handled the previous part: "create an X, make the
+Y <color>, and delete the Z" is three delegations, object_agent, then
+appearance_agent, then object_agent. SCENE OBJECTS is always current and complete for every XR object;
+read facts about XR objects directly from it, never through a subagent. A
+delegated task keeps every user word; when a subagent reports that a task
+belongs to another agent, re-delegate the same full instruction to the
+right agent, never a reduced one. An utterance that
+requests nothing (a fragment, "Okay.", a correction whose target is
+unknown) gets one short conversational reply or question, never a subagent
+call, and never re-executes a request from [Recent conversation] that the
+current utterance does not restate. Questions
+about earlier conversation go to memory_agent and questions about what the
+camera sees or saw go to vision_agent; never answer either kind yourself.
+Do not repeat a completed mutation, but a request the current utterance
+itself makes always requires a subagent call now, even when [Recent
+conversation] shows the same or related work completed. An existing object
+never satisfies a new creation request: "make a cone" with a cone already
+in SCENE OBJECTS still creates another one, never a move and never a reply
+that one exists. Never report a change you did not delegate this turn. When the work is complete, reply
+with one short plain-English sentence spoken through text-to-speech: no
+coordinates, object ids, unit symbols, tool syntax, JSON, or private
+reasoning; describe positions in everyday words.

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor_prompt.txt
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor_prompt.txt
@@ -29,4 +29,7 @@ one, never a move and never a reply that one exists. Never report a
 change you did not delegate this turn. When the work is complete, reply
 with one short plain-English sentence spoken through text-to-speech: no
 coordinates, object ids, unit symbols, tool syntax, JSON, or private
-reasoning; describe positions in everyday words.
+reasoning; describe positions in everyday words. The reply describes only
+what this turn's subagents observed or did; never name a physical object
+that only [Recent conversation] mentions, since the user may have changed
+what they hold or wear between turns.

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor_prompt.txt
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor_prompt.txt
@@ -1,29 +1,39 @@
-You are the supervisor for an XR scene assistant. Satisfy the complete user
-request by routing focused, self-contained tasks to the subagent tools; each
-tool's description states the work it owns and how to phrase its
-instructions. Call no subagent for ordinary conversation, one for a focused
-request, or several in sequence for a compound request, at most one per
-model response, and include the relevant stable XR object ids when they are
-known. In a compound request, route each part to the agent that owns it,
-never to whichever agent handled the previous part: "create an X, make the
-Y <color>, and delete the Z" is three delegations, object_agent, then
-appearance_agent, then object_agent. SCENE OBJECTS is always current and complete for every XR object;
-read facts about XR objects directly from it, never through a subagent. A
-delegated task keeps every user word; when a subagent reports that a task
-belongs to another agent, re-delegate the same full instruction to the
-right agent, never a reduced one. An utterance that
-requests nothing (a fragment, "Okay.", a correction whose target is
-unknown) gets one short conversational reply or question, never a subagent
-call, and never re-executes a request from [Recent conversation] that the
-current utterance does not restate. Questions
-about earlier conversation go to memory_agent and questions about what the
-camera sees or saw go to vision_agent; never answer either kind yourself.
-Do not repeat a completed mutation, but a request the current utterance
-itself makes always requires a subagent call now, even when [Recent
-conversation] shows the same or related work completed. An existing object
-never satisfies a new creation request: "make a cone" with a cone already
-in SCENE OBJECTS still creates another one, never a move and never a reply
-that one exists. Never report a change you did not delegate this turn. When the work is complete, reply
+You are the supervisor for an XR scene assistant. Satisfy the complete
+user request by routing focused, self-contained tasks to the subagent
+tools; each tool's description states the work it owns and how to phrase
+its instructions. Call no subagent for ordinary conversation, one for a
+focused request, or several in sequence for a compound request, at most
+one per model response, and include the relevant stable XR object ids
+when they are known. In a compound request, route each part to the agent
+that owns it, never to whichever agent handled the previous part: "move
+the X, make the Y <color>, and create a Z" is three delegations,
+placement_agent, then appearance_agent, then object_agent. When one part
+cannot be done (for example vision is unavailable), say so for that part
+and still complete the others. SCENE OBJECTS is always current and
+complete for every XR object; answer questions about XR objects directly
+from it, never through a subagent. A delegated task keeps every user
+word; when a subagent reports that part of a task belongs to another
+agent, re-delegate that part to the right agent with the user's words
+kept whole. An utterance that requests nothing (a fragment, "Okay.", a
+correction whose target is unknown) gets one short conversational reply
+or question, never a subagent call, and never re-executes a request from
+[Recent conversation] that the current utterance does not restate.
+Questions about earlier conversation go to memory_agent, and questions
+about what the camera sees or saw, including what the user is holding,
+wearing, or looking at, go to vision_agent, every time the question is
+asked; never answer either kind yourself, and no reply in [Recent
+conversation] makes a fresh perception question rhetorical. A request to
+describe or identify what is visible means the user's physical view
+through the camera, never a recital of SCENE OBJECTS, and when the user
+tells you to look or to use the camera instead of answering a question
+you asked, delegate vision_agent with the pending question, never those
+literal words. Do not repeat a completed mutation, but a request
+the current utterance itself makes always requires a subagent call now,
+even when [Recent conversation] shows the same or related work
+completed. An existing object never satisfies a new creation request:
+"make a cone" with a cone already in SCENE OBJECTS still creates another
+one, never a move and never a reply that one exists. Never report a
+change you did not delegate this turn. When the work is complete, reply
 with one short plain-English sentence spoken through text-to-speech: no
 coordinates, object ids, unit symbols, tool syntax, JSON, or private
 reasoning; describe positions in everyday words.

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor_prompt.txt
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor_prompt.txt
@@ -18,16 +18,9 @@ kept whole. An utterance that requests nothing (a fragment, "Okay.", a
 correction whose target is unknown) gets one short conversational reply
 or question, never a subagent call, and never re-executes a request from
 [Recent conversation] that the current utterance does not restate.
-Questions about earlier conversation go to memory_agent, and questions
-about what the camera sees or saw, including what the user is holding,
-wearing, or looking at, go to vision_agent, every time the question is
-asked; never answer either kind yourself, and no reply in [Recent
-conversation] makes a fresh perception question rhetorical. A request to
-describe or identify what is visible means the user's physical view
-through the camera, never a recital of SCENE OBJECTS, and when the user
-tells you to look or to use the camera instead of answering a question
-you asked, delegate vision_agent with the pending question, never those
-literal words. Do not repeat a completed mutation, but a request
+Questions about earlier conversation go to memory_agent and questions
+about what the camera sees or saw go to vision_agent; never answer
+either kind yourself. Do not repeat a completed mutation, but a request
 the current utterance itself makes always requires a subagent call now,
 even when [Recent conversation] shows the same or related work
 completed. An existing object never satisfies a new creation request:

--- a/agent-samples/xr-render-demo/yaml/xr_render_demo_worker.yaml
+++ b/agent-samples/xr-render-demo/yaml/xr_render_demo_worker.yaml
@@ -14,6 +14,11 @@ voice_gate_yaml: voice_gate.yaml
 scene_endpoint: tcp://127.0.0.1:8320
 openxr_endpoint: tcp://127.0.0.1:8330
 video_memory_endpoint: tcp://127.0.0.1:8310
+# Past-moment questions ("what was I holding a moment ago?") need recorded
+# video: enable video_recording in device_io_hub.yaml and set recordings_dir
+# in video_memory_service.yaml, then turn this on. Off, vision_agent answers
+# from the live camera only.
+video_history_enabled: false
 text_memory_dir: /dev/shm/xr-ai/text-memory
 
 # ── Voice activity detection (Silero VAD, ONNX backend) ──────────────────────

--- a/docs/source/reference/xr-render-demo.md
+++ b/docs/source/reference/xr-render-demo.md
@@ -310,8 +310,13 @@ in one place:
 
 Each agent has its own prompt file under
 `worker/xr_render_demo_worker/` (supervisor plus five subagents, six files total).
-The supervisor prompt routes requests to subagents; each subagent prompt
-is worked-example heavy and opens with pronoun and reference resolution.
+The supervisor prompt carries only cross-cutting turn discipline; the
+routing rules and ownership boundaries live in each subagent's tool
+`DESCRIPTION` constant (`agents/<name>/agent.py`), the surface the
+supervisor's model reads when selecting a tool. A few rules are stated in
+both places on purpose: descriptions alone are under-weighted mid-loop, so
+the supervisor prompt keeps a short backstop copy. Each subagent prompt is
+worked-example heavy and opens with pronoun and reference resolution.
 
 The placement agent's prompt maps utterance shapes to tools with contrast
 pairs: a stated distance is a shift (`nudge`); a user-anchored destination

--- a/docs/source/reference/xr-render-demo.md
+++ b/docs/source/reference/xr-render-demo.md
@@ -313,7 +313,10 @@ Each agent has its own prompt file under
 The supervisor prompt carries only cross-cutting turn discipline; the
 routing rules and ownership boundaries live in each subagent's tool
 `DESCRIPTION` constant (`agents/<name>/agent.py`), the surface the
-supervisor's model reads when selecting a tool. A few rules are stated in
+supervisor's model reads when selecting a tool. The vision agent selects
+between two descriptions at construction time: the full one when video
+memory is wired, and a live-only variant that disclaims past-moment
+questions when it is not. A few rules are stated in
 both places on purpose: descriptions alone are under-weighted mid-loop, so
 the supervisor prompt keeps a short backstop copy. Each subagent prompt is
 worked-example heavy and opens with pronoun and reference resolution.
@@ -360,6 +363,7 @@ so they do not mutate the LOVR scene.
 | Live manipulation | `xr_render_demo_live_manip` | Running demo stack and real scene state | Minutes |
 | Live speech noise | `xr_render_demo_live_garble` | Running demo stack with noisy utterances | Minutes |
 | Live exploration | `xr_render_demo_live_explore` | Running demo stack with novel prompts | Minutes |
+| Live perception routing | `xr_render_demo_live_perception` | Running demo stack and the worker's transcript store | Minutes |
 
 Run all commands from `agent-samples/xr-render-demo/eval/`:
 
@@ -395,6 +399,7 @@ uv run xr_render_demo_live_pose_matrix
 uv run xr_render_demo_live_manip
 uv run xr_render_demo_live_garble
 uv run xr_render_demo_live_explore
+uv run xr_render_demo_live_perception
 ```
 
 Live drivers join as synthetic participants, inject typed text, set simulated
@@ -416,6 +421,15 @@ stutters. Its restraint scoring fails incorrect mutations and accepts a
 clarifying response. `xr_render_demo_live_explore` sends novel conversational
 phrasing and scores intent invariants. Promote any violation into a permanent
 tier case before fixing it.
+
+`xr_render_demo_live_perception` builds real multi-turn history, then sends
+perception utterances and judges the reply text read back from the worker's
+transcript store. The live stack publishes no camera track, so a correctly
+routed perception turn must report an honest inability, recite no scene
+object, and leave the scene unchanged; one case also injects stale
+transcript turns to pin the supervisor's parrot guard. It catches routing
+misses the offline tiers cannot reproduce, whose recalled history is far
+shorter than a live session's.
 
 ### Add or change a case
 

--- a/docs/source/reference/xr-render-demo.md
+++ b/docs/source/reference/xr-render-demo.md
@@ -239,6 +239,9 @@ services. On each accepted `xr-render.user-query` event:
 
 1. **Recent conversation** is recalled from `TextMemoryTools` and injected
    as context so the model understands references like "fix that" or "undo".
+   The block is session-scoped: only the last eight turns since the
+   participant last departed, and within ten minutes of the request, are
+   injected; older history is memory_agent's to recall.
 2. **Supervisor loop** (`run_tool_loop`, up to 12 iterations) — Nemotron-Omni
    :8108 routes the request to one or more subagent tools. Each subagent
    runs its own inner `run_tool_loop` (up to 4 iterations) against the
@@ -426,10 +429,11 @@ tier case before fixing it.
 perception utterances and judges the reply text read back from the worker's
 transcript store. The live stack publishes no camera track, so a correctly
 routed perception turn must report an honest inability, recite no scene
-object, and leave the scene unchanged; one case also injects stale
-transcript turns to pin the supervisor's parrot guard. It catches routing
-misses the offline tiers cannot reproduce, whose recalled history is far
-shorter than a live session's.
+object, and leave the scene unchanged; one case also injects cross-session
+transcript turns to pin the supervisor's recall recency window, which keeps
+them out of [Recent conversation]. It catches routing misses the offline
+tiers cannot reproduce, whose recalled history is far shorter than a live
+session's.
 
 ### Add or change a case
 
@@ -460,7 +464,7 @@ parameter is the precedent: the model copies descriptors verbatim, and
 `spatial_ops` resolves shapes, damaged nouns, and colors against scene state.
 
 Run `uv run xr_render_demo_eval utterances` after every prompt or operations
-change. Its 35 cases take about three minutes. Run the longer scenario and
+change. Its cases take about three minutes. Run the longer scenario and
 precision tiers before completing a tuning round.
 
 (prompt-eval-overlap-audit)=

--- a/tests/test_xr_render_demo_supervisor.py
+++ b/tests/test_xr_render_demo_supervisor.py
@@ -362,3 +362,119 @@ async def test_failing_supervisor_publishes_failure_notice() -> None:
     assert published[0].text == "Something went wrong. Please try again."
     assert published[0].final is True
     assert published[0].response_id == "trace-1"
+
+
+def _seed_turn(memory: _RecordingMemory, participant: str, user: str, agent: str) -> None:
+    memory.records.append(AddTranscriptRequest(
+        source_id=f"{participant}:user", timestamp_us=1, text=user))
+    memory.records.append(AddTranscriptRequest(
+        source_id=f"{participant}:agent", timestamp_us=2, text=agent))
+
+
+async def test_parrot_reply_is_renudged_and_speaks_subagent_evidence(monkeypatch) -> None:
+    """A no-tool reply that repeats a recalled turn answering a different
+    utterance gets one retry; a second parrot yields the retry's own
+    subagent result."""
+    memory = _RecordingMemory()
+    _seed_turn(memory, "alice", "What is in my hand?", "You are not holding anything.")
+    supervisor, _fake = _make_supervisor(memory)
+    calls = []
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        calls.append(messages)
+        if len(calls) == 1:
+            return SimpleNamespace(
+                content="You are not holding anything.", messages=list(messages), tool_calls=())
+        record = SimpleNamespace(
+            call=SimpleNamespace(name="vision_agent"),
+            message=SimpleNamespace(content='{"result": "The camera view is currently unavailable."}'),
+        )
+        return SimpleNamespace(
+            content="You are not holding anything.", messages=list(messages), tool_calls=(record,))
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    reply = await supervisor.handle(
+        SceneRequest(transcript="What am I holding?", participant_id="alice"))
+    assert len(calls) == 2
+    assert reply.response == "The camera view is currently unavailable."
+
+
+async def test_parrot_with_numeric_evidence_falls_back_to_honest_reply(monkeypatch) -> None:
+    """Subagent evidence carrying ids or numbers is never spoken; the
+    fallback keeps the TTS contract."""
+    memory = _RecordingMemory()
+    _seed_turn(memory, "alice", "What is in my hand?", "You are not holding anything.")
+    supervisor, _fake = _make_supervisor(memory)
+    calls = []
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        calls.append(messages)
+        record = SimpleNamespace(
+            call=SimpleNamespace(name="vision_agent"),
+            message=SimpleNamespace(content='{"result": "capsule-8 shows RGB (1.0, 0.0, 0.0)."}'),
+        )
+        return SimpleNamespace(
+            content="You are not holding anything.", messages=list(messages),
+            tool_calls=(record,) if len(calls) > 1 else ())
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    reply = await supervisor.handle(
+        SceneRequest(transcript="What am I holding?", participant_id="alice"))
+    assert len(calls) == 2
+    assert reply.response == "I can't check that right now."
+
+
+async def test_repeated_question_may_repeat_its_answer(monkeypatch) -> None:
+    """The same question honestly re-answered with the same words is not a
+    parrot; no retry runs."""
+    memory = _RecordingMemory()
+    _seed_turn(memory, "alice", "How many boxes are in the scene?",
+               "There are two boxes in the scene.")
+    supervisor, _fake = _make_supervisor(memory)
+    calls = []
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        calls.append(messages)
+        return SimpleNamespace(
+            content="There are two boxes in the scene.", messages=list(messages), tool_calls=())
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    reply = await supervisor.handle(
+        SceneRequest(transcript="How many boxes are in the scene?", participant_id="alice"))
+    assert len(calls) == 1
+    assert reply.response == "There are two boxes in the scene."
+
+
+def test_parrot_helpers_edge_cases() -> None:
+    from xr_render_demo_worker.supervisor import (
+        _is_parrot, _last_subagent_result, _normalize, _tts_safe,
+    )
+
+    recalled = {"you are not holding anything.": frozenset({"what is in my hand?"})}
+    assert _is_parrot("You are not holding anything.", "What am I holding?", recalled)
+    assert not _is_parrot("You are not holding anything.", "What is in my hand?", recalled)
+    assert not _is_parrot("Which capsule do you mean?", "What am I holding?", recalled)
+    assert not _is_parrot("", "What am I holding?", recalled)
+    assert not _is_parrot("Something new entirely.", "What am I holding?", recalled)
+
+    assert _normalize("You  AREN’T here") == "you aren't here"
+
+    assert _last_subagent_result(SimpleNamespace(tool_calls=())) == ""
+    bad = SimpleNamespace(tool_calls=(SimpleNamespace(message=SimpleNamespace(content="not json")),))
+    assert _last_subagent_result(bad) == ""
+    err = SimpleNamespace(tool_calls=(SimpleNamespace(
+        message=SimpleNamespace(content='{"error": "boom"}')),))
+    assert _last_subagent_result(err) == ""
+    none_content = SimpleNamespace(tool_calls=(SimpleNamespace(
+        message=SimpleNamespace(content=None)),))
+    assert _last_subagent_result(none_content) == ""
+    listy = SimpleNamespace(tool_calls=(SimpleNamespace(
+        message=SimpleNamespace(content='["a"]')),))
+    assert _last_subagent_result(listy) == ""
+
+    assert _tts_safe("The camera view is unavailable.")
+    assert not _tts_safe("capsule-8 is red")
+    assert not _tts_safe("")

--- a/tests/test_xr_render_demo_supervisor.py
+++ b/tests/test_xr_render_demo_supervisor.py
@@ -39,11 +39,11 @@ class _RecordingMemory:
     async def _recall(self, req: RecallConversationRequest) -> RecallConversationResult:
         entries = [
             ConversationEntry(
-                timestamp_us=index,
+                timestamp_us=record.timestamp_us,
                 role=record.source_id.rsplit(":", 1)[1],
                 text=record.text,
             )
-            for index, record in enumerate(self.records)
+            for record in self.records
             if record.source_id.startswith(f"{req.participant_id}:")
         ]
         return RecallConversationResult(entries=entries)
@@ -364,117 +364,112 @@ async def test_failing_supervisor_publishes_failure_notice() -> None:
     assert published[0].response_id == "trace-1"
 
 
-def _seed_turn(memory: _RecordingMemory, participant: str, user: str, agent: str) -> None:
+_REF_US = harness.EVAL_REFERENCE_US
+
+
+def _seed_turn(memory: _RecordingMemory, participant: str, user: str, agent: str,
+               base_us: int = _REF_US - 30_000_000) -> None:
     memory.records.append(AddTranscriptRequest(
-        source_id=f"{participant}:user", timestamp_us=1, text=user))
+        source_id=f"{participant}:user", timestamp_us=base_us, text=user))
     memory.records.append(AddTranscriptRequest(
-        source_id=f"{participant}:agent", timestamp_us=2, text=agent))
+        source_id=f"{participant}:agent", timestamp_us=base_us + 1, text=agent))
 
 
-async def test_parrot_reply_is_renudged_and_speaks_subagent_evidence(monkeypatch) -> None:
-    """A no-tool reply that repeats a recalled turn answering a different
-    utterance gets one retry; a second parrot yields the retry's own
-    subagent result."""
+async def test_stale_recalled_turns_stay_out_of_recent_conversation(monkeypatch) -> None:
+    """Turns older than the recency window never enter [Recent conversation]."""
     memory = _RecordingMemory()
-    _seed_turn(memory, "alice", "What is in my hand?", "You are not holding anything.")
+    _seed_turn(memory, "alice", "What is in my hand?", "You are not holding anything.",
+               base_us=1)
     supervisor, _fake = _make_supervisor(memory)
-    calls = []
+    seen_user_messages: list[str] = []
 
     async def fake_loop(messages, toolset, call_model, max_iterations=12):
-        calls.append(messages)
-        if len(calls) == 1:
-            return SimpleNamespace(
-                content="You are not holding anything.", messages=list(messages), tool_calls=())
-        record = SimpleNamespace(
-            call=SimpleNamespace(name="vision_agent"),
-            message=SimpleNamespace(content='{"result": "The camera view is currently unavailable."}'),
-        )
-        return SimpleNamespace(
-            content="You are not holding anything.", messages=list(messages), tool_calls=(record,))
+        seen_user_messages.extend(m.content for m in messages if m.role == "user")
+        return SimpleNamespace(content="Okay.", messages=list(messages), tool_calls=())
 
     monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
 
-    reply = await supervisor.handle(
-        SceneRequest(transcript="What am I holding?", participant_id="alice"))
-    assert len(calls) == 2
-    assert reply.response == "The camera view is currently unavailable."
+    await supervisor.handle(SceneRequest(
+        transcript="What am I holding?", participant_id="alice",
+        timestamp_us=_REF_US))
+    assert seen_user_messages
+    assert all("[Recent conversation]" not in content for content in seen_user_messages)
+    assert all("not holding anything" not in content for content in seen_user_messages)
 
 
-async def test_parrot_with_numeric_evidence_falls_back_to_honest_reply(monkeypatch) -> None:
-    """Subagent evidence carrying ids or numbers is never spoken; the
-    fallback keeps the TTS contract."""
+async def test_recency_window_boundary_is_inclusive(monkeypatch) -> None:
+    """A turn exactly at the cutoff enters [Recent conversation]; one
+    microsecond older does not."""
+    from xr_render_demo_worker.supervisor import _RECENT_WINDOW_US
+
     memory = _RecordingMemory()
-    _seed_turn(memory, "alice", "What is in my hand?", "You are not holding anything.")
+    _seed_turn(memory, "alice", "Older question?", "Older answer.",
+               base_us=_REF_US - _RECENT_WINDOW_US - 2)
+    _seed_turn(memory, "alice", "Edge question?", "Edge answer.",
+               base_us=_REF_US - _RECENT_WINDOW_US)
     supervisor, _fake = _make_supervisor(memory)
-    calls = []
+    seen_user_messages: list[str] = []
 
     async def fake_loop(messages, toolset, call_model, max_iterations=12):
-        calls.append(messages)
-        record = SimpleNamespace(
-            call=SimpleNamespace(name="vision_agent"),
-            message=SimpleNamespace(content='{"result": "capsule-8 shows RGB (1.0, 0.0, 0.0)."}'),
-        )
-        return SimpleNamespace(
-            content="You are not holding anything.", messages=list(messages),
-            tool_calls=(record,) if len(calls) > 1 else ())
+        seen_user_messages.extend(m.content for m in messages if m.role == "user")
+        return SimpleNamespace(content="Okay.", messages=list(messages), tool_calls=())
 
     monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
 
-    reply = await supervisor.handle(
-        SceneRequest(transcript="What am I holding?", participant_id="alice"))
-    assert len(calls) == 2
-    assert reply.response == "I can't check that right now."
+    await supervisor.handle(SceneRequest(
+        transcript="What did I just say?", participant_id="alice", timestamp_us=_REF_US))
+    joined = "\n".join(seen_user_messages)
+    assert "Edge question?" in joined
+    assert "Edge answer." in joined
+    assert "Older answer." not in joined
 
 
-async def test_repeated_question_may_repeat_its_answer(monkeypatch) -> None:
-    """The same question honestly re-answered with the same words is not a
-    parrot; no retry runs."""
+async def test_unset_timestamp_still_excludes_stale_turns(monkeypatch) -> None:
+    """A request without a timestamp gets the wall clock, so the recency
+    window still applies."""
     memory = _RecordingMemory()
-    _seed_turn(memory, "alice", "How many boxes are in the scene?",
-               "There are two boxes in the scene.")
+    _seed_turn(memory, "alice", "What is in my hand?", "You are not holding anything.",
+               base_us=1)
     supervisor, _fake = _make_supervisor(memory)
-    calls = []
+    seen_user_messages: list[str] = []
 
     async def fake_loop(messages, toolset, call_model, max_iterations=12):
-        calls.append(messages)
-        return SimpleNamespace(
-            content="There are two boxes in the scene.", messages=list(messages), tool_calls=())
+        seen_user_messages.extend(m.content for m in messages if m.role == "user")
+        return SimpleNamespace(content="Okay.", messages=list(messages), tool_calls=())
 
     monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
 
-    reply = await supervisor.handle(
-        SceneRequest(transcript="How many boxes are in the scene?", participant_id="alice"))
-    assert len(calls) == 1
-    assert reply.response == "There are two boxes in the scene."
+    await supervisor.handle(SceneRequest(transcript="What am I holding?", participant_id="alice"))
+    assert seen_user_messages
+    assert all("not holding anything" not in content for content in seen_user_messages)
 
 
-def test_parrot_helpers_edge_cases() -> None:
-    from xr_render_demo_worker.supervisor import (
-        _is_parrot, _last_subagent_result, _normalize, _tts_safe,
-    )
+async def test_departure_ends_the_session_for_recall(monkeypatch) -> None:
+    """Turns before a participant's last departure never re-enter
+    [Recent conversation], however recent."""
+    import time as _time
 
-    recalled = {"you are not holding anything.": frozenset({"what is in my hand?"})}
-    assert _is_parrot("You are not holding anything.", "What am I holding?", recalled)
-    assert not _is_parrot("You are not holding anything.", "What is in my hand?", recalled)
-    assert not _is_parrot("Which capsule do you mean?", "What am I holding?", recalled)
-    assert not _is_parrot("", "What am I holding?", recalled)
-    assert not _is_parrot("Something new entirely.", "What am I holding?", recalled)
+    now_us = _time.time_ns() // 1_000
+    memory = _RecordingMemory()
+    _seed_turn(memory, "alice", "What is in my hand?", "You are holding a torch.",
+               base_us=now_us - 5_000_000)
+    supervisor, _fake = _make_supervisor(memory)
+    seen_user_messages: list[str] = []
 
-    assert _normalize("You  AREN’T here") == "you aren't here"
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        seen_user_messages.extend(m.content for m in messages if m.role == "user")
+        return SimpleNamespace(content="Okay.", messages=list(messages), tool_calls=())
 
-    assert _last_subagent_result(SimpleNamespace(tool_calls=())) == ""
-    bad = SimpleNamespace(tool_calls=(SimpleNamespace(message=SimpleNamespace(content="not json")),))
-    assert _last_subagent_result(bad) == ""
-    err = SimpleNamespace(tool_calls=(SimpleNamespace(
-        message=SimpleNamespace(content='{"error": "boom"}')),))
-    assert _last_subagent_result(err) == ""
-    none_content = SimpleNamespace(tool_calls=(SimpleNamespace(
-        message=SimpleNamespace(content=None)),))
-    assert _last_subagent_result(none_content) == ""
-    listy = SimpleNamespace(tool_calls=(SimpleNamespace(
-        message=SimpleNamespace(content='["a"]')),))
-    assert _last_subagent_result(listy) == ""
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
 
-    assert _tts_safe("The camera view is unavailable.")
-    assert not _tts_safe("capsule-8 is red")
-    assert not _tts_safe("")
+    await supervisor.handle(SceneRequest(
+        transcript="Hello again.", participant_id="alice", timestamp_us=now_us))
+    assert any("holding a torch" in content for content in seen_user_messages)
+
+    supervisor.forget_participant("alice")
+    seen_user_messages.clear()
+    await supervisor.handle(SceneRequest(
+        transcript="Hello once more.", participant_id="alice",
+        timestamp_us=_time.time_ns() // 1_000))
+    assert seen_user_messages
+    assert all("holding a torch" not in content for content in seen_user_messages)

--- a/tests/test_xr_render_demo_supervisor.py
+++ b/tests/test_xr_render_demo_supervisor.py
@@ -19,7 +19,7 @@ from xr_ai_voice import UserQuery
 from xr_render_demo_eval import harness
 from xr_render_demo_worker.agent import RenderAgent
 from xr_render_demo_worker.models import SceneRequest
-from xr_render_demo_worker.supervisor import SceneSupervisor
+from xr_render_demo_worker.supervisor import _TRUNCATED_ASK, SceneSupervisor
 
 
 class _RecordingMemory:
@@ -473,3 +473,35 @@ async def test_departure_ends_the_session_for_recall(monkeypatch) -> None:
         timestamp_us=_time.time_ns() // 1_000))
     assert seen_user_messages
     assert all("holding a torch" not in content for content in seen_user_messages)
+
+
+async def test_departure_drops_pending_truncated_ask(monkeypatch) -> None:
+    """A clipped ask left before departure never completes a reconnecting
+    participant's first words, even inside the completion window."""
+    import time as _time
+
+    now_us = _time.time_ns() // 1_000
+    memory = _RecordingMemory()
+    _seed_turn(memory, "alice", "Make a", f"{_TRUNCATED_ASK} A what?",
+               base_us=now_us - 2_000_000)
+    supervisor, _fake = _make_supervisor(memory)
+    supervisor.forget_participant("alice")
+    seen_user_messages: list[str] = []
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        seen_user_messages.extend(m.content for m in messages if m.role == "user")
+        return SimpleNamespace(content="Okay.", messages=list(messages), tool_calls=())
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    await supervisor.handle(SceneRequest(
+        transcript="Cube please.", participant_id="alice", timestamp_us=now_us))
+    assert seen_user_messages
+    assert all("Make a" not in content for content in seen_user_messages)
+
+
+def test_departure_records_expire_with_the_recall_window() -> None:
+    supervisor, _fake = _make_supervisor()
+    supervisor._left_at_us["stale"] = 1
+    supervisor.forget_participant("alice")
+    assert set(supervisor._left_at_us) == {"alice"}

--- a/tests/test_xr_render_demo_wire.py
+++ b/tests/test_xr_render_demo_wire.py
@@ -120,7 +120,7 @@ def test_eval_case_filter_rejects_unknown_names_in_mixed_selection() -> None:
 def test_eval_utterances_alias_selects_the_complete_battery() -> None:
     from xr_render_demo_eval import harness
 
-    assert len(harness.UTTERANCES) == 35
+    assert len(harness.UTTERANCES) == 39
     assert harness._resolve_case_names(["utterances"]) == {
         case.name for case in harness.UTTERANCES
     }
@@ -460,3 +460,21 @@ def test_tool_def_to_openai_wire_shape() -> None:
             },
         },
     }
+
+
+def test_vision_description_matches_video_capability() -> None:
+    """The tool description offered to the supervisor must not advertise
+    recorded video when no video memory is wired."""
+    from xr_render_demo_worker.agents.vision import agent as vision
+
+    assert vision._SHARED_RULES in vision.DESCRIPTION
+    assert vision._SHARED_RULES in vision._LIVE_ONLY_DESCRIPTION
+    assert "recorded video when the question is about a past moment" in vision.DESCRIPTION
+    assert "Recorded video is not available" in vision._LIVE_ONLY_DESCRIPTION
+
+    with_video = vision.make_vision_agent(
+        llm=None, current_frame=None, image_query=None, video=object())
+    without_video = vision.make_vision_agent(
+        llm=None, current_frame=None, image_query=None, video=None)
+    assert with_video.description == vision.DESCRIPTION
+    assert without_video.description == vision._LIVE_ONLY_DESCRIPTION

--- a/tests/test_xr_render_demo_wire.py
+++ b/tests/test_xr_render_demo_wire.py
@@ -73,6 +73,8 @@ def test_worker_config_loads_sample_yaml() -> None:
     config = load_config(_SAMPLE / "yaml/xr_render_demo_worker.yaml")
     assert config.models_config == _SAMPLE / "yaml/models.json"
     assert config.voice_gate_yaml.exists()
+    # The shipped hub disables recording, so the worker must not wire recorded video.
+    assert config.video_history_enabled is False
 
 
 def test_all_agent_modules_export_descriptions() -> None:

--- a/tests/test_xr_render_demo_wire.py
+++ b/tests/test_xr_render_demo_wire.py
@@ -120,7 +120,7 @@ def test_eval_case_filter_rejects_unknown_names_in_mixed_selection() -> None:
 def test_eval_utterances_alias_selects_the_complete_battery() -> None:
     from xr_render_demo_eval import harness
 
-    assert len(harness.UTTERANCES) == 39
+    assert len(harness.UTTERANCES) == 40
     assert harness._resolve_case_names(["utterances"]) == {
         case.name for case in harness.UTTERANCES
     }

--- a/tests/test_xr_render_demo_wire.py
+++ b/tests/test_xr_render_demo_wire.py
@@ -239,6 +239,35 @@ def test_worker_config_idle_timeout_opt_in(tmp_path) -> None:
     assert cfg.idle_timeout_secs == 300.0
 
 
+def test_worker_config_video_history_requires_yaml_boolean(tmp_path) -> None:
+    from xr_render_demo_worker.config import load_config
+
+    y = tmp_path / "w.yaml"
+    y.write_text("video_history_enabled: true\n")
+    assert load_config(y).video_history_enabled is True
+    y.write_text('video_history_enabled: "false"\n')
+    with pytest.raises(ValueError, match="video_history_enabled"):
+        load_config(y)
+
+
+async def test_close_clients_skips_disabled_video() -> None:
+    from types import SimpleNamespace
+
+    from xr_render_demo_worker.app import close_clients
+
+    closed: list[str] = []
+
+    async def _close(name: str) -> None:
+        closed.append(name)
+
+    scene = SimpleNamespace(client=SimpleNamespace(close=lambda: _close("scene")))
+    tracking = SimpleNamespace(close=lambda: _close("tracking"))
+    await close_clients(scene, tracking, None)
+    assert closed == ["scene", "tracking"]
+    await close_clients(scene, tracking, SimpleNamespace(close=lambda: _close("video")))
+    assert closed == ["scene", "tracking", "scene", "tracking", "video"]
+
+
 # ── untooled chat wire golden ─────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Large PR: yes

The render demo supervisor prompt had grown to ~150 lines, restating each subagent's responsibilities alongside their tool definitions. This moves routing rules and instruction-phrasing contracts into the subagent tool `DESCRIPTION` constants (the surface the routing model actually reads), leaving the supervisor prompt with cross-cutting turn discipline only. The vision agent selects between two descriptions, and the worker now wires recorded video only when `video_history_enabled` is set (default off, matching the shipped hub config), so a video-less deployment never advertises past-frame capability.

Live testing surfaced perception-routing misses the offline tiers couldn't reproduce, driven by stale context: the transcript store persists across sessions under a reused participant id, so `[Recent conversation]` could carry hours-old turns that the model imitated ("You are not holding anything." replayed for a new question). Fixed structurally: recall is session-scoped (cut at the participant's last departure, with a 10-minute window covering worker restarts; departure records expire with that window), the same cutoff governs completion of a clipped utterance so a pre-disconnect "Make a..." never splices onto a reconnecting user's first words, a clarifying ask for a clipped utterance expires after 8 seconds, and an unset request timestamp falls back to the wall clock so the window can't silently disable. Recolors misrouted to object_agent are refused and reported back for re-delegation, and `spatial_ops.shape()` rejects color words instead of fuzzy-matching them to a shape.

New eval coverage: a `live_perception` tier that builds real multi-turn history and judges replies from the transcript store (including a poisoned-history case that fails without session scoping), plus offline cases for describe-view routing, camera imperatives, compound partial failure, and object_agent recolor refusal; the train/test audit now also scans supervisor.py and the live tier's texts, and the harness gained a `reply_excludes` assertion.

## Why this lands as one PR

Every group here is a consequence of the same live investigation, and the groups only pass the eval battery together:

- **Tool-description migration** is the fix itself: routing moved from the prompt to the descriptions. Splitting it from the prompt slimming would ship a prompt that says less while the descriptions still say nothing, and the routing model would regress on the very cases this PR adds.
- **Session-scoped recall and the clipped-utterance lifecycle** share one code path (`_recent_conversation`) and one cutoff. The poisoned-history live case fails without both, and the reconnect regression test fails if either is applied alone.
- **Recorded-video capability selection** exists because the migrated vision description advertises past-frame lookups; once routing lives in the description, the description has to reflect what the deployment can actually do.
- **Recolor and shape routing** were the two remaining misroutes the same live sessions exposed; they are the refusal-and-redelegate counterpart of the description contract.
- **The live_perception driver** is the catch-first test for the session-scoping change. Landing the fix without its catcher would leave the regression undetectable, since the offline tiers cannot reproduce a long live history.

Prompt and description text is token-sensitive at temperature 0: several wordings that looked equivalent flipped offline cases. Splitting the groups would mean re-running the full battery per PR with a prompt that is mid-transition, and the intermediate states are not ones we would want deployed.

## Validation and risk

Validated per the sample's eval policy, all on the final head: live_manip 13/13, live_perception 4/4, offline scenarios/precision/utterances at main's baseline (54/69, 13/16, 37/40; the remaining failures pre-exist on clean main), supervisor delegation and subagent tiers unchanged from head-before-review (18/23, 49/50, identical failing cases), 1366 non-GPU tests, ruff clean. Risk is concentrated in the routing model's reading of the new descriptions; the live tiers exercise the real stack end to end, and the two deliberate prompt/description duplications are marked in comments as intentional backstops.
