### PR TITLE
Remove XR transcript truncation heuristic

### DIFF
--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor.py
@@ -43,33 +43,10 @@ from .scene import SceneContext
 
 _PROMPT = Path(__file__).with_name("supervisor_prompt.txt")
 
-_DANGLING_DETERMINERS = frozenset("a an the my your its".split())
-
-_DANGLING_PREPOSITIONS = frozenset(
-    "of to on in at by and or with near under over "
-    "onto into between behind above below beside toward towards from".split()
-)
-
-_ARTICLES = frozenset({"a", "an", "the", "my", "your", "its"})
-
 # Shared punctuation strip set, unicode ellipsis and quotes included.
-# Detection strips per word; the ask-back strips the transcript tail.
 _EDGE_PUNCT = ".,!?;:\"'…“”‘’"
 
-_WH_WORDS = frozenset("what which where when why who whom whose how".split())
-
-# Subjects that make a following -ing word a progressive verb ("the wall
-# I'm staring at" is complete; "the lamp on the ceiling in" is not).
-_PROGRESSIVE_SUBJECTS = frozenset(
-    "am is are was were be been being "
-    "i'm im he's she's it's you're we're they're user user's".split()
-)
-
-_TRUNCATED_ASK = "I think I missed the end of that."
-
-_CANCEL_PHRASES = frozenset({
-    "never mind", "nevermind", "forget it", "forget that", "cancel", "cancel that", "no", "stop",
-})
+_WH_WORDS = frozenset("what what's whats which where when why who whom whose how".split())
 
 _ACTION_VERBS = frozenset(
     "put place move make create add remove delete drop turn rotate resize double halve shrink "
@@ -87,9 +64,6 @@ _SCENE_SETTLE_S = 0.15
 # persists across sessions, and older turns read as answers to new
 # questions. History beyond the window is memory_agent's to recall.
 _RECENT_WINDOW_US = 10 * 60 * 1_000_000
-
-_PENDING_ASK_WINDOW_US = 8 * 1_000_000
-
 
 # Leading words that mark a status question about past work ("Did you move
 # the cube?"); unlike can/could/will, they cannot open a polite command.
@@ -119,61 +93,6 @@ def _claims_completion(text: str) -> bool:
 
 def _is_question(text: str) -> bool:
     return text.rstrip().rstrip("\"'”’)").rstrip().endswith("?")
-
-
-def _is_truncated(transcript: str) -> bool:
-    words = [w.strip(_EDGE_PUNCT) for w in transcript.strip().lower().split()]
-    words = [w for w in words if w]
-    if not words:
-        return False
-    if words[-1] in _DANGLING_DETERMINERS:
-        return True
-    if words[-1] in _DANGLING_PREPOSITIONS:
-        # Only a recognized complete tail construction exempts a trailing
-        # preposition: a leading wh-question ("What am I looking at") or a
-        # progressive construction right before it ("the wall I'm staring
-        # at"). Terminal punctuation, embedded wh-words, and bare -ing nouns
-        # ("the ceiling in") all appear on cut input.
-        if words[0] in _WH_WORDS:
-            return False
-        prev = words[-2] if len(words) >= 2 else ""
-        subject = words[-3] if len(words) >= 3 else ""
-        if prev.endswith("ing") and subject in _PROGRESSIVE_SUBJECTS:
-            return False
-        return True
-    return False
-
-
-def _truncated_reply(transcript: str) -> str:
-    words = transcript.strip().rstrip(_EDGE_PUNCT).split()
-    tail = words[-1]
-    if tail.lower() in _ARTICLES and len(words) >= 2:
-        tail = f"{words[-2]} {tail}"
-    return f"{_TRUNCATED_ASK} {tail.capitalize()} what?"
-
-
-def _splice_completion(prefix: str, completion: str) -> str:
-    head = prefix.strip().rstrip(".?!,;")
-    tail_words = completion.strip().rstrip(".?!,;").split()
-    head_words = head.split()
-    for overlap in (3, 2, 1):
-        if (
-            len(head_words) >= overlap
-            and len(tail_words) >= overlap
-            and [w.lower() for w in head_words[-overlap:]] == [w.lower() for w in tail_words[:overlap]]
-        ):
-            tail_words = tail_words[overlap:]
-            break
-    return f"{head} {' '.join(tail_words)}".strip() + "."
-
-
-def _resolve_truncation_reply(prefix: str, transcript: str) -> str | None:
-    words = transcript.strip().rstrip(".?!,;").lower()
-    if words in _CANCEL_PHRASES:
-        return None
-    if any(word in _ACTION_VERBS for word in words.split()):
-        return transcript
-    return _splice_completion(prefix, transcript)
 
 
 class SceneSupervisor:
@@ -236,38 +155,27 @@ class SceneSupervisor:
 
     async def _recent_conversation(
         self, participant_id: str, reference_us: int
-    ) -> tuple[str, str]:
+    ) -> str:
         recalled = await self._text_memory.recall_conversation.execute(
             RecallConversationRequest(participant_id=participant_id)
         )
-        # A departure ends the session: turns before the last leave neither
-        # re-enter the block nor complete a clipped ask, however recent.
+        # A departure ends the session: turns before the last leave do not
+        # re-enter the block, however recent.
         left_us = self._left_at_us.get(participant_id, 0)
         session = [e for e in recalled.entries if e.timestamp_us >= left_us]
-        # A clipped utterance is completed within seconds or not at all.
-        pending = ""
-        tail = session[-2:]
-        if (
-            len(tail) == 2
-            and tail[1].role == "agent"
-            and tail[1].text.startswith(_TRUNCATED_ASK)
-            and tail[1].timestamp_us >= reference_us - _PENDING_ASK_WINDOW_US
-            and tail[0].role == "user"
-        ):
-            pending = tail[0].text
         # User turns carry the hub's clock, agent turns the worker's; the
         # window assumes both are wall-clock microseconds. The age window
         # covers worker restarts, which leave no departure record.
         cutoff_us = reference_us - _RECENT_WINDOW_US
         entries = [e for e in session if e.timestamp_us >= cutoff_us][-8:]
         if not entries:
-            return "", pending
+            return ""
         lines = [f"  {'User' if e.role == 'user' else 'Agent'}: {e.text}" for e in entries]
         block = (
             "[Recent conversation] (already handled; never a source of new work)\n"
             + "\n".join(lines) + "\n\n"
         )
-        return block, pending
+        return block
 
     async def _persist_turn(self, request: SceneRequest, user_text: str, reply_text: str) -> None:
         await self._text_memory.add_transcript.execute(
@@ -292,13 +200,6 @@ class SceneSupervisor:
         current_trace_id.set(request.trace_id)
         current_participant_id.set(request.participant_id)
         current_reference_time_us.set(request.timestamp_us)
-        if _is_truncated(request.transcript):
-            # The ask must reach memory: the next turn's completion splice
-            # keys off the recalled truncated-ask reply.
-            reply = _truncated_reply(request.transcript)
-            await self._persist_turn(request, request.transcript, reply)
-            return SceneReply(response=reply)
-
         async with self._participant_locks[request.participant_id]:
             return await self._handle(request)
 
@@ -307,17 +208,10 @@ class SceneSupervisor:
             "supervisor turn participant={} trace={} transcript={!r}",
             request.participant_id, request.trace_id, request.transcript[:80],
         )
-        conversation, pending_truncation = await self._recent_conversation(
+        conversation = await self._recent_conversation(
             request.participant_id, request.timestamp_us
         )
         transcript = request.transcript
-        if pending_truncation:
-            resolved = _resolve_truncation_reply(pending_truncation, transcript)
-            if resolved is None:
-                reply = "Okay, never mind that."
-                await self._persist_turn(request, request.transcript, reply)
-                return SceneReply(response=reply)
-            transcript = resolved
 
         async with self._scene_lock:
             return await self._handle_scene(request, transcript, conversation)

--- a/tests/test_xr_render_demo_supervisor.py
+++ b/tests/test_xr_render_demo_supervisor.py
@@ -1,8 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Supervisor turn-lifecycle tests: scene-lock serialization, failure
-publishing, and two-turn memory persistence — all over fakes, no LLM."""
+"""Supervisor turn-lifecycle tests over fakes, without an LLM."""
 from __future__ import annotations
 
 import asyncio
@@ -19,7 +18,7 @@ from xr_ai_voice import UserQuery
 from xr_render_demo_eval import harness
 from xr_render_demo_worker.agent import RenderAgent
 from xr_render_demo_worker.models import SceneRequest
-from xr_render_demo_worker.supervisor import _TRUNCATED_ASK, SceneSupervisor
+from xr_render_demo_worker.supervisor import SceneSupervisor
 
 
 class _RecordingMemory:
@@ -87,9 +86,8 @@ async def test_scene_mutations_serialize_across_participants(monkeypatch) -> Non
     assert max_active == 1
 
 
-async def test_two_turn_memory_without_preseeding(monkeypatch) -> None:
-    """A truncated turn is persisted by the supervisor itself, so the next
-    turn's completion splices against real recalled memory."""
+async def test_every_transcript_reaches_the_supervisor_loop(monkeypatch) -> None:
+    """Transcript shape never triggers a canned response before the model."""
     memory = _RecordingMemory()
     supervisor, _fake = _make_supervisor(memory)
     seen_user_messages: list[str] = []
@@ -100,21 +98,18 @@ async def test_two_turn_memory_without_preseeding(monkeypatch) -> None:
 
     monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
 
-    first = await supervisor.handle(
-        SceneRequest(transcript="Put the sphere on the", participant_id="alice"))
-    assert "what?" in first.response.lower()
-    assert [record.source_id for record in memory.records] == ["alice:user", "alice:agent"]
-
-    second = await supervisor.handle(
-        SceneRequest(transcript="On the box.", participant_id="alice"))
-    assert second.response == "Placed it?"
-    assert any(
-        "User request: Put the sphere on the box." in content
-        for content in seen_user_messages
+    transcripts = (
+        "Hey Agent, what am I looking at?",
+        "Assistant, tell me what object I'm looking at.",
+        "Put the sphere on the",
+        "Move the cube to",
     )
-    assert [record.source_id for record in memory.records] == [
-        "alice:user", "alice:agent", "alice:user", "alice:agent",
-    ]
+    for transcript in transcripts:
+        reply = await supervisor.handle(
+            SceneRequest(transcript=transcript, participant_id="alice")
+        )
+        assert reply.response == "Placed it?"
+        assert any(f"User request: {transcript}" in content for content in seen_user_messages)
 
 
 async def test_mixed_vision_and_mutation_request_still_verifies(monkeypatch) -> None:
@@ -473,31 +468,6 @@ async def test_departure_ends_the_session_for_recall(monkeypatch) -> None:
         timestamp_us=_time.time_ns() // 1_000))
     assert seen_user_messages
     assert all("holding a torch" not in content for content in seen_user_messages)
-
-
-async def test_departure_drops_pending_truncated_ask(monkeypatch) -> None:
-    """A clipped ask left before departure never completes a reconnecting
-    participant's first words, even inside the completion window."""
-    import time as _time
-
-    now_us = _time.time_ns() // 1_000
-    memory = _RecordingMemory()
-    _seed_turn(memory, "alice", "Make a", f"{_TRUNCATED_ASK} A what?",
-               base_us=now_us - 2_000_000)
-    supervisor, _fake = _make_supervisor(memory)
-    supervisor.forget_participant("alice")
-    seen_user_messages: list[str] = []
-
-    async def fake_loop(messages, toolset, call_model, max_iterations=12):
-        seen_user_messages.extend(m.content for m in messages if m.role == "user")
-        return SimpleNamespace(content="Okay.", messages=list(messages), tool_calls=())
-
-    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
-
-    await supervisor.handle(SceneRequest(
-        transcript="Cube please.", participant_id="alice", timestamp_us=now_us))
-    assert seen_user_messages
-    assert all("Make a" not in content for content in seen_user_messages)
 
 
 def test_departure_records_expire_with_the_recall_window() -> None:

--- a/tests/test_xr_render_demo_wire.py
+++ b/tests/test_xr_render_demo_wire.py
@@ -133,56 +133,6 @@ def test_entry_module_imports(entry: str) -> None:
     __import__(entry)
 
 
-def test_truncation_replies_resolve() -> None:
-    from xr_render_demo_worker.supervisor import _resolve_truncation_reply, _splice_completion
-
-    assert _splice_completion("Put the sphere on the", "On the box.") == "Put the sphere on the box."
-    assert _splice_completion("Put the sphere on the", "The box.") == "Put the sphere on the box."
-    assert _splice_completion("Move it towards", "The window.") == "Move it towards The window."
-    assert _resolve_truncation_reply("Put the sphere on the", "Never mind.") is None
-    assert _resolve_truncation_reply("Put the sphere on the", "Cancel") is None
-    fresh = _resolve_truncation_reply("Put the sphere on the", "Put the sphere on the box.")
-    assert fresh == "Put the sphere on the box."
-
-
-def test_truncated_transcripts_detected() -> None:
-    from xr_render_demo_worker.supervisor import _is_truncated, _truncated_reply
-
-    assert _is_truncated("Add a red sphere in")
-    assert not _is_truncated("Add a red sphere in front of me.")
-    assert _truncated_reply("Add a red sphere in") is not None
-    assert not _is_truncated("What am I looking at?")
-    assert not _is_truncated("What are you looking at")
-    assert not _is_truncated('"What are you looking at')
-    assert not _is_truncated("Where is it at?")
-    assert _is_truncated("Put the sphere on the")
-    assert _is_truncated("Put the sphere on the.")
-    assert _is_truncated("Put the sphere on the…")
-    assert _is_truncated("Can you put the sphere on the")
-    assert _is_truncated("What color is the")
-    assert _is_truncated("Is the sphere behind the")
-    assert not _is_truncated("Add a cube that matches the wall I'm looking at.")
-    assert not _is_truncated("Add a cube that matches the wall I'm looking at")
-    assert not _is_truncated("Make a sphere match what I'm looking at")
-    assert not _is_truncated('“What are you looking at”')
-    assert _is_truncated("Move the sphere in")
-    # Auxiliaries are not the wh-exemption: a polite request cut at a
-    # preposition is still a cut.
-    assert _is_truncated("Can you put the sphere on")
-    assert _is_truncated("Can you move the cube to")
-    assert _is_truncated("Put it near the ring in")
-    # Neither terminal punctuation nor an embedded wh-word makes a dangling
-    # preposition complete.
-    assert _is_truncated("Can you put the sphere on.")
-    assert _is_truncated("Can you tell me what color to")
-    assert _is_truncated("Move what I selected to")
-    # A bare -ing noun is not a progressive construction.
-    assert _is_truncated("Put the lamp on the ceiling in")
-    assert _is_truncated("Hang it on the railing above")
-    assert _is_truncated("Move the cube near the painting behind")
-    assert _is_truncated("Put it in the opening near")
-
-
 # ── models profile round-trip ─────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- remove the regex-based transcript truncation detector that intercepted valid utterances before the supervisor model
- remove its pending completion-splicing state and canned clarification path
- pass every transcript to the supervisor unchanged
- replace obsolete heuristic tests with coverage that confirms varied transcript shapes reach the supervisor loop

No prompts, vision routing, CloudXR, LOVR, VAD, or shutdown behavior are changed.

## Validation

- focused pytest: 38 passed
- Ruff: passed
- git diff checks: passed
- single DCO-signed commit based on the latest release branch