### PR TITLE
Move XR render routing rules from supervisor prompt to tool descriptions

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -608,6 +608,7 @@ generator scripts. Nothing installs from the directory.
   - `xr_render_demo_live_explore` → `xr_render_demo_eval.live_explore:run`
   - `xr_render_demo_live_garble` → `xr_render_demo_eval.live_garble:run`
   - `xr_render_demo_live_manip` → `xr_render_demo_eval.live_manip:run`
+  - `xr_render_demo_live_perception` → `xr_render_demo_eval.live_perception:run`
   - `xr_render_demo_live_pose_matrix` → `xr_render_demo_eval.live_pose_matrix:run`
   - `xr_render_demo_live_smoke` → `xr_render_demo_eval.live_smoke:run`
 

--- a/agent-samples/xr-render-demo/eval/README.md
+++ b/agent-samples/xr-render-demo/eval/README.md
@@ -23,6 +23,7 @@ uv run xr_render_demo_live_pose_matrix
 uv run xr_render_demo_live_manip
 uv run xr_render_demo_live_garble
 uv run xr_render_demo_live_explore
+uv run xr_render_demo_live_perception
 ```
 
 <!-- Compatibility anchors for headings consolidated into the documentation. -->

--- a/agent-samples/xr-render-demo/eval/pyproject.toml
+++ b/agent-samples/xr-render-demo/eval/pyproject.toml
@@ -32,6 +32,7 @@ xr_render_demo_live_pose_matrix = "xr_render_demo_eval.live_pose_matrix:run"
 xr_render_demo_live_manip = "xr_render_demo_eval.live_manip:run"
 xr_render_demo_live_garble = "xr_render_demo_eval.live_garble:run"
 xr_render_demo_live_explore = "xr_render_demo_eval.live_explore:run"
+xr_render_demo_live_perception = "xr_render_demo_eval.live_perception:run"
 
 [tool.hatch.build.targets.wheel]
 packages = ["xr_render_demo_eval"]

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/harness.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/harness.py
@@ -77,10 +77,15 @@ class _FakeTextMemoryTools:
     def __init__(self, fake: "FakeScene") -> None:
         async def recall(req: RecallConversationRequest) -> RecallConversationResult:
             fake.calls.append(("recall_conversation", req.model_dump()))
+            # History ends seconds before the case's request timestamp, so
+            # the recency window (and the pending-ask window, for truncation
+            # cases) treats it as part of this session.
+            base_us = EVAL_REFERENCE_US - 4_000_000 - max(len(fake.history) - 1, 0) * 2_000_000
             entries: list[ConversationEntry] = []
             for i, (user_text, agent_text) in enumerate(fake.history):
-                entries.append(ConversationEntry(timestamp_us=(i + 1) * 1_000_000, role="user", text=user_text))
-                entries.append(ConversationEntry(timestamp_us=(i + 1) * 1_000_000 + 1, role="agent", text=agent_text))
+                turn_us = base_us + i * 2_000_000
+                entries.append(ConversationEntry(timestamp_us=turn_us, role="user", text=user_text))
+                entries.append(ConversationEntry(timestamp_us=turn_us + 1, role="agent", text=agent_text))
             if fake.memory_answer:
                 entries.append(ConversationEntry(timestamp_us=1, role="agent", text=fake.memory_answer))
             return RecallConversationResult(entries=entries)
@@ -189,6 +194,10 @@ class _FakeImageQueryTool:
         )
 
 
+# One clock for eval requests and the fake recall entries windowed against them.
+EVAL_REFERENCE_US = 1_700_000_000_000_000
+
+
 @dataclass(frozen=True)
 class Case:
     name: str
@@ -207,6 +216,7 @@ class Case:
     memory: str = ""
     history: tuple[tuple[str, str], ...] = ()
     reply_contains: str = ""
+    reply_excludes: str = ""
     camera_error: str = ""
     physical_expect_source: str = ""
 
@@ -313,7 +323,10 @@ CASES = (
         name="durable_memory",
         request="What object did we discuss in the earlier session?",
         memory="We discussed a small cyan sphere.",
-        required_tools=frozenset({"recall_conversation"}),
+        # The supervisor's own block recall is call one; memory_agent's
+        # recall is the second.
+        expected_call_counts=(("recall_conversation", 2),),
+        reply_contains="cyan",
     ),
     Case(
         name="placement_despite_camera_off",
@@ -693,7 +706,7 @@ async def run_corpus_case(case: dict[str, Any]) -> bool:
                 SceneRequest(
                     transcript=case["user"],
                     participant_id=_PARTICIPANT,
-                    timestamp_us=1_700_000_000_000_000,
+                    timestamp_us=EVAL_REFERENCE_US,
                 )
             )
             response = reply.response
@@ -800,6 +813,66 @@ UTTERANCES = (
         expected_colors=(("sphere-0", (0.0, 0.4, 1.0)),),
     ),
     Case(
+        name="basics_describe_view_is_camera",
+        # A describe-the-view request means the physical world; reciting
+        # SCENE OBJECTS is never the answer.
+        request="Describe what you can see.",
+        scene=(
+            {"id": "sphere-0", "type": "sphere",
+             "position": {"x": 0.0, "y": 1.6, "z": -1.5},
+             "color": {"r": 0, "g": 0.8, "b": 0}, "size": 0.1},
+            {"id": "box-0", "type": "box",
+             "position": {"x": 0.5, "y": 1.4, "z": -1.2},
+             "color": {"r": 1, "g": 0.5, "b": 0}, "size": 0.1},
+        ),
+        vision="A cluttered desk with a laptop and a coffee mug.",
+        required_tools=frozenset({"look_at_current_frame"}),
+        forbidden_tools=_FORBID_MUTATIONS,
+        reply_contains="desk",
+    ),
+    Case(
+        name="basics_use_the_camera_imperative",
+        # Telling the agent to consult the camera re-enters the pending
+        # question; the literal words are never the delegation.
+        request="Use the camera.",
+        vision="A bookshelf against a white wall.",
+        history=(
+            ("What's behind me right now?",
+             "Could you say more about what you mean?"),
+        ),
+        required_tools=frozenset({"look_at_current_frame"}),
+        forbidden_tools=_FORBID_MUTATIONS,
+        reply_contains="bookshelf",
+    ),
+    Case(
+        name="basics_holding_after_scene_work",
+        # A perception question right after ordinary scene work is fresh;
+        # neither SCENE OBJECTS nor the transcript holds the answer.
+        request="What's in my hand right now?",
+        scene=(
+            {"id": "box-1", "type": "box",
+             "position": {"x": -0.5, "y": 1.6, "z": -1.5},
+             "color": {"r": 0, "g": 0.8, "b": 0}, "size": 0.1},
+        ),
+        history=(
+            ("Make a green box.", "Created a green box in front of you."),
+            ("Move it left.", "Moved the box to your left."),
+        ),
+        vision="A phone in the user's hand.",
+        required_tools=frozenset({"look_at_current_frame"}),
+        forbidden_tools=_FORBID_MUTATIONS,
+        reply_contains="phone",
+    ),
+    Case(
+        name="basics_compound_one_part_blocked",
+        # One blocked part of a compound turn never blocks the others: the
+        # creation still lands while the perception part reports the outage.
+        request="Create a purple ring, then tell me what is printed on my shirt.",
+        camera_error="RPCError: camera feed unavailable",
+        required_tools=frozenset({"add_primitive"}),
+        expected_colors=(("ring-0", (0.6, 0.0, 1.0)),),
+    ),
+    Case(
         name="basics_physical_source_camera_down",
         # The camera outage must degrade to an honest no-change reply: the
         # resolver was attempted, nothing mutated, no invented color.
@@ -812,6 +885,19 @@ UTTERANCES = (
         camera_error="RPCError: camera feed unavailable",
         required_tools=frozenset({"current_frame"}),
         forbidden_tools=_FORBID_MUTATIONS,
+    ),
+    Case(
+        name="basics_stale_held_object_not_renamed",
+        # The user swapped objects between turns: the reply describes what
+        # this turn's camera read, never the object a recalled turn named.
+        # A guard for the supervisor prompt's reply rule; offline
+        # composition does not reproduce the failure, so this cannot catch
+        # the rule's removal.
+        request="Make a cube the color of what I'm holding.",
+        history=(("What am I holding?", "You are holding a red soda can."),),
+        vision="The item in the user's hand is gray.",
+        expected_colors=(("box-0", (0.5, 0.5, 0.5)),),
+        reply_excludes="soda",
     ),
     Case(
         name="basics_holding_color_with_history",
@@ -1102,7 +1188,7 @@ async def run_case(case: Case) -> bool:
                 SceneRequest(
                     transcript=case.request,
                     participant_id=_PARTICIPANT,
-                    timestamp_us=1_700_000_000_000_000,
+                    timestamp_us=EVAL_REFERENCE_US,
                 )
             )
             response = reply.response
@@ -1149,6 +1235,8 @@ async def run_case(case: Case) -> bool:
     }
     wrong_reply = bool(
         case.reply_contains and case.reply_contains.lower() not in response.lower()
+    ) or bool(
+        case.reply_excludes and case.reply_excludes.lower() in response.lower()
     )
     passed = (
         not errored
@@ -1190,7 +1278,8 @@ def audit_prompts() -> None:
     # Model-visible text lives in the prompt files and in the tool field
     # descriptions of spatial_ops.py; both shape the model's templates.
     prompts = (sorted(worker.rglob("*prompt*.txt"))
-               + [worker / "spatial_ops.py", worker / "_physical_color.py"]
+               + [worker / "spatial_ops.py", worker / "_physical_color.py",
+                  worker / "supervisor.py"]
                + sorted(worker.glob("agents/*/agent.py")))
     utterances = [case["user"] for case in CORPUS_CASES if case.get("user")]
     utterances += [case.request for case in (*CASES, *UTTERANCES)]
@@ -1238,6 +1327,21 @@ def audit_prompts() -> None:
             for text in turn
         ]
         fixture_ids |= {item["id"] for case in eval_supervisor.CASES for item in case.scene}
+    try:
+        from . import live_perception
+    except ImportError:
+        pass
+    else:
+        utterances += [case["prompt"] for case in live_perception.CASES]
+        utterances += [
+            turn for case in live_perception.CASES for turn in case.get("history", ())
+        ]
+        utterances += [case["pending"] for case in live_perception.CASES if "pending" in case]
+        eval_texts += [
+            text
+            for case in live_perception.CASES
+            for _role, text in case.get("poisoned", ())
+        ]
     for prompt_path in prompts:
         label = str(prompt_path.relative_to(worker))
         text = prompt_path.read_text(encoding="utf-8")

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/live_perception.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/live_perception.py
@@ -1,0 +1,234 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Live perception-routing tests: real conversation history, reply-text verdict.
+
+The live eval stack publishes no camera track, so a correctly routed
+perception turn must come back as an honest inability report from
+vision_agent. That invariant catches the misses the offline tiers cannot
+reproduce (their [Recent conversation] is far shorter than a live one):
+a perception question answered from the transcript, or a describe-the-view
+request answered by reciting SCENE OBJECTS. Same-session turns inside the
+supervisor's recall window are out of scope here; diagnose those from the
+worker log and the transcript store.
+
+Run subsets: `live_perception.py [case-name ...]`.
+"""
+
+import asyncio
+import os
+import sys
+import time
+from pathlib import Path
+
+from xr_ai_hub import DataMessage
+from xr_ai_tools.rpc import RPCClient
+from xr_ai_tools.text_memory import AddTranscriptRequest, RecallConversationRequest, TextMemoryTools
+from xr_render_demo_worker.config import load_config
+from xr_render_scene import AddPrimitiveRequest, EmptyRequest, RemovePrimitiveRequest, SceneClient
+
+from ._live_endpoint import LiveEvalEndpoint, live_participant
+
+CANONICAL = {"position": {"x": 0, "y": 1.6, "z": 0}, "forward": {"x": 0, "y": 0, "z": -1},
+             "right": {"x": 1, "y": 0, "z": 0}, "up": {"x": 0, "y": 1, "z": 0},
+             "yaw_deg": 0.0, "pitch_deg": 0.0, "ts": 1}
+
+def _text_memory_dir() -> str:
+    """The driver reads the same transcript store the worker writes."""
+    yaml_path = Path(__file__).resolve().parents[2] / "yaml" / "xr_render_demo_worker.yaml"
+    return load_config(yaml_path).text_memory_dir
+
+
+# Bare "camera"/"vision" are excluded: a confabulated answer may mention the
+# camera while still claiming to see.
+INABILITY_MARKERS = (
+    "can't see", "cannot see", "couldn't see", "can not see",
+    "unable", "not able", "no camera", "no view",
+    "unavailable", "not available", "can't access", "cannot access",
+    "don't have", "do not have", "can't tell", "cannot tell",
+    "can't check", "cannot check", "couldn't check",
+)
+
+# Words that appear in a reply only when the model recites the XR scene.
+SCENE_RECITAL_WORDS = ("cube", "box", "sphere", "ball", "cone", "capsule", "cylinder", "pyramid")
+
+_WORD_TYPES = {"cube": "box", "ball": "sphere", "donut": "torus"}
+
+# Each case: history prompts that must change the scene (real turns that
+# fill [Recent conversation]), then one perception prompt judged on the
+# reply text and on the scene staying unchanged.
+CASES = [
+    {
+        "name": "holding_mid_conversation",
+        "history": ["Make a green cube.", "Move it to the left."],
+        "prompt": "What is the thing in my hand?",
+    },
+    {
+        "name": "describe_view_not_scene",
+        "history": ["Make a green cube.", "Add a blue ball next to it."],
+        "prompt": "Tell me what everything around me looks like.",
+    },
+    {
+        "name": "camera_imperative_pending",
+        "history": ["Make a green cube."],
+        "pending": "Make a ball the color of the item in my hand.",
+        "prompt": "Go ahead and look.",
+    },
+    {
+        # The transcript store persists across sessions, so [Recent
+        # conversation] can carry old turns where perception questions were
+        # answered without the camera. Those replies are few-shot poison:
+        # the supervisor must still delegate vision, never imitate them.
+        "name": "holding_after_poisoned_history",
+        "fixtures": [("box", 0.0, 1.6, -1.5, 1, 0, 0, 0.1)],
+        "poisoned": [
+            ("user", "What do you see?"),
+            ("agent", "I see a red box located at position x=0.0, y=1.6, z=-1.5."),
+            ("user", "Look at the camera and describe what you see."),
+            ("agent", "The camera shows a red cube (id: box-0) positioned at "
+                      "coordinates (0.0, 1.6, -1.5) in the scene."),
+            ("user", "What is in my hand?"),
+            ("agent", "You are not holding anything."),
+        ],
+        "prompt": "What am I holding?",
+    },
+]
+
+
+async def _inject_poisoned(memory, participant, turns):
+    # Two hours old: unambiguously cross-session, the condition this eval
+    # reproduces.
+    base_us = time.time_ns() // 1_000 - 7_200_000_000
+    for offset, (role, text) in enumerate(turns):
+        await memory.add_transcript.execute(AddTranscriptRequest(
+            source_id=f"{participant}:{role}",
+            timestamp_us=base_us + offset * 5_000_000,
+            text=text,
+        ))
+
+
+async def clear_scene(scene):
+    state = await scene.get_scene_state(EmptyRequest())
+    for item in state.objects:
+        await scene.remove_primitive(RemovePrimitiveRequest(obj_id=item.id))
+
+
+async def _agent_replies_since(memory, participant, after_us):
+    recalled = await memory.recall_conversation.execute(
+        RecallConversationRequest(participant_id=participant))
+    return [
+        entry.text
+        for entry in recalled.entries
+        if entry.role == "agent" and entry.timestamp_us >= after_us
+    ]
+
+
+async def _send_and_wait_reply(endpoint, memory, participant, prompt, timeout_s=75):
+    # Correlating by timestamp keeps a straggler reply to the previous
+    # prompt from being judged as this one's.
+    sent_us = time.time_ns() // 1_000
+    await endpoint.inject_data(DataMessage(
+        participant_id=participant, topic="", pts_us=sent_us, data=prompt.encode()))
+    deadline = asyncio.get_running_loop().time() + timeout_s
+    while asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(2)
+        replies = await _agent_replies_since(memory, participant, sent_us)
+        if replies:
+            return replies[0]
+    return ""
+
+
+def _judge(reply, scene_unchanged, asked_words=()):
+    lowered = reply.lower().replace("’", "'")
+    if not reply:
+        return False, "no reply within timeout"
+    if not scene_unchanged:
+        return False, "scene changed on a perception turn"
+    # A shape word the case's own utterances used is the request echoed,
+    # not the scene recited.
+    recited = [w for w in SCENE_RECITAL_WORDS if w in lowered and w not in asked_words]
+    if recited:
+        return False, f"reply recites scene objects {recited}: {reply!r}"
+    if not any(marker in lowered for marker in INABILITY_MARKERS):
+        return False, f"reply claims an answer with no camera: {reply!r}"
+    return True, reply
+
+
+async def main() -> None:
+    scene = SceneClient("tcp://127.0.0.1:8320")
+    memory = TextMemoryTools(_text_memory_dir())
+    tracking = RPCClient("tcp://127.0.0.1:8330", timeout_s=10.0)
+    endpoint = LiveEvalEndpoint()
+    await asyncio.sleep(0.5)
+    try:
+        await tracking.call("set_sim_pose", CANONICAL)
+    except Exception as error:
+        print(f"openxr service refused set_sim_pose ({error}); set allow_sim_pose: true in "
+              "../yaml/openxr_service.yaml and restart the stack")
+        await scene.close()
+        await tracking.close()
+        await endpoint.close()
+        raise SystemExit(2) from None
+    try:
+        wanted = set(sys.argv[1:])
+        unknown = wanted - {case["name"] for case in CASES}
+        if unknown:
+            raise SystemExit(f"unknown cases: {sorted(unknown)}")
+        passed = failed = 0
+        for index, case in enumerate(CASES):
+            if wanted and case["name"] not in wanted:
+                continue
+            participant = f"live-perception-{os.getpid()}-{int(time.time())}-{index}"
+            async with live_participant(endpoint, participant):
+                await clear_scene(scene)
+                ok, detail = True, ""
+                for prim_type, x, y, z, r, g, b, size in case.get("fixtures", ()):
+                    await scene.add_primitive(AddPrimitiveRequest(
+                        prim_type=prim_type, x=x, y=y, z=z, r=r, g=g, b=b, size=size))
+                if "poisoned" in case:
+                    await _inject_poisoned(memory, participant, case["poisoned"])
+                for turn in case.get("history", ()):
+                    before = {i.id: i for i in (await scene.get_scene_state(EmptyRequest())).objects}
+                    await _send_and_wait_reply(endpoint, memory, participant, turn)
+                    after = {i.id: i for i in (await scene.get_scene_state(EmptyRequest())).objects}
+                    if before == after:
+                        ok, detail = False, f"history turn made no scene change: {turn!r}"
+                        break
+                if ok and "pending" in case:
+                    await _send_and_wait_reply(endpoint, memory, participant, case["pending"])
+                if ok:
+                    before = {i.id: i for i in (await scene.get_scene_state(EmptyRequest())).objects}
+                    reply = await _send_and_wait_reply(endpoint, memory, participant, case["prompt"])
+                    after = {i.id: i for i in (await scene.get_scene_state(EmptyRequest())).objects}
+                    # Only the judged turn's own words are exempt, and only
+                    # while no scene object of that type exists; history
+                    # words must still count as recital.
+                    asked = f"{case['prompt']} {case.get('pending', '')}".lower()
+                    scene_types = {item.type for item in before.values()}
+                    asked_words = tuple(
+                        w for w in SCENE_RECITAL_WORDS
+                        if w in asked and _WORD_TYPES.get(w, w) not in scene_types
+                    )
+                    ok, detail = _judge(reply, before == after, asked_words)
+            print(f"{'PASS' if ok else 'FAIL'} {case['name']:28s} {detail[:220]}", flush=True)
+            passed += ok
+            failed += not ok
+        print(f"\nlive perception: {passed} passed, {failed} failed", flush=True)
+    finally:
+        try:
+            await tracking.call("clear_sim_pose", {})
+        except Exception:
+            # Best-effort cleanup; the stack may already be gone.
+            pass
+        await scene.close()
+        await tracking.close()
+        await endpoint.close()
+    sys.exit(1 if failed else 0)
+
+
+def run() -> None:
+    asyncio.run(main())
+
+
+if __name__ == "__main__":
+    run()

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/subagents.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/subagents.py
@@ -493,6 +493,18 @@ CASES = (
         ),
     ),
     SubagentCase(
+        name="recolor_reports_back",
+        agent="object",
+        instruction="Make cone-0 pink.",
+        scene=(_CONE,),
+        forbid_tools=("add_primitive", "update_primitive", "remove_primitive"),
+        answer_contains="recolor",
+    ),
+    # Mixed instructions pairing a recolor with owned work ("make it pink
+    # and twice as big") are deliberately untested: the supervisor's
+    # compound-splitting rule guarantees they never reach this agent, and
+    # that rule is covered end to end by three_actions_compound.
+    SubagentCase(
         name="recolor_explicit_rgb",
         agent="appearance",
         instruction="Set cone-0 to the observed wall color: normalized RGB (1.0, 0.5, 0.0).",
@@ -730,7 +742,7 @@ async def run_case(case: SubagentCase) -> bool:
             physical_color=make_fake_physical_color(scene),
         )
         current_participant_id.set(_PARTICIPANT)
-        current_reference_time_us.set(1_700_000_000_000_000)
+        current_reference_time_us.set(harness.EVAL_REFERENCE_US)
         errored = False
         try:
             reply = await agent.execute(SubagentTask(instruction=case.instruction))

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/supervisor.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/supervisor.py
@@ -284,7 +284,7 @@ async def run_case(case: RoutingCase) -> bool:
                 SceneRequest(
                     transcript=case.request,
                     participant_id="eval-user",
-                    timestamp_us=1_700_000_000_000_000,
+                    timestamp_us=harness.EVAL_REFERENCE_US,
                 )
             )
         except Exception as exc:

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/appearance/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/appearance/agent.py
@@ -19,7 +19,13 @@ from ...scene import SceneContext
 from ...spatial_ops import TurnGuard, make_appearance_tools
 
 _PROMPT = Path(__file__).with_name("prompt.txt")
-DESCRIPTION = "Change only the color of existing XR objects."
+DESCRIPTION = (
+    "Change only the color of existing XR objects: every recolor of an existing object is this "
+    "agent, whatever the verb, never object_agent. The instruction keeps the user's color "
+    "source words verbatim: a color word, an XR object to copy (\"same as capsule-8\"), or a "
+    "physical-world phrase (\"match my jacket\") whose color this agent reads from the camera "
+    "itself; never guess a physical color and never send vision_agent to look one up."
+)
 
 
 _prompt_text = _PROMPT.read_text(encoding="utf-8").strip()

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/memory/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/memory/agent.py
@@ -21,9 +21,15 @@ from ..._trace import current_participant_id, current_reference_time_us, current
 from ...models import SubagentResult, SubagentTask
 
 _PROMPT = Path(__file__).with_name("prompt.txt")
-DESCRIPTION = ("Recall what was said in earlier conversation turns, including objects and "
-               "colors mentioned there; never a source for present-day or physical-world "
-               "facts like the color of a real surface.")
+DESCRIPTION = (
+    "Recall what was said, asked, or done in earlier conversation turns, including objects and "
+    "colors mentioned there. Every history question (\"which shape did I request first?\", "
+    "\"what did I ask you to build?\") routes here, even when [Recent conversation] seems to "
+    "contain the answer; that block only resolves references, and guessing a history answer is "
+    "always wrong. Never a source for present-day or physical-world facts, and what the camera "
+    "saw earlier belongs to vision_agent, not memory: only the conversation's own turns live "
+    "in the transcript."
+)
 
 _MAX_END_US = RecallConversationRequest.model_fields["end_us"].default
 

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/object/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/object/agent.py
@@ -20,9 +20,23 @@ from ...scene import SceneContext
 from ...spatial_ops import CreationLedger, TurnGuard, make_object_tools
 
 _PROMPT = Path(__file__).with_name("prompt.txt")
+# The creation-always-new rule intentionally duplicates supervisor_prompt.txt; see
+# docs/source/reference/xr-render-demo.md ("stated in both places on purpose").
 DESCRIPTION = (
-    "Create new XR objects at their requested initial positions, and remove, resize, duplicate, or "
-    "reshape existing ones; never moves an existing object, including putting one in, on, or next to another."
+    "Create new XR objects at their requested initial positions, and remove, resize, duplicate, "
+    "or reshape existing ones; never moves or recolors an existing object. Moving includes "
+    "putting one in, on, or next to another, and any color change of an existing object belongs "
+    "to appearance_agent. A creation request always makes a new object, even when SCENE OBJECTS "
+    "already lists an identical one. Creation carries its position in the same single call, "
+    "whether user-relative, anchored on scene objects, or between two of them; this agent "
+    "resolves tracking and anchor geometry itself. Phrase creation as: Create <count, when more "
+    "than one> <color> <shape>(s) <the user's own spatial words>, with the user's color words "
+    "verbatim (a color word, \"same as capsule-8\", or a physical phrase like \"the color of my "
+    "apron\") and every requested copy in the one instruction. When the user named no position "
+    "at all, end with \"no position stated\"; never add that phrase when spatial words are "
+    "present, and never invent a position. Removal words with a side (\"the X on the left\") "
+    "stay a removal; a resize instruction carries the resolved id (\"Resize capsule-8 to half "
+    "its current size\")."
 )
 
 

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/object/prompt.txt
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/object/prompt.txt
@@ -10,7 +10,10 @@ id or tool argument.
 
 Handle creation, including a new object's initial position, plus deletion,
 shape changes, resizing, and duplication. Do not change color or move an
-existing object; the supervisor will invoke appearance or placement separately.
+existing object; the supervisor will invoke appearance or placement
+separately. An instruction that names an existing object and a color while
+changing nothing else is a recolor, never a creation, and never a removal
+followed by recreation in the new color.
 
 Quote the instruction's own shape word as prim_type, mangled spellings
 included; the tools map it to a renderer shape themselves. A shape word you
@@ -89,7 +92,12 @@ factor 3.
 
 If the instruction asks to move, contain, swap, or restore an existing
 object, make no tool call; report that the task is movement of an existing
-object so the supervisor can route it to placement_agent.
+object so the supervisor can route it to placement_agent. If it asks to
+change an existing object's color, never alter that color by any means,
+including removing and recreating the object: complete only the non-color
+parts of the instruction, if any, and report that the color part is a
+recolor so the supervisor can route it to appearance_agent. A pure recolor
+instruction gets no tool call at all.
 
 Tool calls must use their declared schemas. Report the stable id of every
 created or changed object so the supervisor can pass it to another subagent.

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/placement/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/placement/agent.py
@@ -21,8 +21,10 @@ from ...spatial_ops import TurnGuard, make_placement_tools
 
 _PROMPT = Path(__file__).with_name("prompt.txt")
 DESCRIPTION = (
-    "Move, swap, contain, stack, or restore existing XR objects; "
-    "never creates, recolors, or removes them."
+    "Move, swap, contain, stack, or restore existing XR objects; never creates, recolors, or "
+    "removes them. Only an object already listed in SCENE OBJECTS can move: \"put the X "
+    "in/on/inside the Y\" with X listed is a move for this agent, while placing an X not yet "
+    "in the scene is a creation for object_agent, initial position included."
 )
 
 

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/vision/agent.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/vision/agent.py
@@ -20,9 +20,34 @@ from ...models import SubagentResult, SubagentTask
 from ...scene import SceneContext
 
 _PROMPT = Path(__file__).with_name("prompt.txt")
+# The SCENE OBJECTS sentence intentionally duplicates supervisor_prompt.txt; see
+# docs/source/reference/xr-render-demo.md ("stated in both places on purpose").
+# _SHARED_RULES ends mid-sentence: each description completes it differently.
+_SHARED_RULES = (
+    "Any request to describe or survey what is visible also means the physical view, never a "
+    "recital of the XR scene. A user statement about the camera itself is not a perception "
+    "request. Never for facts about XR objects: SCENE OBJECTS is always current and complete, "
+    "tracking resolves user-relative placement, and the mutating agents read the camera "
+    "themselves for physical color sources. A new question about what the user holds, wears, "
+    "or sees is always a fresh delegation, every time it is asked, whatever earlier turns said "
+    "about cameras or showed as replies; \"check the camera\" or any telling you to look or "
+    "observe, as an answer to a clarifying question, means delegating the original pending "
+    "question, never those literal words. If live vision is unavailable this agent reports so"
+)
+
 DESCRIPTION = (
-    "Answer a question about the physical world from the live or recorded camera; "
-    "never for XR scene state or placement."
+    "Answer a question about the user's physical surroundings from the live camera, or from "
+    "recorded video when the question is about a past moment: \"what am I looking at?\" and "
+    "\"what was I holding a moment ago?\" are always this agent, never answered without "
+    "delegating here. " + _SHARED_RULES + "; never redelegate with historical video "
+    "substituted for the present."
+)
+
+_LIVE_ONLY_DESCRIPTION = (
+    "Answer a question about the user's present physical surroundings from the live camera: "
+    "\"what am I looking at?\" is always this agent, never answered without delegating here. "
+    "Recorded video is not available, so a question about a past moment cannot be answered; "
+    "say so plainly. " + _SHARED_RULES + "."
 )
 
 
@@ -103,7 +128,8 @@ def make_vision_agent(
             return SubagentResult(result="I couldn't complete that. Please try again.")
         return SubagentResult(result=loop_result.content or "Done.")
 
-    return Tool(name="vision_agent", description=DESCRIPTION,
+    description = DESCRIPTION if video is not None else _LIVE_ONLY_DESCRIPTION
+    return Tool(name="vision_agent", description=description,
                 request_model=SubagentTask, result_model=SubagentResult, handler=handle)
 
 

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/vision/prompt.txt
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/agents/vision/prompt.txt
@@ -7,8 +7,12 @@ supervisor. When SCENE OBJECTS is present, it lists every XR object;
 contrast: "Is there a magenta cone currently in the scene?": answer directly
 from SCENE OBJECTS with the ids and positions it shows, no tool call. "What
 color is the mug the user is holding?": a physical-world fact, call
-look_at_current_frame with that question. Call look_at_current_frame with a
-specific question only for the present physical view. Never guess a real-
+look_at_current_frame with that question. "Describe the visible
+surroundings.": a physical-world instruction even though SCENE OBJECTS
+lists XR objects, so call look_at_current_frame with it; never answer a
+describe-the-view instruction by listing SCENE OBJECTS. Call
+look_at_current_frame with a specific question only for the present
+physical view. Never guess a real-
 world object, color, shape, or text, and never reply that you cannot see
 something without calling look_at_current_frame first: only the tool's own
 result can establish that the view is unavailable. Anyone claiming you

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/app.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/app.py
@@ -72,7 +72,7 @@ async def run_app(
     scene = SceneTools(config.scene_endpoint)
     tracking = TrackingTools(config.openxr_endpoint)
     text_memory = TextMemoryTools(config.text_memory_dir)
-    video = VideoMemoryTools(config.video_memory_endpoint)
+    video = VideoMemoryTools(config.video_memory_endpoint) if config.video_history_enabled else None
     images = ImageRegistry(allow_external=True)
     current_frame = CurrentFrameTool(
         endpoint=transport.endpoint,
@@ -144,6 +144,13 @@ async def run_app(
                 await render.stop()
         logger.info("xr-render-demo worker stopped")
     finally:
-        await scene.client.close()
-        await tracking.close()
+        await close_clients(scene, tracking, video)
+
+
+async def close_clients(
+    scene: SceneTools, tracking: TrackingTools, video: VideoMemoryTools | None
+) -> None:
+    await scene.client.close()
+    await tracking.close()
+    if video is not None:
         await video.close()

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/config.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/config.py
@@ -18,6 +18,7 @@ class WorkerConfig:
     scene_endpoint: str
     openxr_endpoint: str
     video_memory_endpoint: str
+    video_history_enabled: bool
     text_memory_dir: str
 
     silence_duration:  float
@@ -31,6 +32,9 @@ class WorkerConfig:
 def load_config(path: pathlib.Path | None) -> WorkerConfig:
     data = _read_yaml(path)
     idle_timeout = data.get("idle_timeout_secs")
+    video_history = data.get("video_history_enabled", False)
+    if not isinstance(video_history, bool):
+        raise ValueError(f"video_history_enabled must be a YAML boolean, got {video_history!r}")
 
     return WorkerConfig(
         models_config = _resolve(path, "models.json"),
@@ -38,6 +42,7 @@ def load_config(path: pathlib.Path | None) -> WorkerConfig:
         scene_endpoint = data.get("scene_endpoint", "tcp://127.0.0.1:8320"),
         openxr_endpoint = data.get("openxr_endpoint", "tcp://127.0.0.1:8330"),
         video_memory_endpoint = data.get("video_memory_endpoint", "tcp://127.0.0.1:8310"),
+        video_history_enabled = video_history,
         text_memory_dir = data.get("text_memory_dir", "/dev/shm/xr-ai/text-memory"),
         silence_duration  = float(data.get("silence_duration",  0.8)),
         min_speech        = float(data.get("min_speech",        0.15)),

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/spatial_ops.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/spatial_ops.py
@@ -249,6 +249,12 @@ class _Leaves:
             if word in _SHAPE_WORDS:
                 return _SHAPE_WORDS[word]
         for word in words:
+            if word in _COLOR_WORDS:
+                raise ValueError(
+                    f"{word!r} is a color, not a shape. Do not change the shape; "
+                    "report the color change back as a recolor for appearance_agent."
+                )
+        for word in words:
             close = difflib.get_close_matches(word, _SHAPE_WORDS, n=1, cutoff=0.6)
             if close:
                 logger.debug("shape words resolved {!r} -> {}", shape_words, _SHAPE_WORDS[close[0]])

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor.py
@@ -83,6 +83,13 @@ _MUTATING_AGENTS = frozenset({"placement_agent", "appearance_agent", "object_age
 # Seconds to let a scene RPC propagate before diffing snapshots.
 _SCENE_SETTLE_S = 0.15
 
+# [Recent conversation] means this conversation: the transcript store
+# persists across sessions, and older turns read as answers to new
+# questions. History beyond the window is memory_agent's to recall.
+_RECENT_WINDOW_US = 10 * 60 * 1_000_000
+
+_PENDING_ASK_WINDOW_US = 8 * 1_000_000
+
 
 # Leading words that mark a status question about past work ("Did you move
 # the cube?"); unlike can/could/will, they cannot open a polite command.
@@ -215,27 +222,46 @@ class SceneSupervisor:
         self._prompt = _PROMPT.read_text(encoding="utf-8").strip()
         self._participant_locks: defaultdict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
         self._scene_lock: asyncio.Lock = asyncio.Lock()
+        self._left_at_us: dict[str, int] = {}
 
     def forget_participant(self, participant_id: str) -> None:
         """Drop per-participant state after departure; a reconnecting id starts clean."""
         self._participant_locks.pop(participant_id, None)
         self._context.forget_participant(participant_id)
+        now_us = time.time_ns() // 1_000
+        expired = [p for p, t in self._left_at_us.items() if t < now_us - _RECENT_WINDOW_US]
+        for p in expired:
+            del self._left_at_us[p]
+        self._left_at_us[participant_id] = now_us
 
-    async def _recent_conversation(self, participant_id: str) -> tuple[str, str]:
+    async def _recent_conversation(
+        self, participant_id: str, reference_us: int
+    ) -> tuple[str, str]:
         recalled = await self._text_memory.recall_conversation.execute(
             RecallConversationRequest(participant_id=participant_id)
         )
-        entries = recalled.entries[-8:]
-        if not entries:
-            return "", ""
+        # A departure ends the session: turns before the last leave neither
+        # re-enter the block nor complete a clipped ask, however recent.
+        left_us = self._left_at_us.get(participant_id, 0)
+        session = [e for e in recalled.entries if e.timestamp_us >= left_us]
+        # A clipped utterance is completed within seconds or not at all.
         pending = ""
+        tail = session[-2:]
         if (
-            len(entries) >= 2
-            and entries[-1].role == "agent"
-            and entries[-1].text.startswith(_TRUNCATED_ASK)
-            and entries[-2].role == "user"
+            len(tail) == 2
+            and tail[1].role == "agent"
+            and tail[1].text.startswith(_TRUNCATED_ASK)
+            and tail[1].timestamp_us >= reference_us - _PENDING_ASK_WINDOW_US
+            and tail[0].role == "user"
         ):
-            pending = entries[-2].text
+            pending = tail[0].text
+        # User turns carry the hub's clock, agent turns the worker's; the
+        # window assumes both are wall-clock microseconds. The age window
+        # covers worker restarts, which leave no departure record.
+        cutoff_us = reference_us - _RECENT_WINDOW_US
+        entries = [e for e in session if e.timestamp_us >= cutoff_us][-8:]
+        if not entries:
+            return "", pending
         lines = [f"  {'User' if e.role == 'user' else 'Agent'}: {e.text}" for e in entries]
         block = (
             "[Recent conversation] (already handled; never a source of new work)\n"
@@ -260,6 +286,9 @@ class SceneSupervisor:
         )
 
     async def handle(self, request: SceneRequest) -> SceneReply:
+        if request.timestamp_us <= 0:
+            # An unset timestamp would disable the recall recency window.
+            request = request.model_copy(update={"timestamp_us": time.time_ns() // 1_000})
         current_trace_id.set(request.trace_id)
         current_participant_id.set(request.participant_id)
         current_reference_time_us.set(request.timestamp_us)
@@ -278,7 +307,9 @@ class SceneSupervisor:
             "supervisor turn participant={} trace={} transcript={!r}",
             request.participant_id, request.trace_id, request.transcript[:80],
         )
-        conversation, pending_truncation = await self._recent_conversation(request.participant_id)
+        conversation, pending_truncation = await self._recent_conversation(
+            request.participant_id, request.timestamp_us
+        )
         transcript = request.transcript
         if pending_truncation:
             resolved = _resolve_truncation_reply(pending_truncation, transcript)

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor_prompt.txt
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor_prompt.txt
@@ -1,146 +1,35 @@
-You are the supervisor for an XR scene assistant. Satisfy the complete user
-request by invoking the focused subagents available as tools. You may call no
-subagent for ordinary conversation, one subagent for a focused request, or
-several subagents in sequence for a compound request.
-
-Delegate only self-contained tasks. Include the relevant stable XR object ids
-when they are known. After each result, decide whether the request is
-complete or whether another focused task is required. Call at most one subagent
-in each model response and wait for its result before selecting the next. Never
-ask one subagent to perform work owned by another.
-
-vision_agent answers questions about the PHYSICAL world only: what the user
-holds, wears, points at, or what a real wall or room looks like. Every fact
-about XR objects, positions, and empty space is already in SCENE OBJECTS, and
-the subagents resolve user-relative placement ("ahead of me", "at my feet",
-"on the left") through tracking. A mutation whose color comes from the
-physical world does not need vision_agent: pass the user's phrase to the
-mutating agent, whose tools read the camera themselves. If present-time
-vision is unavailable, never retry or substitute historical video; when the
-request truly depends on the missing visual fact, tell the user, and
-otherwise continue satisfying the request without vision. A user statement
-about the camera itself is not a perception request, but a new question
-about what the user holds, wears, or sees always is, no matter what [Recent
-conversation] says about cameras or earlier looks: delegate vision_agent
-again fresh each time. When the user answers a clarifying question of yours
-by telling you to observe instead of answering ("check the camera", "use
-your eyes", or similar), delegate vision_agent with the original pending
-question, never those literal words.
-Never call vision_agent to look up, confirm, or verify the color, shape,
-position, or existence of any object already listed in SCENE OBJECTS; that
-data is always current and complete. Read those values directly from SCENE
-OBJECTS and pass them in the subagent instruction. If an utterance is incomplete,
-self-corrected, commenting on the interaction, or a fragment that does not
-itself request anything ("Creative.", "Okay.", a cut-off phrase), reply
-conversationally or ask one short question; never call a subagent, and never
-re-execute a request from [Recent conversation] that the current utterance
-does not restate.
-
-memory_agent answers questions about the conversation itself. Route every
-question about what was said, asked, or done earlier ("which shape did I
-request first?", "what did I ask you to build?") to memory_agent
-once, even when [Recent conversation] seems to contain the answer; that
-block exists to resolve references, never to answer history questions from,
-and guessing a history answer is always wrong. But questions about what the
-camera saw earlier ("what color was the thing in my hand a while ago?") are
-vision_agent with the past-time question, never memory_agent: the camera's
-past lives in recorded video, the conversation's past in the transcript.
-Present-day facts about the user's clothing, body, or surroundings are
-never memory either; they are perception.
-
-appearance_agent changes only color. placement_agent moves objects that
-already exist, including swaps, containment, stacking, and undo; those are
-moves, never creation. object_agent creates new objects and also removes,
-resizes, duplicates, or changes object shape.
-Use multiple subagents when a request spans those responsibilities, even when a
-single lower-level render function could technically modify several fields.
-
-Routing examples:
-- "Creative." / "Okay." / a cut-off fragment after earlier requests: no
-  subagent call; reply with one short question like "What would you like me
-  to do?" even though [Recent conversation] shows completed work.
-- "That's the wrong capsule" / "no, not that one", right after a change:
-  the intended target is unknown, so nothing can be fixed, created, or
-  removed yet; the whole turn is one short question: "Which capsule should
-  it sit above?"
-- "Put/place the X in/on/inside the Y", X already in SCENE OBJECTS: a move,
-  placement_agent, never object_agent.
-- "Add/create an X inside the Y": a creation, object_agent.
-- "Put/place a lavender cone above the teal capsule" and SCENE OBJECTS in
-  this message lists no lavender cone: a creation with an anchor,
-  object_agent in one call, never placement_agent; only an X that already
-  exists can move. SCENE OBJECTS already states what exists and where;
-  vision_agent never answers either question.
-- "Put an ivory pyramid above the teal capsule" and the capsule appears in
-  SCENE OBJECTS: one object_agent call with the anchor name. Never call
-  vision_agent first to find where the capsule is; its position is in
-  SCENE OBJECTS and object_agent resolves the geometry itself.
-- "Put a teal cone between the ivory capsule and the lavender cylinder" and
-  both appear in SCENE OBJECTS: one object_agent call naming both anchors.
-  The positions are in SCENE OBJECTS; never call vision_agent to find them.
-- "Make the navy cylinder the same color as the teal capsule" and both
-  appear in SCENE OBJECTS: read the teal color directly from SCENE OBJECTS,
-  then call appearance_agent once with that value. Never call vision_agent
-  to look up the color of either object.
-- "Make a lavender cone two meters ahead of me" (or any position relative
-  to the user's body): object_agent directly in one call; never
-  vision_agent first, and never a vision check afterwards — tracking
-  already knows where the user stands and faces, camera or no camera.
-- "Create a cone matching my jacket" / "Make the capsule the same color
-  as the curtains" / "Recolor the torus to match my sweater": a physical
-  color source (a real-world thing, including the user's clothing) goes
-  straight to the mutating agent with the user's own words ("Create a cone the color of my jacket,
-  no position stated"); its tools read the camera themselves. What is
-  never fine is guessing: brands and typical looks are not observations.
-  An anchor that names an XR object, whatever its color or shape:
-  object_agent alone, never vision.
-- "What am I looking at?" / "Describe what you can see": the user means
-  their physical view; one vision_agent question about what is in front
-  of the user.
-- "What color is the mug on my table?": the mug is physical (not in SCENE
-  OBJECTS), so vision_agent once with that question; never answer from the
-  XR scene that no such object exists.
-- "What's in my hand?", even right after turns discussing the camera or a
-  clarifying question you asked: one vision_agent question ("What is the
-  user holding?"). Nothing in [Recent conversation] makes a fresh
-  perception question rhetorical.
-- "What was I holding a moment ago?" or any question about what the camera
-  saw at an earlier time: vision_agent once with the past-time question; it
-  consults the recorded video.
-- "What was the first thing I asked you to create?" / "What did I ask you
-  to build earlier?": memory_agent once with the question. The transcript
-  store is the only reliable history; answering from [Recent conversation]
-  or from your own impression invents facts.
-- "Remove/delete the X on the left": removal, object_agent; the side words
-  only select which X, never a move.
-- "Double it / make the X half the size": resize, object_agent, and the
-  instruction carries the id resolved from SCENE OBJECTS or [Recent
-  conversation]: "Resize capsule-8 to half its current size".
-
-Phrase every creation instruction as: Create <count, when more than one>
-<color> <shape>(s) <the user's own spatial words>. The color slot carries
-the user's color words verbatim: a color word, an XR object to copy
-("same as capsule-8"), or the user's physical phrase ("the color of my
-apron"); the mutating agent resolves them. If the user named no
-position at all, end with "no position stated" in place of spatial words;
-never add "no position stated" when spatial words are present. Use that
-exact phrasing whatever verb the user chose (add, make, spawn, put up), and
-keep every requested copy in the one instruction: "Create three teal cones
-in a row, no position stated", never one call per cone. Never invent a
-position the user did not say. A task an agent reports back keeps
-every word: re-delegate the same instruction to the right agent, never a
-reduced one. Do not split initial placement into a later
-placement_agent call. Use placement_agent only when an object that already
-exists must move.
-
-Do not repeat a completed mutation, and never report a change you did not
-delegate this turn: a request like "triple its size" always requires a
-subagent call now, even when [Recent conversation] shows related earlier
-work. An existing object never satisfies a new creation request: "make a
-cone" with a cone already in SCENE OBJECTS still creates another one;
-never answer that the user already has one. When all required work is complete, respond
-with one short plain-English sentence. That sentence is spoken aloud through
-text-to-speech: never include numeric coordinates, object ids, or unit
-symbols; describe positions in everyday words, like "just below the teal
-capsule" or "in front of you". Never expose tool syntax, intermediate
-instructions, JSON, or private reasoning.
+You are the supervisor for an XR scene assistant. Satisfy the complete
+user request by routing focused, self-contained tasks to the subagent
+tools; each tool's description states the work it owns and how to phrase
+its instructions. Call no subagent for ordinary conversation, one for a
+focused request, or several in sequence for a compound request, at most
+one per model response, and include the relevant stable XR object ids
+when they are known. In a compound request, route each part to the agent
+that owns it, never to whichever agent handled the previous part: "move
+the X, make the Y <color>, and create a Z" is three delegations,
+placement_agent, then appearance_agent, then object_agent. When one part
+cannot be done (for example vision is unavailable), say so for that part
+and still complete the others. SCENE OBJECTS is always current and
+complete for every XR object; answer questions about XR objects directly
+from it, never through a subagent. A delegated task keeps every user
+word; when a subagent reports that part of a task belongs to another
+agent, re-delegate that part to the right agent with the user's words
+kept whole. An utterance that requests nothing (a fragment, "Okay.", a
+correction whose target is unknown) gets one short conversational reply
+or question, never a subagent call, and never re-executes a request from
+[Recent conversation] that the current utterance does not restate.
+Questions about earlier conversation go to memory_agent and questions
+about what the camera sees or saw go to vision_agent; never answer
+either kind yourself. Do not repeat a completed mutation, but a request
+the current utterance itself makes always requires a subagent call now,
+even when [Recent conversation] shows the same or related work
+completed. An existing object never satisfies a new creation request:
+"make a cone" with a cone already in SCENE OBJECTS still creates another
+one, never a move and never a reply that one exists. Never report a
+change you did not delegate this turn. When the work is complete, reply
+with one short plain-English sentence spoken through text-to-speech: no
+coordinates, object ids, unit symbols, tool syntax, JSON, or private
+reasoning; describe positions in everyday words. The reply describes only
+what this turn's subagents observed or did; never name a physical object
+that only [Recent conversation] mentions, since the user may have changed
+what they hold or wear between turns.

--- a/agent-samples/xr-render-demo/yaml/xr_render_demo_worker.yaml
+++ b/agent-samples/xr-render-demo/yaml/xr_render_demo_worker.yaml
@@ -14,6 +14,11 @@ voice_gate_yaml: voice_gate.yaml
 scene_endpoint: tcp://127.0.0.1:8320
 openxr_endpoint: tcp://127.0.0.1:8330
 video_memory_endpoint: tcp://127.0.0.1:8310
+# Past-moment questions ("what was I holding a moment ago?") need recorded
+# video: enable video_recording in device_io_hub.yaml and set recordings_dir
+# in video_memory_service.yaml, then turn this on. Off, vision_agent answers
+# from the live camera only.
+video_history_enabled: false
 text_memory_dir: /dev/shm/xr-ai/text-memory
 
 # ── Voice activity detection (Silero VAD, ONNX backend) ──────────────────────

--- a/docs/source/reference/xr-render-demo.md
+++ b/docs/source/reference/xr-render-demo.md
@@ -239,6 +239,9 @@ services. On each accepted `xr-render.user-query` event:
 
 1. **Recent conversation** is recalled from `TextMemoryTools` and injected
    as context so the model understands references like "fix that" or "undo".
+   The block is session-scoped: only the last eight turns since the
+   participant last departed, and within ten minutes of the request, are
+   injected; older history is memory_agent's to recall.
 2. **Supervisor loop** (`run_tool_loop`, up to 12 iterations) — Nemotron-Omni
    :8108 routes the request to one or more subagent tools. Each subagent
    runs its own inner `run_tool_loop` (up to 4 iterations) against the
@@ -310,8 +313,16 @@ in one place:
 
 Each agent has its own prompt file under
 `worker/xr_render_demo_worker/` (supervisor plus five subagents, six files total).
-The supervisor prompt routes requests to subagents; each subagent prompt
-is worked-example heavy and opens with pronoun and reference resolution.
+The supervisor prompt carries only cross-cutting turn discipline; the
+routing rules and ownership boundaries live in each subagent's tool
+`DESCRIPTION` constant (`agents/<name>/agent.py`), the surface the
+supervisor's model reads when selecting a tool. The vision agent selects
+between two descriptions at construction time: the full one when video
+memory is wired, and a live-only variant that disclaims past-moment
+questions when it is not. A few rules are stated in
+both places on purpose: descriptions alone are under-weighted mid-loop, so
+the supervisor prompt keeps a short backstop copy. Each subagent prompt is
+worked-example heavy and opens with pronoun and reference resolution.
 
 The placement agent's prompt maps utterance shapes to tools with contrast
 pairs: a stated distance is a shift (`nudge`); a user-anchored destination
@@ -355,6 +366,7 @@ so they do not mutate the LOVR scene.
 | Live manipulation | `xr_render_demo_live_manip` | Running demo stack and real scene state | Minutes |
 | Live speech noise | `xr_render_demo_live_garble` | Running demo stack with noisy utterances | Minutes |
 | Live exploration | `xr_render_demo_live_explore` | Running demo stack with novel prompts | Minutes |
+| Live perception routing | `xr_render_demo_live_perception` | Running demo stack and the worker's transcript store | Minutes |
 
 Run all commands from `agent-samples/xr-render-demo/eval/`:
 
@@ -390,6 +402,7 @@ uv run xr_render_demo_live_pose_matrix
 uv run xr_render_demo_live_manip
 uv run xr_render_demo_live_garble
 uv run xr_render_demo_live_explore
+uv run xr_render_demo_live_perception
 ```
 
 Live drivers join as synthetic participants, inject typed text, set simulated
@@ -411,6 +424,16 @@ stutters. Its restraint scoring fails incorrect mutations and accepts a
 clarifying response. `xr_render_demo_live_explore` sends novel conversational
 phrasing and scores intent invariants. Promote any violation into a permanent
 tier case before fixing it.
+
+`xr_render_demo_live_perception` builds real multi-turn history, then sends
+perception utterances and judges the reply text read back from the worker's
+transcript store. The live stack publishes no camera track, so a correctly
+routed perception turn must report an honest inability, recite no scene
+object, and leave the scene unchanged; one case also injects cross-session
+transcript turns to pin the supervisor's recall recency window, which keeps
+them out of [Recent conversation]. It catches routing misses the offline
+tiers cannot reproduce, whose recalled history is far shorter than a live
+session's.
 
 ### Add or change a case
 
@@ -441,7 +464,7 @@ parameter is the precedent: the model copies descriptors verbatim, and
 `spatial_ops` resolves shapes, damaged nouns, and colors against scene state.
 
 Run `uv run xr_render_demo_eval utterances` after every prompt or operations
-change. Its 35 cases take about three minutes. Run the longer scenario and
+change. Its cases take about three minutes. Run the longer scenario and
 precision tiers before completing a tuning round.
 
 (prompt-eval-overlap-audit)=

--- a/tests/test_xr_render_demo_supervisor.py
+++ b/tests/test_xr_render_demo_supervisor.py
@@ -19,7 +19,7 @@ from xr_ai_voice import UserQuery
 from xr_render_demo_eval import harness
 from xr_render_demo_worker.agent import RenderAgent
 from xr_render_demo_worker.models import SceneRequest
-from xr_render_demo_worker.supervisor import SceneSupervisor
+from xr_render_demo_worker.supervisor import _TRUNCATED_ASK, SceneSupervisor
 
 
 class _RecordingMemory:
@@ -39,11 +39,11 @@ class _RecordingMemory:
     async def _recall(self, req: RecallConversationRequest) -> RecallConversationResult:
         entries = [
             ConversationEntry(
-                timestamp_us=index,
+                timestamp_us=record.timestamp_us,
                 role=record.source_id.rsplit(":", 1)[1],
                 text=record.text,
             )
-            for index, record in enumerate(self.records)
+            for record in self.records
             if record.source_id.startswith(f"{req.participant_id}:")
         ]
         return RecallConversationResult(entries=entries)
@@ -362,3 +362,146 @@ async def test_failing_supervisor_publishes_failure_notice() -> None:
     assert published[0].text == "Something went wrong. Please try again."
     assert published[0].final is True
     assert published[0].response_id == "trace-1"
+
+
+_REF_US = harness.EVAL_REFERENCE_US
+
+
+def _seed_turn(memory: _RecordingMemory, participant: str, user: str, agent: str,
+               base_us: int = _REF_US - 30_000_000) -> None:
+    memory.records.append(AddTranscriptRequest(
+        source_id=f"{participant}:user", timestamp_us=base_us, text=user))
+    memory.records.append(AddTranscriptRequest(
+        source_id=f"{participant}:agent", timestamp_us=base_us + 1, text=agent))
+
+
+async def test_stale_recalled_turns_stay_out_of_recent_conversation(monkeypatch) -> None:
+    """Turns older than the recency window never enter [Recent conversation]."""
+    memory = _RecordingMemory()
+    _seed_turn(memory, "alice", "What is in my hand?", "You are not holding anything.",
+               base_us=1)
+    supervisor, _fake = _make_supervisor(memory)
+    seen_user_messages: list[str] = []
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        seen_user_messages.extend(m.content for m in messages if m.role == "user")
+        return SimpleNamespace(content="Okay.", messages=list(messages), tool_calls=())
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    await supervisor.handle(SceneRequest(
+        transcript="What am I holding?", participant_id="alice",
+        timestamp_us=_REF_US))
+    assert seen_user_messages
+    assert all("[Recent conversation]" not in content for content in seen_user_messages)
+    assert all("not holding anything" not in content for content in seen_user_messages)
+
+
+async def test_recency_window_boundary_is_inclusive(monkeypatch) -> None:
+    """A turn exactly at the cutoff enters [Recent conversation]; one
+    microsecond older does not."""
+    from xr_render_demo_worker.supervisor import _RECENT_WINDOW_US
+
+    memory = _RecordingMemory()
+    _seed_turn(memory, "alice", "Older question?", "Older answer.",
+               base_us=_REF_US - _RECENT_WINDOW_US - 2)
+    _seed_turn(memory, "alice", "Edge question?", "Edge answer.",
+               base_us=_REF_US - _RECENT_WINDOW_US)
+    supervisor, _fake = _make_supervisor(memory)
+    seen_user_messages: list[str] = []
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        seen_user_messages.extend(m.content for m in messages if m.role == "user")
+        return SimpleNamespace(content="Okay.", messages=list(messages), tool_calls=())
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    await supervisor.handle(SceneRequest(
+        transcript="What did I just say?", participant_id="alice", timestamp_us=_REF_US))
+    joined = "\n".join(seen_user_messages)
+    assert "Edge question?" in joined
+    assert "Edge answer." in joined
+    assert "Older answer." not in joined
+
+
+async def test_unset_timestamp_still_excludes_stale_turns(monkeypatch) -> None:
+    """A request without a timestamp gets the wall clock, so the recency
+    window still applies."""
+    memory = _RecordingMemory()
+    _seed_turn(memory, "alice", "What is in my hand?", "You are not holding anything.",
+               base_us=1)
+    supervisor, _fake = _make_supervisor(memory)
+    seen_user_messages: list[str] = []
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        seen_user_messages.extend(m.content for m in messages if m.role == "user")
+        return SimpleNamespace(content="Okay.", messages=list(messages), tool_calls=())
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    await supervisor.handle(SceneRequest(transcript="What am I holding?", participant_id="alice"))
+    assert seen_user_messages
+    assert all("not holding anything" not in content for content in seen_user_messages)
+
+
+async def test_departure_ends_the_session_for_recall(monkeypatch) -> None:
+    """Turns before a participant's last departure never re-enter
+    [Recent conversation], however recent."""
+    import time as _time
+
+    now_us = _time.time_ns() // 1_000
+    memory = _RecordingMemory()
+    _seed_turn(memory, "alice", "What is in my hand?", "You are holding a torch.",
+               base_us=now_us - 5_000_000)
+    supervisor, _fake = _make_supervisor(memory)
+    seen_user_messages: list[str] = []
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        seen_user_messages.extend(m.content for m in messages if m.role == "user")
+        return SimpleNamespace(content="Okay.", messages=list(messages), tool_calls=())
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    await supervisor.handle(SceneRequest(
+        transcript="Hello again.", participant_id="alice", timestamp_us=now_us))
+    assert any("holding a torch" in content for content in seen_user_messages)
+
+    supervisor.forget_participant("alice")
+    seen_user_messages.clear()
+    await supervisor.handle(SceneRequest(
+        transcript="Hello once more.", participant_id="alice",
+        timestamp_us=_time.time_ns() // 1_000))
+    assert seen_user_messages
+    assert all("holding a torch" not in content for content in seen_user_messages)
+
+
+async def test_departure_drops_pending_truncated_ask(monkeypatch) -> None:
+    """A clipped ask left before departure never completes a reconnecting
+    participant's first words, even inside the completion window."""
+    import time as _time
+
+    now_us = _time.time_ns() // 1_000
+    memory = _RecordingMemory()
+    _seed_turn(memory, "alice", "Make a", f"{_TRUNCATED_ASK} A what?",
+               base_us=now_us - 2_000_000)
+    supervisor, _fake = _make_supervisor(memory)
+    supervisor.forget_participant("alice")
+    seen_user_messages: list[str] = []
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        seen_user_messages.extend(m.content for m in messages if m.role == "user")
+        return SimpleNamespace(content="Okay.", messages=list(messages), tool_calls=())
+
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    await supervisor.handle(SceneRequest(
+        transcript="Cube please.", participant_id="alice", timestamp_us=now_us))
+    assert seen_user_messages
+    assert all("Make a" not in content for content in seen_user_messages)
+
+
+def test_departure_records_expire_with_the_recall_window() -> None:
+    supervisor, _fake = _make_supervisor()
+    supervisor._left_at_us["stale"] = 1
+    supervisor.forget_participant("alice")
+    assert set(supervisor._left_at_us) == {"alice"}

--- a/tests/test_xr_render_demo_wire.py
+++ b/tests/test_xr_render_demo_wire.py
@@ -73,6 +73,8 @@ def test_worker_config_loads_sample_yaml() -> None:
     config = load_config(_SAMPLE / "yaml/xr_render_demo_worker.yaml")
     assert config.models_config == _SAMPLE / "yaml/models.json"
     assert config.voice_gate_yaml.exists()
+    # The shipped hub disables recording, so the worker must not wire recorded video.
+    assert config.video_history_enabled is False
 
 
 def test_all_agent_modules_export_descriptions() -> None:
@@ -120,7 +122,7 @@ def test_eval_case_filter_rejects_unknown_names_in_mixed_selection() -> None:
 def test_eval_utterances_alias_selects_the_complete_battery() -> None:
     from xr_render_demo_eval import harness
 
-    assert len(harness.UTTERANCES) == 35
+    assert len(harness.UTTERANCES) == 40
     assert harness._resolve_case_names(["utterances"]) == {
         case.name for case in harness.UTTERANCES
     }
@@ -235,6 +237,35 @@ def test_worker_config_idle_timeout_opt_in(tmp_path) -> None:
     y.write_text("idle_timeout_secs: 300\n")
     cfg = load_config(y)
     assert cfg.idle_timeout_secs == 300.0
+
+
+def test_worker_config_video_history_requires_yaml_boolean(tmp_path) -> None:
+    from xr_render_demo_worker.config import load_config
+
+    y = tmp_path / "w.yaml"
+    y.write_text("video_history_enabled: true\n")
+    assert load_config(y).video_history_enabled is True
+    y.write_text('video_history_enabled: "false"\n')
+    with pytest.raises(ValueError, match="video_history_enabled"):
+        load_config(y)
+
+
+async def test_close_clients_skips_disabled_video() -> None:
+    from types import SimpleNamespace
+
+    from xr_render_demo_worker.app import close_clients
+
+    closed: list[str] = []
+
+    async def _close(name: str) -> None:
+        closed.append(name)
+
+    scene = SimpleNamespace(client=SimpleNamespace(close=lambda: _close("scene")))
+    tracking = SimpleNamespace(close=lambda: _close("tracking"))
+    await close_clients(scene, tracking, None)
+    assert closed == ["scene", "tracking"]
+    await close_clients(scene, tracking, SimpleNamespace(close=lambda: _close("video")))
+    assert closed == ["scene", "tracking", "scene", "tracking", "video"]
 
 
 # ── untooled chat wire golden ─────────────────────────────────────────────────
@@ -460,3 +491,21 @@ def test_tool_def_to_openai_wire_shape() -> None:
             },
         },
     }
+
+
+def test_vision_description_matches_video_capability() -> None:
+    """The tool description offered to the supervisor must not advertise
+    recorded video when no video memory is wired."""
+    from xr_render_demo_worker.agents.vision import agent as vision
+
+    assert vision._SHARED_RULES in vision.DESCRIPTION
+    assert vision._SHARED_RULES in vision._LIVE_ONLY_DESCRIPTION
+    assert "recorded video when the question is about a past moment" in vision.DESCRIPTION
+    assert "Recorded video is not available" in vision._LIVE_ONLY_DESCRIPTION
+
+    with_video = vision.make_vision_agent(
+        llm=None, current_frame=None, image_query=None, video=object())
+    without_video = vision.make_vision_agent(
+        llm=None, current_frame=None, image_query=None, video=None)
+    assert with_video.description == vision.DESCRIPTION
+    assert without_video.description == vision._LIVE_ONLY_DESCRIPTION


### PR DESCRIPTION
Cherry-picks #458 onto `release/beta-v0.2.0rc1`.

## Testing

- `uv run pytest -m "not gpu" test_xr_render_demo_supervisor.py test_xr_render_demo_wire.py` (41 passed)