### PR TITLE
Support explicit CUDA devices for Pocket TTS

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -405,7 +405,7 @@ drift:
   - `hatchling`
 - Runtime dependencies:
   - `pocket-tts==3.0.2`
-  - `torch>=2.5.0` (index: `pytorch-cpu`)
+  - `torch>=2.5.0`
   - `huggingface-hub>=0.32.0`
   - `hf-xet>=1.1.2,<2.0.0`
   - `fastapi>=0.111`

--- a/agent-samples/model-servers/yaml/96G_blackwell/pocket_tts_server.yaml
+++ b/agent-samples/model-servers/yaml/96G_blackwell/pocket_tts_server.yaml
@@ -1,9 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Shared CPU Pocket TTS service. bill_boerst is a CC0 Voice-Zero recording.
+# Shared CUDA Pocket TTS service. bill_boerst is a CC0 Voice-Zero recording.
+# Keep GPU capacity available alongside the LLM and VLM. No CPU fallback.
 voice: bill_boerst
 language: english
+device: cuda:0
 port: 8105
 startup_timeout_s: 600
 model_cache: ../../../../models

--- a/docs/source/components/ai-services.md
+++ b/docs/source/components/ai-services.md
@@ -539,12 +539,23 @@ cleanup.
   ignored. Set `startup_timeout_s` to a positive finite number to override the
   600-second cold-start budget.
 - **magpie-tts** loads magpie_tts_multilingual_357m via NeMo TTS in-process.
-- **pocket-tts** loads the compact `kyutai/pocket-tts` model on CPU and serves
+- **pocket-tts** loads the compact `kyutai/pocket-tts` model on CPU or CUDA and serves
   the configured voice through the repository's OpenAI-compatible TTS API.
   Model loading and synthesis run outside the asyncio event loop. The default
   `bill_boerst` voice derives from a CC0 Voice-Zero recording and is the only
   voice accepted by this release. The service logs whether it loaded the gated
   voice-cloning weights or the ungated fallback.
+  Set `device: cuda` to use the current visible GPU, or `device: cuda:N` to select
+  a visible device index. The portable default is `cpu`; the 96 GB Blackwell
+  profile selects `cuda:0`. CUDA requires a compatible driver and CUDA-enabled
+  PyTorch. The service no longer forces CPU-only Linux wheels and fails startup
+  instead of falling back when requested CUDA is unavailable. The model moves
+  before the voice state is loaded, and `/health` reports the active device.
+  Stop the owned persistent TTS service before switching devices: an explicit
+  device request rejects a healthy listener reporting a different device, or
+  a legacy listener without device metadata, without stopping it automatically.
+  Speech responses remain buffered WAV or PCM; selecting CUDA does not enable
+  incremental audio delivery through the voice SDK.
 - **embedding-server** serves `nvidia/llama-nemotron-embed-1b-v2` through
   `/v1/embeddings`. It emits 2048-dimensional Matryoshka embeddings and can
   truncate them to 384, 512, 768, 1024, or 2048 dimensions. The checked-in

--- a/services/pocket-tts/pocket_tts_server.yaml
+++ b/services/pocket-tts/pocket_tts_server.yaml
@@ -8,6 +8,10 @@
 
 voice:       bill_boerst
 language:    english
+# CPU remains the portable default. Set cuda or cuda:N to require a visible GPU.
+# CUDA needs a compatible Torch build and driver; it never silently falls back.
+# Stop the owned persistent TTS service before changing this setting.
+device:      cpu
 port:        8105
 startup_timeout_s: 600
 model_cache: ../../models

--- a/services/pocket-tts/pocket_tts_server/__main__.py
+++ b/services/pocket-tts/pocket_tts_server/__main__.py
@@ -4,7 +4,7 @@
 """
 pocket_tts_server — Pocket TTS HTTP server.
 
-Pocket TTS is a compact, streaming-capable CPU model. This wrapper exposes the
+Pocket TTS is a compact, streaming-capable model. This wrapper exposes the
 repository's existing OpenAI-compatible API:
 
     POST /v1/audio/speech
@@ -21,6 +21,7 @@ Config keys
 -----------
     voice:        str   Must be "bill_boerst" (required)
     language:     str   Pocket TTS language/model variant (default: "english")
+    device:       str   "cpu", "cuda", or "cuda:N" (default: "cpu")
     port:         int   HTTP port (default: 8105)
     host:         str   Bind address (default: "0.0.0.0")
     startup_timeout_s: float  Seconds allowed for a cold start (default: 600)
@@ -30,8 +31,10 @@ Config keys
 import argparse
 import asyncio
 import io
+import json
 import math
 import os
+import re
 import socket
 import sys
 import threading
@@ -56,6 +59,15 @@ _SUPPORTED_VOICES = frozenset({"bill_boerst"})
 
 class _SynthesisCancelled(RuntimeError):
     """A queued request was abandoned before generation started."""
+
+
+def _parse_device(value: object) -> str:
+    """Validate the supported device choices without importing Torch at bootstrap."""
+    if value in ("cpu", "cuda"):
+        return value
+    if isinstance(value, str) and re.fullmatch(r"cuda:[0-9]+", value):
+        return f"cuda:{int(value.split(':')[1])}"
+    raise ValueError("'device' must be cpu, cuda, or cuda:N with a non-negative index")
 
 
 def _parse_startup_timeout(value: object) -> float:
@@ -85,9 +97,11 @@ def _resolve_model_cache(cfg: dict, yaml_dir: Path) -> Path:
 class _PocketTTSBackend:
     """Thread-safe Pocket TTS voice loader and synthesizer."""
 
-    def __init__(self, voice: str, language: str) -> None:
+    def __init__(self, voice: str, language: str, device: str = "cpu") -> None:
         self._voice_name = voice
         self._language = language
+        self._requested_device = _parse_device(device)
+        self.device: str | None = None
         self._model = None
         self._voice_state = None
         self._load_lock = threading.Lock()
@@ -108,19 +122,36 @@ class _PocketTTSBackend:
 
             from pocket_tts import TTSModel
 
-            logger.info("Loading Pocket TTS language {!r}…", self._language)
-            model = TTSModel.load_model(language=self._language)
+            device = self._requested_device
+            if device.startswith("cuda"):
+                import torch
+
+                if not torch.cuda.is_available():
+                    raise RuntimeError(
+                        "Pocket TTS requested CUDA, but CUDA is unavailable. Install a CUDA-enabled "
+                        "Torch build and check the NVIDIA driver, or select device: cpu."
+                    )
+                index = int(device.split(":")[1]) if ":" in device else torch.cuda.current_device()
+                if index >= torch.cuda.device_count():
+                    raise ValueError(f"Pocket TTS CUDA device index {index} is not visible")
+                device = f"cuda:{index}"
+
+            logger.info("Loading Pocket TTS language {!r} on {}…", self._language, device)
+            model = TTSModel.load_model(language=self._language).to(device)
             logger.info("Loading voice {!r}…", self._voice_name)
+            # Precomputed voice tensors use model.device; load them after moving the model.
             voice_state = model.get_state_for_audio_prompt(self._voice_name)
             self._model = model
             self._voice_state = voice_state
+            self.device = device
             weights = (
                 "gated voice-cloning"
                 if model.has_voice_cloning
                 else "ungated no-voice-cloning fallback"
             )
             logger.info(
-                "Pocket TTS ready  sample_rate={} weights={}",
+                "Pocket TTS ready  device={} sample_rate={} weights={}",
+                device,
                 model.sample_rate,
                 weights,
             )
@@ -181,7 +212,7 @@ def _build_app(cfg: dict, _model_cache: Path):
 
     voice_name = cfg["voice"]
     language = str(cfg.get("language", "english"))
-    backend = _PocketTTSBackend(voice_name, language)
+    backend = _PocketTTSBackend(voice_name, language, cfg.get("device", "cpu"))
     generation_lock = asyncio.Lock()
 
     app = FastAPI(title="Pocket TTS Server", version="0.1.0")
@@ -197,7 +228,7 @@ def _build_app(cfg: dict, _model_cache: Path):
     def health():
         if not backend.ready:
             raise HTTPException(status_code=503, detail="model not loaded")
-        return {"status": "ok"}
+        return {"status": "ok", "device": backend.device}
 
     @app.get("/v1/models")
     def list_models():
@@ -244,6 +275,25 @@ def _health_url_ok(health_url: str) -> bool:
             return response.status == 200
     except Exception:
         return False
+
+
+def _check_reused_device(health_url: str, requested: str) -> None:
+    """Reject a mismatched or legacy listener without stopping an existing service."""
+    try:
+        with urllib.request.urlopen(health_url, timeout=2) as response:
+            info = json.load(response)
+        actual = info.get("device") if isinstance(info, dict) else None
+    except (OSError, ValueError) as exc:
+        raise RuntimeError(f"cannot verify the existing Pocket TTS device: {exc}") from exc
+    matches = actual == requested or (
+        requested == "cuda" and isinstance(actual, str) and re.fullmatch(r"cuda:[0-9]+", actual)
+    )
+    if not matches:
+        raise RuntimeError(
+            f"existing TTS service reports device={actual!r}, requested {requested!r}. "
+            "Stop the owned TTS service before changing device or upgrading a legacy listener; "
+            "it has not been stopped automatically."
+        )
 
 
 def _probe_host(bind_host: str) -> str:
@@ -439,11 +489,17 @@ def run() -> None:
         startup_timeout_s = _parse_startup_timeout(
             cfg.get("startup_timeout_s", _DEFAULT_STARTUP_TIMEOUT_S)
         )
+        device = _parse_device(cfg.get("device", "cpu"))
     except ValueError as exc:
         raise SystemExit(f"[pocket_tts_server] {exc}") from exc
     health_url = _health_url(probe_host, port)
 
     if _health_url_ok(health_url):
+        if "device" in cfg:
+            try:
+                _check_reused_device(health_url, device)
+            except RuntimeError as exc:
+                raise SystemExit(f"[pocket_tts_server] {exc}") from exc
         print(
             f"[pocket_tts_server] already running on port {port} — reusing",
             flush=True,

--- a/services/pocket-tts/pyproject.toml
+++ b/services/pocket-tts/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.1.0"
 requires-python = ">=3.11,<3.13"
 dependencies = [
     "pocket-tts==3.0.2",
-    # Keep this CPU-only service off PyPI's CUDA-enabled Linux Torch wheel.
+    # PyPI supplies CUDA-enabled Linux wheels; device selection belongs to YAML.
     "torch>=2.5.0",
     "huggingface-hub>=0.32.0",
     "hf-xet>=1.1.2,<2.0.0",
@@ -25,13 +25,7 @@ dependencies = [
 pocket_tts_server = "pocket_tts_server.__main__:run"
 
 [tool.uv.sources]
-torch = { index = "pytorch-cpu", marker = "sys_platform == 'linux' or sys_platform == 'win32'" }
 xr-ai-logging = { path = "../../utils/xr-ai-logging", editable = true }
-
-[[tool.uv.index]]
-name = "pytorch-cpu"
-url = "https://download.pytorch.org/whl/cpu"
-explicit = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["pocket_tts_server"]

--- a/tests/test_pocket_tts.py
+++ b/tests/test_pocket_tts.py
@@ -65,6 +65,10 @@ def _write_fake_pocket_tts(root: Path) -> None:
     sample_rate = 24000
     has_voice_cloning = False
 
+    def to(self, device):
+        self.device = device
+        return self
+
     def get_state_for_audio_prompt(self, voice):
         return {"voice": voice}
 
@@ -120,16 +124,24 @@ class _FakeModel:
 
     def __init__(self) -> None:
         self.generated: list[tuple[object, str]] = []
+        self.device = None
+        self.load_order = []
+
+    def to(self, device):
+        self.device = device
+        self.load_order.append(("model", device))
+        return self
 
     def get_state_for_audio_prompt(self, voice: str) -> object:
-        return {"voice": voice}
+        self.load_order.append(("voice", self.device))
+        return {"voice": voice, "device": self.device}
 
     def generate_audio(self, state: object, text: str) -> _FakeTensor:
         self.generated.append((state, text))
         return _FakeTensor([-2.0, -0.5, 0.5, 2.0])
 
 
-def _loaded_backend(module, monkeypatch: pytest.MonkeyPatch):
+def _loaded_backend(module, monkeypatch: pytest.MonkeyPatch, device="cpu"):
     model = _FakeModel()
     load_model = Mock(return_value=model)
     monkeypatch.setitem(
@@ -137,7 +149,7 @@ def _loaded_backend(module, monkeypatch: pytest.MonkeyPatch):
         "pocket_tts",
         SimpleNamespace(TTSModel=SimpleNamespace(load_model=load_model)),
     )
-    backend = module._PocketTTSBackend("bill_boerst", "english")
+    backend = module._PocketTTSBackend("bill_boerst", "english", device)
     backend._ensure_loaded()
     return backend, model, load_model
 
@@ -157,6 +169,97 @@ async def test_backend_loads_selected_model_and_voice(monkeypatch) -> None:
     assert backend.ready
     assert backend.sample_rate == 24000
     load_model.assert_called_once_with(language="english")
+    assert backend.device == "cpu"
+
+
+@pytest.mark.parametrize("device,expected", [("cuda", "cuda:1"), ("cuda:0", "cuda:0")])
+async def test_cuda_model_moves_before_loading_voice(monkeypatch, device, expected) -> None:
+    module = _load_main_module()
+    monkeypatch.setitem(sys.modules, "torch", SimpleNamespace(cuda=SimpleNamespace(
+        is_available=lambda: True, current_device=lambda: 1, device_count=lambda: 2,
+    )))
+    backend, model, _load_model = _loaded_backend(module, monkeypatch, device)
+    assert backend.device == expected
+    assert model.load_order == [("model", expected), ("voice", expected)]
+    assert backend._voice_state["device"] == expected
+    assert backend.ready
+
+
+@pytest.mark.parametrize("available,device,message", [
+    (False, "cuda:0", "CUDA is unavailable"),
+    (True, "cuda:2", "device index 2 is not visible"),
+])
+async def test_cuda_configuration_fails_without_cpu_fallback(monkeypatch, available, device, message) -> None:
+    module = _load_main_module()
+    load_model = Mock()
+    monkeypatch.setitem(sys.modules, "pocket_tts", SimpleNamespace(TTSModel=SimpleNamespace(load_model=load_model)))
+    monkeypatch.setitem(sys.modules, "torch", SimpleNamespace(cuda=SimpleNamespace(
+        is_available=lambda: available, device_count=lambda: 1,
+    )))
+    backend = module._PocketTTSBackend("bill_boerst", "english", device)
+    with pytest.raises((RuntimeError, ValueError), match=message):
+        backend._ensure_loaded()
+    load_model.assert_not_called()
+    assert not backend.ready
+    assert backend.device is None
+
+
+@pytest.mark.parametrize("device", [None, True, 0, "", "auto", "mps", "cuda:-1", "cuda:one", "cpu:0"])
+async def test_rejects_invalid_device(device) -> None:
+    module = _load_main_module()
+    with pytest.raises(ValueError, match="'device' must be"):
+        module._PocketTTSBackend("bill_boerst", "english", device)
+
+
+async def test_blackwell_profile_selects_cuda() -> None:
+    config = yaml.safe_load(_PROFILE_CONFIGS[2].read_text())
+    assert config["device"] == "cuda:0"
+
+
+async def test_cpu_only_torch_index_is_not_forced() -> None:
+    import tomllib
+
+    project = tomllib.loads((_PROJECT / "pyproject.toml").read_text())
+    assert "torch" not in project["tool"]["uv"]["sources"]
+
+
+@pytest.mark.parametrize("requested,actual", [("cpu", "cpu"), ("cuda", "cuda:1"), ("cuda:1", "cuda:1")])
+async def test_reuse_accepts_matching_device(monkeypatch, requested, actual) -> None:
+    module = _load_main_module()
+    monkeypatch.setattr(module.urllib.request, "urlopen", lambda *_a, **_k: io.BytesIO(
+        json.dumps({"status": "ok", "device": actual}).encode(),
+    ))
+    module._check_reused_device("http://localhost:8105/health", requested)
+
+
+@pytest.mark.parametrize("actual", [None, "cpu", "cuda:1"])
+async def test_cuda_reuse_rejects_legacy_or_wrong_device(monkeypatch, tmp_path, actual) -> None:
+    module = _load_main_module()
+    config_path = tmp_path / "pocket.yaml"
+    config_path.write_text(yaml.safe_dump({"device": "cuda:0"}))
+    ready = tmp_path / "ready"
+    monkeypatch.setattr(module, "setup_logging", lambda *_args: None)
+    monkeypatch.setattr(module, "_health_url_ok", lambda _url: True)
+    monkeypatch.setattr(module.urllib.request, "urlopen", lambda *_a, **_k: io.BytesIO(
+        json.dumps({"status": "ok", "device": actual}).encode(),
+    ))
+    monkeypatch.setattr(module.os, "execvpe", Mock(side_effect=AssertionError("must not replace listener")))
+    monkeypatch.setattr(module.sys, "argv", [
+        "pocket_tts_server", "--config", str(config_path), "--ready-file", str(ready),
+    ])
+    with pytest.raises(SystemExit, match="Stop the owned TTS service"):
+        module.run()
+    assert not ready.exists()
+
+
+async def test_health_reports_actual_loaded_device(monkeypatch, tmp_path) -> None:
+    module = _load_main_module()
+    app, backend = module._build_app({"voice": "bill_boerst", "device": "cuda:0"}, tmp_path)
+    assert backend._requested_device == "cuda:0"
+    backend._model = _FakeModel()
+    backend.device = "cuda:0"
+    health = next(route.endpoint for route in app.routes if route.path == "/health")
+    assert health() == {"status": "ok", "device": "cuda:0"}
 
 
 async def test_backend_returns_wav_and_pcm(monkeypatch) -> None:


### PR DESCRIPTION
Adds cpu/cuda/cuda:N selection, device health metadata, and safe rejection of mismatched persistent listeners. Loads voice state after model device placement. Enables CUDA in the 96 GB Blackwell profile and removes the CPU-only Torch index constraint. Validation: 51 portable Pocket tests passed, Ruff passed, dependency resolution and generated inventory checked. Two existing process-management tests need the Linux environment; real GPU HTTP smoke is being validated on the demo workstation. Speech delivery remains buffered.