### PR TITLE
Document the primitives the render sample draws

### DIFF
--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -398,8 +398,8 @@ Agent: [Changes the sphere's color or explains why it could not.]
 ```
 
 Speak naturally: the agent accepts questions, commands, and follow-up requests.
-Refer to {doc}`Connecting clients <clients>` for headset and native-client
-setup.
+The scene draws two shapes, boxes and spheres; ask for either by name. Refer to
+{doc}`Connecting clients <clients>` for headset and native-client setup.
 
 To stop the model servers when done:
 

--- a/docs/source/reference/xr-render-demo.md
+++ b/docs/source/reference/xr-render-demo.md
@@ -276,9 +276,10 @@ Final messages are also persisted through native
 
 ## Native capability composition
 
-The sample-local scene process owns scene state and LOVR. `openxr-service`
-owns the headless tracking session, and `video-memory-service` owns recorded
-video decoding. `LiveFrameSource` supplies current-frame requests. Relay-managed
+The sample-local scene process owns scene state and LOVR. The LOVR app draws
+two primitive types, box and sphere. `openxr-service` owns the headless
+tracking session, and `video-memory-service` owns recorded video decoding.
+`LiveFrameSource` supplies current-frame requests. Relay-managed
 native tools provide the typed surface over those services; the demo does
 not launch or call MCP adapters.
 


### PR DESCRIPTION
Update quickstart and lovr docs with supported shapes for render demo.