### PR TITLE
docs: support withdrawn release tags

### DIFF
--- a/.github/scripts/docs_release_policy.py
+++ b/.github/scripts/docs_release_policy.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared policy for release tags published in the documentation site."""
+from __future__ import annotations
+
+import os
+import re
+
+_WITHDRAWN_TAGS_ENV = "XR_AI_DOCS_WITHDRAWN_TAGS"
+
+
+def withdrawn_tags() -> frozenset[str]:
+    """Return release tags excluded from documentation publication."""
+    value = os.environ.get(_WITHDRAWN_TAGS_ENV, "")
+    return frozenset(filter(None, re.split(r"[\s,]+", value)))
+
+
+def tag_whitelist(semver_pattern: str) -> str:
+    """Return an anchored semantic-version pattern excluding withdrawn tags."""
+    withdrawn = "|".join(re.escape(tag) for tag in sorted(withdrawn_tags()))
+    exclusion = rf"(?!(?:{withdrawn})$)" if withdrawn else ""
+    return rf"^{exclusion}{semver_pattern}$"

--- a/.github/scripts/select_latest_docs_release.py
+++ b/.github/scripts/select_latest_docs_release.py
@@ -7,6 +7,11 @@ from __future__ import annotations
 import re
 import sys
 from dataclasses import dataclass
+from pathlib import Path
+from runpy import run_path
+
+_POLICY = run_path(str(Path(__file__).with_name("docs_release_policy.py")))
+_withdrawn_tags = _POLICY["withdrawn_tags"]
 
 _SEMVER = re.compile(
     r"^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
@@ -59,7 +64,12 @@ def _parse(tag: str) -> _Version | None:
 
 
 def select_latest(tags: list[str]) -> str | None:
-    versions = [version for tag in tags if (version := _parse(tag))]
+    withdrawn = _withdrawn_tags()
+    versions = [
+        version
+        for tag in tags
+        if tag not in withdrawn and (version := _parse(tag))
+    ]
     stable = [version for version in versions if version.prerelease is None]
     candidates = stable or versions
     if not candidates:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -30,6 +30,9 @@
 # refs are rejected.
 name: Docs
 
+env:
+  XR_AI_DOCS_WITHDRAWN_TAGS: ${{ vars.XR_AI_DOCS_WITHDRAWN_TAGS }}
+
 on:
   push:
     branches: [main]
@@ -49,6 +52,7 @@ on:
       - "agent-samples/**/*.yml"
       - ".github/workflows/docs.yaml"
       - ".github/scripts/check_latest_docs_links.py"
+      - ".github/scripts/docs_release_policy.py"
       - ".github/scripts/select_latest_docs_release.py"
       - ".github/scripts/publish_docs.sh"
       - ".github/scripts/remove_docs_preview.sh"
@@ -70,6 +74,7 @@ on:
       - "agent-samples/**/*.yml"
       - ".github/workflows/docs.yaml"
       - ".github/scripts/check_latest_docs_links.py"
+      - ".github/scripts/docs_release_policy.py"
       - ".github/scripts/select_latest_docs_release.py"
       - ".github/scripts/publish_docs.sh"
       - ".github/scripts/remove_docs_preview.sh"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,6 +16,9 @@ sys.path.insert(0, str(Path(__file__).parent))
 _API_CONTRACT = run_path(str(Path(__file__).with_name("_api_contract.py")))
 API_PACKAGE_DIRS = _API_CONTRACT["API_PACKAGE_DIRS"]
 PUBLIC_API_MODULES = _API_CONTRACT["PUBLIC_API_MODULES"]
+_RELEASE_POLICY = run_path(
+    str(Path(__file__).resolve().parents[2] / ".github/scripts/docs_release_policy.py")
+)
 _PUBLIC_PACKAGE_EXPORTS = {
     package_dir.name: frozenset(
         _API_CONTRACT["_literal_exports"](
@@ -154,7 +157,7 @@ myst_heading_anchors = 3
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # Keep release documentation immutable and publish main as development docs.
-smv_tag_whitelist = rf"^{_SEMVER_TAG}$"
+smv_tag_whitelist = _RELEASE_POLICY["tag_whitelist"](_SEMVER_TAG)
 smv_branch_whitelist = r"^main$"
 smv_remote_whitelist = None
 smv_released_pattern = r"^tags/.*$"

--- a/tests/test_docs_versions.py
+++ b/tests/test_docs_versions.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for documentation release selection policy."""
+import os
 import re
 import runpy
 import subprocess
@@ -45,12 +46,15 @@ def _sample_projects() -> list[tuple[Path, str]]:
     return projects
 
 
-def _select(*tags: str) -> str:
+def _select(*tags: str, withdrawn: str = "") -> str:
+    environment = os.environ.copy()
+    environment["XR_AI_DOCS_WITHDRAWN_TAGS"] = withdrawn
     result = subprocess.run(
         [sys.executable, str(_SELECTOR)],
         input="\n".join(tags),
         check=True,
         capture_output=True,
+        env=environment,
         text=True,
     )
     return result.stdout.strip()
@@ -74,13 +78,46 @@ def test_invalid_semver_tags_are_ignored() -> None:
     assert _select("release-2", "v1.0", "v1.0.0-01") == ""
 
 
-def test_tag_whitelist_rejects_the_same_invalid_semver_tags() -> None:
+def test_withdrawn_release_is_not_selected_as_latest() -> None:
+    assert (
+        _select(
+            "v0.1.0-beta",
+            "v0.2.0-beta",
+            withdrawn="v0.2.0-beta",
+        )
+        == "v0.1.0-beta"
+    )
+    assert (
+        _select(
+            "v0.2.0-beta",
+            "v0.2.0-beta.1",
+            withdrawn="v0.2.0-beta, v0.1.0-beta",
+        )
+        == "v0.2.0-beta.1"
+    )
+
+
+def test_tag_whitelist_rejects_invalid_and_withdrawn_tags(monkeypatch) -> None:
+    monkeypatch.setenv("XR_AI_DOCS_WITHDRAWN_TAGS", "v0.2.0-beta v0.3.0-beta")
     whitelist = runpy.run_path(str(_CONF))["smv_tag_whitelist"]
 
     assert re.fullmatch(whitelist, "v1.0.0")
     assert re.fullmatch(whitelist, "v1.0.0-rc.1")
+    assert re.fullmatch(whitelist, "v0.2.0-beta.1")
     assert not re.fullmatch(whitelist, "v01.0.0")
     assert not re.fullmatch(whitelist, "v1.0.0-01")
+    assert not re.fullmatch(whitelist, "v0.2.0-beta")
+    assert not re.fullmatch(whitelist, "v0.3.0-beta")
+
+
+def test_docs_workflow_supplies_withdrawn_release_policy() -> None:
+    workflow = (_ROOT / ".github" / "workflows" / "docs.yaml").read_text()
+
+    assert (
+        "XR_AI_DOCS_WITHDRAWN_TAGS: ${{ vars.XR_AI_DOCS_WITHDRAWN_TAGS }}"
+        in workflow
+    )
+    assert workflow.count('- ".github/scripts/docs_release_policy.py"') == 2
 
 
 def test_source_links_use_the_current_documentation_ref(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- read withdrawn documentation tags from the XR_AI_DOCS_WITHDRAWN_TAGS repository variable
- exclude withdrawn tags from Sphinx Multiversion output and latest-release selection
- keep the shared policy helper in the Docs workflow path filters

The repository variable is configured as v0.2.0-beta.

## Testing

- uvx --from pytest pytest --noconftest -q tests/test_docs_versions.py
- uvx ruff@0.15.16 check .github/scripts/docs_release_policy.py .github/scripts/select_latest_docs_release.py docs/source/conf.py tests/test_docs_versions.py