### PR TITLE
XR render shape synonyms and hard stop on unknown shapes

### DIFF
--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/_live_endpoint.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/_live_endpoint.py
@@ -18,6 +18,11 @@ import zmq
 import zmq.asyncio
 from xr_ai_hub._codec import encode
 from xr_ai_hub._types import DataMessage, MsgType, ParticipantEvent
+from xr_ai_tools.rpc import RPCClient
+
+CANONICAL_POSE = {"position": {"x": 0, "y": 1.6, "z": 0}, "forward": {"x": 0, "y": 0, "z": -1},
+                  "right": {"x": 1, "y": 0, "z": 0}, "up": {"x": 0, "y": 1, "z": 0},
+                  "yaw_deg": 0.0, "pitch_deg": 0.0, "ts": 1}
 
 
 class LiveEvalEndpoint:
@@ -44,6 +49,27 @@ class LiveEvalEndpoint:
 
     async def close(self) -> None:
         self._push.close(linger=0)
+
+
+@asynccontextmanager
+async def simulated_pose(pose: dict = CANONICAL_POSE, endpoint: str = "tcp://127.0.0.1:8330"):
+    """Inject a head pose for one driver run and always clear it afterwards."""
+    tracking = RPCClient(endpoint, timeout_s=10.0)
+    try:
+        await tracking.call("set_sim_pose", pose)
+    except Exception as error:
+        print(f"openxr service refused set_sim_pose ({error}); set allow_sim_pose: true in "
+              "agent-samples/xr-render-demo/yaml/openxr_service.yaml and restart the stack")
+        await tracking.close()
+        raise SystemExit(2) from None
+    try:
+        yield tracking
+    finally:
+        try:
+            await tracking.call("clear_sim_pose", {})
+        except Exception:
+            pass
+        await tracking.close()
 
 
 @asynccontextmanager

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/cases.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/cases.py
@@ -422,7 +422,7 @@ CASES = [
         "name":  "three_objects_around_me",
         "scene": [],
         "user":  "Put a red sphere in front of me, a blue cube to my right, "
-                 "and a green pyramid behind me.",
+                 "and a green ball behind me.",
         "result": [
             {"tool": "add_primitive",
              "args": {"prim_type": "sphere",
@@ -433,7 +433,7 @@ CASES = [
                       "b": (0.5, 1.0), "r": (0.0, 0.3), "g": (0.0, 0.5),
                       "x": (0.3, 3.0)}},
             {"tool": "add_primitive",
-             "args": {"prim_type": "pyramid",
+             "args": {"prim_type": "sphere",
                       "g": (0.5, 1.0), "r": (0.0, 0.4), "b": (0.0, 0.4),
                       "z": (0.3, 3.0)}},
         ],
@@ -791,10 +791,10 @@ CASES = [
             {"id": "box-0", "type": "box",
              "pos": [-2.0, 1.6, 0.0], "color": [1, 1, 0], "size": 0.1},
         ],
-        "user":  "Put a green pyramid between the red sphere and the blue sphere.",
+        "user":  "Put a green cube between the red sphere and the blue sphere.",
         "result": [
             {"tool": "add_primitive",
-             "args": {"prim_type": "pyramid",
+             "args": {"prim_type": "box",
                       "g": (0.5, 1.0), "r": (0.0, 0.4), "b": (0.0, 0.4),
                       "x": (-0.05, 0.05),
                       "y": ( 1.55, 1.65),

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/harness.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/harness.py
@@ -283,7 +283,7 @@ CASES = (
     ),
     Case(
         name="create_in_front_of_moved_user",
-        request="Add a yellow cone ahead of me.",
+        request="Add a yellow cube ahead of me.",
         pose=SpatialFrame(
             origin=Vector3(x=2.0, y=1.6, z=1.5),
             forward=Vector3(x=0, y=0, z=-1),
@@ -379,6 +379,58 @@ CASES = (
         expected_colors=(("cylinder-0", (0.0, 0.8, 0.8)),),
     ),
     Case(
+        name="scene_question_reads_scene_objects_not_camera",
+        request="What's in the scene right now?",
+        scene=(
+            {"id": "sphere-0", "type": "sphere",
+             "position": {"x": 0.0, "y": 1.6, "z": -1.5},
+             "color": {"r": 1, "g": 0, "b": 0}, "size": 0.1},
+        ),
+        forbidden_tools=frozenset({
+            "look_at_current_frame", "look_at_past_frame",
+            "add_primitive", "update_primitive", "remove_primitive",
+        }),
+        reply_contains="sphere",
+    ),
+    Case(
+        name="generic_creation_asks_for_shape",
+        request="Create an object.",
+        forbidden_tools=frozenset({"add_primitive", "update_primitive", "remove_primitive"}),
+        reply_contains="?",
+    ),
+    Case(
+        name="rectangle_creates_box",
+        request="Create a red rectangle.",
+        expected_call_counts=(("add_primitive", 1),),
+        expected_colors=(("box-0", (1.0, 0.0, 0.0)),),
+    ),
+    Case(
+        name="rectangle_recolor_finds_box",
+        request="Make the rectangle green.",
+        scene=(
+            {"id": "box-0", "type": "box",
+             "position": {"x": 0.0, "y": 1.6, "z": -1.5},
+             "color": {"r": 1, "g": 0, "b": 0}, "size": 0.1},
+        ),
+        history=(("Create a red rectangle.", "Added a red rectangle in front of you."),),
+        forbidden_tools=frozenset({"add_primitive", "remove_primitive"}),
+        expected_colors=(("box-0", (0.0, 0.8, 0.0)),),
+    ),
+    Case(
+        name="unknown_shape_never_substitutes",
+        request="Create a red hexagon.",
+        forbidden_tools=frozenset({"add_primitive", "update_primitive", "remove_primitive"}),
+        reply_contains="sphere",
+        reply_excludes="cone",
+    ),
+    Case(
+        name="unknown_shape_keeps_the_rest_of_the_request",
+        request="Create a red hexagon and a blue sphere.",
+        expected_call_counts=(("add_primitive", 1),),
+        expected_colors=(("sphere-0", (0.0, 0.4, 1.0)),),
+        reply_contains="hexagon",
+    ),
+    Case(
         name="create_between_two_xr_objects",
         request="Put a green sphere between the red box and the blue capsule.",
         scene=(
@@ -415,9 +467,9 @@ CASES = (
                 "size": 0.1,
             },
         ),
-        required_tools=frozenset({"add_primitive"}),
-        forbidden_tools=frozenset({"update_primitive", "remove_primitive"}),
-        expected_call_counts=(("add_primitive", 1),),
+        forbidden_tools=frozenset({"add_primitive", "update_primitive", "remove_primitive"}),
+        expected_colors=(("sphere-0", (1.0, 0.0, 0.0)),),
+        reply_contains="?",
     ),
     Case(
         name="unavailable_live_camera",
@@ -867,10 +919,10 @@ UTTERANCES = (
         name="basics_compound_one_part_blocked",
         # One blocked part of a compound turn never blocks the others: the
         # creation still lands while the perception part reports the outage.
-        request="Create a purple ring, then tell me what is printed on my shirt.",
+        request="Create a purple cube, then tell me what is printed on my shirt.",
         camera_error="RPCError: camera feed unavailable",
         required_tools=frozenset({"add_primitive"}),
-        expected_colors=(("ring-0", (0.6, 0.0, 1.0)),),
+        expected_colors=(("box-0", (0.6, 0.0, 1.0)),),
     ),
     Case(
         name="basics_physical_source_camera_down",
@@ -1267,7 +1319,7 @@ async def run_case(case: Case) -> bool:
 # memorizes as templates; any overlap with case inputs, history turns, or
 # fixture text means the eval scores recall, not behavior.
 _EVAL_VOCAB_COLORS = ("red", "green", "blue", "yellow", "cyan", "orange", "purple", "white", "black")
-_EVAL_VOCAB_SHAPES = ("sphere", "cube", "box", "ball")
+_EVAL_VOCAB_SHAPES = ("sphere", "cube", "box", "ball", "rectangle", "hexagon")
 
 
 def audit_prompts() -> None:

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/live_manip.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/live_manip.py
@@ -12,11 +12,8 @@ from xr_ai_hub import DataMessage
 from xr_ai_tools.rpc import RPCClient
 from xr_render_scene import AddPrimitiveRequest, EmptyRequest, SceneClient
 
+from ._live_endpoint import CANONICAL_POSE as CANONICAL
 from ._live_endpoint import LiveEvalEndpoint, live_participant
-
-CANONICAL = {"position": {"x": 0, "y": 1.6, "z": 0}, "forward": {"x": 0, "y": 0, "z": -1},
-             "right": {"x": 1, "y": 0, "z": 0}, "up": {"x": 0, "y": 1, "z": 0},
-             "yaw_deg": 0.0, "pitch_deg": 0.0, "ts": 1}
 
 # Each case: fixtures (type, x, y, z, r, g, b, size), prompt, then checks on
 # the scene: expressions over {id: object} keyed by fixture creation order.
@@ -126,11 +123,8 @@ CASES = [
         "name": "unusual_shape_existing_objects_untouched",
         "fixtures": [("sphere", 0.0, 1.6, -1.5, 1, 0, 0, 0.1)],
         "prompt": "Add a purple pyramid next to the red sphere.",
-        "check": lambda ids, o: (
-            ids[0] in o and o[ids[0]].type == "sphere" and o[ids[0]].color.r > 0.8
-            and any(item.type == "pyramid" and item.color.r > 0.3 and item.color.b > 0.3
-                    for key, item in o.items() if key not in ids)
-        ),
+        "no_change_ok": True,
+        "check": lambda ids, o: False,
     },
 ]
 
@@ -176,9 +170,12 @@ async def main() -> None:
                 await endpoint.inject_data(DataMessage(
                     participant_id=participant, topic="",
                     pts_us=time.time_ns() // 1_000, data=case["prompt"].encode()))
+                # A turn answers in a few seconds; a no-change case only needs to
+                # outlast that, a change case gets the full window.
+                window = 10 if case.get("no_change_ok") else 75
                 verdict = "PASS" if case.get("no_change_ok") else "FAIL"
-                detail = "no change within 75s"
-                deadline = asyncio.get_running_loop().time() + 75
+                detail = f"no change within {window}s"
+                deadline = asyncio.get_running_loop().time() + window
                 while asyncio.get_running_loop().time() < deadline:
                     await asyncio.sleep(2)
                     objects = {i.id: i for i in (await scene.get_scene_state(EmptyRequest())).objects}

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/live_smoke.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/live_smoke.py
@@ -10,7 +10,7 @@ import time
 from xr_ai_hub import DataMessage
 from xr_render_scene import EmptyRequest, SceneClient
 
-from ._live_endpoint import LiveEvalEndpoint, live_participant
+from ._live_endpoint import LiveEvalEndpoint, live_participant, simulated_pose
 
 
 async def main() -> None:
@@ -18,12 +18,11 @@ async def main() -> None:
     participant = f"live-smoke-{int(time.time())}"
     endpoint = LiveEvalEndpoint()
     scene = SceneClient("tcp://127.0.0.1:8320")
-    before = {item.id: item for item in (await scene.get_scene_state(EmptyRequest())).objects}
-
-    await asyncio.sleep(0.5)
     changed = False
     try:
-        async with live_participant(endpoint, participant):
+        before = {item.id: item for item in (await scene.get_scene_state(EmptyRequest())).objects}
+        await asyncio.sleep(0.5)
+        async with simulated_pose(), live_participant(endpoint, participant):
             await endpoint.inject_data(DataMessage(
                 participant_id=participant,
                 topic="",

--- a/agent-samples/xr-render-demo/eval/xr_render_demo_eval/subagents.py
+++ b/agent-samples/xr-render-demo/eval/xr_render_demo_eval/subagents.py
@@ -208,11 +208,11 @@ CASES = (
     SubagentCase(
         name="misspelled_color_create",
         agent="object",
-        instruction="Create a teel capsule, no position stated.",
+        instruction="Create a teel cube, no position stated.",
         forbid_tools=("resolve_physical_color",),
         expect=(
             {"tool": "add_primitive",
-             "args": {"prim_type": "capsule", "r": (0.0, 0.1), "g": (0.75, 0.85), "b": (0.75, 0.85)}},
+             "args": {"prim_type": "box", "r": (0.0, 0.1), "g": (0.75, 0.85), "b": (0.75, 0.85)}},
         ),
     ),
     SubagentCase(

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/_trace.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/_trace.py
@@ -18,13 +18,16 @@ current_reference_time_us: ContextVar[int] = ContextVar("current_reference_time_
 
 
 class MutationEvidence:
-    """Count of scene writes actually applied (or found already satisfied)
-    this turn; the supervisor's success gate reads it instead of trusting
-    the model's wording."""
+    """Per-turn counts of scene writes applied, writes found already satisfied,
+    and shape refusals, plus the renderer shapes the user's utterance named;
+    the supervisor's success gate reads these instead of trusting the model's
+    wording."""
 
     def __init__(self) -> None:
         self.applied = 0
         self.satisfied = 0
+        self.refused = 0
+        self.uttered_shapes: set[str] = set()
 
 
 current_mutation_evidence: ContextVar[MutationEvidence | None] = ContextVar(

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/spatial_ops.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/spatial_ops.py
@@ -51,12 +51,33 @@ _COLOR_WORDS = {
     "white": (1, 1, 1), "black": (0, 0, 0), "teal": (0, 0.8, 0.8), "turquoise": (0.2, 0.9, 1),
     "lavender": (0.6, 0.4, 1), "pink": (1, 0.5, 0.8), "gray": (0.5, 0.5, 0.5), "grey": (0.5, 0.5, 0.5),
 }
+# LOVR draws box and sphere, so creation accepts only words for those two.
+_DRAWN_SHAPES = ("box", "sphere")
 _SHAPE_WORDS = {
-    "box": "box", "cube": "box", "block": "box", "crate": "box",
-    "sphere": "sphere", "ball": "sphere", "orb": "sphere",
-    "cone": "cone", "cylinder": "cylinder", "capsule": "capsule",
-    "ring": "ring", "pyramid": "pyramid", "torus": "torus", "donut": "torus",
+    "box": "box", "cube": "box", "block": "box", "crate": "box", "brick": "box",
+    "cuboid": "box", "rectangle": "box", "rectangular": "box", "prism": "box", "square": "box",
+    "sphere": "sphere", "ball": "sphere", "orb": "sphere", "globe": "sphere", "circle": "sphere",
 }
+# Fuzzy matching repairs misspellings of these nouns only; against every synonym,
+# "triangle" matches rectangle and "star" matches square.
+_FUZZY_SHAPE_NOUNS = ("ball", "box", "cube", "sphere")
+
+
+def _shape_word(word: str, scene_types: frozenset[str] = frozenset()) -> str | None:
+    """Canonical shape for one word: a creation synonym, or the type of an object
+    already in the scene so seeded objects of other types stay addressable."""
+    if word in _SHAPE_WORDS:
+        return _SHAPE_WORDS[word]
+    if word in scene_types:
+        return word
+    close = difflib.get_close_matches(word, _FUZZY_SHAPE_NOUNS, n=1, cutoff=0.7)
+    return _SHAPE_WORDS[close[0]] if close else None
+
+
+def canonical_shapes(text: str) -> set[str]:
+    """Every renderer shape the text names, misspellings repaired."""
+    words = re.findall(r"[a-z]+", text.lower())
+    return {shape for word in words if (shape := _shape_word(word)) is not None}
 
 # A discriminated color source: the subagent LLM picks the kind through the
 # tool schema; the code dispatches on it without reinterpreting the phrase.
@@ -201,7 +222,12 @@ class _Leaves:
             logger.debug("spatial op lookup failed: {!r} not in {}", object_ref, known)
             raise ValueError(f"No scene object with id {object_ref!r}; the scene has {known}")
         words = re.findall(r"[a-z]+", wanted)
-        exact_shape = next((_SHAPE_WORDS[word] for word in words if word in _SHAPE_WORDS), None)
+        scene_types = frozenset(item.type for item in state.objects)
+        exact_shape = next(
+            (_shape_word(word, scene_types) for word in reversed(words)
+             if word in _SHAPE_WORDS or word in scene_types),
+            None,
+        )
         color = next((_COLOR_WORDS[word] for word in words if word in _COLOR_WORDS), None)
 
         def select(shape: str | None) -> list[SceneObject]:
@@ -221,9 +247,8 @@ class _Leaves:
             for word in words:
                 if word in _COLOR_WORDS:
                     continue
-                close = difflib.get_close_matches(word, _SHAPE_WORDS, n=1, cutoff=0.6)
-                if close:
-                    fuzzy = select(_SHAPE_WORDS[close[0]])
+                if (shape := _shape_word(word, scene_types)) is not None:
+                    fuzzy = select(shape)
                     if fuzzy and (not candidates or len(fuzzy) < len(candidates)):
                         candidates = fuzzy
                     break
@@ -244,23 +269,39 @@ class _Leaves:
         )
 
     def shape(self, shape_words: str) -> str:
+        # The last shape word is the noun ("square pyramid" is a pyramid).
         words = re.findall(r"[a-z]+", shape_words.lower())
-        for word in words:
+        for word in reversed(words):
             if word in _SHAPE_WORDS:
-                return _SHAPE_WORDS[word]
+                return self._not_substituted(_SHAPE_WORDS[word], shape_words)
         for word in words:
             if word in _COLOR_WORDS:
                 raise ValueError(
                     f"{word!r} is a color, not a shape. Do not change the shape; "
                     "report the color change back as a recolor for appearance_agent."
                 )
-        for word in words:
-            close = difflib.get_close_matches(word, _SHAPE_WORDS, n=1, cutoff=0.6)
-            if close:
-                logger.debug("shape words resolved {!r} -> {}", shape_words, _SHAPE_WORDS[close[0]])
-                return _SHAPE_WORDS[close[0]]
-        shapes = ", ".join(sorted(set(_SHAPE_WORDS.values())))
-        raise ValueError(f"Unknown shape {shape_words!r}; the renderer draws: {shapes}")
+        for word in reversed(words):
+            if (shape := _shape_word(word)) is not None:
+                logger.debug("shape words resolved {!r} -> {}", shape_words, shape)
+                return self._not_substituted(shape, shape_words)
+        logger.debug("shape words refused {!r}", shape_words)
+        _record("refused")
+        shapes = ", ".join(_DRAWN_SHAPES)
+        raise ValueError(
+            f"Unknown shape {shape_words!r}; the renderer draws only: {shapes}. Never substitute "
+            "another shape; make no further tool call and report back asking which of those is meant."
+        )
+
+    @staticmethod
+    def _not_substituted(shape: str, shape_words: str) -> str:
+        evidence = current_mutation_evidence.get()
+        if evidence is None or not evidence.refused or shape in evidence.uttered_shapes:
+            return shape
+        raise ValueError(
+            f"{shape_words!r} is a substitute: this turn already refused a shape the user asked "
+            "for, and the user never said this one. Make no further tool call and report that "
+            "refusal back."
+        )
 
     async def resolve_color(self, kind: _ColorKind, value: str) -> tuple[float, float, float]:
         if kind == "literal":
@@ -753,5 +794,5 @@ def make_object_tools(
 __all__ = [
     "CreatedObject", "CreationLedger", "MovedObject", "RecoloredObject", "RemovedObject",
     "SwappedObjects", "TurnGuard",
-    "make_appearance_tools", "make_object_tools", "make_placement_tools",
+    "canonical_shapes", "make_appearance_tools", "make_object_tools", "make_placement_tools",
 ]

--- a/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor.py
+++ b/agent-samples/xr-render-demo/worker/xr_render_demo_worker/supervisor.py
@@ -18,6 +18,7 @@ from xr_ai_tools.current_frame import CurrentFrameTool
 from xr_ai_tools.image import ImageRegistry
 from xr_ai_tools.text_memory import AddTranscriptRequest, RecallConversationRequest, TextMemoryTools
 from xr_ai_tools.tool_calling import ToolLoopError, run_tool_loop
+from xr_ai_tools.tools import ToolInvocationResult
 from xr_ai_tools.tracking import TrackingTools
 from xr_ai_tools.video_memory import VideoMemoryTools
 from xr_ai_tools.vision import ImageQueryTool
@@ -40,6 +41,7 @@ from .agents import (
 )
 from .models import SceneReply, SceneRequest
 from .scene import SceneContext
+from .spatial_ops import canonical_shapes
 
 _PROMPT = Path(__file__).with_name("supervisor_prompt.txt")
 
@@ -56,6 +58,29 @@ _ACTION_VERBS = frozenset(
 
 
 _MUTATING_AGENTS = frozenset({"placement_agent", "appearance_agent", "object_agent"})
+
+_REFUSAL_REPLY = "I can only make a box or a sphere. Which would you like?"
+
+
+class _FinalOnRefusal(Tool):
+    """End the turn once a shape was refused and nothing was written: left to
+    the model, the supervisor re-delegates substitute shapes until the
+    iteration limit."""
+
+    async def invoke(self, arguments: str) -> ToolInvocationResult:
+        result = await super().invoke(arguments)
+        evidence = current_mutation_evidence.get()
+        if evidence is not None and evidence.refused and not (evidence.applied or evidence.satisfied):
+            return ToolInvocationResult(content=_REFUSAL_REPLY, return_direct=True)
+        return result
+
+
+def _final_on_refusal(tools: list[Tool]) -> ToolSet:
+    return ToolSet([
+        _FinalOnRefusal(tool.name, tool.description, tool.request_model, tool.result_model,
+                        tool.handler, return_direct=tool.return_direct)
+        for tool in tools
+    ])
 
 # Seconds to let a scene RPC propagate before diffing snapshots.
 _SCENE_SETTLE_S = 0.15
@@ -137,7 +162,7 @@ class SceneSupervisor:
         self._llm = llm
         self._context = context
         self._text_memory = text_memory
-        self._toolset = ToolSet(subagent_tools)
+        self._toolset = _final_on_refusal(subagent_tools)
         self._prompt = _PROMPT.read_text(encoding="utf-8").strip()
         self._participant_locks: defaultdict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
         self._scene_lock: asyncio.Lock = asyncio.Lock()
@@ -220,6 +245,7 @@ class SceneSupervisor:
         self, request: SceneRequest, transcript: str, conversation: str
     ) -> SceneReply:
         evidence = MutationEvidence()
+        evidence.uttered_shapes = canonical_shapes(transcript)
         current_mutation_evidence.set(evidence)
         before = await self._context.snapshot()
 
@@ -257,7 +283,9 @@ class SceneSupervisor:
 
         await asyncio.sleep(_SCENE_SETTLE_S)
         if needs_verification and not SceneContext.changes(before, await self._context.snapshot()):
-            if delegated & _MUTATING_AGENTS:
+            if evidence.refused:
+                nudge = None
+            elif delegated & _MUTATING_AGENTS:
                 nudge = (
                     "Verified scene changes this turn: none. If the request needed a"
                     " scene change, delegate the remaining work now; if it needed"
@@ -273,18 +301,19 @@ class SceneSupervisor:
                     " be done, say plainly that nothing was changed and why; never"
                     " reply that a change was made."
                 )
-            verification_messages = list(result.messages) + [
-                ChatMessage(role="user", content=nudge),
-            ]
-            try:
-                result2 = await run_tool_loop(
-                    verification_messages, self._toolset, _call_model, max_iterations=6
-                )
-            except ToolLoopError as exc:
-                logger.warning("supervisor verification failed ({})", exc)
-            else:
-                output = result2.content
-            await asyncio.sleep(_SCENE_SETTLE_S)
+            if nudge is not None:
+                verification_messages = list(result.messages) + [
+                    ChatMessage(role="user", content=nudge),
+                ]
+                try:
+                    result2 = await run_tool_loop(
+                        verification_messages, self._toolset, _call_model, max_iterations=6
+                    )
+                except ToolLoopError as exc:
+                    logger.warning("supervisor verification failed ({})", exc)
+                else:
+                    output = result2.content
+                await asyncio.sleep(_SCENE_SETTLE_S)
             # Success is evidence-backed: a completion claim may stand only
             # when a scene write was applied (or the requested state already
             # held), never on the model's wording alone. A claim-free

--- a/docs/source/reference/xr-render-demo.md
+++ b/docs/source/reference/xr-render-demo.md
@@ -250,9 +250,12 @@ services. On each accepted `xr-render.user-query` event:
    mutating subagent was delegated, or a non-question utterance contains a
    change-requesting verb): if no scene change is observed within 150 ms
    of the loop completing, a second `run_tool_loop` call is made so the
-   supervisor can delegate remaining work or confirm a no-op turn. Success
-   is then evidence-backed: unless a scene write was applied somewhere in
-   the turn (or a recolor found the requested color already in place), a
+   supervisor can delegate remaining work or confirm a no-op turn. A turn
+   in which a tool refused a shape word skips this pass: the refusal is the
+   answer, and any later creation of a shape the utterance never named is
+   rejected as a substitute. Success is then evidence-backed: unless a
+   scene write was applied somewhere in the turn (or a recolor found the
+   requested color already in place), a
    completion claim is replaced with a fixed honest no-change sentence and
    any other non-question reply gets the no-change fact appended. Evidence
    is counted per turn, not per delegated task.

--- a/tests/test_render_spatial_ops.py
+++ b/tests/test_render_spatial_ops.py
@@ -11,7 +11,15 @@ directly.
 import pytest
 from xr_ai_tools import Tool
 from xr_ai_tools.types import EmptyRequest, SpatialFrame, Vector3
-from xr_render_demo_worker.spatial_ops import CreationLedger, TurnGuard, _Leaves
+from xr_render_demo_worker._trace import MutationEvidence, current_mutation_evidence
+from xr_render_demo_worker.spatial_ops import (
+    CreationLedger,
+    TurnGuard,
+    _CreateUserRelativeRequest,
+    _Leaves,
+    canonical_shapes,
+    make_object_tools,
+)
 from xr_render_scene import (
     AddPrimitiveRequest,
     AddPrimitiveResult,
@@ -208,9 +216,71 @@ def test_shape_words_resolve_and_reject():
     leaves, _ = _leaves([])
     assert leaves.shape("spear") == "sphere"
     assert leaves.shape("kube") == "box"
-    assert leaves.shape("cone") == "cone"
+    for word in ("xylophone", "triangle", "star", "tile", "quad", "thing", "cone", "pyramid"):
+        with pytest.raises(ValueError, match="Unknown shape"):
+            leaves.shape(word)
+
+
+def test_flat_and_solid_synonyms_resolve_explicitly():
+    leaves, _ = _leaves([])
+    for word in ("rectangle", "rectangular prism", "cuboid", "square", "brick"):
+        assert leaves.shape(word) == "box", word
+    for word in ("circle", "globe"):
+        assert leaves.shape(word) == "sphere", word
+
+
+async def test_last_shape_word_is_the_noun():
+    leaves, _ = _leaves([_obj("sphere-0", "sphere", (1, 0, 0)), _obj("box-0", "box", (1, 0, 0))])
+    assert leaves.shape("square ball") == "sphere"
+    assert (await leaves.find("the square ball")).id == "sphere-0"
+
+
+async def test_seeded_scene_types_stay_addressable_by_name():
+    leaves, _ = _leaves([_obj("cone-0", "cone", (0, 0.8, 0.8)), _obj("box-0", "box", (0, 0.8, 0.8))])
+    assert (await leaves.find("the teal cone")).id == "cone-0"
     with pytest.raises(ValueError, match="Unknown shape"):
-        leaves.shape("xylophone")
+        leaves.shape("cone")
+
+
+def test_canonical_shapes_from_utterance():
+    assert canonical_shapes("Create a red hexagon and a blue spear.") == {"sphere"}
+    assert canonical_shapes("Create an object.") == set()
+
+
+def test_unknown_shape_records_refusal_without_halting():
+    guard = TurnGuard()
+    leaves, _ = _leaves([], guard=guard)
+    evidence = MutationEvidence()
+    token = current_mutation_evidence.set(evidence)
+    try:
+        with pytest.raises(ValueError, match="Unknown shape"):
+            leaves.shape("xylophone")
+    finally:
+        current_mutation_evidence.reset(token)
+    assert evidence.refused == 1 and evidence.applied == 0
+    assert not guard.halted
+
+
+async def test_refused_turn_rejects_shapes_the_user_never_said():
+    fake = _FakeScene([])
+    tools = {tool.name: tool for tool in make_object_tools(_FakeSceneTools(fake), _FakeTrackingTools())}
+    evidence = MutationEvidence()
+    evidence.uttered_shapes = canonical_shapes("Create a red hexagon and a blue sphere.")
+    token = current_mutation_evidence.set(evidence)
+    try:
+        with pytest.raises(ValueError, match="Unknown shape"):
+            await tools["create_user_relative"].handler(_CreateUserRelativeRequest(
+                prim_type="hexagon", direction="front", distance=1.5))
+        with pytest.raises(ValueError, match="substitute"):
+            await tools["create_user_relative"].handler(_CreateUserRelativeRequest(
+                prim_type="box", direction="front", distance=1.5))
+        assert not fake.calls
+        created = await tools["create_user_relative"].handler(_CreateUserRelativeRequest(
+            prim_type="sphere", direction="front", distance=1.5))
+    finally:
+        current_mutation_evidence.reset(token)
+    assert created.id == "sphere-0"
+    assert [name for name, _args in fake.calls] == ["add_primitive"]
 
 
 async def test_ledger_dedupes_identical_creates():
@@ -324,7 +394,6 @@ async def test_empty_value_required_for_non_literal_kinds():
 
 
 async def test_recolor_records_applied_and_satisfied_evidence():
-    from xr_render_demo_worker._trace import MutationEvidence, current_mutation_evidence
     from xr_render_demo_worker.spatial_ops import _RecolorRequest, make_appearance_tools
 
     fake = _FakeScene([_obj("cone-0", "cone", (0, 0.8, 0))])

--- a/tests/test_xr_render_demo_supervisor.py
+++ b/tests/test_xr_render_demo_supervisor.py
@@ -16,6 +16,7 @@ from xr_ai_tools.text_memory import (
 )
 from xr_ai_voice import UserQuery
 from xr_render_demo_eval import harness
+from xr_render_demo_worker._trace import current_mutation_evidence
 from xr_render_demo_worker.agent import RenderAgent
 from xr_render_demo_worker.models import SceneRequest
 from xr_render_demo_worker.supervisor import SceneSupervisor
@@ -138,6 +139,80 @@ async def test_mixed_vision_and_mutation_request_still_verifies(monkeypatch) -> 
     assert loop_calls == 2
 
 
+def _refusing_loop(content: str):
+    calls = {"n": 0, "uttered": None}
+
+    async def fake_loop(messages, toolset, call_model, max_iterations=12):
+        calls["n"] += 1
+        evidence = current_mutation_evidence.get()
+        evidence.refused += 1
+        calls["uttered"] = evidence.uttered_shapes
+        return SimpleNamespace(
+            content=content,
+            messages=list(messages),
+            tool_calls=(SimpleNamespace(call=SimpleNamespace(name="object_agent")),),
+        )
+
+    return fake_loop, calls
+
+
+async def test_refused_shape_skips_verification_nudge(monkeypatch) -> None:
+    supervisor, _fake = _make_supervisor()
+    fake_loop, calls = _refusing_loop("I can't draw a xylophone. Would you like a box or a sphere?")
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    reply = await supervisor.handle(SceneRequest(
+        transcript="Create a red xylophone next to the spear.", participant_id="alice"))
+    assert calls["n"] == 1
+    assert calls["uttered"] == {"sphere"}
+    assert reply.response == "I can't draw a xylophone. Would you like a box or a sphere?"
+
+
+async def test_refused_shape_completion_claim_is_replaced(monkeypatch) -> None:
+    supervisor, _fake = _make_supervisor()
+    fake_loop, calls = _refusing_loop("Added a red box.")
+    monkeypatch.setattr("xr_render_demo_worker.supervisor.run_tool_loop", fake_loop)
+
+    reply = await supervisor.handle(SceneRequest(
+        transcript="Create a red xylophone.", participant_id="alice"))
+    assert calls["n"] == 1
+    assert reply.response == "I couldn't make that change; nothing in the scene was changed."
+
+
+async def test_refusal_ends_the_turn_with_a_fixed_question() -> None:
+    from xr_render_demo_worker._trace import MutationEvidence
+    from xr_render_demo_worker.models import SubagentResult, SubagentTask
+    from xr_render_demo_worker.supervisor import _REFUSAL_REPLY, _final_on_refusal
+
+    async def refuse(request: SubagentTask) -> SubagentResult:
+        current_mutation_evidence.get().refused += 1
+        return SubagentResult(result="Unknown shape.")
+
+    async def create(request: SubagentTask) -> SubagentResult:
+        current_mutation_evidence.get().applied += 1
+        return SubagentResult(result="Created sphere-0.")
+
+    toolset = _final_on_refusal([
+        Tool("object_agent", "Objects.", SubagentTask, SubagentResult, refuse),
+        Tool("other_agent", "Other.", SubagentTask, SubagentResult, create),
+    ])
+    tools = dict(toolset.items())
+    token = current_mutation_evidence.set(MutationEvidence())
+    try:
+        first = await tools["other_agent"].invoke('{"instruction": "Create a sphere."}')
+        assert not first.return_direct and "sphere-0" in first.content
+        second = await tools["object_agent"].invoke('{"instruction": "Create a hexagon."}')
+        assert not second.return_direct
+    finally:
+        current_mutation_evidence.reset(token)
+    token = current_mutation_evidence.set(MutationEvidence())
+    try:
+        only = await tools["object_agent"].invoke('{"instruction": "Create a hexagon."}')
+    finally:
+        current_mutation_evidence.reset(token)
+    assert only.return_direct and only.content == _REFUSAL_REPLY
+
+
 async def test_verification_never_offers_repeat_when_mutation_undelegated(monkeypatch) -> None:
     """A change-requesting utterance whose first pass delegated no mutating
     subagent must get a verification nudge with no repeat-your-answer out."""
@@ -199,7 +274,6 @@ def test_status_questions_are_not_mutation_intent() -> None:
 async def test_already_satisfied_reply_stands_on_evidence(monkeypatch) -> None:
     """A recolor that found the requested state already holding records
     satisfied evidence; the model's reply stands despite no scene diff."""
-    from xr_render_demo_worker._trace import current_mutation_evidence
 
     supervisor, _fake = _make_supervisor()
 


### PR DESCRIPTION
Rectangle, circle, and square were refused or silently became a box; an unknown shape was retried as a box after the tool rejected it; and moving a shape that does not exist moved whatever the supervisor picked. This makes the shape vocabulary explicit and puts every refusal in code.

- Creation accepts only words for the two shapes LOVR draws: cube, block, crate, brick, cuboid, rectangle, rectangular, prism, and square are box; ball, orb, globe, and circle are sphere. Cone, cylinder, capsule, ring, pyramid, and torus are refused instead of being drawn as spheres.
- An unknown shape ends the turn with a fixed spoken sentence naming box and sphere. The supervisor cannot re-delegate a substitute, which live logs showed it doing up to five times per turn.
- A creation or lookup whose shape the user never said is refused. "Move the pyramid" with only a box present moves nothing and says there is no pyramid; "a red hexagon and a blue sphere" still creates the sphere.
- Fuzzy spelling repair matches only the shape nouns at a higher cutoff, so triangle and star are refused rather than becoming rectangle or square. The last shape word is the noun, so "square pyramid" is not a box. Lookups still match types already in the scene.

Evals: new offline cases for each behavior above plus the scene question and generic "Create an object"; cases that created other shapes now create cubes or balls. Live smoke sets the simulated pose like the other drivers, the pose helper is shared, and no-change cases wait 10 seconds. All live tiers pass except three garble cases that fail on the release head independently (two truncation cases, one that needs a camera).
